### PR TITLE
Support for option validation with RegEx

### DIFF
--- a/lib/instance/watchout_production/watchout_production.js
+++ b/lib/instance/watchout_production/watchout_production.js
@@ -39,7 +39,8 @@ instance.prototype.config_fields = function () {
 			type: 'textinput',
 			id: 'host',
 			label: 'Production Computer IP',
-			width: 6
+			width: 6,
+			regex: '/^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/'
 		}
 	]
 };
@@ -84,7 +85,8 @@ instance.prototype.actions = function(system) {
 				type: 'textinput',
 				label: 'time position',
 				id: 'time',
-				default: '"00:00:00.000"'
+				default: '"00:00:00.000"',
+				regex: '/^(\\d{1,12})|("\\d{1,2}:\\d{1,2}:\\d{1,2}\\.\\d{1,3}")$/'
 			},{
 				type: 'textinput',
 				label: 'timeline (optional)',
@@ -109,14 +111,16 @@ instance.prototype.actions = function(system) {
 				type: 'textinput',
 				label: 'go online',
 				id: 'online',
-				default: 'true'
+				default: 'true',
+				regex: '/^(true)|(false)|0|1$/i'
 			}]},
 		'standby': { label: 'Enter Standby',
 			options: [{
 				type: 'textinput',
 				label: 'Enter Standby',
 				id: 'standby',
-				default: 'true'
+				default: 'true',
+				regex: '/^(true)|(false)|0|1$/i'
 			}]},
 		'setinput': {
 			label: 'Set Input',
@@ -129,12 +133,14 @@ instance.prototype.actions = function(system) {
 				type: 'textinput',
 				label: 'Value',
 				id: 'inputvalue',
-				default: '1.0'
+				default: '1.0',
+				regex: '/^\\d+\\.?\\d*$/'
 			},{
 				type: 'textinput',
 				label: 'Fadetime (ms)',
 				id: 'inputfade',
-				default: '0'
+				default: '0',
+				regex: '/^\\d+$/'
 			}]}
 
 	});

--- a/public/action.js
+++ b/public/action.js
@@ -15,6 +15,11 @@ $(function() {
 
 	$('#bankActions').on('keyup', '.action-option-keyup', function() {
 		socket.emit('bank_update_action_option', page, bank,  $(this).data('action-id'), $(this).data('option-id'), $(this).val() );
+		if ($(this).val().match($(this).data('option-regex')) != null) {
+			this.style.color = "black";
+		} else {
+			this.style.color = "red";
+		}
 	});
 
 	$('#bankActions').on('change', '.action-option-change', function() {
@@ -66,6 +71,7 @@ $(function() {
 					for (var n in options) {
 						var option = options[n];
 
+
 						var $opt_label = $("<label>"+option.label+"</label>");
 						$options.append($opt_label);
 
@@ -73,6 +79,13 @@ $(function() {
 							var $opt_input = $("<input type='text' class='action-option-keyup form-control'>");
 							$opt_input.data('action-id', action.id);
 							$opt_input.data('option-id', option.id);
+
+							if (option.regex){
+								var flags = option.regex.replace(/.*\/([gimy]*)$/, '$1');
+								var pattern = option.regex.replace(new RegExp('^/(.*?)/'+flags+'$'), '$1');
+								var regex = new RegExp(pattern, flags);
+								$opt_input.data('option-regex', regex);
+							}
 
 							// if options never been stored on this action
 							if (action.options === undefined) {

--- a/public/instance.js
+++ b/public/instance.js
@@ -97,7 +97,7 @@ $(function() {
 
 		for (var n in store.module) {
 			if (store.module[n].id === store.db[id].instance_type) {
-				$('#instanceConfig h4').text( store.module[n].label + ' configuration');				
+				$('#instanceConfig h4').text( store.module[n].label + ' configuration');
 			}
 		}
 		console.log(store,res,config);
@@ -109,18 +109,30 @@ $(function() {
 
 		for (var n in res) {
 			var field = res[n];
+			if (field.regex){
+				var flags = field.regex.replace(/.*\/([gimy]*)$/, '$1');
+				var pattern = field.regex.replace(new RegExp('^/(.*?)/'+flags+'$'), '$1');
+				var regex = new RegExp(pattern, flags);
+			}
 			var $sm = $('<div class="col-sm-'+field.width+'"><label>'+field.label+'</label></div>')
 			if (field.type == 'textinput') {
 				var $inp = $("<input type='text' class='form-control instanceConfigField' data-type='"+field.type+"' data-id='"+field.id+"'>");
-				(function(f1,f2,inp) {
+				(function(f1,f2,inp,reg) {
 					inp.keyup(function(){
 						if (f2 == 'label') {
 							$("#label_"+ f1).text(inp.val());
 						}
+							console.log("edited:", field.label, " f1 ", f1, " f2 ", f2, " reg ", reg);
+							if (inp.val().match(reg) != null) {
+								this.style.color = "black";
+							} else {
+								this.style.color = "red";
+							}
+
 						socket.emit('instance_config_set', f1, f2, inp.val() );
 						$("#elgbuttons").click();
 					});
-				})(id,field.id,$inp);
+				})(id,field.id,$inp,regex);
 				$sm.append($inp);
 			}
 			else {


### PR DESCRIPTION
Module and Action options can be validated during input with regex. You have to add "regex"-attribute to the action. When using backslash in the regex the backslashes have to be backslashed themself (double backslash). In the input field text not matching the regex gets colored red otherwise black.