### PR TITLE
Use of "main" property of package.json for requiring a module

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -38,7 +38,9 @@ function instance(system) {
 			var folder = module_folders[i];
 
 			try {
-				var mod = require(path + '/' + folder + '/' + folder + '.js');
+				var packagefile = fs.readFileSync(path +'/'+ folder + '/package.json');
+				var moduleconfig = JSON.parse(packagefile);
+				var mod = require(path + '/' + folder + '/' + moduleconfig.main);
 
 				self.store.module.push(mod.module_info);
 				self.modules[folder] = mod;


### PR DESCRIPTION
Better than just using the parent folder name.