### PR TITLE
Added needed packages for raspi-builts

### DIFF
--- a/documentation/raspberrypi.md
+++ b/documentation/raspberrypi.md
@@ -4,7 +4,7 @@ in your raspberry pi console (```pi@raspberry:~/ $```)
 
 1. Install node, git, curl, etc.
 ```
-apt-get install nodejs git build-essential
+apt-get install nodejs git build-essential libudev-dev libusb-1.0-0-dev
 sudo npm install n -g
 n 8.11.1
 curl -o- -L https://yarnpkg.com/install.sh | bash


### PR DESCRIPTION
libudev-dev and libusb-1.0-0-dev are needed for successful updating core with yarn and thus added to the documentation.