### PR TITLE
Module config field validation can skip regex checks

### DIFF
--- a/public/instance.js
+++ b/public/instance.js
@@ -468,7 +468,7 @@ $(function() {
 							$("#label_"+ f1).text(inp.val());
 						}
 
-						if (regex === undefined || inp.val().match(reg) !== null) {
+						if (reg === undefined || inp.val().match(reg) !== null) {
 							this.style.color = "black";
 
 							$(this).data('valid', true);


### PR DESCRIPTION
_Apologies for the the duplicate PR. I cleaned up my development environment which resulted in this._

If a module's last connection config field doesn't define `regex`, then an undefined `regex` variable will be bound to all of the module's textinput fields' keyup event. This makes the validation check `regex === undefined` always true, which then skips the real regex validation.

Scenario:
  - Module has two config fields: IP, password.
  - regex is only defined for the IP field.
  - `undefined` gets bound to `keyup` event closure, short-circuiting the IF statement.
  - Regex validation is skipped for any/all fields, allowing any value to be accepted.
