### PR TITLE
Issue 430 Patch

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -172,7 +172,7 @@ function instance(system) {
 				}
 
 				// Generate label
-				if (moduleconfig.name !== undefined) {
+				if (moduleconfig.name !== undefined && moduleconfig.manufacturer != 'Bitfocus') {
 					if (typeof moduleconfig.product == 'string') {
 						moduleconfig.label = moduleconfig.manufacturer + ":" + moduleconfig.product;
 					}


### PR DESCRIPTION
Bypasses the 'Bitfocus Companion' module from being added to modules_name array and therefore searchable in 'Add by search' Interface tab.

Tested.  Properly inhibits the module from 'Add by search' and did not see any errors in the normal execution or background load of the module/instance.