### PR TITLE
Prevent 'feedback_instance_check' from executing with an empty instance

### DIFF
--- a/lib/feedback.js
+++ b/lib/feedback.js
@@ -50,7 +50,9 @@ function feedback(system) {
 
 		system.emit('instance_get', instance_id, function (instance) {
 			//debug("calling feedback_instance_check", instance);
-			system.emit('feedback_instance_check', instance);
+			if (instance !== undefined) {
+				system.emit('feedback_instance_check', instance);
+			}
 		});
 
 	});


### PR DESCRIPTION
#487 
Didn't want to merge this without a 2nd set of eyes looking at the overall issue.