### PR TITLE
Add ability to control button style with osc.

### DIFF
--- a/lib/osc.js
+++ b/lib/osc.js
@@ -62,8 +62,49 @@ function osc(system) {
 				}
 
 			}
+		} else if (message.address.match(/^\/style\/bgcolor\/\d+\/\d+$/)) {
+			if (message.args.length > 2) {
+				var r = message.args[0].value;
+				var g = message.args[1].value;
+				var b = message.args[2].value;
+				if (typeof r === "number" && typeof g === "number" && typeof b === "number") {
+					var col = rgb(r, g, b);
+					debug("Got /style/bgcolor", parseInt(a[3]), "button", parseInt(a[4]))
+					system.emit('bank_set_key', parseInt(a[3]), parseInt(a[4]), 'bgcolor', col);
+					system.emit('graphics_invalidate_bank', parseInt(a[3]), parseInt(a[4]));
+				}
+			}
+		} else if (message.address.match(/^\/style\/color\/\d+\/\d+$/)) {
+			if (message.args.length > 2) {
+				var r = message.args[0].value;
+				var g = message.args[1].value;
+				var b = message.args[2].value;
+				if (typeof r === "number" && typeof g === "number" && typeof b === "number") {
+					var col = rgb(r, g, b);
+					debug("Got /style/color", parseInt(a[3]), "button", parseInt(a[4]))
+					system.emit('bank_set_key', parseInt(a[3]), parseInt(a[4]), 'color', col);
+					system.emit('graphics_invalidate_bank', parseInt(a[3]), parseInt(a[4]));
+				}
+			}
+		} else if (message.address.match(/^\/style\/text\/\d+\/\d+$/)) {
+			if (message.args.length > 0) {
+				var text = message.args[0].value;
+				if (typeof text === "string") {
+					debug("Got /style/text", parseInt(a[3]), "button", parseInt(a[4]))
+					system.emit('bank_set_key', parseInt(a[3]), parseInt(a[4]), 'text', text);
+					system.emit('graphics_invalidate_bank', parseInt(a[3]), parseInt(a[4]));
+				}
+			}
 		}
 	});
+
+	function rgb(r,g,b) {
+		return (
+			((r & 0xff) << 16) |
+			((g & 0xff) << 8) |
+			(b & 0xff)
+		);
+	};
 
 	self.system.on('osc_send', function(host, port, path, args) {
 		self.listener.send({


### PR DESCRIPTION
Along side pressing the button, this adds /style/bgcolor, /style/color and /style/text...

Pretty simple really, but I needed for an event so that QLab could update button labels based on very specific things. It could be argued this should be done as feedback on the OSC module, but I figured this was simpler.