### PR TITLE
Minor: Add feedback definition callback

### DIFF
--- a/lib/feedback.js
+++ b/lib/feedback.js
@@ -106,15 +106,22 @@ function feedback(system) {
 
 						if (feedback.instance_id == instance.id) {
 							system.emit('get_bank', page, bank, function (bank_obj) {
+								var definition;
+
+								if (self.feedback_definitions[instance.id] !== undefined && self.feedback_definitions[instance.id][feedback.type] !== undefined) {
+									definition = self.feedback_definitions[instance.id][feedback.type];
+								}
 
 								// Ask instance to check bank for custom styling
-								if (typeof instance.feedback == 'function') {
+								if (definition !== undefined && definition.callback !== undefined && typeof definition.callback == 'function') {
+									var result = definition.callback(feedback, bank_obj);
+									self.setStyle(page, bank, feedback.id, result);
+								} else if (typeof instance.feedback == 'function') {
 									var result = instance.feedback(feedback, bank_obj);
 									self.setStyle(page, bank, feedback.id, result);
 								} else {
 									debug('ERROR: instance ' + instance.label + ' does not have a feedback() function');
 								}
-
 							});
 						}
 					}


### PR DESCRIPTION
Allows for feedback definitions to include a 'callback' function to process feedback as an alternate to using the feedbacks(...) function in the module.

Usage sample to follow in videohub update.