### PR TITLE
New action controls (checkbox and number/range input)

### DIFF
--- a/public/action.js
+++ b/public/action.js
@@ -247,7 +247,7 @@ $(function() {
 
 								$opt_input.spectrum({
 
-									color: int2hex(action.options[f_oid]),
+									color: int2hex($opt_input.val()),
 									preferredFormat: "rgb",
 									showInput: true,
 									showPalette: true,

--- a/public/action.js
+++ b/public/action.js
@@ -60,6 +60,44 @@ $(function() {
 		socket.emit('bank_update_action_option', page, bank,  $(this).data('action-id'), $(this).data('option-id'), $(this).val() );
 	});
 
+	$('#bankActions').on('change', '.action-checkbox', function() {
+		socket.emit('bank_update_action_option', page, bank, $(this).data('action-id'), $(this).data('option-id'), $(this).prop('checked') );
+	});
+
+	$('#bankActions').on('change', '.action-number', function() {
+
+		var $this = $(this);
+		let min   = parseFloat($this.attr('min'));
+		let max   = parseFloat($this.attr('max'));
+		let value = parseFloat($this.val());
+
+		if (!$this.attr('required') && isNaN(value)) {
+			// Not required and isn't a number (could be empty).
+			this.style.color = 'black';
+		} else if (!isNaN(parseFloat(value)) && isFinite(value) && value >= min && value <= max) {
+			// Is required and the value is a number within range.
+			this.style.color = 'black';
+		} else {
+			this.style.color = 'red';
+			return;
+		}
+
+		if (isNaN(value)) {
+			// The value was empty (not required) and cast to a float, which makes it NaN.
+			// Set it to an empty string and store that.
+			value = '';
+		}
+
+		// If 'option.range === true' this option will contain both number and a range input types.
+		// Keep both options' values in sync.
+		$this.parents('.action-number-row').find('.action-number').each(function(index, element) {
+			$(element).val(value);
+		});
+
+		socket.emit('bank_update_action_option', page, bank, $this.data('action-id'), $this.data('option-id'), value);
+
+	});
+
 	$("#testBankButton").on('mousedown', function() {
 		socket.emit('hot_press',page,bank, true);
 	});
@@ -301,6 +339,95 @@ $(function() {
 							}
 
 							$options.append($opt_input);
+
+						}
+
+						else if (option.type == 'checkbox') {
+
+							var $opt_checkbox = $("<input type='checkbox' class='action-checkbox form-control'>");
+							if (option.tooltip !== undefined) {
+								$opt_checkbox.attr('title', option.tooltip);
+							}
+
+							// Force as a boolean
+							option.default = option.default === true;
+
+							$opt_checkbox.data('action-id', action.id)
+								.data('option-id', option.id);
+
+							// if this option never has been saved, set default
+							if (action.options[option.id] === undefined) {
+								socket.emit('bank_update_action_option', page, bank, action.id, option.id, option.default);
+								$opt_checkbox.prop('checked', option.default);
+							}
+
+							// else set the db value for this option.
+							else {
+								$opt_checkbox.prop('checked', action.options[option.id]);
+							}
+
+							$options.append($opt_checkbox);
+
+						}
+
+						else if (option.type == 'number') {
+
+							// Create both the number and the range inputs.
+							// The range will only be used if option.range is used.
+							let $opt_num   = $('<input type="number" class="action-number form-control">');
+							let $opt_range = $("<input type='range' class='action-number form-control'>");
+							
+
+							if (option.tooltip !== undefined) {
+								$opt_num.attr('title', option.tooltip);
+								$opt_range.attr('title', option.tooltip);
+							}
+
+							$opt_num.data('action-id', action.id)
+								.data('option-id', option.id)
+								.attr('min', option.min)
+								.attr('max', option.max)
+								.attr('required', option.range || option.required === true);
+
+							// if this option never has been saved, set default
+							if (action.options[option.id] === undefined) {
+								socket.emit('bank_update_action_option', page, bank, action.id, option.id, option.default);
+								$opt_num.val(option.default);
+							}
+
+							// else set the db value for this option.
+							else {
+								$opt_num.val(action.options[option.id]);
+							}
+
+							
+							if (option.range !== true) {
+
+								$options.append(
+									$('<div class="row action-number-row">').append([
+										$('<div class="col-sm-12">').append($opt_num)
+									])
+								);
+
+							}
+
+							// else include the range input in the row too
+							else {
+
+								$opt_range.data('action-id', action.id)
+									.data('option-id', option.id)
+									.attr('min', option.min)
+									.attr('max', option.max)
+									.val($opt_num.val());
+
+								$options.append(
+									$('<div class="row action-number-row">').append([
+										$('<div class="col-sm-8">').append($opt_range),
+										$('<div class="col-sm-4">').append($opt_num)
+									])
+								);
+
+							}
 
 						}
 

--- a/public/feedback.js
+++ b/public/feedback.js
@@ -24,6 +24,45 @@ $(function() {
 		socket.emit('bank_update_feedback_option', page, bank,  $(this).data('feedback-id'), $(this).data('option-id'), $(this).val() );
 	});
 
+	
+	$('#bankFeedbacks').on('change', '.feedback-action-checkbox', function() {
+		socket.emit('bank_update_feedback_option', page, bank, $(this).data('action-id'), $(this).data('option-id'), $(this).prop('checked') );
+	});
+
+	$('#bankFeedbacks').on('change', '.feedback-action-number', function() {
+
+		var $this = $(this);
+		let min   = parseFloat($this.attr('min'));
+		let max   = parseFloat($this.attr('max'));
+		let value = $this.attr('required') ? parseFloat($this.val()) : $this.val();
+
+		if (!$this.attr('required') && isNaN(value)) {
+			// Not required and isn't a number (could be empty).
+			this.style.color = 'black';
+		} else if (!isNaN(parseFloat(value)) && isFinite(value) && value >= min && value <= max) {
+			// Is required and the value is a number within range.
+			this.style.color = 'black';
+		} else {
+			this.style.color = 'red';
+			return;
+		}
+
+		if (isNaN(value)) {
+			// The value was empty (not required) and cast to a float, which makes it NaN.
+			// Set it to an empty string and store that.
+			value = '';
+		}
+
+		// If 'option.range === true' then this option will contain both number and a range input types.
+		// Keep both options' values in sync.
+		$this.parents('.action-number-row').find('.feedback-action-number').each(function(index, element) {
+			$(element).val(value);
+		});
+
+		socket.emit('bank_update_feedback_option', page, bank, $this.data('action-id'), $this.data('option-id'), value);
+
+	});
+
 	socket.on('bank_get_feedbacks:result', function(page, bank, feedbacks) {
 		$ba = $("#bankFeedbacks");
 		$ba.html("");
@@ -192,6 +231,95 @@ $(function() {
 									}
 								});
 							})(int2hex(val), feedback.id, option.id);
+
+						}
+				
+						else if (option.type == 'checkbox') {
+
+							var $opt_checkbox = $("<input type='checkbox' class='feedback-action-checkbox form-control'>");
+							if (option.tooltip !== undefined) {
+								$opt_checkbox.attr('title', option.tooltip);
+							}
+
+							$opt_checkbox.data('action-id', feedback.id)
+								.data('option-id', option.id);
+
+							// Force as a boolean
+							option.default = option.default === true;
+
+							// if this option never has been saved, set default
+							if (feedback.options[option.id] === undefined) {
+								socket.emit('bank_update_feedback_option', page, bank, feedback.id, option.id, option.default);
+								$opt_checkbox.prop('checked', option.default);
+							}
+
+							// else set the db value for this option.
+							else {
+								$opt_checkbox.prop('checked', feedback.options[option.id]);
+							}
+
+							$options.append($opt_checkbox);
+
+						}
+
+						else if (option.type == 'number') {
+
+							// Create both the number and the range inputs.
+							// The range will only be used if option.range is used.
+							let $opt_num   = $('<input type="number" class="feedback-action-number form-control">');
+							let $opt_range = $("<input type='range' class='feedback-action-number form-control'>");
+							
+
+							if (option.tooltip !== undefined) {
+								$opt_num.attr('title', option.tooltip);
+								$opt_range.attr('title', option.tooltip);
+							}
+
+							$opt_num.data('action-id', feedback.id)
+								.data('option-id', option.id)
+								.attr('min', option.min)
+								.attr('max', option.max)
+								.attr('required', option.range || option.required === true);
+
+							// if this option never has been saved, set default
+							if (feedback.options[option.id] === undefined) {
+								socket.emit('bank_update_feedback_option', page, bank, feedback.id, option.id, option.default);
+								$opt_num.val(option.default);
+							}
+
+							// else set the db value for this option.
+							else {
+								$opt_num.val(feedback.options[option.id]);
+							}
+
+							
+							if (option.range !== true) {
+
+								$options.append(
+									$('<div class="row action-number-row">').append([
+										$('<div class="col-sm-12">').append($opt_num)
+									])
+								);
+
+							}
+
+							// else include the range input in the row too
+							else {
+
+								$opt_range.data('action-id', feedback.id)
+									.data('option-id', option.id)
+									.attr('min', option.min)
+									.attr('max', option.max)
+									.val($opt_num.val());
+
+								$options.append(
+									$('<div class="row action-number-row">').append([
+										$('<div class="col-sm-8">').append($opt_range),
+										$('<div class="col-sm-4">').append($opt_num)
+									])
+								);
+
+							}
 
 						}
 

--- a/public/release_action.js
+++ b/public/release_action.js
@@ -232,7 +232,7 @@ $(function() {
 
 								$opt_input.spectrum({
 
-									color: int2hex(action.options[f_oid]),
+									color: int2hex($opt_input.val()),
 									preferredFormat: "rgb",
 									showInput: true,
 									showPalette: true,


### PR DESCRIPTION
Two new controls available for actions and feedbacks:

![new-action-options](https://user-images.githubusercontent.com/9618303/59153010-ecde3a80-8a04-11e9-8384-b959d966e139.gif)

## Checkbox
A checkbox with a boolean value of `true` when checked and `false` when unchecked. The `default` property must be a boolean.

The value returned will be a boolean.

```
{
  type: 'checkbox',
  label: 'Invert',
  id: 'invert'
  tooltip: 'Inverts the layer',
  default: false
}
```


## Number
Creates a [number input](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number) element which will only accept integers between `min` and `max` (inclusive). The `default` property must be a number (or `""` if not required). If the `required` property is `true` then the field can't be left empty.

If the `range` property is `true` then a [range input](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range) will also be created. Adding a range input will always make the field required since a range always has a value.

The value returned will always be a number (example: `50`, not `"50"`), unless the field isn't required and was left empty, in which case it will be an empty string.

```
{
  type: 'number',
  label: 'Opacity',
  id: 'opacity',
  tooltip: 'Sets the opacity percent (0-100)',
  min: 0,
  max: 100,
  default: 50,
  required: true,
  range: false
}
```
----

PR also includes a bug fix to allow the default color to be set (`action.js` and `release_actions.js`). Default color was previously ignored in favor of the saved value, which didn't yet exist for new actions.