### PR TITLE
Allow REST POST to set headers and connection options

### DIFF
--- a/lib/rest.js
+++ b/lib/rest.js
@@ -47,16 +47,22 @@ function rest(system) {
 
 	});
 
-	system.on('rest', function(url, data, cb) {
+	system.on('rest', function(url, data, cb, extra_headers, extra_args) {
 
 		debug('making request:', url, data);
 
-		var client = new Client();
+		var client = new Client(extra_args);
 
 		var args = {
-				data: data,
-				headers: { "Content-Type": "application/json" }
+			data: data,
+			headers: { "Content-Type": "application/json" }
 		};
+
+		if (extra_headers !== undefined) {
+			for (var header in extra_headers) {
+				args.headers[header] = extra_headers[header];
+			}
+		}
 
 		client.post(url, args, function (data, response) {
 			cb(null, { data: data, response: response });


### PR DESCRIPTION
`system.on('rest_get')` can set additional headers and client connection options. Make those same options available to `system.on('rest')` for the POST method.