### PR TITLE
New instance config controls (checkbox and number input) 

### DIFF
--- a/public/action.js
+++ b/public/action.js
@@ -71,7 +71,7 @@ $(function() {
 		let max   = parseFloat($this.attr('max'));
 		let value = parseFloat($this.val());
 
-		if (!$this.attr('required') && isNaN(value)) {
+		if (!$this.prop('required') && isNaN(value)) {
 			// Not required and isn't a number (could be empty).
 			this.style.color = 'black';
 		} else if (!isNaN(parseFloat(value)) && isFinite(value) && value >= min && value <= max) {
@@ -354,6 +354,11 @@ $(function() {
 
 							$opt_checkbox.data('action-id', action.id)
 								.data('option-id', option.id);
+								
+							// if options never been stored on this action
+							if (action.options === undefined) {
+								action.options = {};
+							}
 
 							// if this option never has been saved, set default
 							if (action.options[option.id] === undefined) {
@@ -387,7 +392,7 @@ $(function() {
 								.data('option-id', option.id)
 								.attr('min', option.min)
 								.attr('max', option.max)
-								.attr('required', option.range || option.required === true);
+								.prop('required', option.range || option.required === true);
 
 							// if this option never has been saved, set default
 							if (action.options[option.id] === undefined) {

--- a/public/feedback.js
+++ b/public/feedback.js
@@ -34,9 +34,9 @@ $(function() {
 		var $this = $(this);
 		let min   = parseFloat($this.attr('min'));
 		let max   = parseFloat($this.attr('max'));
-		let value = $this.attr('required') ? parseFloat($this.val()) : $this.val();
+		let value = $this.prop('required') ? parseFloat($this.val()) : $this.val();
 
-		if (!$this.attr('required') && isNaN(value)) {
+		if (!$this.prop('required') && isNaN(value)) {
 			// Not required and isn't a number (could be empty).
 			this.style.color = 'black';
 		} else if (!isNaN(parseFloat(value)) && isFinite(value) && value >= min && value <= max) {
@@ -247,6 +247,11 @@ $(function() {
 							// Force as a boolean
 							option.default = option.default === true;
 
+							// if options never been stored on this action
+							if (feedback.options === undefined) {
+								feedback.options = {};
+							}
+
 							// if this option never has been saved, set default
 							if (feedback.options[option.id] === undefined) {
 								socket.emit('bank_update_feedback_option', page, bank, feedback.id, option.id, option.default);
@@ -279,7 +284,7 @@ $(function() {
 								.data('option-id', option.id)
 								.attr('min', option.min)
 								.attr('max', option.max)
-								.attr('required', option.range || option.required === true);
+								.prop('required', option.range || option.required === true);
 
 							// if this option never has been saved, set default
 							if (feedback.options[option.id] === undefined) {

--- a/public/release_action.js
+++ b/public/release_action.js
@@ -67,9 +67,9 @@ $(function() {
 		var $this = $(this);
 		let min   = parseFloat($this.attr('min'));
 		let max   = parseFloat($this.attr('max'));
-		let value = $this.attr('required') ? parseFloat($this.val()) : $this.val();
+		let value = $this.prop('required') ? parseFloat($this.val()) : $this.val();
 
-		if (!$this.attr('required') && isNaN(value)) {
+		if (!$this.prop('required') && isNaN(value)) {
 			// Not required and isn't a number (could be empty).
 			this.style.color = 'black';
 		} else if (!isNaN(parseFloat(value)) && isFinite(value) && value >= min && value <= max) {
@@ -302,6 +302,11 @@ $(function() {
 							// Force as a boolean
 							option.default = option.default === true;
 
+							// if options never been stored on this action
+							if (action.options === undefined) {
+								action.options = {};
+							}
+
 							// if this option never has been saved, set default
 							if (action.options[option.id] === undefined) {
 								socket.emit('bank_release_action_update_option', page, bank, action.id, option.id, option.default);
@@ -334,7 +339,7 @@ $(function() {
 								.data('option-id', option.id)
 								.attr('min', option.min)
 								.attr('max', option.max)
-								.attr('required', option.range || option.required === true);
+								.prop('required', option.range || option.required === true);
 
 							// if this option never has been saved, set default
 							if (action.options[option.id] === undefined) {


### PR DESCRIPTION
Two new controls available for instance configs:

![Screen Shot 2019-06-12 at 9 48 35 PM](https://user-images.githubusercontent.com/9618303/59404606-04e2f080-8d5c-11e9-9ad4-ca2327f92e01.jpg)

## Checkbox
A checkbox with a boolean value of `true` when checked and `false` when unchecked. The `default` property must be a boolean.

The value returned will be a boolean.
```
{
  type: 'checkbox',
  label: 'HTTPS Connection',
  id: 'https',
  tooltip: 'Whether the connection is made over HTTPS',
  default: false
}
```

## Number
Creates a [number input](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number) element which will only accept integers between min and max (inclusive). The `default` property must be a number (or `""` if not required). If the `required` property is `true` then the field can't be left empty.

The value returned will always be a number (example: `50`, not `"50"`), unless the field isn't required and was left empty, in which case it will be an empty string.

```
{
  type: 'number',
  label: 'Port',
  id: 'port',
  tooltip: 'The port to make the connection on',
  min: 1,
  max: 65535,
  default: 5000,
  required: true
}
```

Note: The `range` property that's available in actions doesn't make sense here and wasn't included.