### PR TITLE
Fix: Listen for UDP 'message' event.

### DIFF
--- a/lib/udp.js
+++ b/lib/udp.js
@@ -95,7 +95,7 @@ function udp(host, port, options) {
 		self.emit.apply(self, ['listening'].concat(Array.from(arguments)));
 	});
 
-	self.socket.on('data', self.emit.bind(self, 'data'));
+	self.socket.on('message', self.emit.bind(self, 'data'));
 
 	udp_sockets.push(self.socket);
 	debug(udp_sockets.length + ' UDP sockets in use (+1)');


### PR DESCRIPTION
UDP/Datagram sockets (https://nodejs.org/api/dgram.html#dgram_event_message) use the `message` event when responding to a sent UDP packet and not a `data` event. Currently it's not possible to receive a response to a sent UDP packet.

I left it to re-emit the event as `data` to remain consistent with [tcp.js](https://github.com/bitfocus/companion/blob/master/lib/tcp.js#L119)'s event.