### PR TITLE
Patch: "number" input type could fail for new values.

### DIFF
--- a/public/action.js
+++ b/public/action.js
@@ -394,6 +394,11 @@ $(function() {
 								.attr('max', option.max)
 								.prop('required', option.range || option.required === true);
 
+							// if options never been stored on this action
+							if (action.options === undefined) {
+								action.options = {};
+							}
+
 							// if this option never has been saved, set default
 							if (action.options[option.id] === undefined) {
 								socket.emit('bank_update_action_option', page, bank, action.id, option.id, option.default);

--- a/public/feedback.js
+++ b/public/feedback.js
@@ -286,6 +286,11 @@ $(function() {
 								.attr('max', option.max)
 								.prop('required', option.range || option.required === true);
 
+							// if options never been stored on this action
+							if (action.options === undefined) {
+								action.options = {};
+							}
+
 							// if this option never has been saved, set default
 							if (feedback.options[option.id] === undefined) {
 								socket.emit('bank_update_feedback_option', page, bank, feedback.id, option.id, option.default);

--- a/public/release_action.js
+++ b/public/release_action.js
@@ -341,6 +341,11 @@ $(function() {
 								.attr('max', option.max)
 								.prop('required', option.range || option.required === true);
 
+							// if options never been stored on this action
+							if (action.options === undefined) {
+								action.options = {};
+							}
+
 							// if this option never has been saved, set default
 							if (action.options[option.id] === undefined) {
 								socket.emit('bank_release_action_update_option', page, bank, action.id, option.id, option.default);


### PR DESCRIPTION
The "number" input type could fail and trigger browser Javascript errors, preventing the action or feedback from being created.