### PR TITLE
Minor: add release_action and feedback support to addUpgradeScript

### DIFF
--- a/lib/feedback.js
+++ b/lib/feedback.js
@@ -111,7 +111,7 @@ function feedback(system) {
 				for (var i in self.feedbacks[page][bank]) {
 					var feedback = self.feedbacks[page][bank][i];
 					if (feedback.instance == instance_id) {
-						fbs.push(action);
+						fbs.push(feedback);
 					}
 				}
 			}

--- a/lib/feedback.js
+++ b/lib/feedback.js
@@ -104,6 +104,21 @@ function feedback(system) {
 		cb(self.feedbacks);
 	});
 
+	system.on('feedbacks_for_instance', function (instance_id, cb) {
+		var fbs = [];
+		for (var page in self.feedbacks) {
+			for (var bank in self.feedbacks[page]) {
+				for (var i in self.feedbacks[page][bank]) {
+					var feedback = self.feedbacks[page][bank][i];
+					if (feedback.instance == instance_id) {
+						fbs.push(action);
+					}
+				}
+			}
+		}
+		cb(fbs);
+	});
+
 	system.on('feedback_instance_check', function (instance, type) {
 		//debug('Instance ' + instance.label + ' wants us to check banks (' + type + ')');
 		for (var page in self.feedbacks) {

--- a/lib/instance_skel.js
+++ b/lib/instance_skel.js
@@ -127,7 +127,7 @@ instance.prototype.upgradeConfig = function () {
 			actions = _actions;
 		});
 		var release_actions = [];
-		self.system.emit('actions_for_instance', self.id, function (_release_actions) {
+		self.system.emit('release_actions_for_instance', self.id, function (_release_actions) {
 			release_actions = _release_actions;
 		});
 		var feedbacks = [];

--- a/lib/instance_skel.js
+++ b/lib/instance_skel.js
@@ -126,10 +126,18 @@ instance.prototype.upgradeConfig = function () {
 		self.system.emit('actions_for_instance', self.id, function (_actions) {
 			actions = _actions;
 		});
+		var release_actions = [];
+		self.system.emit('actions_for_instance', self.id, function (_release_actions) {
+			release_actions = _release_actions;
+		});
+		var feedbacks = [];
+		self.system.emit('feedbacks_for_instance', self.id, function (_feedbacks) {
+			feedbacks = _feedbacks;
+		});
 
 		var result;
 		try {
-			result = self._versionscripts[i](self.config, actions);
+			result = self._versionscripts[i](self.config, actions, release_actions, feedbacks);
 		} catch (e) {
 			debug("Upgradescript in " + self.package_info.name + ' failed', e);
 		}
@@ -139,6 +147,8 @@ instance.prototype.upgradeConfig = function () {
 		if (result) {
 			self.system.emit('config_save');
 			self.system.emit('action_save');
+			self.system.emit('release_action_save');
+			self.system.emit('feedback_save');
 			self.system.emit('instance_save');
 			self.system.emit('db_save');
 		}


### PR DESCRIPTION
addUpgradeScript does not currently support release_actions or feedback, meaning it is functionally broken.  These should be the necessary fixes, however, I have not had an opportunity to test.  Someone else may be able to get to that before I can and this can be merged once that is done.