### PR TITLE
Added 8 buttons as maximum per width on tablet.html (backport)

### DIFF
--- a/public/tablet.html
+++ b/public/tablet.html
@@ -53,7 +53,6 @@
 
 		.page {
 			padding: 20px;
-			// Sets 8 buttons as the maximum amount in width
 			max-width: 1648px;
 			margin: 0 auto;
 		}

--- a/public/tablet.html
+++ b/public/tablet.html
@@ -53,6 +53,9 @@
 
 		.page {
 			padding: 20px;
+			// Sets 8 buttons as the maximum amount in width
+			max-width: 1648px;
+			margin: 0 auto;
 		}
 
 		.page-bank-content {
@@ -69,10 +72,6 @@
 
 		.disable-dbl-tap-zoom {
   			touch-action: manipulation;
-		}
-
-		*{
-			touch-action: manipulation;
 		}
 
 		* {


### PR DESCRIPTION
## Added 8 buttons as maximum per width
Requested by: https://github.com/bitfocus/companion/pull/806#issuecomment-528705414
Adds a maximum limit of 8 buttons wide (like an *Elgato Stream Deck XL*). 

**Large Screen Example:**
![Large Screen Example](https://imgur.com/XL3OXoB.png)
*This image is showing the master branch version, will make a backport image version when I can*

Thanks to **[ChrisRowtcliff](https://github.com/ChrisRowtcliff)**
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;With some web dev help. 