### PR TITLE
fix: move apply changes button in device configuration page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -291,6 +291,7 @@
 									<div class="tab-pane" id="instanceConfig" role="tabpanel">
 										<h4></h4>
 										<div id='instanceConfigFields' class="row"></div>
+										<div id='instanceConfigButtons'></div>
 										<hr>
 										<div id='instanceConfigVariables' class="row col-lg-12">
 											<h4>List of dynamic variables</h4>

--- a/public/instance.js
+++ b/public/instance.js
@@ -696,7 +696,7 @@ $(function() {
 		$brow.append($bcontainer);
 
 		$('#config_save').remove();
-		$('#instanceConfig').append($brow);
+		$('#instanceConfigButtons').append($brow);
 
 		$button.click(function () {
 			saveConfig(this, id);


### PR DESCRIPTION
A small tweak to move the apply changes button to above the list of dynamic variables.

Some devices (eg all ATEM) have over 100 variables, so having to scroll past those to save config changes is confusing and annoying.

After: 
![image](https://user-images.githubusercontent.com/1327476/65057264-3f1aea00-d96a-11e9-94b8-206fbbc6c426.png)
