### PR TITLE
fix: feedback not updating on creation or deletion

### DIFF
--- a/lib/feedback.js
+++ b/lib/feedback.js
@@ -162,10 +162,10 @@ function feedback(system) {
 
 	system.on('feedback_delete', function (page, bank, id) {
 		if (self.feedback_styles[page] !== undefined && self.feedback_styles[page][bank] !== undefined) {
-			delete self.feedback_styles[page][bank][feedback.id];
+			delete self.feedback_styles[page][bank][id];
 		}
 
-		system.emit('feedback_check_bank', page, bank);
+		system.emit('graphics_bank_invalidate', page, bank);
 	});
 
 	system.on('instance_delete', function (id) {
@@ -241,12 +241,11 @@ function feedback(system) {
 
 			system.emit('feedback_save');
 			client.emit('bank_get_feedbacks:result', page, bank, self.feedbacks[page][bank] );
-			// feedback_instance_check
+			// feedback_instance_check will be called as the options get filled in
 		});
 
 		client.on('bank_delFeedback', function(page, bank, id) {
 			var feedbacks = self.feedbacks[page][bank];
-			system.emit('feedback_delete', page, bank, feedback.id);
 
 			for (var i = 0; i < feedbacks.length; ++i) {
 				if (feedbacks[i].id == id) {
@@ -255,9 +254,10 @@ function feedback(system) {
 				}
 			}
 
+			system.emit('feedback_delete', page, bank, id);
+
 			system.emit('feedback_save');
 			client.emit('bank_get_feedbacks:result', page, bank, self.feedbacks[page][bank] );
-			// feedback_instance_check
 		});
 
 		client.on('bank_update_feedback_option', function(page, bank, feedbackid, option, value) {
@@ -272,6 +272,7 @@ function feedback(system) {
 						}
 						feedback.options[option] = value;
 						self.system.emit('feedback_save');
+						self.system.emit('feedback_instanceid_check', feedback.instance_id)
 					}
 				}
 			}


### PR DESCRIPTION
Feedback wasn't updating for the button while editing the list in the ui. In each of adding, removing or editing the style would stay in the previous state.

This was especially bad when removing a feedback, as the style it defined would be remembered, and would persist until restart.

It will now trigger an update to make the button always be following the rules as shown in the ui.