### PR TITLE
Minor: Add autocomplete for variables

### DIFF
--- a/lib/server_http.js
+++ b/lib/server_http.js
@@ -56,6 +56,7 @@ express.use('/js/flag-icon-css', Express.static(require('app-root-path') + '/nod
 express.use('/js/font-awesome', Express.static(require('app-root-path') + '/node_modules/font-awesome'));
 express.use('/js/moment', Express.static(require('app-root-path') + '/node_modules/moment'));
 express.use('/select2', Express.static(require('app-root-path') + '/node_modules/select2/dist'));
+express.use('/tributejs', Express.static(require('app-root-path') + '/node_modules/tributejs/dist'));
 
 require('app-root-path') + '';
 

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "socket.io": "^2.1.0",
     "socket.io-client": "^2.1.0",
     "strip-ansi": "^5.2.0",
+    "tributejs": "^3.7.3",
     "websocket": "^1.0.28"
   },
   "collective": {

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "socket.io": "^2.1.0",
     "socket.io-client": "^2.1.0",
     "strip-ansi": "^5.2.0",
-    "tributejs": "^3.7.3",
+    "tributejs": "github:peschuster/tribute",
     "websocket": "^1.0.28"
   },
   "collective": {

--- a/public/bank.js
+++ b/public/bank.js
@@ -56,6 +56,7 @@ function hex2int(hex) {
 
 var page = 1;
 var bank = undefined;
+var variables_autocomplete = undefined;
 
 
 $(function() {
@@ -65,6 +66,36 @@ $(function() {
 
 	$("#editbankli").hide();
 	selected_bank = {};
+
+	variables_autocomplete = new Tribute({
+		values: [],
+		trigger: '$',
+
+		// function called on select that returns the content to insert
+		selectTemplate: function (item) {
+		  return '$(' + item.original.value + ')';
+		},
+	  
+		// template for displaying item in menu
+		menuItemTemplate: function (item) {
+		  return '<span class="var-name">' + item.original.value + '</span><span class="var-label">' + item.original.label + '</span>';
+		},
+	});
+
+	socket.on('variable_instance_definitions_get:result', function (err, data) {
+		if (data) {
+			var auto_complete_list = [];
+			for (var instance in data) {
+				for (var index in data[instance]) {
+					var item = data[instance][index];
+					var variable_name = instance + ':' + item.name;
+					auto_complete_list.push({ key: '(' + variable_name + ')', value: variable_name, label: item.label });
+				}
+			}
+
+			variables_autocomplete.append(0, auto_complete_list, true);
+		}
+	});
 
 	function bank_preview_page(_page) {
 
@@ -341,6 +372,9 @@ $(function() {
 		$(".active_field[data-special=\"color\"]").click(change);
 		$(".active_field[data-special=\"alignment\"]").click(change);
 
+		var text_field = $("input[data-fieldid=\"text\"]");
+		variables_autocomplete.attach(text_field);
+		text_field.on('tribute-replaced', change);
 	}
 
 	$(window).keyup(function(e) {

--- a/public/bank.js
+++ b/public/bank.js
@@ -69,7 +69,7 @@ $(function() {
 
 	variables_autocomplete = new Tribute({
 		values: [],
-		trigger: '$',
+		trigger: '$(',
 
 		// function called on select that returns the content to insert
 		selectTemplate: function (item) {
@@ -89,7 +89,7 @@ $(function() {
 				for (var index in data[instance]) {
 					var item = data[instance][index];
 					var variable_name = instance + ':' + item.name;
-					auto_complete_list.push({ key: '(' + variable_name + ')', value: variable_name, label: item.label });
+					auto_complete_list.push({ key: variable_name + ')', value: variable_name, label: item.label });
 				}
 			}
 

--- a/public/index.css
+++ b/public/index.css
@@ -666,3 +666,14 @@ h4 {
 	color: #846314;
 	border-color: #fff2cf;
 }
+
+/* Style for autocomplete of variable */
+.tribute-container li span {
+    display: block;
+}
+.tribute-container li span.var-label {
+    overflow: hidden;
+	font-weight: inherit;
+	text-overflow: ellipsis;
+  	white-space: nowrap;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -36,6 +36,7 @@
 		<link href="css/style.css" rel="stylesheet">
 		<link href="vendors/pace-progress/css/pace.min.css" rel="stylesheet">
 		<link href="/fa/css/all.css" rel="stylesheet">
+		<link href="/tributejs/tribute.css" rel="stylesheet" />
 		<link href="index.css" rel="stylesheet">
 		<link href='css/spectrum.css' rel='stylesheet'>
 		<link href="select2/css/select2.min.css" rel="stylesheet" />
@@ -771,6 +772,7 @@
 		<script src='js/spectrum.js'></script>
 		<script src="js/preview.js"></script>
 		<script src="select2/js/select2.min.js"></script>
+		<script src="tributejs/tribute.min.js"></script>
 		<script src="page.js"></script>
 		<script src="bank.js"></script>
 		<script src="userconfig.js"></script>


### PR DESCRIPTION
This adds autocomplete for variables to the button text field using the "[tributejs](https://github.com/zurb/tribute)" package.

Preview:
![variables_autocomplete](https://user-images.githubusercontent.com/281340/66139410-ab4f4c00-e600-11e9-8740-f2f1102a6524.gif)


Summary:
- opens list of variables after entering `$(`
- list is filtered during typing
- use suggestions with `Enter`or by clicking on the item in the list