### PR TITLE
Check if HID function is available before using.

### DIFF
--- a/lib/elgato_dm.js
+++ b/lib/elgato_dm.js
@@ -26,7 +26,9 @@ var satelliteDevice = require('./satellite_device');
 var preview = require('./preview');
 var system;
 
-HID.setDriverType('libusb');
+if (typeof HID.setDriverType === 'function'){
+	HID.setDriverType('libusb');
+}
 
 debug("module required");
 


### PR DESCRIPTION
This should fix the latest windows error mentioned in #836 
My development 1.4.0 branch seems to have newer node libraries than a bare 1.4.0 build.
linux needs the first patch to run with newer libraries, this one checks if the function exists first.
That function is available only in newer libraries that need it.
