### PR TITLE
minor: Allow specifying step for numeric ui inputs

### DIFF
--- a/public/action.js
+++ b/public/action.js
@@ -491,6 +491,10 @@ $(function() {
 							let $opt_num   = $('<input type="number" class="action-number form-control">');
 							let $opt_range = $("<input type='range' class='action-number form-control'>");
 							
+							if (option.step !== undefined) {
+								$opt_num.attr('step', option.step);
+								$opt_range.attr('step', option.step);
+							}
 
 							if (option.tooltip !== undefined) {
 								$opt_num.attr('title', option.tooltip);

--- a/public/feedback.js
+++ b/public/feedback.js
@@ -280,6 +280,10 @@ $(function() {
 							let $opt_num   = $('<input type="number" class="feedback-action-number form-control">');
 							let $opt_range = $("<input type='range' class='feedback-action-number form-control'>");
 							
+							if (option.step !== undefined) {
+								$opt_num.attr('step', option.step);
+								$opt_range.attr('step', option.step);
+							}
 
 							if (option.tooltip !== undefined) {
 								$opt_num.attr('title', option.tooltip);

--- a/public/release_action.js
+++ b/public/release_action.js
@@ -438,6 +438,10 @@ $(function() {
 							let $opt_num   = $('<input type="number" class="release-action-number form-control">');
 							let $opt_range = $("<input type='range' class='release-action-number form-control'>");
 							
+							if (option.step !== undefined) {
+								$opt_num.attr('step', option.step);
+								$opt_range.attr('step', option.step);
+							}
 
 							if (option.tooltip !== undefined) {
 								$opt_num.attr('title', option.tooltip);


### PR DESCRIPTION
This will let modules use smaller steps on number inputs, if it make sense for that device.
(eg https://github.com/bitfocus/companion-module-atem/issues/34)