### PR TITLE
Store the project selected by the user in the instance config

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -327,15 +327,18 @@ function instance(system) {
 
 	});
 
-	system.on('instance_add', function (module, cb) {
+	system.on('instance_add', function (data, cb) {
+		var module = data.type;
+		var product = data.product;
 		var mod = self.modules[module];
 		var id = shortid.generate();
 
 		self.store.db[id] = {};
 
-		self.system.emit('log', 'instance('+id+')', 'info', 'instance add ' + module);
+		self.system.emit('log', 'instance('+id+')', 'info', 'instance add ' + module + ' ' + product);
 
 		self.store.db[id].instance_type = module;
+		self.store.db[id].product = product;
 
 		var label = self.package_info[module].shortname;
 		var i = 1;

--- a/lib/loadsave.js
+++ b/lib/loadsave.js
@@ -349,7 +349,9 @@ function loadsave(_system) {
 
 				for (var key in data.instances) {
 					if (key != 'bitfocus-companion' && data.instances[key].import_to == 'new') {
-						system.emit('instance_add', data.instances[key].instance_type, function (id, config) {
+						var type = data.instances[key].instance_type;
+						var product = data.instances[key].product;
+						system.emit('instance_add', { type, product }, function (id, config) {
 							data.instances[key].import_to = id;
 
 							for (var i in data.instances[key]) {

--- a/public/instance.js
+++ b/public/instance.js
@@ -239,6 +239,7 @@ $(function() {
 
 						$x.prepend($button);
 						$x.data('id', x);
+						$x.data('product', prods[prod]);
 
 						var $help = $('<div class="instance_help"><i class="fa fa-question-circle"></i></div>')
 
@@ -261,7 +262,8 @@ $(function() {
 						$button.click(function(e) {
 							e.preventDefault();
 							var instance_type = $(this).parents('div').first().data('id');
-							socket.emit('instance_add', instance_type );
+							var product = $(this).parents('div').first().data('product');
+							socket.emit('instance_add', { type: instance_type, product: product });
 							$aisr.html("");
 							$aisf.val("");
 
@@ -291,7 +293,8 @@ $(function() {
 	// add instance code
 	$(".add-instance-ul").on('click', '.instance-addable', function() {
 		var instance_type = $(this).data('id');
-		socket.emit('instance_add', instance_type );
+		var product = $(this).data('product');
+		socket.emit('instance_add', { type: instance_type, product: product });
 
 		socket.once('instance_add:result', function(id,db) {
 			instance.db = db;
@@ -336,7 +339,7 @@ $(function() {
 
 					for (var prod in prods) {
 						var subprod = manuf + " " + prods[prod];
-						var $entry_sub_li = $('<li><div class="dropdown-content instance-addable" data-id="'+res_id+'">'+subprod+'</div></li>');
+						var $entry_sub_li = $('<li><div class="dropdown-content instance-addable" data-id="'+res_id+'" data-product="'+prods[prod]+'">'+subprod+'</div></li>');
 						$entry_sub_ul.append($entry_sub_li);
 					}
 
@@ -367,7 +370,7 @@ $(function() {
 
 					for (var prod in prods) {
 						var subprod = manuf + " " + prods[prod];
-						var $entry_sub_li = $('<li><div class="dropdown-content instance-addable" data-id="'+inx+'">'+subprod+'</div></li>');
+						var $entry_sub_li = $('<li><div class="dropdown-content instance-addable" data-id="'+inx+'" data-product="'+prods[prod]+'">'+subprod+'</div></li>');
 						$entry_sub_ul.append($entry_sub_li);
 					}
 
@@ -822,7 +825,7 @@ $(function() {
 	});
 
 	$(".addInstance").click(function() {
-		socket.emit('instance_add', $(this).data('id'));
+		socket.emit('instance_add', { type: $(this).data('id'), product: $(this).data('product') });
 		$("#elgbuttons").click();
 	});
 


### PR DESCRIPTION
Currently when adding a new instance, the user is presented with all products supported by the module (defined in package.json) and they choose a specific product to add.  However, this product selection is not being captured anywhere that I can see (only the instance type is emitted and stored in the instance config).  To illustrate, the `panasonic-ptz` module include many products:
<img width="555" alt="Screen Shot 2019-11-24 at 11 44 46 PM" src="https://user-images.githubusercontent.com/13731537/69513078-9f06b180-0f14-11ea-8c9c-50407361bb52.png">
but regardless of which of the products is selected, the module is always handed the following config:
```js
{
  config: {
    instance_type: 'panasonic-ptz',
    label: 'Panasonic-PTZ'
  }
}
```

This PR modifies the client to send both the instance type and product in the `instance_add` event and updates the server to include the product in the instance config stored in the DB.  This allows modules to customize the available functionality depending on the specific product selected without having to include a manual "model" config option.  Now, the config given to the module looks like this:
```js
{
  config: {
    instance_type: 'panasonic-ptz',
    product: 'AW-HE40',
    label: 'Panasonic-PTZ'
  }
}
```

To test, I verified that the product is stored when adding an instance via the following operations:
* Add by category
* Add by manufacturer
* Add by search
* Import page (when the export lacks the product field)
* Import page (when the export includes the product field)

The "instance add" log entry now includes the product:
<img width="524" alt="Screen Shot 2019-11-24 at 10 38 40 PM" src="https://user-images.githubusercontent.com/13731537/69512745-35d26e80-0f13-11ea-9bb1-f4f4b7f4404f.png">
