### PR TITLE
fix: upgradeConfig run at every startup. run with no feedbacks

### DIFF
--- a/lib/feedback.js
+++ b/lib/feedback.js
@@ -110,7 +110,7 @@ function feedback(system) {
 			for (var bank in self.feedbacks[page]) {
 				for (var i in self.feedbacks[page][bank]) {
 					var feedback = self.feedbacks[page][bank][i];
-					if (feedback.instance == instance_id) {
+					if (feedback.instance_id == instance_id) {
 						fbs.push(feedback);
 					}
 				}

--- a/lib/instance_skel.js
+++ b/lib/instance_skel.js
@@ -158,6 +158,12 @@ instance.prototype.upgradeConfig = function () {
 			self.system.emit('db_save');
 		}
 	}
+
+	if (idx + 1 < self._versionscripts.length) {
+		// Save the _configIdx change
+		this.saveConfig()
+	}
+
 	debug('instance save');
 	self.system.emit('instance_save');
 };


### PR DESCRIPTION
A couple of bugs here with the upgrade config scripts.

1) No feedback was being passed into the scripts, as feedback properties are named differently to actions, and the loop to find them was using the wrong name. 

1) Every restart of companion was running the same scripts over again, as the change to _configIdx was not explicitly being saved