### PR TITLE
Issue #596 Prevent stale page button graphics

### DIFF
--- a/lib/action.js
+++ b/lib/action.js
@@ -278,6 +278,10 @@ function action(system) {
 				// because the 'release' would immediately un-latch the button
 				if (direction && (pushed != 1)) {
 					skipNext[pb] = deviceid;
+				} else if (direction && pushed) {
+					// button is latched, prevent duplicate down actions
+					// the following 'release' will run the up actions
+					return;
 				}
 			});
 		}

--- a/lib/action.js
+++ b/lib/action.js
@@ -246,6 +246,7 @@ function action(system) {
 
 	// skipNext needed for 'bank_pressed' callback
 	var skipNext = {};
+	var pageStyles = ['pageup','pagenum','pagedown'];
 
 	self.system.on('bank_pressed', function(page, bank, direction, deviceid) {
 		var bank_config;
@@ -266,7 +267,7 @@ function action(system) {
 				// ignore release after latching press
 				// from this device
 				if (skipNext[pb] == deviceid) {
-					skipNext[pb] = '';
+					delete skipNext[pb];	// reduce memory creep
 					return;
 				}
 			}
@@ -281,20 +282,29 @@ function action(system) {
 			});
 		}
 
-		system.emit('graphics_indicate_push', page, bank, direction, deviceid);
+		// magic page keys only respond to push so ignore the release
+		// they also don't have a 'pushed' graphics indication
+		// so process the action and return before trying to
+		// indicate 'pushed'. Otherwise when the 'unpush' graphics
+		// occurs, it will re-draw the old button on the new (wrong) page
+		if (pageStyles.includes(bank_config.style)) {
+			if (direction === false) {
+				if (bank_config.style == 'pageup') {
+					self.system.emit('device_page_up', deviceid);
+				}
+				else if (bank_config.style == 'pagenum') {
+					self.system.emit('device_page_set', deviceid, 1);
+				}
+				else if (bank_config.style == 'pagedown') {
+					self.system.emit('device_page_down', deviceid);
+				}
+			}
+			// no actions allowed on page buttons so we're done
+			return;
 
-		if (bank_config.style == 'pageup' && direction) {
-			self.system.emit('device_page_up', deviceid);
-			return;
 		}
-		else if (bank_config.style == 'pagenum' && direction) {
-			self.system.emit('device_page_set', deviceid, 1);
-			return;
-		}
-		else if (bank_config.style == 'pagedown' && direction) {
-			self.system.emit('device_page_down', deviceid);
-			return;
-		}
+
+		system.emit('graphics_indicate_push', page, bank, direction, deviceid);
 
 
 		var obj = self.bank_actions;


### PR DESCRIPTION
This is part of the fix for #596 and friends.
There is another patch for the submodule bitfocus-companion.

Fixed a potential (small) memory creep.