### PR TITLE
Button gfx timing adjust

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -367,9 +367,10 @@ device.prototype.updateBank = function(page, bank) {
 		var img = graphics.getBank(page, bank);
 
 		if (page == self.page) {
-			setImmediate(function () {
-				self.panel.draw(bank - 1, img.buffer);
-			});
+			// 12-Jan-2020: was wrapped with setImmediate
+			// which delays the button draw.
+			// if the page changed, the old button gfx gets put on the new page
+			self.panel.draw(bank - 1, img.buffer);
 		}
 	} else {
 		self.datap = graphics.getImagesForPincode(self.currentpin);


### PR DESCRIPTION
Allow button graphics update without drawing on the new page.
Fixes #596 