### PR TITLE
Fix page button oops

### DIFF
--- a/lib/action.js
+++ b/lib/action.js
@@ -292,7 +292,7 @@ function action(system) {
 		// indicate 'pushed'. Otherwise when the 'unpush' graphics
 		// occurs, it will re-draw the old button on the new (wrong) page
 		if (pageStyles.includes(bank_config.style)) {
-			if (direction === false) {
+			if (direction === true) {
 				if (bank_config.style == 'pageup') {
 					self.system.emit('device_page_up', deviceid);
 				}


### PR DESCRIPTION
During my last round of testing for stale button images, I had the magic 'page' buttons responding on button release instead of press. It works, but not how you'd expect.
This restores the action to button press.

