### PR TITLE
fix: github actions unable to build native dependencies on windows

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -56,6 +56,8 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: npm install, build, and test
       run: |
+        # hack around node-gyp<5.0 not supporting vs2019
+        yarn config set msbuild_path "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\MSBuild\\Current\\Bin\\MSBuild.exe"
         yarn update
         yarn run windist
     - name: rename and upload stuff


### PR DESCRIPTION
This is a more durable fix for the windows build failures. This should ensure that any native dependency building can be done on windows when needed.

Example reproduction showing the pass and failure of building node-hid without using prebuilds: https://github.com/Julusian/test/runs/453623106?check_suite_focus=true

The builds in this project are now passing due to prebuilds of node-hid being published, but it is possible something else may try using node-gyp and fail later.

This was caused by node-gyp (used to build native dependencies) doesnt support the version of visual studio used by the github-actions windows image. This is fixed in node-gyp 5, but node8 is stuck on 3.8