### PR TITLE
fix: latch button fires down action on second press

### DIFF
--- a/lib/action.js
+++ b/lib/action.js
@@ -272,6 +272,7 @@ function action(system) {
 				}
 			}
 
+			let reject = false
 			system.emit('graphics_is_pushed', page, bank, function (pushed) {
 				// button is being pressed but not yet latched
 				// the next button-release from this device needs to be skipped
@@ -281,9 +282,13 @@ function action(system) {
 				} else if (direction && pushed) {
 					// button is latched, prevent duplicate down actions
 					// the following 'release' will run the up actions
-					return;
+					reject = true
 				}
 			});
+
+			if (reject) {
+				return
+			}
 		}
 
 		// magic page keys only respond to push so ignore the release


### PR DESCRIPTION
the code was almost right, but the return was inside a callback, and needed to be bubbled up a layer