### PR TITLE
Minor: Add module typescript definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,7 +75,3 @@ typings/
 
 # next.js build output
 .next
-
-# Ignore atem-hack
-lib/instance_skel.d.ts
-lib/instance_skel_types.d.ts

--- a/lib/instance_skel.d.ts
+++ b/lib/instance_skel.d.ts
@@ -1,0 +1,98 @@
+import {
+  CompanionActions,
+  CompanionInputField,
+  CompanionFeedbacks,
+  CompanionPreset,
+  CompanionSystem,
+  CompanionVariable,
+  CompanionActionEvent,
+  CompanionFeedbackEvent,
+  CompanionFeedbackResult,
+  CompanionUpgradeScript
+} from './instance_skel_types'
+
+declare abstract class InstanceSkel<TConfig> {
+  protected system: CompanionSystem
+  public id: string
+  public config: TConfig
+
+  /**
+   * Create an instance of the module.
+   * @since 1.0.0
+   */
+  constructor(system: CompanionSystem, id: string, config: TConfig)
+
+  /**
+   * Main initialization function called once the module
+   * is OK to start doing things.
+   * @since 1.0.0
+   */
+  abstract init(): void
+
+  /**
+   * Clean up the instance before it is destroyed.
+   * @since 1.0.0
+   */
+  abstract destroy(): void
+
+  /**
+   * Process an updated configuration array.
+   * @since 1.0.0
+   */
+  abstract updateConfig(config: TConfig): void
+
+  /**
+   * Creates the configuration fields for web config.
+   * @since 1.0.0
+   */
+  abstract config_fields(): CompanionInputField[]
+
+  /**
+   * Executes the provided action.
+   * @since 1.0.0
+   */
+  abstract action(action: CompanionActionEvent): void
+
+  /**
+   * Processes a feedback state.
+   * @since 1.0.0
+   */
+  feedback?(feedback: CompanionFeedbackEvent): CompanionFeedbackResult
+
+  addUpgradeScript(fcn: CompanionUpgradeScript<TConfig>): void
+
+  setActions(actions: CompanionActions): void
+  setVariableDefinitions(variables: CompanionVariable[]): void
+  setFeedbackDefinitions(feedbacks: CompanionFeedbacks): void
+  setPresetDefinitions(presets: CompanionPreset[]): void
+
+  setVariable(variableId: string, value: string): void
+  checkFeedbacks(feedbackId?: string): void
+
+  status(level: null | 0 | 1 | 2, message?: string): void
+
+  log(level: 'info' | 'warn' | 'error' | 'debug', info: string): void
+  debug(formatter: string, ...args: any[]): void
+
+  rgb(red: number, green: number, blue: number): number
+
+  STATUS_UNKNOWN: null
+  STATUS_OK: 0
+  STATUS_WARNING: 1
+  STATUS_ERROR: 2
+
+  REGEX_IP: string
+  REGEX_BOOLEAN: string
+  REGEX_PORT: string
+  REGEX_PERCENT: string
+  REGEX_FLOAT: string
+  REGEX_FLOAT_OR_INT: string
+  REGEX_SIGNED_FLOAT: string
+  REGEX_NUMBER: string
+  REGEX_SOMETHING: string
+  REGEX_SIGNED_NUMBER: string
+  REGEX_TIMECODE: string
+  CHOICES_YESNO_BOOLEAN: any
+}
+
+export = InstanceSkel

--- a/lib/instance_skel_types.d.ts
+++ b/lib/instance_skel_types.d.ts
@@ -1,0 +1,145 @@
+/// <reference types="node" />
+import { EventEmitter } from 'events'
+
+export interface CompanionSystem extends EventEmitter {}
+
+export type InputValue = number | string | boolean
+
+export interface CompanionAction {
+  label: string
+  options: SomeCompanionInputField[]
+}
+export interface CompanionActionEvent {
+  action: string
+  options: { [key: string]: InputValue | undefined }
+}
+
+export interface CompanionFeedbackEvent {
+  type: string
+  options: { [key: string]: InputValue | undefined }
+}
+export interface CompanionFeedbackResult {
+  color?: number
+  bgcolor?: number
+}
+
+export type ConfigValue = string | number
+export interface DropdownChoice {
+  id: ConfigValue
+  label: string
+}
+
+export type SomeCompanionInputField =
+  | CompanionInputFieldText
+  | CompanionInputFieldColor
+  | CompanionInputFieldTextInput
+  | CompanionInputFieldDropdown
+  | CompanionInputFieldNumber
+  | CompanionInputFieldCheckbox
+export interface CompanionInputField {
+  id: string
+  type: 'text' | 'textinput' | 'dropdown' | 'colorpicker' | 'number' | 'checkbox' // TODO - multiselect
+  label: string
+  tooltip?: string
+}
+export interface CompanionInputFieldText extends CompanionInputField {
+  type: 'text'
+  value: string
+}
+export interface CompanionInputFieldColor extends CompanionInputField {
+  type: 'colorpicker'
+  default: number
+}
+export interface CompanionInputFieldTextInput extends CompanionInputField {
+  type: 'textinput'
+  regex?: string
+  default?: string
+}
+export interface CompanionInputFieldDropdown extends CompanionInputField {
+  type: 'dropdown'
+  default: ConfigValue
+  choices: DropdownChoice[]
+}
+export interface CompanionInputFieldCheckbox extends CompanionInputField {
+  type: 'checkbox'
+  default: boolean
+}
+export interface CompanionInputFieldNumber extends CompanionInputField {
+  type: 'number'
+  min: number
+  max: number
+  step?: number
+  range?: boolean
+  required?: boolean
+  default: number
+}
+
+export interface CompanionConfigField extends CompanionInputField {
+  width: number
+}
+export type SomeCompanionConfigField = SomeCompanionInputField & CompanionConfigField
+
+export interface CompanionVariable {
+  label: string
+  name: string
+}
+export interface CompanionFeedback {
+  label: string
+  description: string
+  options: SomeCompanionInputField[]
+  callback?: (feedback: CompanionFeedbackEvent) => CompanionFeedbackResult
+}
+export interface CompanionPreset {
+  category: string
+  label: string
+  bank: {
+    style: 'text'
+    text: string
+    size: 'auto' | '7' | '14' | '18' | '24' | '30' | '44'
+    color: number
+    bgcolor: number
+  }
+  feedbacks: Array<{
+    type: string
+    options: { [key: string]: InputValue | undefined }
+  }>
+  actions: Array<{
+    action: string
+    options: { [key: string]: InputValue | undefined }
+  }>
+}
+
+export interface CompanionFeedbacks {
+  [id: string]: CompanionFeedback | undefined
+}
+export interface CompanionActions {
+  [id: string]: CompanionAction | undefined
+}
+
+export type CompanionUpgradeScript<TConfig> = (
+  config: CompanionCoreInstanceconfig & TConfig,
+  actions: CompanionMigrationAction[],
+  release_actions: CompanionMigrationAction[],
+  feedbacks: CompanionMigrationFeedback[]
+) => boolean
+
+export interface CompanionCoreInstanceconfig {
+  instance_type: string
+  label: string
+  enabled: boolean
+}
+
+export interface CompanionMigrationAction {
+  readonly id: string
+  readonly instance: string
+  label: string
+  action: string
+  options: { [key: string]: InputValue | undefined }
+}
+
+export interface CompanionMigrationFeedback {
+  readonly id: string
+  readonly instance_id: string
+  type: string
+  options: { [key: string]: InputValue | undefined }
+}


### PR DESCRIPTION
This moves the typescript definitions used by the atem module into core. I really should have done this a while ago, but there was no need to as only the atem module consumed them.

It will have no impact on any other module.

These have been left to stabilise for a few months, so should be pretty accurate but there could still be some small errors. 