### PR TITLE
Fix positioning and sizing of number range/spinner controls for smaller screens

### DIFF
--- a/public/action.js
+++ b/public/action.js
@@ -544,9 +544,9 @@ $(function() {
 									.val($opt_num.val());
 
 								$options.append(
-									$('<div class="row action-number-row">').append([
-										$('<div class="col-sm-8">').append($opt_range),
-										$('<div class="col-sm-4">').append($opt_num)
+									$('<div class="row action-number-row action-number-range-row">').append([
+										$('<div class="action-number-range">').append($opt_range),
+										$('<div class="action-number-number">').append($opt_num)
 									])
 								);
 

--- a/public/index.css
+++ b/public/index.css
@@ -692,3 +692,9 @@ h4 {
 	text-overflow: ellipsis;
   	white-space: nowrap;
 }
+
+.action-number-range-row {
+	display: grid;
+	padding: 0 15px;
+	grid-template-columns: minmax(70px, 1fr) minmax(75px, 85px);
+}

--- a/public/index.css
+++ b/public/index.css
@@ -695,8 +695,9 @@ h4 {
 
 .action-number-range-row {
 	display: grid;
-	padding: 0 15px;
 	grid-template-columns: minmax(70px, 1fr) minmax(75px, 85px);
+	/* Use the same td padding as in css/style.css */
+	padding: 0 0.75rem;
 }
 input[type="range"].action-number.form-control {
 	/* Remove the horizontal padding added by default to all .form-control elements. */

--- a/public/index.css
+++ b/public/index.css
@@ -698,3 +698,8 @@ h4 {
 	padding: 0 15px;
 	grid-template-columns: minmax(70px, 1fr) minmax(75px, 85px);
 }
+input[type="range"].action-number.form-control {
+	/* Remove the horizontal padding added by default to all .form-control elements. */
+	padding-left: 0;
+	padding-right: 0;
+}


### PR DESCRIPTION
Improves the positioning and sizing of the number range/spinner controls when viewed on smaller screens.

Also removes the default horizontal padding on the number range control, so that 0% and 100% actually reflect the edges of the control.

![number-range](https://user-images.githubusercontent.com/9618303/76713173-1dfa4280-66dc-11ea-8f65-9dfed52ac5ba.gif)