### PR TITLE
Added getVariable wrapper to instance_skel

### DIFF
--- a/lib/instance_skel.d.ts
+++ b/lib/instance_skel.d.ts
@@ -67,7 +67,7 @@ declare abstract class InstanceSkel<TConfig> {
   setPresetDefinitions(presets: CompanionPreset[]): void
 
   setVariable(variableId: string, value: string): void
-  getVariable(variableId: string, cb: function): void
+  getVariable(variableId: string, cb: (value: string) => void): void
   checkFeedbacks(feedbackId?: string): void
 
   status(level: null | 0 | 1 | 2, message?: string): void

--- a/lib/instance_skel.d.ts
+++ b/lib/instance_skel.d.ts
@@ -67,6 +67,7 @@ declare abstract class InstanceSkel<TConfig> {
   setPresetDefinitions(presets: CompanionPreset[]): void
 
   setVariable(variableId: string, value: string): void
+  getVariable(variableId: string, cb: function): void
   checkFeedbacks(feedbackId?: string): void
 
   status(level: null | 0 | 1 | 2, message?: string): void

--- a/lib/instance_skel.js
+++ b/lib/instance_skel.js
@@ -199,6 +199,12 @@ instance.prototype.setVariable = function(variable, value) {
 	self.system.emit('variable_instance_set', self, variable, value);
 };
 
+instance.prototype.getVariable = function(variable, cb) {
+	var self = this;
+
+	self.system.emit('variable_get', self.label, variable, cb);
+};
+
 instance.prototype.setFeedbackDefinitions = function(feedbacks) {
 	var self = this;
 


### PR DESCRIPTION
Saw that there was a setVariable but no getVariable, and other modules just went around the issue by managing their own copy of the dynamic variable states. So I thought why not.