### PR TITLE
Minor: Added module help button to the instance config page

### DIFF
--- a/public/instance.js
+++ b/public/instance.js
@@ -528,7 +528,20 @@ $(function() {
 
 		for (var n in store.module) {
 			if (store.module[n].name === store.db[id].instance_type) {
-				$('#instanceConfig h4:first').text( store.module[n].shortname + ' configuration');
+
+				var help = '';
+				if (store.module[n].help) {
+					help = '<div class="instance_help"><i class="fa fa-question-circle"></i></div>';
+				}
+
+				$('#instanceConfig h4:first').html(help + store.module[n].shortname + ' configuration');
+
+				(function (name) {
+					$('#instanceConfig').find('.instance_help').click(function () {
+						show_module_help(name);
+					});
+				})(store.module[n].name);
+
 			}
 		}
 


### PR DESCRIPTION
Added the module help button to the instance config page.

Rationale: The help document may contain instructions on how to configure a module. This makes that document available without having to flip back and forth between the Instances tab and an instance's Config tab.

![image](https://user-images.githubusercontent.com/9618303/77464754-e28b0280-6dc4-11ea-9be1-99d1e542441b.png)
