### PR TITLE
Include documentation/* in the compiled builds. See PR #1045

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
 			"assets/trayTemplate.png",
 			"assets/trayTemplate@2x.png",
 			"!font/*",
-			"!documentation/*",
 			"!tools/*",
 			"!*.md"
 		]


### PR DESCRIPTION
package.json excludes `documentation/*` from the builds, which stops documentation/gettingstarted.md from rendering ([PR #1045](https://github.com/bitfocus/companion/pull/1045#issuecomment-604491356)).

This PR removes that exclusion. My local `npm run macdist` builds now include the files as expected.