### PR TITLE
Minor: add feedback hooks (subscribe, unsubscribe)

### DIFF
--- a/lib/feedback.js
+++ b/lib/feedback.js
@@ -181,75 +181,6 @@ function feedback(system) {
 		}
 	});
 
-	system.on('feedback_instance_refresh', function (instance, type) {
-		//debug('Instance ' + instance.label + ' wants us to check banks (' + type + ')');
-		for (var page in self.feedbacks) {
-			for (var bank in self.feedbacks[page]) {
-
-				// Iterate through feedbacks on this bank
-				if (self.feedbacks[page][bank] !== undefined) {
-					for (var i in self.feedbacks[page][bank]) {
-						var feedback = self.feedbacks[page][bank][i];
-
-						if (type !== undefined && feedback.type != type) {
-							continue;
-						}
-
-						if (feedback.instance_id == instance.id) {
-							self.refreshFeedback(feedback);
-						}
-					}
-				}
-			}
-		}
-	});
-
-	system.on('feedback_instance_subscribe', function (instance, type) {
-		//debug('Instance ' + instance.label + ' wants us to check banks (' + type + ')');
-		for (var page in self.feedbacks) {
-			for (var bank in self.feedbacks[page]) {
-
-				// Iterate through feedbacks on this bank
-				if (self.feedbacks[page][bank] !== undefined) {
-					for (var i in self.feedbacks[page][bank]) {
-						var feedback = self.feedbacks[page][bank][i];
-
-						if (type !== undefined && feedback.type != type) {
-							continue;
-						}
-
-						if (feedback.instance_id == instance.id) {
-							self.subscribeFeedback(feedback);
-						}
-					}
-				}
-			}
-		}
-	});
-
-	system.on('feedback_instance_unsubscribe', function (instance, type) {
-		//debug('Instance ' + instance.label + ' wants us to check banks (' + type + ')');
-		for (var page in self.feedbacks) {
-			for (var bank in self.feedbacks[page]) {
-
-				// Iterate through feedbacks on this bank
-				if (self.feedbacks[page][bank] !== undefined) {
-					for (var i in self.feedbacks[page][bank]) {
-						var feedback = self.feedbacks[page][bank][i];
-
-						if (type !== undefined && feedback.type != type) {
-							continue;
-						}
-
-						if (feedback.instance_id == instance.id) {
-							self.unsubscribeFeedback(feedback);
-						}
-					}
-				}
-			}
-		}
-	});
-
 	system.on('feedback_delete', function (page, bank, id) {
 		if(self.feedbacks[page] !== undefined && self.feedbacks[page][bank] !== undefined && self.feedbacks[page][bank][id]!== undefined) {
 			self.unsubscribeFeedback(self.feedbacks[page][bank][id])
@@ -407,20 +338,6 @@ function feedback(system) {
 
 }
 
-feedback.prototype.refreshFeedback = function(feedback) {
-	var self = this;
-
-	if (feedback.type !== undefined && feedback.instance_id !== undefined) {
-		if (self.feedback_definitions[feedback.instance_id] !== undefined && self.feedback_definitions[feedback.instance_id][feedback.type] !== undefined) {
-			let definition = self.feedback_definitions[feedback.instance_id][feedback.type];
-			// Run the subscribe function if needed
-			if (definition !== undefined && definition.subscribe !== undefined && typeof definition.subscribe == 'function') {
-				definition.refresh(feedback);
-			}
-		}
-	}
-};
-
 feedback.prototype.subscribeFeedback = function(feedback) {
 	var self = this;
 
@@ -428,7 +345,7 @@ feedback.prototype.subscribeFeedback = function(feedback) {
 		if (self.feedback_definitions[feedback.instance_id] !== undefined && self.feedback_definitions[feedback.instance_id][feedback.type] !== undefined) {
 			let definition = self.feedback_definitions[feedback.instance_id][feedback.type];
 			// Run the subscribe function if needed
-			if (definition !== undefined && definition.subscribe !== undefined && typeof definition.subscribe == 'function') {
+			if (definition.subscribe !== undefined && typeof definition.subscribe == 'function') {
 				definition.subscribe(feedback);
 			}
 		}
@@ -441,8 +358,8 @@ feedback.prototype.unsubscribeFeedback = function(feedback) {
 	if (feedback.type !== undefined && feedback.instance_id !== undefined) {
 		if (self.feedback_definitions[feedback.instance_id] !== undefined && self.feedback_definitions[feedback.instance_id][feedback.type] !== undefined) {
 			let definition = self.feedback_definitions[feedback.instance_id][feedback.type];
-			// Run the subscribe function if needed
-			if (definition !== undefined && definition.unsubscribe !== undefined && typeof definition.unsubscribe == 'function') {
+			// Run the unsubscribe function if needed
+			if (definition.unsubscribe !== undefined && typeof definition.unsubscribe == 'function') {
 				definition.unsubscribe(feedback);
 			}
 		}

--- a/lib/feedback.js
+++ b/lib/feedback.js
@@ -77,6 +77,7 @@ function feedback(system) {
 			self.feedback_styles[page] = {};
 		}
 		if (self.feedbacks[page] !== undefined && self.feedbacks[page][bank] !== undefined) {
+			system.emit('feedback_unsubscribe_bank', page, bank);
 			self.feedbacks[page][bank] = [];
 		}
 		if (self.feedback_styles[page] !== undefined && self.feedback_styles[page][bank] !== undefined) {
@@ -97,6 +98,26 @@ function feedback(system) {
 		ids = Object.keys(ids);
 		for (var i = 0; i < ids.length; ++i) {
 			system.emit('feedback_instanceid_check', ids[i]);
+		}
+	});
+
+	system.on('feedback_subscribe_bank', function (page, bank) {
+		var ids = {};
+		if (self.feedbacks[page] !== undefined && self.feedbacks[page][bank] !== undefined) {
+			// find all instance-ids in feedbacks for bank
+			for (var i in self.feedbacks[page][bank]) {
+				self.subscribeFeedback(self.feedbacks[page][bank][i]);
+			}
+		}
+	});
+
+	system.on('feedback_unsubscribe_bank', function (page, bank) {
+		var ids = {};
+		if (self.feedbacks[page] !== undefined && self.feedbacks[page][bank] !== undefined) {
+			// find all instance-ids in feedbacks for bank
+			for (var i in self.feedbacks[page][bank]) {
+				self.unsubscribeFeedback(self.feedbacks[page][bank][i]);
+			}
 		}
 	});
 
@@ -160,7 +181,79 @@ function feedback(system) {
 		}
 	});
 
+	system.on('feedback_instance_refresh', function (instance, type) {
+		//debug('Instance ' + instance.label + ' wants us to check banks (' + type + ')');
+		for (var page in self.feedbacks) {
+			for (var bank in self.feedbacks[page]) {
+
+				// Iterate through feedbacks on this bank
+				if (self.feedbacks[page][bank] !== undefined) {
+					for (var i in self.feedbacks[page][bank]) {
+						var feedback = self.feedbacks[page][bank][i];
+
+						if (type !== undefined && feedback.type != type) {
+							continue;
+						}
+
+						if (feedback.instance_id == instance.id) {
+							self.refreshFeedback(feedback);
+						}
+					}
+				}
+			}
+		}
+	});
+
+	system.on('feedback_instance_subscribe', function (instance, type) {
+		//debug('Instance ' + instance.label + ' wants us to check banks (' + type + ')');
+		for (var page in self.feedbacks) {
+			for (var bank in self.feedbacks[page]) {
+
+				// Iterate through feedbacks on this bank
+				if (self.feedbacks[page][bank] !== undefined) {
+					for (var i in self.feedbacks[page][bank]) {
+						var feedback = self.feedbacks[page][bank][i];
+
+						if (type !== undefined && feedback.type != type) {
+							continue;
+						}
+
+						if (feedback.instance_id == instance.id) {
+							self.subscribeFeedback(feedback);
+						}
+					}
+				}
+			}
+		}
+	});
+
+	system.on('feedback_instance_unsubscribe', function (instance, type) {
+		//debug('Instance ' + instance.label + ' wants us to check banks (' + type + ')');
+		for (var page in self.feedbacks) {
+			for (var bank in self.feedbacks[page]) {
+
+				// Iterate through feedbacks on this bank
+				if (self.feedbacks[page][bank] !== undefined) {
+					for (var i in self.feedbacks[page][bank]) {
+						var feedback = self.feedbacks[page][bank][i];
+
+						if (type !== undefined && feedback.type != type) {
+							continue;
+						}
+
+						if (feedback.instance_id == instance.id) {
+							self.unsubscribeFeedback(feedback);
+						}
+					}
+				}
+			}
+		}
+	});
+
 	system.on('feedback_delete', function (page, bank, id) {
+		if(self.feedbacks[page] !== undefined && self.feedbacks[page][bank] !== undefined && self.feedbacks[page][bank][id]!== undefined) {
+			self.unsubscribeFeedback(self.feedbacks[page][bank][id])
+		}
 		if (self.feedback_styles[page] !== undefined && self.feedback_styles[page][bank] !== undefined) {
 			delete self.feedback_styles[page][bank][id];
 		}
@@ -250,6 +343,7 @@ function feedback(system) {
 			}
 
 			self.feedbacks[page][bank].push(fb);
+			self.subscribeFeedback(fb);
 
 			system.emit('feedback_save');
 			client.emit('bank_get_feedbacks:result', page, bank, self.feedbacks[page][bank] );
@@ -279,12 +373,14 @@ function feedback(system) {
 				for (var n in feedbacks) {
 					var feedback = feedbacks[n];
 					if (feedback !== undefined && feedback.id === feedbackid) {
+						self.unsubscribeFeedback(feedback);
 						if (feedback.options === undefined) {
 							feedback.options = {};
 						}
 						feedback.options[option] = value;
 						self.system.emit('feedback_save');
-						self.system.emit('feedback_instanceid_check', feedback.instance_id)
+						self.system.emit('feedback_instanceid_check', feedback.instance_id);
+						self.subscribeFeedback(feedback);
 					}
 				}
 			}
@@ -310,6 +406,48 @@ function feedback(system) {
 	});
 
 }
+
+feedback.prototype.refreshFeedback = function(feedback) {
+	var self = this;
+
+	if (feedback.type !== undefined && feedback.instance_id !== undefined) {
+		if (self.feedback_definitions[feedback.instance_id] !== undefined && self.feedback_definitions[feedback.instance_id][feedback.type] !== undefined) {
+			let definition = self.feedback_definitions[feedback.instance_id][feedback.type];
+			// Run the subscribe function if needed
+			if (definition !== undefined && definition.subscribe !== undefined && typeof definition.subscribe == 'function') {
+				definition.refresh(feedback);
+			}
+		}
+	}
+};
+
+feedback.prototype.subscribeFeedback = function(feedback) {
+	var self = this;
+
+	if (feedback.type !== undefined && feedback.instance_id !== undefined) {
+		if (self.feedback_definitions[feedback.instance_id] !== undefined && self.feedback_definitions[feedback.instance_id][feedback.type] !== undefined) {
+			let definition = self.feedback_definitions[feedback.instance_id][feedback.type];
+			// Run the subscribe function if needed
+			if (definition !== undefined && definition.subscribe !== undefined && typeof definition.subscribe == 'function') {
+				definition.subscribe(feedback);
+			}
+		}
+	}
+};
+
+feedback.prototype.unsubscribeFeedback = function(feedback) {
+	var self = this;
+
+	if (feedback.type !== undefined && feedback.instance_id !== undefined) {
+		if (self.feedback_definitions[feedback.instance_id] !== undefined && self.feedback_definitions[feedback.instance_id][feedback.type] !== undefined) {
+			let definition = self.feedback_definitions[feedback.instance_id][feedback.type];
+			// Run the subscribe function if needed
+			if (definition !== undefined && definition.unsubscribe !== undefined && typeof definition.unsubscribe == 'function') {
+				definition.unsubscribe(feedback);
+			}
+		}
+	}
+};
 
 feedback.prototype.setStyle = function(page, bank, feedback_id, style) {
 	var self = this;

--- a/lib/instance_skel.d.ts
+++ b/lib/instance_skel.d.ts
@@ -70,6 +70,21 @@ declare abstract class InstanceSkel<TConfig> {
   getVariable(variableId: string, cb: (value: string) => void): void
   checkFeedbacks(feedbackId?: string): void
 
+  /**
+   * Get an array of all the feedbacks for this instance
+   */
+  getAllFeedbacks(): CompanionFeedbackEvent[]
+  /**
+   * Trigger the subscribe callback on all feedbacks for this instance
+   * @param feedbackId Feedback type to call for, or undefined for all
+   */
+  subscribeFeedbacks(feedbackId?: string): void
+  /**
+   * Trigger the unsubscribe callback on all feedbacks for this instance
+   * @param feedbackId Feedback type to call for, or undefined for all
+   */
+  unsubscribeFeedbacks(feedbackId?: string): void
+
   status(level: null | 0 | 1 | 2, message?: string): void
 
   log(level: 'info' | 'warn' | 'error' | 'debug', info: string): void

--- a/lib/instance_skel.js
+++ b/lib/instance_skel.js
@@ -252,6 +252,24 @@ instance.prototype.checkFeedbacks = function(type) {
 	self.system.emit('feedback_instance_check', self, type);
 };
 
+instance.prototype.refreshFeedbacks = function(type) {
+	var self = this;
+
+	self.system.emit('feedback_instance_refresh', self, type);
+};
+
+instance.prototype.subscribeFeedbacks = function(type) {
+	var self = this;
+
+	self.system.emit('feedback_instance_subscribe', self, type);
+};
+
+instance.prototype.unsubscribeFeedbacks = function(type) {
+	var self = this;
+
+	self.system.emit('feedback_instance_unsubscribe', self, type);
+};
+
 instance.extendedBy = function (module) {
 	util.inherits(module, instance);
 };

--- a/lib/instance_skel.js
+++ b/lib/instance_skel.js
@@ -27,6 +27,7 @@ function instance(system, id, config) {
 	self.id = id;
 	self.config = config;
 	self.package_info = {};
+	self._feedbackDefinitions = {};
 
 	// we need this object from instance, and I don't really know how to get it
 	// out of instance.js without adding an argument to instance() for every
@@ -208,6 +209,13 @@ instance.prototype.getVariable = function(variable, cb) {
 instance.prototype.setFeedbackDefinitions = function(feedbacks) {
 	var self = this;
 
+	if (feedbacks === undefined) {
+		self._feedbackDefinitions = {};
+	}
+	else {
+		self._feedbackDefinitions = feedbacks;
+	}
+
 	self.system.emit('feedback_instance_definitions_set', self, feedbacks);
 };
 
@@ -252,22 +260,72 @@ instance.prototype.checkFeedbacks = function(type) {
 	self.system.emit('feedback_instance_check', self, type);
 };
 
-instance.prototype.refreshFeedbacks = function(type) {
+instance.prototype.getAllFeedbacks = function() {
 	var self = this;
+	var result = undefined;
 
-	self.system.emit('feedback_instance_refresh', self, type);
+	self.system.emit('feedbacks_for_instance', self.id, function(_result) {
+		result = _result;
+	});
+	return result;
 };
 
 instance.prototype.subscribeFeedbacks = function(type) {
 	var self = this;
+	var feedbacks = self.getAllFeedbacks();
 
-	self.system.emit('feedback_instance_subscribe', self, type);
+	if (feedbacks.length > 0) {
+		for (var i in feedbacks) {
+			let feedback = feedbacks[i];
+
+			if (type !== undefined && feedback.type != type) {
+				continue;
+			}
+
+			self.subscribeFeedback(feedback);
+		}
+	}
 };
 
 instance.prototype.unsubscribeFeedbacks = function(type) {
 	var self = this;
+	var feedbacks = self.getAllFeedbacks();
 
-	self.system.emit('feedback_instance_unsubscribe', self, type);
+	if (feedbacks.length > 0) {
+		for (var i in feedbacks) {
+			let feedback = feedbacks[i];
+
+			if (type !== undefined && feedback.type != type) {
+				continue;
+			}
+
+			self.unsubscribeFeedback(feedback);
+		}
+	}
+};
+
+instance.prototype.subscribeFeedback = function(feedback) {
+	var self = this;
+
+	if (feedback.type !== undefined && self._feedbackDefinitions[feedback.type] !== undefined) {
+		let definition = self._feedbackDefinitions[feedback.type];
+		// Run the subscribe function if needed
+		if (definition.subscribe !== undefined && typeof definition.subscribe == 'function') {
+			definition.subscribe(feedback);
+		}
+	}
+};
+
+instance.prototype.unsubscribeFeedback = function(feedback) {
+	var self = this;
+
+	if (feedback.type !== undefined && self._feedbackDefinitions[feedback.type] !== undefined) {
+		let definition = self._feedbackDefinitions[feedback.type];
+		// Run the unsubscribe function if needed
+		if (definition.unsubscribe !== undefined && typeof definition.unsubscribe == 'function') {
+			definition.unsubscribe(feedback);
+		}
+	}
 };
 
 instance.extendedBy = function (module) {

--- a/lib/instance_skel_types.d.ts
+++ b/lib/instance_skel_types.d.ts
@@ -88,6 +88,8 @@ export interface CompanionFeedback {
   description: string
   options: SomeCompanionInputField[]
   callback?: (feedback: CompanionFeedbackEvent) => CompanionFeedbackResult
+  subscribe?: (feedback: CompanionFeedbackEvent) => void
+  unsubscribe?: (feedback: CompanionFeedbackEvent) => void
 }
 export interface CompanionPreset {
   category: string

--- a/lib/loadsave.js
+++ b/lib/loadsave.js
@@ -471,6 +471,7 @@ function loadsave(_system) {
 		system.emit('graphics_bank_invalidate', page, bank);
 		system.emit('bank_update', self.config);
 		system.emit('feedback_check_bank', page, bank);
+		system.emit('feedback_subscribe_bank', page, bank);
 
 		debug('Imported config to bank ' + page + '.' + bank);
 		if (typeof cb == 'function') {


### PR DESCRIPTION
This PR adds 2 callbacks to the feedback definitions:
- `subscribe`: allows the feedback to send a `SUBSCRIBE` or `NOTIFY` command if it must request to receive updates for the associated data; or a simple `GET` can be sent to warm up the data should the device not have a catch-up method for its feedback data
- `unsubscribe`: allows the feedback to send a, `UNSUBSCRIBE` command should update subscription be required and the device recommends unsubscribing when certain updates are no longer required

These callbacks are invoked via two methods in an instance:
1. Manually via direct calls (outlined below) in the instance class.
2. Automatic `subscribe` and `unsubscribe` firing based on events such as:
    - New feedback (subscribe)
    - Edit feedback (unsubscribe old; subscribe new)
    - Delete feedback (unsubscribe)
    - Preset drop (unsubscribe old; subscribe new)
    - Import page/config (unsubscribe old; subscribe new)

This PR also exposes a new `getAllFeedbacks()` function in `instance_skel` to request all of the active feedbacks from the core.

## Feedback Definition
_ES6 example_
```javascript
initFeedbacks() {
	var feedbacks = {
		input_bg: {
			label: 'Change background color by output',
			description: 'If the input specified is in use by the output specified, change background color of the bank',
			options: [
				this.FG_COLOR_FIELD(this.rgb(0,0,0)),
				this.BG_COLOR_FIELD(this.rgb(255,255,0)),
				this.INPUT_FIELD,
				this.OUTPUT_FIELD
			],
			callback: (feedback, bank) => {
				if (this.getOutput(feedback.options.output).route == feedback.options.input) {
					return {
						color: feedback.options.fg,
						bgcolor: feedback.options.bg
					};
				}
			},
			subscribe: (feedback) => {
				if (this.socket !== undefined && this.socket.connected) {
					this.sendCommand(`SUBSCRIBE Out${feedback.options.output} In${feedback.options.input}`);
				}
			},
			unsubscribe: (feedback) => {
				if (this.socket !== undefined && this.socket.connected) {
					this.sendCommand(`UNSUBSCRIBE Out${feedback.options.output} In${feedback.options.input}`);
				}
			}
		}
	};

	this.setFeedbackDefinitions(feedbacks);
}
```

## Instance Calls
Within a module, calls have been setup to execute these callbacks either across all feedbacks that have them or for a particular type via text parameter:
_ES6 examples_
```javascript
this.subscribeFeedbacks();
this.subscribeFeedbacks('input_bg');

this.unsubscribeFeedbacks();
this.unsubscribeFeedbacks('input_bg');
```
You can also get an array of all user feedbacks in order to index them or fire custom commands:
_ES6 example_
```javascript
processFeedbacks() {
	let feedbacks = this.getAllFeedbacks();

	if (feedbacks.length > 0) {
		for (var x in feedbacks) {
			let feedback = feedbacks[x];
			...
		}
	}
}
```
## Use Cases
A typical module requiring this would execute the subscribe commands after connecting to the device:
_ES6 example_
```javascript
this.socket.on('connect', () => {
	...
	this.subscribeFeedbacks();
	...
});
```

Unsubscribe might be necessary for some devices prior to Companion shutting down or the instance being disabled:
_ES6 example_
```javascript
destroy() {
	if (this.socket !== undefined) {
		this.unsubscribeFeedbacks();
		this.socket.destroy();
	}

	this.debug("destroy", this.id);;
}
```