### PR TITLE
Minor: add actions callbacks to match feedbacks (callback, subscribe, unsubscribe)

### DIFF
--- a/lib/action.js
+++ b/lib/action.js
@@ -79,7 +79,6 @@ function action(system) {
 	self.system.on('instance_save', function() {
 		setImmediate(function() {
 			self.io.emit('actions', self.actions);
-			self.io.emit('release_actions', self.release_actions);
 		});
 	});
 
@@ -432,10 +431,6 @@ function action(system) {
 				client.emit('actions', self.actions);
 			});
 
-			client.on('release_actions_get', function() {
-				client.emit('release_actions', self.release_actions);
-			});
-
 			client.on('bank_update_action_delay', function(page,bank,action,value) {
 				var bp = self.bank_actions[page][bank];
 				if (bp !== undefined) {
@@ -648,13 +643,6 @@ function action(system) {
 			}
 		}
 		self.system.emit('actions_update');
-		for (var n in self.release_actions) {
-			var x = n.split(/:/);
-			if (x[0] == id) {
-				delete self.release_actions[n];
-			}
-		}
-		self.system.emit('release_actions_update');
 	});
 
 	self.system.on('bank_reset', function (page, bank) {
@@ -680,11 +668,6 @@ function action(system) {
 		self.io.emit('actions', self.actions);
 	});
 
-	self.system.on('release_actions_update', function() {
-		debug('release_actions_update:', self.release_actions);
-		self.io.emit('release_actions', self.release_actions);
-	});
-
 	self.system.on('instance_actions', function(id, actions) {
 		for (var n in actions) {
 			var a = actions[n];
@@ -692,15 +675,6 @@ function action(system) {
 			debug('adding action', id+':'+n);
 		}
 		self.io.emit('actions', self.actions);
-	});
-
-	self.system.on('instance_release_actions', function(id, actions) {
-		for (var n in actions) {
-			var a = actions[n];
-			self.release_actions[id+':'+n] = a;
-			debug('adding release_action', id+':'+n);
-		}
-		self.io.emit('release_actions', self.release_actions);
 	});
 
 	return self;

--- a/lib/action.js
+++ b/lib/action.js
@@ -91,6 +91,7 @@ function action(system) {
 
 						if (action.instance == id) {
 							debug('Deleting action ' + i + ' from button ' + page + '.' + bank);
+							self.unsubscribeAction(self.bank_actions[page][bank][i])
 							self.bank_actions[page][bank].splice(i, 1);
 							self.system.emit('instance_status_check_bank', page, bank);
 							i--;
@@ -107,6 +108,7 @@ function action(system) {
 						var action = self.bank_release_actions[page][bank][i];
 						if (action.instance == id) {
 							debug('Deleting release action ' + i + ' from button ' + page + '.' + bank);
+							self.unsubscribeAction(self.bank_release_actions[page][bank][i])
 							self.bank_release_actions[page][bank].splice(i, 1);
 							self.system.emit('instance_status_check_bank', page, bank);
 							i--;
@@ -488,10 +490,12 @@ function action(system) {
 					for (var n in bp) {
 						var obj = bp[n];
 						if (obj !== undefined && obj.id === action) {
+							self.unsubscribeAction(obj);
 							if (obj.options === undefined) {
-								self.bank_actions[page][bank][n].options = {};
+								obj.options = {};
 							}
-							self.bank_actions[page][bank][n].options[option] = value;
+							obj.options[option] = value;
+							self.subscribeAction(obj);
 							self.system.emit('action_save');
 						}
 					}
@@ -505,10 +509,12 @@ function action(system) {
 					for (var n in bp) {
 						var obj = bp[n];
 						if (obj !== undefined && obj.id === action) {
+							self.unsubscribeAction(obj);
 							if (obj.options === undefined) {
-								self.bank_release_actions[page][bank][n].options = {};
+								obj.options = {};
 							}
-							self.bank_release_actions[page][bank][n].options[option] = value;
+							obj.options[option] = value;
+							self.subscribeAction(obj);
 							self.system.emit('release_action_save');
 						}
 					}
@@ -540,6 +546,7 @@ function action(system) {
 				}
 
 				self.bank_actions[page][bank].push(act);
+				self.subscribeAction(act);
 
 				system.emit('action_save');
 				client.emit('bank_actions_get:result', page, bank, self.bank_actions[page][bank] );
@@ -571,6 +578,7 @@ function action(system) {
 				}
 
 				self.bank_release_actions[page][bank].push(act);
+				self.subscribeAction(act);
 
 				system.emit('release_action_save');
 				client.emit('bank_release_actions_get:result', page, bank, self.bank_release_actions[page][bank] );
@@ -582,6 +590,7 @@ function action(system) {
 
 				for (var n in ba) {
 					if (ba[n].id == id) {
+						self.unsubscribeAction(self.bank_actions[page][bank][n])
 						delete self.bank_actions[page][bank][n];
 						break;
 					}
@@ -607,6 +616,7 @@ function action(system) {
 
 				for (var n in ba) {
 					if (ba[n].id == id) {
+						self.unsubscribeAction(self.bank_release_actions[page][bank][n])
 						delete self.bank_release_actions[page][bank][n];
 						break;
 					}
@@ -669,7 +679,40 @@ function action(system) {
 		self.system.emit('actions_update');
 	});
 
+	system.on('action_subscribe_bank', function (page, bank) {
+		if (self.bank_actions[page] !== undefined && self.bank_actions[page][bank] !== undefined) {
+			// find all instance-ids in feedbacks for bank
+			for (var i in self.bank_actions[page][bank]) {
+				self.subscribeAction(self.bank_actions[page][bank][i]);
+			}
+		}
+		if (self.bank_release_actions[page] !== undefined && self.bank_release_actions[page][bank] !== undefined) {
+			// find all instance-ids in feedbacks for bank
+			for (var i in self.bank_release_actions[page][bank]) {
+				self.subscribeAction(self.bank_release_actions[page][bank][i]);
+			}
+		}
+	});
+
+	system.on('action_unsubscribe_bank', function (page, bank) {
+		if (self.bank_actions[page] !== undefined && self.bank_actions[page][bank] !== undefined) {
+			// find all instance-ids in feedbacks for bank
+			for (var i in self.bank_actions[page][bank]) {
+				self.unsubscribeAction(self.bank_actions[page][bank][i]);
+			}
+		}
+		if (self.bank_release_actions[page] !== undefined && self.bank_release_actions[page][bank] !== undefined) {
+			// find all instance-ids in feedbacks for bank
+			for (var i in self.bank_release_actions[page][bank]) {
+				self.unsubscribeAction(self.bank_release_actions[page][bank][i]);
+			}
+		}
+	});
+
+
 	self.system.on('bank_reset', function (page, bank) {
+
+		system.emit('action_unsubscribe_bank', page, bank);
 
 		if (self.bank_actions[page] === undefined) {
 			self.bank_actions[page] = {};
@@ -704,8 +747,36 @@ function action(system) {
 	return self;
 }
 
-action.prototype.func = function () {
+action.prototype.subscribeAction = function(action) {
 	var self = this;
+
+	console.log(action)
+
+	if (action.action !== undefined && action.instance !== undefined) {
+		const actionId = `${action.instance}:${action.action}`
+		if (self.actions[actionId] !== undefined) {
+			let definition = self.actions[actionId];
+			// Run the subscribe function if needed
+			if (definition.subscribe !== undefined && typeof definition.subscribe == 'function') {
+				definition.subscribe(action);
+			}
+		}
+	}
+};
+
+action.prototype.unsubscribeAction = function(action) {
+	var self = this;
+
+	if (action.action !== undefined && action.instance !== undefined) {
+		const actionId = `${action.instance}:${action.action}`
+		if (self.actions[actionId] !== undefined) {
+			let definition = self.actions[actionId];
+			// Run the unsubscribe function if needed
+			if (definition.unsubscribe !== undefined && typeof definition.unsubscribe == 'function') {
+				definition.unsubscribe(action);
+			}
+		}
+	}
 };
 
 exports = module.exports = function (system) {

--- a/lib/action.js
+++ b/lib/action.js
@@ -681,13 +681,13 @@ function action(system) {
 
 	system.on('action_subscribe_bank', function (page, bank) {
 		if (self.bank_actions[page] !== undefined && self.bank_actions[page][bank] !== undefined) {
-			// find all instance-ids in feedbacks for bank
+			// find all instance-ids in actions for bank
 			for (var i in self.bank_actions[page][bank]) {
 				self.subscribeAction(self.bank_actions[page][bank][i]);
 			}
 		}
 		if (self.bank_release_actions[page] !== undefined && self.bank_release_actions[page][bank] !== undefined) {
-			// find all instance-ids in feedbacks for bank
+			// find all instance-ids in release_actions for bank
 			for (var i in self.bank_release_actions[page][bank]) {
 				self.subscribeAction(self.bank_release_actions[page][bank][i]);
 			}
@@ -696,13 +696,13 @@ function action(system) {
 
 	system.on('action_unsubscribe_bank', function (page, bank) {
 		if (self.bank_actions[page] !== undefined && self.bank_actions[page][bank] !== undefined) {
-			// find all instance-ids in feedbacks for bank
+			// find all instance-ids in actions for bank
 			for (var i in self.bank_actions[page][bank]) {
 				self.unsubscribeAction(self.bank_actions[page][bank][i]);
 			}
 		}
 		if (self.bank_release_actions[page] !== undefined && self.bank_release_actions[page][bank] !== undefined) {
-			// find all instance-ids in feedbacks for bank
+			// find all instance-ids in release_actions for bank
 			for (var i in self.bank_release_actions[page][bank]) {
 				self.unsubscribeAction(self.bank_release_actions[page][bank][i]);
 			}

--- a/lib/action.js
+++ b/lib/action.js
@@ -423,6 +423,30 @@ function action(system) {
 		}
 	});
 
+	self.system.on('action_run', function(action, extras) {
+
+		if (self.instance !== undefined && self.instance.store !== undefined && self.instance.store.db !== undefined) {
+			self.system.emit('instance_get', action.instance, function(instance) {
+				if (self.instance.store.db[action.instance] !== undefined && self.instance.store.db[action.instance].enabled !== false) {
+					const definition = self.actions[`${action.instance}:${action.action}`]
+
+					// Ask instance to execute action
+					if (definition !== undefined && definition.callback !== undefined && typeof definition.callback == 'function') {
+						definition.callback(action, extras);
+					} else if (typeof instance.action == 'function') {
+						instance.action(action, extras);
+					} else {
+						debug('ERROR: instance ' + instance.label + ' does not have an action() function');
+					}
+
+				}
+				else {
+					debug("trying to run action on a deleted instance.", action)
+				}
+			})
+		}
+	});
+
 	self.system.emit('io_get', function(io) {
 		self.io = io;
 		self.system.on('io_connect', function(client) {

--- a/lib/feedback.js
+++ b/lib/feedback.js
@@ -102,7 +102,6 @@ function feedback(system) {
 	});
 
 	system.on('feedback_subscribe_bank', function (page, bank) {
-		var ids = {};
 		if (self.feedbacks[page] !== undefined && self.feedbacks[page][bank] !== undefined) {
 			// find all instance-ids in feedbacks for bank
 			for (var i in self.feedbacks[page][bank]) {
@@ -112,7 +111,6 @@ function feedback(system) {
 	});
 
 	system.on('feedback_unsubscribe_bank', function (page, bank) {
-		var ids = {};
 		if (self.feedbacks[page] !== undefined && self.feedbacks[page][bank] !== undefined) {
 			// find all instance-ids in feedbacks for bank
 			for (var i in self.feedbacks[page][bank]) {

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -316,17 +316,6 @@ function instance(system) {
 		});
 	});
 
-	system.on('action_run', function(action, extras) {
-
-		if (self.active[action.instance] !== undefined) {
-			self.active[action.instance].action(action, extras);
-		}
-		else {
-			debug("trying to run action on a deleted instance.", action)
-		}
-
-	});
-
 	system.on('instance_add', function (data, cb) {
 		var module = data.type;
 		var product = data.product;

--- a/lib/instance_skel.d.ts
+++ b/lib/instance_skel.d.ts
@@ -85,6 +85,21 @@ declare abstract class InstanceSkel<TConfig> {
    */
   unsubscribeFeedbacks(feedbackId?: string): void
 
+  /**
+   * Get an array of all the actions and release_actions for this instance
+   */
+  getAllActions(): CompanionFeedbackEvent[]
+  /**
+   * Trigger the subscribe callback on all actions and release_actions for this instance
+   * @param actionId Action type to call for, or undefined for all
+   */
+  subscribeActions(actionId?: string): void
+  /**
+   * Trigger the unsubscribe callback on all actions and release_actions for this instance
+   * @param actionId Action type to call for, or undefined for all
+   */
+  unsubscribeActions(actionId?: string): void
+
   status(level: null | 0 | 1 | 2, message?: string): void
 
   log(level: 'info' | 'warn' | 'error' | 'debug', info: string): void

--- a/lib/instance_skel.d.ts
+++ b/lib/instance_skel.d.ts
@@ -51,7 +51,7 @@ declare abstract class InstanceSkel<TConfig> {
    * Executes the provided action.
    * @since 1.0.0
    */
-  abstract action(action: CompanionActionEvent): void
+  action?(action: CompanionActionEvent): void
 
   /**
    * Processes a feedback state.

--- a/lib/instance_skel.js
+++ b/lib/instance_skel.js
@@ -386,7 +386,7 @@ instance.prototype.unsubscribeActions = function(type) {
 instance.prototype.subscribeAction = function(action) {
 	var self = this;
 
-	if (action.type !== undefined && self._actionDefinitions[action.action] !== undefined) {
+	if (action.action !== undefined && self._actionDefinitions[action.action] !== undefined) {
 		let definition = self._actionDefinitions[action.action];
 		// Run the subscribe function if needed
 		if (definition.subscribe !== undefined && typeof definition.subscribe == 'function') {
@@ -398,7 +398,7 @@ instance.prototype.subscribeAction = function(action) {
 instance.prototype.unsubscribeAction = function(action) {
 	var self = this;
 
-	if (action.type !== undefined && self._actionDefinitions[action.action] !== undefined) {
+	if (action.action !== undefined && self._actionDefinitions[action.action] !== undefined) {
 		let definition = self._actionDefinitions[action.action];
 		// Run the unsubscribe function if needed
 		if (definition.unsubscribe !== undefined && typeof definition.unsubscribe == 'function') {

--- a/lib/instance_skel.js
+++ b/lib/instance_skel.js
@@ -28,6 +28,7 @@ function instance(system, id, config) {
 	self.config = config;
 	self.package_info = {};
 	self._feedbackDefinitions = {};
+	self._actionDefinitions = {};
 
 	// we need this object from instance, and I don't really know how to get it
 	// out of instance.js without adding an argument to instance() for every
@@ -185,6 +186,13 @@ instance.prototype.addUpgradeScript = function (cb) {
 instance.prototype.setActions = function(actions) {
 	var self = this;
 
+	if (actions === undefined) {
+		self._actionDefinitions = {};
+	}
+	else {
+		self._actionDefinitions = actions;
+	}
+
 	self.system.emit('instance_actions', self.id, actions);
 };
 
@@ -324,6 +332,77 @@ instance.prototype.unsubscribeFeedback = function(feedback) {
 		// Run the unsubscribe function if needed
 		if (definition.unsubscribe !== undefined && typeof definition.unsubscribe == 'function') {
 			definition.unsubscribe(feedback);
+		}
+	}
+};
+
+instance.prototype.getAllActions = function() {
+	var self = this;
+	var result = [];
+
+	self.system.emit('actions_for_instance', self.id, function(_result) {
+		result = _result;
+	});
+	self.system.emit('release_actions_for_instance', self.id, function(_result) {
+		result.push(..._result)
+	});
+	return result;
+};
+
+instance.prototype.subscribeActions = function(type) {
+	var self = this;
+	var actions = self.getAllActions();
+
+	if (actions.length > 0) {
+		for (var i in actions) {
+			let action = actions[i];
+
+			if (type !== undefined && action.action != type) {
+				continue;
+			}
+
+			self.subscribeAction(action);
+		}
+	}
+};
+
+instance.prototype.unsubscribeActions = function(type) {
+	var self = this;
+	var actions = self.getAllActions();
+
+	if (actions.length > 0) {
+		for (var i in actions) {
+			let action = actions[i];
+
+			if (type !== undefined && action.action != type) {
+				continue;
+			}
+
+			self.unsubscribeAction(action);
+		}
+	}
+};
+
+instance.prototype.subscribeAction = function(action) {
+	var self = this;
+
+	if (action.type !== undefined && self._actionDefinitions[action.action] !== undefined) {
+		let definition = self._actionDefinitions[action.action];
+		// Run the subscribe function if needed
+		if (definition.subscribe !== undefined && typeof definition.subscribe == 'function') {
+			definition.subscribe(action);
+		}
+	}
+};
+
+instance.prototype.unsubscribeAction = function(action) {
+	var self = this;
+
+	if (action.type !== undefined && self._actionDefinitions[action.action] !== undefined) {
+		let definition = self._actionDefinitions[action.action];
+		// Run the unsubscribe function if needed
+		if (definition.unsubscribe !== undefined && typeof definition.unsubscribe == 'function') {
+			definition.unsubscribe(action);
 		}
 	}
 };

--- a/lib/instance_skel_types.d.ts
+++ b/lib/instance_skel_types.d.ts
@@ -8,6 +8,7 @@ export type InputValue = number | string | boolean
 export interface CompanionAction {
   label: string
   options: SomeCompanionInputField[]
+  callback?: (feedback: CompanionActionEvent) => void
 }
 export interface CompanionActionEvent {
   action: string

--- a/lib/instance_skel_types.d.ts
+++ b/lib/instance_skel_types.d.ts
@@ -8,7 +8,9 @@ export type InputValue = number | string | boolean
 export interface CompanionAction {
   label: string
   options: SomeCompanionInputField[]
-  callback?: (feedback: CompanionActionEvent) => void
+  callback?: (action: CompanionActionEvent) => void
+  subscribe?: (action: CompanionActionEvent) => void
+  unsubscribe?: (action: CompanionActionEvent) => void
 }
 export interface CompanionActionEvent {
   action: string

--- a/lib/loadsave.js
+++ b/lib/loadsave.js
@@ -480,6 +480,7 @@ function loadsave(_system) {
 		system.emit('bank_update', self.config);
 		system.emit('feedback_check_bank', page, bank);
 		system.emit('feedback_subscribe_bank', page, bank);
+		system.emit('action_subscribe_bank', page, bank);
 
 		debug('Imported config to bank ' + page + '.' + bank);
 		if (typeof cb == 'function') {

--- a/public/release_action.js
+++ b/public/release_action.js
@@ -30,8 +30,6 @@ function hex2int(hex) {
 }
 
 $(function() {
-	socket.emit('release_actions_get');
-
 	var $aba = $("#addBankReleaseAction");
 	$aba.select2({
 		theme: 'option',


### PR DESCRIPTION
Related: https://github.com/bitfocus/companion/pull/1062

This PR adds 3 callbacks to the action definitions, identical to those already on feedback definitions to allow for similar use cases:
- `callback`: execute the action. Takes priority over the instance level `action()` handler if this exists
- `subscribe`: allows the action to send a `SUBSCRIBE` or `NOTIFY` command if it must request to receive updates for the associated data; or a simple `GET` can be sent to warm up the data should the device not have a catch-up method for its action data
- `unsubscribe`: allows the action to send a, `UNSUBSCRIBE` command should update subscription be required and the device recommends unsubscribing when certain updates are no longer required

Note: for these, actions and release_actions are being treated the same. There is no distinction being made, and the difference is hidden from the modules.

These callbacks are invoked via two methods in an instance:
1. Manually via direct calls (outlined below) in the instance class.
2. Automatic `subscribe` and `unsubscribe` firing based on events such as:
    - New action (subscribe)
    - Edit action (unsubscribe old; subscribe new)
    - Delete action (unsubscribe)
    - Preset drop (unsubscribe old; subscribe new)
    - Import page/config (unsubscribe old; subscribe new)

This PR also exposes a new `getAllActions()` function in `instance_skel` to request all of the active action from the core.

## Action Definition
_ES6 example_
```javascript
initActions() {
	var actions = {
		input_bg: {
			label: 'Set output to input',
			options: [
				this.INPUT_FIELD,
				this.OUTPUT_FIELD
			],
			callback: (action, bank) => {
				this.setOutput(action.options.output, action.options.input)
			},
			subscribe: (action) => {
				if (this.socket !== undefined && this.socket.connected) {
					this.sendCommand(`SUBSCRIBE Out${action.options.output} In${action.options.input}`);
				}
			},
			unsubscribe: (action) => {
				if (this.socket !== undefined && this.socket.connected) {
					this.sendCommand(`UNSUBSCRIBE Out${action.options.output} In${action.options.input}`);
				}
			}
		}
	};

	this.setActions(actions);
}
```

## Instance Calls
Within a module, calls have been setup to execute these callbacks either across all actions that have them or for a particular type via text parameter:
_ES6 examples_
```javascript
this.subscribeActions();
this.subscribeActions('input_bg');

this.unsubscribeActions();
this.unsubscribeActions('input_bg');
```
You can also get an array of all user actions in order to index them or fire custom commands:
_ES6 example_
```javascript
processActions() {
	let actions = this.getAllActions();

	if (actions.length > 0) {
		for (var x in actions) {
			let action = actions[x];
			...
		}
	}
}
```

## Use Cases
This will have less use than the feedback versions will, but this allows for some actions to operate based on the current state. Such as toggle, increment or decrement.

A good example, is in the behringer-x32, where the mute action can toggle. This means that if there is a mute set to toggle, the module needs to ensure it knows the state of the mute at all times. 
The x32 doesnt send any data upon connection, any wanted state has to be asked for. one field at a time.
Rather than having to load in the state of anything that might have a toggle action, this allows it to instead only load the ones that are needed