### PR TITLE
Admin Stops Working

### DIFF
--- a/lib/server_http.js
+++ b/lib/server_http.js
@@ -32,7 +32,7 @@ express.use(function(req, res, next) {
 	next();
 });
 
-express.use(Express.static(__dirname + '/../public', {
+express.use(Express.static(path.join(__dirname, '/../public'), {
 	dotfiles: 'ignore',
 	etag: true,
 	extensions: [

--- a/package.json
+++ b/package.json
@@ -11,7 +11,22 @@
 			"extendInfo": {
 				"LSBackgroundOnly": 1,
 				"LSUIElement": 1
-			}
+			},
+			"asarUnpack": [
+				"public",
+				"node_modules/jquery",
+				"node_modules/popper.js/**",
+				"node_modules/bootstrap",
+				"node_modules/bootstrap-colorpicker",
+				"node_modules/pace-progress",
+				"node_modules/perfect-scrollbar",
+				"node_modules/@coreui/coreui",
+				"node_modules/flag-icon-css",
+				"node_modules/font-awesome",
+				"node_modules/moment",
+				"node_modules/select2",
+				"node_modules/tributejs/dist"
+			]
 		},
 		"win": {
 			"target": "nsis"


### PR DESCRIPTION
This seems to have fixed #567 for me.

This keeps the static resources needed by express outside of the asar, which have issues after Companion runs for about a week. Before fix I was able to consistently replicate the issue, and after this change cannot.