### PR TITLE
Corrected rosstalk listener documentation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -564,7 +564,7 @@ href="https://join.slack.com/t/bitfocusio/shared_invite/enQtODk4NTYzNTkzMjU1LTMz
 										<p><strong>Commands:</strong>
 											<ul>
 
-												<li><code>CC</code> &lt;bank&gt;:&lt;page&gt;<br>
+												<li><code>CC</code> &lt;page&gt;:&lt;button&gt;<br>
 													<i>Press and release button</i></li>
 											</ul>
 										</p>
@@ -572,8 +572,8 @@ href="https://join.slack.com/t/bitfocusio/shared_invite/enQtODk4NTYzNTkzMjU1LTMz
 											<strong>Examples</strong>
 										</p>
 
-										<p>Press and release button 5 on bank 2<br>
-											<code>CC 2.5</code></p>
+										<p>Press and release button 5 on page 2<br>
+											<code>CC 2:5</code></p>
 									</div>
 								</div>
 							</div>


### PR DESCRIPTION
Documentation for the listener was reversed compared to what was expected. There was also a mix of terms used. I changed it to the terms page and button as well as correcting the . to : in the example.