### PR TITLE
Patch: correct typo in REGEX_FLOAT_OR_INT: fixes #1217

### DIFF
--- a/lib/instance_skel.js
+++ b/lib/instance_skel.js
@@ -48,7 +48,7 @@ function instance(system, id, config) {
 	self.defineConst('REGEX_PORT',          '/^([1-9]|[1-8][0-9]|9[0-9]|[1-8][0-9]{2}|9[0-8][0-9]|99[0-9]|[1-8][0-9]{3}|9[0-8][0-9]{2}|99[0-8][0-9]|999[0-9]|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-4])$/');
 	self.defineConst('REGEX_PERCENT',       '/^(100|[0-9]|[0-9][0-9])$/');
 	self.defineConst('REGEX_FLOAT',         '/^([0-9]*\\.)?[0-9]+$/');
-	self.defineConst('REGEX_FLOAT_OR_INT',  '/^([0-9]+)(\\.[0-9+])?$/');
+	self.defineConst('REGEX_FLOAT_OR_INT',  '/^([0-9]+)(\\.[0-9]+)?$/');
 	self.defineConst('REGEX_SIGNED_FLOAT',  '/^[+-]?([0-9]*\\.)?[0-9]+$/');
 	self.defineConst('REGEX_NUMBER',        '/^\\d+$/');
 	self.defineConst('REGEX_SOMETHING',     '/^.+$/');


### PR DESCRIPTION
Fixes #1217 

`REGEX_FLOAT_OR_INT` should accept more than one digit after the decimal point