### PR TITLE
Prevent multiple up on latch buttons

### DIFF
--- a/lib/action.js
+++ b/lib/action.js
@@ -273,22 +273,27 @@ function action(system) {
 				}
 			}
 
-			let reject = false
+			let reject = false;
 			system.emit('graphics_is_pushed', page, bank, function (pushed) {
+				let isPushed = (1 == pushed? true : false);
 				// button is being pressed but not yet latched
 				// the next button-release from this device needs to be skipped
 				// because the 'release' would immediately un-latch the button
-				if (direction && (pushed != 1)) {
+				if (direction && !isPushed) {
 					skipNext[pb] = deviceid;
 				} else if (direction && pushed) {
 					// button is latched, prevent duplicate down actions
 					// the following 'release' will run the up actions
-					reject = true
+					reject = true;
+				} else if (!(direction || pushed)) {
+					// button is up, prevent duplicate up actions
+					reject = true;
 				}
 			});
 
 			if (reject) {
-				return
+				//debug("Latch button duplicate " + (direction? "down":"up") )
+				return;
 			}
 		}
 


### PR DESCRIPTION
Missing fix for last piece of #775.
Existing patches prevented multiple 'press' (down) events from running down actions, 
but missed the case of multiple 'release' (up) events.
This patch adds that case.
