### PR TITLE
Fix: Node12 Buffer Update

### DIFF
--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -293,7 +293,7 @@ graphics.prototype.drawBankImage = function (c, page, bank) {
 		if (c.png64 !== undefined) {
 
 			try {
-				var data = new Buffer(c.png64, 'base64');
+				var data = Buffer.from(c.png64, 'base64');
 				var halign = c.pngalignment.split(":",2)[0];
 				var valign = c.pngalignment.split(":",2)[1];
 				img.drawFromPNGdata(data, 0, 14, 72, 58, halign, valign);

--- a/lib/image.js
+++ b/lib/image.js
@@ -40,7 +40,7 @@ function image(width,height) {
 	self.lastBackgroundColor = self.rgb(0,0,0);
 
 	for (var y = 0; y < self.height; y++) {
-		var buf = new Buffer(self.width * 3); // * 3 for RGB.
+		var buf = Buffer.alloc(self.width * 3); // * 3 for RGB.
 		self.canvas.push(buf);
 	}
 
@@ -618,7 +618,7 @@ image.prototype.drawPixelBuffer = function (x, y, width, height, buffer, type) {
 	}
 
 	if (type === 'base64') {
-		buffer = new Buffer(buffer, 'base64');
+		buffer = Buffer.from(buffer, 'base64');
 	}
 
 	if (buffer.length < width * height * 3) {

--- a/lib/satellite_protocol.js
+++ b/lib/satellite_protocol.js
@@ -157,14 +157,14 @@ protocol.sendPacket = function(socket, command, data) {
 	var self = this;
 
 	if (data === undefined) {
-		data = new Buffer('');
+		data = Buffer.from('');
 	}
 
 	if (typeof data !== 'object' || !(data instanceof Buffer)) {
-		data = new Buffer(data);
+		data = Buffer.from(data);
 	}
 
-	var buffer = new Buffer(5 + data.length + 1);
+	var buffer = Buffer.alloc(5 + data.length + 1);
 
 	var header = {
 		signature: 0x5A7E,

--- a/lib/satellite_server.js
+++ b/lib/satellite_server.js
@@ -53,7 +53,7 @@ satelliteServer.prototype.initSocket = function (socket) {
 	var self = this;
 	debug('new connection from ' + socket.name);
 
-	socket.buffer = new Buffer('');
+	socket.buffer = Buffer.from('');
 
 	socket.on('data', function (data) {
 		socket.buffer = Buffer.concat([ socket.buffer, data ]);

--- a/lib/telnet.js
+++ b/lib/telnet.js
@@ -233,8 +233,8 @@ function telnetStream(options) {
 
 	this._options = options = options || {};
 
-	this.buffer = new Buffer('');
-	this.subbuffer = new Buffer('');
+	this.buffer = Buffer.from('');
+	this.subbuffer = Buffer.from('');
 	this.state = DATA;
 
 	debug("new telnetStreamer(", options, ")");
@@ -265,7 +265,7 @@ telnetStream.prototype._handleByte = function(byte) {
 			return;
 		}
 
-		self.buffer = Buffer.concat([ self.buffer, new Buffer([ byte ]) ]);
+		self.buffer = Buffer.concat([ self.buffer, Buffer.from([ byte ]) ]);
 	}
 
 	else if (self.state === IAC) {
@@ -295,11 +295,11 @@ telnetStream.prototype._handleByte = function(byte) {
 		if (byte === SE) {
 			self.emit('sb', self.subbuffer);
 			self.state = DATA;
-			self.subbuffer = new Buffer('');
+			self.subbuffer = Buffer.from('');
 			return;
 		}
 
-		self.subbuffer = Buffer.concat([ self.subbuffer, new Buffer([byte]) ]);
+		self.subbuffer = Buffer.concat([ self.subbuffer, Buffer.from([byte]) ]);
 	}
 
 };
@@ -308,7 +308,7 @@ telnetStream.prototype._getData = function(arguments) {
 	var self = this;
 	var buff = self.buffer;
 
-	self.buffer = new Buffer('');
+	self.buffer = Buffer.from('');
 
 	return buff;
 };

--- a/lib/usb/common.js
+++ b/lib/usb/common.js
@@ -60,7 +60,7 @@ common.prototype.handleBuffer = function(buffer) {
 	var self = this;
 
 	if (buffer.type == 'Buffer') {
-		buffer = new Buffer(buffer.data);
+		buffer = Buffer.from(buffer.data);
 	}
 
 	if (buffer === undefined || buffer.length != 15552) {
@@ -70,7 +70,7 @@ common.prototype.handleBuffer = function(buffer) {
 	}
 
 	if (self.config.rotation === -90) {
-		var buf = new Buffer(15552);
+		var buf = Buffer.alloc(15552);
 
 		for (var x = 0; x < 72; ++x) {
 			for (var y = 0; y < 72; ++y) {
@@ -81,7 +81,7 @@ common.prototype.handleBuffer = function(buffer) {
 	}
 
 	if (self.config.rotation === 180) {
-		var buf = new Buffer(15552);
+		var buf = Buffer.alloc(15552);
 
 		for (var x = 0; x < 72; ++x) {
 			for (var y = 0; y < 72; ++y) {
@@ -92,7 +92,7 @@ common.prototype.handleBuffer = function(buffer) {
 	}
 
 	if (self.config.rotation === 90) {
-		var buf = new Buffer(15552);
+		var buf = Buffer.alloc(15552);
 
 		for (var x = 0; x < 72; ++x) {
 			for (var y = 0; y < 72; ++y) {


### PR DESCRIPTION
Updated uses of the deprecated `new Buffer()` to the Node12 compliant functions `Buffer.from()` and `Buffer.alloc()`.

Changes made following the guidelines of Variant 1 of the NodeJS Buffer constructor deprecation guide  https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/