### PR TITLE
Minor: Add context-menu to tray icon

### DIFF
--- a/lib/elgato_dm.js
+++ b/lib/elgato_dm.js
@@ -48,16 +48,16 @@ function elgatoDM(_system) {
 		cb(ary);
 	});
 
+	system.on('devices_reenumerate', function() {
+		self.refreshDevices();
+	});
+
 	system.emit('io_get', function (io) {
 		self.io = io;
 
 		system.on('io_connect', function (socket) {
 			socket.on('devices_list_get', function () {
 				self.updateDevicesList(socket);
-			});
-
-			system.on('devices_reenumerate', function() {
-				self.refreshDevices();
 			});
 
 			socket.on('devices_reenumerate', function () {

--- a/window.js
+++ b/window.js
@@ -1,6 +1,5 @@
 var Client = require('electron-rpc/client')
 var client = new Client();
-var exec = require('child_process').exec;
 var network = require('network');
 
 var skeleton_info = {
@@ -29,19 +28,7 @@ function skeleton_info_draw() {
 }
 
 document.getElementById('launch').addEventListener('click', function() {
-	var isWin = process.platform == 'win32';
-	var isMac = process.platform == 'darwin';
-	var isLinux = process.platform == 'linux';
-
-	if (skeleton_info.appURL.match(/http/)) {
-		if (isWin) {
-			exec('start ' + skeleton_info.appURL, function callback(error, stdout, stderr){});
-		} else if (isMac) {
-			exec('open ' + skeleton_info.appURL, function callback(error, stdout, stderr){});
-		} else if (isLinux) {
-			exec('xdg-open ' + skeleton_info.appURL, function callback(error, stdout, stderr){});
-		}
-	}
+	client.request('skeleton-launch-gui');
 });
 
 document.getElementById('hide').addEventListener('click', function() {


### PR DESCRIPTION
Adds a small context-menu to the tray-icon, which is shown on right-click (existing behaviour on other clicks)

![tempsnip](https://user-images.githubusercontent.com/1327476/101297783-a3052900-3822-11eb-89ef-4e1cf597a1f1.png)
Since the screenshot, I also added a 'Launch GUI' option, which behaves the same as shown in the skeleton window

This is the easy part of #1274
