### PR TITLE
Patch: hide the dynamic variables section on empty table

### DIFF
--- a/public/instance.js
+++ b/public/instance.js
@@ -491,7 +491,8 @@ $(function() {
 				var variable = instance_variables[current_instance][i];
 				$icvl.append('<tr data-id="' + current_instance + ':' + variable.name + '"><td>$(' + current_instance + ':' + variable.name + ')</td><td>' + variable.label + '</td><td>' + instance_variabledata[current_instance + ':' + variable.name] + '</td></tr>');
 			}
-
+		} else {
+			$icv.hide();
 		}
 	}
 


### PR DESCRIPTION
Adds #1319 
When `instance_variables[]` are programmatically removed the `#instanceConfigVariables` element should be hidden.