### PR TITLE
Minor: Change module load to just-in-time

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -31,6 +31,7 @@ function instance(system) {
 	self.modules_manufacturer = {};
 	self.modules_category = {};
 	self.modules_name = {};
+	self.modules_main = {};
 	self.package_info = {};
 	self.status = {};
 
@@ -161,7 +162,7 @@ function instance(system) {
 
 				var packagefile = fs.readFileSync(path +'/'+ folder + '/package.json');
 				var moduleconfig = JSON.parse(packagefile);
-				var mod = require(path + '/' + folder + '/' + moduleconfig.main);
+				var main = path + '/' + folder + '/' + moduleconfig.main;
 				if (fs.existsSync(path +'/'+ folder + '/HELP.md')) {
 					moduleconfig.help = true;
 				} else {
@@ -169,7 +170,7 @@ function instance(system) {
 				}
 
 				self.store.module.push(moduleconfig);
-				self.modules[folder] = mod;
+				self.modules_main[folder] = main;
 				self.package_info[folder] = moduleconfig;
 
 				// Generate keywords list
@@ -260,7 +261,7 @@ function instance(system) {
 					config.instance_type = mod_redirects[config.instance_type];
 				}
 
-				if (self.modules[config.instance_type] !== undefined) {
+				if (self.checkModuleLoaded(config.instance_type)) {
 
 					if (config.enabled === false) {
 						debug("Won't load disabled module " + id + " (" + config.instance_type + ")");
@@ -332,47 +333,50 @@ function instance(system) {
 	system.on('instance_add', function (data, cb) {
 		var module = data.type;
 		var product = data.product;
-		var mod = self.modules[module];
-		var id = shortid.generate();
 
-		self.store.db[id] = {};
+		if (self.checkModuleLoaded(module)) {
+			var mod = self.modules[module];
+			var id = shortid.generate();
 
-		self.system.emit('log', 'instance('+id+')', 'info', 'instance add ' + module + ' ' + product);
+			self.store.db[id] = {};
 
-		self.store.db[id].instance_type = module;
-		self.store.db[id].product = product;
+			self.system.emit('log', 'instance('+id+')', 'info', 'instance add ' + module + ' ' + product);
 
-		var label = self.package_info[module].shortname;
-		var i = 1;
-		var freename = false;
+			self.store.db[id].instance_type = module;
+			self.store.db[id].product = product;
 
-		while (!freename) {
-			freename = true;
-			for (var key in self.store.db) {
-				if (self.store.db[key].label == label) {
-					i++;
-					label = self.package_info[module].shortname + i;
-					freename = false;
-					break;
+			var label = self.package_info[module].shortname;
+			var i = 1;
+			var freename = false;
+
+			while (!freename) {
+				freename = true;
+				for (var key in self.store.db) {
+					if (self.store.db[key].label == label) {
+						i++;
+						label = self.package_info[module].shortname + i;
+						freename = false;
+						break;
+					}
 				}
 			}
-		}
 
-		self.store.db[id].label = label;
-		if (self.active[id] !== undefined) {
-			self.active[id].label = self.store.db[id].label;
-		}
+			self.store.db[id].label = label;
+			if (self.active[id] !== undefined) {
+				self.active[id].label = self.store.db[id].label;
+			}
 
-		self.activate_module(id, mod);
+			self.activate_module(id, mod);
 
-		self.io.emit('instance_add:result', id, self.store.db);
-		debug('instance_add', id);
-		self.system.emit('instance_save');
-		self.system.emit('actions_update')
-		self.system.emit('feedback_update')
+			self.io.emit('instance_add:result', id, self.store.db);
+			debug('instance_add', id);
+			self.system.emit('instance_save');
+			self.system.emit('actions_update')
+			self.system.emit('feedback_update')
 
-		if (typeof cb == 'function') {
-			cb(id, self.store.db[id]);
+			if (typeof cb == 'function') {
+				cb(id, self.store.db[id]);
+			}
 		}
 	});
 
@@ -447,7 +451,7 @@ instance.prototype.activate_module = function(id,modin) {
 	if (modin !== undefined) {
 		mod = modin;
 	}
-	else {
+	else if (self.checkModuleLoaded(self.store.db[id].instance_type)) {
 		mod = self.modules[self.store.db[id].instance_type];
 	}
 
@@ -505,6 +509,28 @@ instance.prototype.calculateErrors = function (inst) {
 
 	self.system.emit('instance_errorcount', [self.numOk, self.numWarn, self.numError] );
 	
+};
+
+instance.prototype.checkModuleLoaded = function(folder) {
+	var self = this;
+	var out = false;
+
+	if (self.modules[folder] === undefined && self.modules_main[folder] !== undefined) {
+		try {
+			var mod = require(self.modules_main[folder]);
+			self.modules[folder] = mod;
+			out = true;
+		}
+		catch(err) {
+			debug("Error loading module " + folder, e);
+			system.emit('log', 'module('+folder+')', 'error', 'Error loading module: '+ e);
+		}
+	}
+	else if (self.modules[folder] !== undefined) {
+		out = true;
+	}
+
+	return out;
 };
 
 instance.prototype.connect = function (client) {
@@ -588,7 +614,7 @@ instance.prototype.connect = function (client) {
 	});
 
 	client.on('instance_get_help', function (module) {
-		if (self.modules[module] !== undefined) {
+		if (self.modules_main[module] !== undefined) {
 			var path = require('app-root-path') + '/lib/module';
 
 			if (fs.existsSync(path +'/'+ module + '/HELP.md')) {

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -169,6 +169,11 @@ function instance(system) {
 					moduleconfig.help = false;
 				}
 
+				if (process.env.LOAD_ALL_MODULES !== undefined) {
+					var mod = require(path + '/' + folder + '/' + moduleconfig.main);
+					self.modules[folder] = mod;
+				}
+
 				self.store.module.push(moduleconfig);
 				self.modules_main[folder] = main;
 				self.package_info[folder] = moduleconfig;
@@ -511,22 +516,22 @@ instance.prototype.calculateErrors = function (inst) {
 	
 };
 
-instance.prototype.checkModuleLoaded = function(folder) {
+instance.prototype.checkModuleLoaded = function(instance_type) {
 	var self = this;
 	var out = false;
 
-	if (self.modules[folder] === undefined && self.modules_main[folder] !== undefined) {
+	if (self.modules[instance_type] === undefined && self.modules_main[instance_type] !== undefined) {
 		try {
-			var mod = require(self.modules_main[folder]);
-			self.modules[folder] = mod;
+			var mod = require(self.modules_main[instance_type]);
+			self.modules[instance_type] = mod;
 			out = true;
 		}
 		catch(e) {
-			debug("Error loading module " + folder, e);
-			self.system.emit('log', 'module('+folder+')', 'error', 'Error loading module: '+ e);
+			debug("Error loading module " + instance_type, e);
+			self.system.emit('log', 'module('+instance_type+')', 'error', 'Error loading module: '+ e);
 		}
 	}
-	else if (self.modules[folder] !== undefined) {
+	else if (self.modules[instance_type] !== undefined) {
 		out = true;
 	}
 

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -521,7 +521,7 @@ instance.prototype.checkModuleLoaded = function(folder) {
 			self.modules[folder] = mod;
 			out = true;
 		}
-		catch(err) {
+		catch(e) {
 			debug("Error loading module " + folder, e);
 			self.system.emit('log', 'module('+folder+')', 'error', 'Error loading module: '+ e);
 		}

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -523,7 +523,7 @@ instance.prototype.checkModuleLoaded = function(folder) {
 		}
 		catch(err) {
 			debug("Error loading module " + folder, e);
-			system.emit('log', 'module('+folder+')', 'error', 'Error loading module: '+ e);
+			self.system.emit('log', 'module('+folder+')', 'error', 'Error loading module: '+ e);
 		}
 	}
 	else if (self.modules[folder] !== undefined) {


### PR DESCRIPTION
This would change execution from loading the main module scripts at launch to a just-in-time load during a validation check at instance add/activation.  With over 200 modules now it doesn't seem necessary to load all module code into RAM at launch.  Though there aren't major benefits either, so the usefulness of a change like this needs review.

Pros:
- ~5MB less RAM use
- Shorter launch speeds.

The RAM drop was from 381MB to 376MB on Win, so a 1% drop or effectively nothing.  The shorter launch speeds were perceivable on Windows, especially since the skeleton will normally hang for a brief period on launch.  This hang goes away completely.

Cons:
- A module add/activate may fail where-as an error related to the module may have shown in the logs at launch instead
- Such an error won't crash the program but will show a module error in the log at that time

This would be required long-term anyway if a shift to running instances in child processes is pursued.

This should be a `Squash and Merge`