### PR TITLE
Minor: ability to clear button image

### DIFF
--- a/lib/bank.js
+++ b/lib/bank.js
@@ -116,7 +116,7 @@ function bank(system) {
 				type: 'textinput',
 				id: 'text',
 				label: 'Text',
-				width: 7,
+				width: 6,
 				default: ''
 			},
 
@@ -142,7 +142,7 @@ function bank(system) {
 				id: 'png',
 				label: '72x58 PNG',
 				accept: 'image/png',
-				width: 2,
+				width: 3,
 				imageMinWidth: 72,
 				imageMinHeight: 58,
 				imageMaxWidth: 72,
@@ -340,6 +340,14 @@ function bank(system) {
 			client.emit('bank_set_png:result', 'ok');
 			system.emit('graphics_bank_invalidate', page, bank);
 		});
+
+		client.on('bank_clear_png', function(page, bank) {
+			delete self.config[page][bank].png64;
+			system.emit('bank_update', self.config);
+
+			client.emit('bank_clear_png:result');
+			system.emit('graphics_bank_invalidate', page, bank);
+		})
 
 		client.on('bank_changefield', function(page, bank, key, val) {
 			system.emit('bank_changefield', page, bank, key, val);

--- a/public/bank.js
+++ b/public/bank.js
@@ -146,6 +146,10 @@ $(function() {
 	function updateFromConfig(page, bank, config, updateText) {
 		$('.active_field[data-special="alignment"]').removeClass('active_color');
 
+		if (config.style === 'png') {
+			$('#clearPngButton')[0].disabled = config.png64 === undefined
+		}
+
 		$(".active_field").each(function() {
 
 			if ($(this).data('fieldid') !== undefined && config[$(this).data('fieldid')] !== undefined) {
@@ -315,9 +319,13 @@ $(function() {
 			}
 
 			else if (field.type == 'filepicker') {
-
 				var $p = $("<p><label>"+field.label+"</label><br></p>");
-				var $div = $("<div class='filechoosercontainer'><label class='btn btn-primary btn-file'>Browse <input type='file' data-fieldid='"+field.id+"' accept='" + field.accept + "' style='display: none;'></label></div>");
+				var $div = $(`
+					<div class='filechoosercontainer'>
+						<label class='btn btn-primary btn-file'>Browse <input type='file' data-fieldid='"+field.id+"' accept='" + field.accept + "' style='display: none;'></label>
+						<button class='btn btn-primary' id='clearPngButton'><i class='fa fa-trash'></i></button>
+					</div>
+				`);
 
 				$p.append($div);
 				$field.append($p);
@@ -339,6 +347,7 @@ $(function() {
 								alert('An error occured while uploading image');
 							} else {
 								bank_preview_page(p);
+								$('#clearPngButton')[0].disabled = false;
 							}
 						});
 					}, function () {
@@ -348,6 +357,18 @@ $(function() {
 						self.value = null;
 					});
 				});
+
+				$field.find('#clearPngButton').click(function () {
+					if (confirm("Clear image for this button?")) {
+						socket.emit('bank_clear_png', p, b);
+						socket.once('bank_clear_png:result', function () {
+							bank_preview_page(p);
+							$('#clearPngButton')[0].disabled = true;
+						});
+					}
+				});
+		
+		
 			}
 			$eb.append($field);
 

--- a/public/index.css
+++ b/public/index.css
@@ -704,3 +704,11 @@ input[type="range"].action-number.form-control {
 	padding-left: 0;
 	padding-right: 0;
 }
+
+.filechoosercontainer {
+	white-space: nowrap;
+}
+
+.filechoosercontainer #clearPngButton {
+	margin-bottom: -4px;
+}


### PR DESCRIPTION
Implementing feature requested in #1358

- adds a button next to the "Browse" image button to clear an existing image
- a confirmation dialog is displayed to confirm the removal action
- the button is disabled when instance button has no image

![image](https://user-images.githubusercontent.com/5514878/103770953-d1fcfd80-5061-11eb-9be6-702c430481ab.png)
