### PR TITLE
Patch: fixed reference to button config during page/bank config init

### DIFF
--- a/lib/bank.js
+++ b/lib/bank.js
@@ -243,7 +243,7 @@ function bank(system) {
 				if (self.config[x] === undefined) {
 					self.config[x] = {};
 					for (var y = 1; y <= global.MAX_BUTTONS; y++) {
-						if (self.config[y] === undefined) {
+						if (self.config[x][y] === undefined) {
 							self.config[x][y] = {};
 						}
 					}


### PR DESCRIPTION
I was in the middle of doing some research and I encountered this error. I'm not certain if it's causing any issues, but I figured we should fix it anyway.
