### PR TITLE
Changed buttons tab to be selected by default

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -197,7 +197,7 @@ href="https://join.slack.com/t/bitfocusio/shared_invite/enQtODk4NTYzNTkzMjU1LTMz
 								<ul class="nav nav-tabs" role="tablist">
 
 									<li class="nav-item">
-										<a class="nav-link active" data-toggle="tab" href="#instances" role="tab" aria-controls="instances">
+										<a class="nav-link" data-toggle="tab" href="#instances" role="tab" aria-controls="instances">
 											<i class="fa fa-plug"></i> Instances
 											<!-- <span class="badge badge-pill badge-success">OK</span> -->
 										</a>
@@ -210,7 +210,7 @@ href="https://join.slack.com/t/bitfocusio/shared_invite/enQtODk4NTYzNTkzMjU1LTMz
 
 
 									<li class="nav-item">
-										<a class="nav-link" data-toggle="tab" href="#elgatobuttons" id='elgbuttons' role="tab" aria-controls="home">
+										<a class="nav-link active" data-toggle="tab" href="#elgatobuttons" id='elgbuttons' role="tab" aria-controls="home">
 											<i class="fa fa-calendar-alt"></i> Buttons
 										</a>
 									</li>
@@ -234,7 +234,7 @@ href="https://join.slack.com/t/bitfocusio/shared_invite/enQtODk4NTYzNTkzMjU1LTMz
 								</ul>
 
 								<div class="tab-content padbottom">
-									<div class="tab-pane active" id="instances" role="tabpanel">
+									<div class="tab-pane" id="instances" role="tabpanel">
 										<h4>Connections / Instances</h4>
 										<p>Instances are the connections companion makes to other devices and software in order to control them.</p>
 
@@ -348,7 +348,7 @@ href="https://join.slack.com/t/bitfocusio/shared_invite/enQtODk4NTYzNTkzMjU1LTMz
 									</div>
 
 
-									<div class="tab-pane" id="elgatobuttons" role="tabpanel">
+									<div class="tab-pane active" id="elgatobuttons" role="tabpanel">
 										<h4>Button layout</h4>
 										<p>The squares below represent each button on your Streamdeck. Click on them to set up how you want them to look, and what they should do when you press or click on them.</p><p>You can navigate between pages using the arrow buttons, or by clicking the page number, typing in a number, and pressing 'Enter' on your keyboard.</p>
 


### PR DESCRIPTION
Title is pretty self explanatory. This is in reference to a thread on Slack (https://bitfocusio.slack.com/archives/CFG7HAN5N/p1611578947020100). I think I got everything changed that is needed. The web interface appears to be loading correctly with the buttons tab selected by default.