### PR TITLE
Adding an instance_status variable which gets emitted with instance e…

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -33,6 +33,7 @@ function instance(system) {
 	self.modules_name = {};
 	self.modules_main = {};
 	self.package_info = {};
+	self.instance_status = {};
 	self.status = {};
 
 	self.store = {
@@ -494,6 +495,7 @@ instance.prototype.calculateErrors = function (inst) {
 	self.numError = 0;
 	self.numWarn = 0;
 	self.numOk = 0;
+	self.instance_status = inst;
 
 	// levels: null = unknown, 0 = ok, 1 = warning, 2 = error
 	for (var i in inst) {
@@ -512,7 +514,7 @@ instance.prototype.calculateErrors = function (inst) {
 		
 	}
 
-	self.system.emit('instance_errorcount', [self.numOk, self.numWarn, self.numError] );
+	self.system.emit('instance_errorcount', [self.numOk, self.numWarn, self.numError, self.instance_status] );
 	
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "companion",
-	"version": "2.2.0",
+	"version": "2.3.0",
 	"description": "Companion",
 	"main": "electron.js",
 	"build": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "companion",
-	"version": "2.3.0",
+	"version": "2.2.0",
 	"description": "Companion",
 	"main": "electron.js",
 	"build": {


### PR DESCRIPTION
Added a variable to keep track of the status of each instance, which also gets emitted with instance_errors in calculateErrors.  This will be used in the bitfocus-companion module to provide instance-specific status feedback.