### PR TITLE
Stable 2.1 dockerfile should force download of branch 2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 # Bitfocus Companion
 
+## Companion v2.1.2 - Release Notes
+
+# 🐞 BUG FIXES
+- VideoLan VLC: apply default hostname
+
 ## Companion v2.1.1 - Release Notes
 
 # 📣 ADDED CORE FEATURES

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH="$HOME/.yarn/bin:$PATH"
 
 # Clone repository and set as workdir 
 RUN cd /root && \
-    git clone https://github.com/bitfocus/companion.git && \
+    git clone --branch stable-2.1 https://github.com/bitfocus/companion.git && \
     mv companion/.[!.]* . && \
     mv companion/* . && \
     rm -rf companion && \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "companion",
-	"version": "2.2.0",
+	"version": "2.1.2",
 	"description": "Companion",
 	"main": "bitfocus-skeleton/main.js",
 	"build": {


### PR DESCRIPTION
If   --branch stable-2.1 is not added to the dockerfile, this branch simply downloads the latest master version, which is NOT 2.1. This PR fixes this by changing to 
` git clone --branch stable-2.1 https://github.com/bitfocus/companion.git`