### PR TITLE
Stable 2.1 dockerfile should force download of branch 2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH="$HOME/.yarn/bin:$PATH"
 
 # Clone repository and set as workdir 
 RUN cd /root && \
-    git clone https://github.com/bitfocus/companion.git && \
+    git clone --branch stable-2.1 https://github.com/bitfocus/companion.git && \
     mv companion/.[!.]* . && \
     mv companion/* . && \
     rm -rf companion && \


### PR DESCRIPTION
If --branch stable-2.1 is not added to the dockerfile, this branch simply downloads the latest master version, which is NOT 2.1. This PR fixes this by changing to
git clone --branch stable-2.1 https://github.com/bitfocus/companion.git