### PR TITLE
Add ability for non-latch button to abort up acts

### DIFF
--- a/lib/action.js
+++ b/lib/action.js
@@ -426,22 +426,22 @@ function action(system) {
 					// is this a timedelayed action?
 					if (delay > 0) {
 						has_delayed = true
-						;(function (action, delay_time) {
-							var timer = setTimeout(function () {
-								self.system.emit('action_run', action, { deviceid: deviceid, page: page, bank: bank })
+							(function (action, delay_time) {
+								var timer = setTimeout(function () {
+									self.system.emit('action_run', action, { deviceid: deviceid, page: page, bank: bank })
 
-								self.timers_running.delete(timer)
+									self.timers_running.delete(timer)
 
-								// Stop timer-indication
-								const hasAnotherTimer = Array.from(self.timers_running.values()).find((v) => v === bankId)
-								if (hasAnotherTimer === undefined) {
-									self.actions_running.delete(bankId)
-									self.system.emit('graphics_bank_invalidate', page, bank)
-								}
-							}, delay_time)
+									// Stop timer-indication
+									const hasAnotherTimer = Array.from(self.timers_running.values()).find((v) => v === bankId)
+									if (hasAnotherTimer === undefined) {
+										self.actions_running.delete(bankId)
+										self.system.emit('graphics_bank_invalidate', page, bank)
+									}
+								}, delay_time)
 
-							self.timers_running.set(timer, bankId)
-						})(a, delay)
+								self.timers_running.set(timer, bankId)
+							})(a, delay)
 					}
 
 					// or is it immediate

--- a/lib/action.js
+++ b/lib/action.js
@@ -268,6 +268,9 @@ function action(system) {
 		}
 	})
 
+	// skipUp needed to abort 'up' actions on non-latch buttons
+	var skipUp = {};
+
 	// If a user wants to abort a single button actions
 	self.system.on('action_abort_bank', function (page, bank, unlatch) {
 		var bid = page + '_' + bank
@@ -289,6 +292,7 @@ function action(system) {
 		// if requested, reset and skip up-actions
 		if (unlatch) {
 			self.system.emit('graphics_indicate_push', page, bank, false)
+			skipUp[page + '_' + bank] = true;
 		}
 
 		if (cleared > 0) {
@@ -302,13 +306,13 @@ function action(system) {
 
 	self.system.on('bank_pressed', function (page, bank, direction, deviceid) {
 		var bank_config
+		var pb = page + '_' + bank
 
 		system.emit('get_bank', page, bank, function (config) {
 			bank_config = config
 		})
 
 		if (bank_config.latch) {
-			var pb = page + '_' + bank
 
 			if (deviceid == undefined) {
 				// web buttons and osc don't set deviceid
@@ -345,6 +349,13 @@ function action(system) {
 			if (reject) {
 				//debug("Latch button duplicate " + (direction? "down":"up") )
 				return
+			}
+		}
+
+		if (skipUp[pb]) {
+			delete skipUp[pb];
+			if (!bank_config.latch) {
+				return;
 			}
 		}
 


### PR DESCRIPTION
Allows `Unlatch?` option for `Abort actions on button` to also skip up-actions on non-latch buttons.
Provides feature requested in #1496 