### PR TITLE
Prevent an instance from being enabled if it is already running

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -378,38 +378,48 @@ function instance(system) {
 	})
 
 	system.on('instance_enable', function (id, state) {
-		self.system.emit(
-			'log',
-			'instance(' + id + ')',
-			'info',
-			(state ? 'Enable' : 'Disable') + ' instance ' + self.store.db[id].label
-		)
-		self.store.db[id].enabled = state
+		if(self.store.db[id].enabled !== state){
+			self.system.emit(
+				'log',
+				'instance(' + id + ')',
+				'info',
+				(state ? 'Enable' : 'Disable') + ' instance ' + self.store.db[id].label
+			)
+			self.store.db[id].enabled = state
 
-		if (state === true) {
-			system.emit('instance_status_update', id, null, 'Enabling')
-		} else {
-			system.emit('instance_status_update', id, -1, 'Disabled')
-		}
-
-		if (state === false) {
-			if (
-				self.active[id] !== undefined &&
-				self.active[id].destroy !== undefined &&
-				typeof self.active[id].destroy == 'function'
-			) {
-				try {
-					self.active[id].destroy()
-				} catch (e) {
-					self.system.emit('log', 'instance(' + id + ')', 'warn', 'Error disabling instance: ' + e.message)
-				}
-				delete self.active[id]
+			if (state === true) {
+				system.emit('instance_status_update', id, null, 'Enabling')
+			} else {
+				system.emit('instance_status_update', id, -1, 'Disabled')
 			}
-		} else {
-			self.activate_module(id)
-		}
 
-		self.system.emit('instance_save')
+			if (state === false) {
+				if (
+					self.active[id] !== undefined &&
+					self.active[id].destroy !== undefined &&
+					typeof self.active[id].destroy == 'function'
+				) {
+					try {
+						self.active[id].destroy()
+					} catch (e) {
+						self.system.emit('log', 'instance(' + id + ')', 'warn', 'Error disabling instance: ' + e.message)
+					}
+					delete self.active[id]
+				}
+			} else {
+				self.activate_module(id)
+			}
+
+			self.system.emit('instance_save')
+		}
+		else{
+			if (state === true) {
+				self.system.emit('log', 'instance(' + id + ')', 'warn', 'Attempting to enable module that is alredy enabled')
+			}
+			else{
+				self.system.emit('log', 'instance(' + id + ')', 'warn', 'Attempting to disable module that is alredy disabled')
+			}
+		}
 	})
 
 	return self


### PR DESCRIPTION
This pull request prevents an instance from being enabled if it is already running. An already running instance could have been enabled by a button action and it would create a second instance that could not be disabled.