### PR TITLE
feat: boolean feedbacks

### DIFF
--- a/instance_skel.d.ts
+++ b/instance_skel.d.ts
@@ -9,6 +9,7 @@ import {
 	CompanionFeedbackEvent,
 	CompanionFeedbackResult,
 	CompanionUpgradeScript,
+	CompanionUpgradeToBooleanFeedbackMap,
 	CompanionActionEventInfo,
 	CompanionFeedbackEventInfo,
 } from './instance_skel_types'
@@ -67,6 +68,12 @@ declare abstract class InstanceSkel<TConfig> {
 	saveConfig(): void
 
 	addUpgradeScript(fcn: CompanionUpgradeScript<TConfig>): void
+	/**
+	 * A helper script to automate the bulk of the process to upgrade feedbacks from 'advanced' to 'boolean'.
+	 * There are some built in rules for properties names based on the most common cases
+	 * @param upgradeMap The feedbacks to upgrade and the properties to convert
+	 */
+	addUpgradeToBooleanFeedbackScript(upgradeMap: CompanionUpgradeToBooleanFeedbackMap): void
 
 	setActions(actions: CompanionActions): void
 	setVariableDefinitions(variables: CompanionVariable[]): void

--- a/instance_skel.js
+++ b/instance_skel.js
@@ -196,6 +196,34 @@ instance.prototype.saveConfig = function () {
 	self.system.emit('instance_config_put', self.id, self.config, true)
 }
 
+instance.prototype.addUpgradeToBooleanFeedbackScript = function (upgrade_map) {
+	var self = this
+
+	self.addUpgradeScript(function (config, actions, release_cctions, feedbacks) {
+		for (const feedback of feedbacks) {
+			let upgrade_rules = upgrade_map[feedback.type]
+			if (upgrade_rules === true) {
+				// These are some automated built in rules. They can help make it easier to migrate
+				upgrade_rules = {
+					bg: 'bgcolor',
+					fg: 'color',
+				}
+			}
+
+			if (upgrade_rules) {
+				if (!feedback.style) feedback.style = {}
+
+				for (const [option_key, style_key] of Object.entries(upgrade_rules)) {
+					if (feedback.options[option_key] !== undefined) {
+						feedback.style[style_key] = feedback.options[option_key]
+						delete feedback.options[option_key]
+					}
+				}
+			}
+		}
+	})
+}
+
 instance.prototype.addUpgradeScript = function (cb) {
 	var self = this
 

--- a/instance_skel_types.d.ts
+++ b/instance_skel_types.d.ts
@@ -30,19 +30,27 @@ export interface CompanionBankRequiredProps {
 	color: number
 	bgcolor: number
 }
-export interface CompanionBankAdditionalProps {
+export interface CompanionBankAdditionalStyleProps {
 	alignment: CompanionAlignment
 	pngalignment: CompanionAlignment
 	png64?: string
+}
+export interface CompanionBankAdditionalCoreProps {
 	latch: boolean
 	relative_delay: boolean
 }
 
-export interface CompanionBankPNG extends CompanionBankRequiredProps, CompanionBankAdditionalProps {
+export interface CompanionBankPNG
+	extends CompanionBankRequiredProps,
+		CompanionBankAdditionalStyleProps,
+		CompanionBankAdditionalCoreProps {
 	style: 'png'
 }
 
-export interface CompanionBankPreset extends CompanionBankRequiredProps, Partial<CompanionBankAdditionalProps> {
+export interface CompanionBankPreset
+	extends CompanionBankRequiredProps,
+		Partial<CompanionBankAdditionalStyleProps>,
+		Partial<CompanionBankAdditionalCoreProps> {
 	style: 'png' | 'text' // 'text' for backwards compatability
 }
 
@@ -162,18 +170,25 @@ export interface CompanionVariable {
 	label: string
 	name: string
 }
-export interface CompanionFeedback {
+
+export interface CompanionFeedbackBase<TRes> {
+	type?: 'boolean' | 'advanced'
 	label: string
 	description: string
 	options: SomeCompanionInputField[]
-	callback?: (
-		feedback: CompanionFeedbackEvent,
-		bank: CompanionBankPNG,
-		info: CompanionFeedbackEventInfo
-	) => CompanionFeedbackResult
+	callback?: (feedback: CompanionFeedbackEvent, bank: CompanionBankPNG, info: CompanionFeedbackEventInfo) => TRes
 	subscribe?: (feedback: CompanionFeedbackEvent) => void
 	unsubscribe?: (feedback: CompanionFeedbackEvent) => void
 }
+export interface CompanionFeedbackBoolean extends CompanionFeedbackBase<boolean> {
+	type: 'boolean'
+	style: Partial<CompanionBankRequiredProps & CompanionBankAdditionalStyleProps>
+}
+export interface CompanionFeedbackAdvanced extends CompanionFeedbackBase<CompanionFeedbackResult> {
+	type?: 'advanced'
+}
+export type CompanionFeedback = CompanionFeedbackBoolean | CompanionFeedbackAdvanced
+
 export interface CompanionPreset {
 	category: string
 	label: string
@@ -181,6 +196,7 @@ export interface CompanionPreset {
 	feedbacks: Array<{
 		type: string
 		options: { [key: string]: InputValue | undefined }
+		style?: Partial<CompanionBankRequiredProps & CompanionBankAdditionalStyleProps>
 	}>
 	actions: Array<{
 		action: string

--- a/instance_skel_types.d.ts
+++ b/instance_skel_types.d.ts
@@ -222,6 +222,16 @@ export type CompanionUpgradeScript<TConfig> = (
 	feedbacks: CompanionMigrationFeedback[]
 ) => boolean
 
+export interface CompanionUpgradeToBooleanFeedbackMap {
+	[feedback_id: string]:
+		| true
+		| {
+				// Option name to style property
+				[option_key: string]: 'text' | 'size' | 'color' | 'bgcolor' | 'alignment' | 'pngalignment' | 'png64'
+		  }
+		| undefined
+}
+
 export interface CompanionCoreInstanceconfig {
 	instance_type: string
 	label: string

--- a/lib/feedback.js
+++ b/lib/feedback.js
@@ -197,27 +197,17 @@ function feedback(system) {
 								}
 
 								try {
-									function handleResult(result) {
-										if ((definition && definition.type === 'boolean') || typeof result === 'boolean') {
-											if (result) {
-												self.setStyle(page, bank, i, { ...feedback.style })
-											} else {
-												self.setStyle(page, bank, i, {})
-											}
-										} else {
-											self.setStyle(page, bank, i, result)
-										}
-									}
-
 									// Ask instance to check bank for custom styling
 									if (
 										definition !== undefined &&
 										definition.callback !== undefined &&
 										typeof definition.callback == 'function'
 									) {
-										handleResult(definition.callback(feedback, bank_obj, { page: page, bank: bank }))
+										const result = definition.callback(feedback, bank_obj, { page: page, bank: bank })
+										self.setStyle(page, bank, i, definition, feedback, result)
 									} else if (typeof instance.feedback == 'function') {
-										handleResult(instance.feedback(feedback, bank_obj, { page: page, bank: bank }))
+										const result = instance.feedback(feedback, bank_obj, { page: page, bank: bank })
+										self.setStyle(page, bank, i, definition, feedback, result)
 									} else {
 										debug('ERROR: instance ' + instance.label + ' does not have a feedback() function')
 									}
@@ -534,8 +524,16 @@ feedback.prototype.unsubscribeFeedback = function (feedback) {
 	}
 }
 
-feedback.prototype.setStyle = function (page, bank, index, style) {
+feedback.prototype.setStyle = function (page, bank, index, definition, feedback, style) {
 	var self = this
+
+	if ((definition && definition.type === 'boolean') || typeof style === 'boolean') {
+		if (style) {
+			style = { ...feedback.style }
+		} else {
+			style = {}
+		}
+	}
 
 	if (self.feedback_styles[page] === undefined) {
 		self.feedback_styles[page] = {}

--- a/lib/feedback.js
+++ b/lib/feedback.js
@@ -197,17 +197,27 @@ function feedback(system) {
 								}
 
 								try {
+									function handleResult(result) {
+										if ((definition && definition.type === 'boolean') || typeof result === 'boolean') {
+											if (result) {
+												self.setStyle(page, bank, i, { ...feedback.style })
+											} else {
+												self.setStyle(page, bank, i, {})
+											}
+										} else {
+											self.setStyle(page, bank, i, result)
+										}
+									}
+
 									// Ask instance to check bank for custom styling
 									if (
 										definition !== undefined &&
 										definition.callback !== undefined &&
 										typeof definition.callback == 'function'
 									) {
-										var result = definition.callback(feedback, bank_obj, { page: page, bank: bank })
-										self.setStyle(page, bank, i, result)
+										handleResult(definition.callback(feedback, bank_obj, { page: page, bank: bank }))
 									} else if (typeof instance.feedback == 'function') {
-										var result = instance.feedback(feedback, bank_obj, { page: page, bank: bank })
-										self.setStyle(page, bank, i, result)
+										handleResult(instance.feedback(feedback, bank_obj, { page: page, bank: bank }))
 									} else {
 										debug('ERROR: instance ' + instance.label + ' does not have a feedback() function')
 									}
@@ -392,6 +402,94 @@ function feedback(system) {
 
 		client.on('feedback_get_definitions', function () {
 			client.emit('feedback_get_definitions:result', self.feedback_definitions)
+		})
+
+		client.on('bank_update_feedback_style_selection', function (page, bank, feedbackid, selected, answer) {
+			debug('bank_update_feedback_style_selection', page, bank, feedbackid, selected)
+			var feedbacks = self.feedbacks[page][bank]
+			if (feedbacks !== undefined) {
+				system.emit('get_bank', page, bank, function (bank_obj) {
+					for (var n in feedbacks) {
+						const feedback = feedbacks[n]
+						if (feedback !== undefined && feedback.id === feedbackid) {
+							const oldStyle = feedback.style || {}
+							const newStyle = {}
+							for (const key of selected) {
+								if (key in oldStyle) {
+									// preserve existing value
+									newStyle[key] = oldStyle[key]
+								} else {
+									// copy bank value, as a default
+									newStyle[key] = bank_obj[key]
+
+									// png needs to be set to something harmless
+									if (key === 'png64' && !newStyle[key]) {
+										newStyle[key] = null
+									}
+								}
+							}
+							feedback.style = newStyle
+
+							self.system.emit('feedback_save')
+							self.system.emit('feedback_instanceid_check', feedback.instance_id)
+
+							break
+						}
+					}
+
+					answer(page, bank, feedbacks)
+				})
+			}
+		})
+
+		client.on('bank_update_feedback_style_set', function (page, bank, feedbackid, key, value, answer) {
+			debug('bank_update_feedback_style_set', page, bank, feedbackid, key, value)
+			var feedbacks = self.feedbacks[page][bank]
+			if (feedbacks !== undefined) {
+				for (var n in feedbacks) {
+					const feedback = feedbacks[n]
+					if (feedback !== undefined && feedback.id === feedbackid) {
+						if (!feedback.style) feedback.style = {}
+						feedback.style[key] = value
+
+						self.system.emit('feedback_save')
+						self.system.emit('feedback_instanceid_check', feedback.instance_id)
+
+						answer(page, bank, feedbacks)
+
+						break
+					}
+				}
+			}
+		})
+
+		client.on('bank_update_feedback_style_set_png', function (page, bank, feedbackid, dataurl, answer) {
+			debug('bank_update_feedback_style_set_png', page, bank, feedbackid)
+
+			if (!dataurl.match(/data:.*?image\/png/)) {
+				return
+			}
+
+			var data = dataurl.replace(/^.*base64,/, '')
+
+			var feedbacks = self.feedbacks[page][bank]
+			if (feedbacks !== undefined) {
+				for (var n in feedbacks) {
+					const feedback = feedbacks[n]
+					if (feedback !== undefined && feedback.id === feedbackid) {
+						if (!feedback.style) feedback.style = {}
+
+						feedback.style.png64 = data
+
+						self.system.emit('feedback_save')
+						self.system.emit('feedback_instanceid_check', feedback.instance_id)
+
+						answer(page, bank, feedbacks)
+
+						break
+					}
+				}
+			}
 		})
 	})
 }

--- a/lib/feedback.js
+++ b/lib/feedback.js
@@ -325,6 +325,7 @@ function feedback(system) {
 				type: s[1],
 				instance_id: s[0],
 				options: {},
+				style: {},
 			}
 
 			if (!self.instance.store.db[fb.instance_id]) {
@@ -341,14 +342,19 @@ function feedback(system) {
 						fb.options[opt.id] = opt.default
 					}
 				}
+
+				if (definition.type === 'boolean' && definition.style) {
+					fb.style = { ...definition.style }
+				}
 			}
 
 			self.feedbacks[page][bank].push(fb)
 			self.subscribeFeedback(fb)
 
 			system.emit('feedback_save')
+			self.system.emit('feedback_instanceid_check', feedback.instance_id)
+
 			sendResult(answer, 'bank_get_feedbacks:result', page, bank, self.feedbacks[page][bank])
-			// feedback_instance_check will be called as the options get filled in
 		})
 
 		client.on('bank_delFeedback', function (page, bank, id, answer) {

--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -260,7 +260,7 @@ graphics.prototype.drawBankImage = function (c, page, bank) {
 	}
 
 	if (c.style == 'png' || c.style == 'text') {
-		if (c.png64 !== undefined) {
+		if (c.png64 !== undefined && c.png64 !== null) {
 			try {
 				var data = Buffer.from(c.png64, 'base64')
 				var halign = c.pngalignment.split(':', 2)[0]

--- a/webui/src/Buttons/EditButton/ButtonStyleConfig.jsx
+++ b/webui/src/Buttons/EditButton/ButtonStyleConfig.jsx
@@ -49,12 +49,6 @@ export function ButtonStyleConfig({ page, bank, config, valueChanged }) {
 		[context.socket, page, bank, valueChanged, config]
 	)
 
-	const setTextValue = useCallback((val) => setValueInner('text', val), [setValueInner])
-	const setSizeValue = useCallback((val) => setValueInner('size', val), [setValueInner])
-	const setAlignmentValue = useCallback((val) => setValueInner('alignment', val), [setValueInner])
-	const setPngAlignmentValue = useCallback((val) => setValueInner('pngalignment', val), [setValueInner])
-	const setColorValue = useCallback((val) => setValueInner('color', val), [setValueInner])
-	const setBackgroundColorValue = useCallback((val) => setValueInner('bgcolor', val), [setValueInner])
 	const setLatchValue = useCallback((val) => setValueInner('latch', val), [setValueInner])
 	const setRelativeDelayValue = useCallback((val) => setValueInner('relative_delay', val), [setValueInner])
 
@@ -87,67 +81,14 @@ export function ButtonStyleConfig({ page, bank, config, valueChanged }) {
 
 			<CForm inline>
 				<CRow form className="button-style-form">
-					<CCol className="fieldtype-textinput" sm={6}>
-						<label>Button text</label>
-						<TextWithVariablesInputField
-							definition={{ default: '', tooltip: 'Button text' }}
-							setValue={setTextValue}
-							value={config.text}
-						/>
-					</CCol>
-
-					<CCol className="fieldtype-dropdown" sm={3} xs={6}>
-						<label>Font size</label>
-						<DropdownInputField
-							definition={{ default: 'auto', choices: FONT_SIZES }}
-							setValue={setSizeValue}
-							value={config.size}
-						/>
-					</CCol>
-
-					<CCol sm={3} xs={6}>
-						<label>72x58 PNG</label>
-						<CButtonGroup className="png-browse">
-							<PNGInputField
-								onSelect={setPng}
-								onError={setPngError}
-								definition={{ min: { width: 72, height: 58 }, max: { width: 72, height: 58 } }}
-							/>
-							<CButton color="danger" disabled={!config.png64} onClick={clearPng}>
-								<FontAwesomeIcon icon={faTrash} />
-							</CButton>
-						</CButtonGroup>
-					</CCol>
-
-					<CCol className="fieldtype-alignment" sm={2} xs={3}>
-						<label>Text Alignment</label>
-						<AlignmentInputField
-							definition={{ default: 'center:center' }}
-							setValue={setAlignmentValue}
-							value={config.alignment}
-						/>
-					</CCol>
-					<CCol className="fieldtype-alignment" sm={2} xs={3}>
-						<label>PNG Alignment</label>
-						<AlignmentInputField
-							definition={{ default: 'center:center' }}
-							setValue={setPngAlignmentValue}
-							value={config.pngalignment}
-						/>
-					</CCol>
-
-					<CCol className="fieldtype-colorpicker" sm={2} xs={3}>
-						<label>Color</label>
-						<ColorInputField definition={{ default: 0xffffff }} setValue={setColorValue} value={config.color} />
-					</CCol>
-					<CCol className="fieldtype-colorpicker" sm={2} xs={3}>
-						<label>Background</label>
-						<ColorInputField
-							definition={{ default: 0x000000 }}
-							setValue={setBackgroundColorValue}
-							value={config.bgcolor}
-						/>
-					</CCol>
+					<ButtonStyleConfigFields
+						values={config}
+						setValueInner={setValueInner}
+						setPng={setPng}
+						setPngError={setPngError}
+						clearPng={clearPng}
+						controlTemplate={ControlWrapper}
+					/>
 
 					<CCol className="fieldtype-checkbox" sm={2} xs={3}>
 						<label>Latch/Toggle</label>
@@ -172,5 +113,115 @@ export function ButtonStyleConfig({ page, bank, config, valueChanged }) {
 				</CRow>
 			</CForm>
 		</CCol>
+	)
+}
+
+function ControlWrapper(id, props, contents) {
+	return <CCol {...props}>{contents}</CCol>
+}
+
+export function ButtonStyleConfigFields({ values, setValueInner, setPng, setPngError, clearPng, controlTemplate }) {
+	const setTextValue = useCallback((val) => setValueInner('text', val), [setValueInner])
+	const setSizeValue = useCallback((val) => setValueInner('size', val), [setValueInner])
+	const setAlignmentValue = useCallback((val) => setValueInner('alignment', val), [setValueInner])
+	const setPngAlignmentValue = useCallback((val) => setValueInner('pngalignment', val), [setValueInner])
+	const setColorValue = useCallback((val) => setValueInner('color', val), [setValueInner])
+	const setBackgroundColorValue = useCallback((val) => setValueInner('bgcolor', val), [setValueInner])
+
+	return (
+		<>
+			{controlTemplate(
+				'text',
+				{ sm: 6 },
+				<>
+					<label>Button text</label>
+					<TextWithVariablesInputField
+						definition={{ default: '', tooltip: 'Button text' }}
+						setValue={setTextValue}
+						value={values.text}
+					/>
+				</>
+			)}
+
+			{controlTemplate(
+				'size',
+				{ sm: 3, xs: 6 },
+				<>
+					<label>Font size</label>
+					<DropdownInputField
+						definition={{ default: 'auto', choices: FONT_SIZES }}
+						setValue={setSizeValue}
+						value={values.size}
+					/>
+				</>
+			)}
+
+			{controlTemplate(
+				'png64',
+				{ sm: 3, xs: 6 },
+				<>
+					<label>72x58 PNG</label>
+					<CButtonGroup className="png-browse">
+						<PNGInputField
+							onSelect={setPng}
+							onError={setPngError}
+							definition={{ min: { width: 72, height: 58 }, max: { width: 72, height: 58 } }}
+						/>
+						{clearPng ? (
+							<CButton color="danger" disabled={!values.png64} onClick={clearPng}>
+								<FontAwesomeIcon icon={faTrash} />
+							</CButton>
+						) : (
+							''
+						)}
+					</CButtonGroup>
+				</>
+			)}
+			{controlTemplate(
+				'alignment',
+				{ sm: 2, xs: 3 },
+				<>
+					<label>Text Alignment</label>
+					<AlignmentInputField
+						definition={{ default: 'center:center' }}
+						setValue={setAlignmentValue}
+						value={values.alignment}
+					/>
+				</>
+			)}
+			{controlTemplate(
+				'pngalignment',
+				{ sm: 2, xs: 3 },
+				<>
+					<label>PNG Alignment</label>
+					<AlignmentInputField
+						definition={{ default: 'center:center' }}
+						setValue={setPngAlignmentValue}
+						value={values.pngalignment}
+					/>
+				</>
+			)}
+
+			{controlTemplate(
+				'color',
+				{ sm: 2, xs: 3 },
+				<>
+					<label>Color</label>
+					<ColorInputField definition={{ default: 0xffffff }} setValue={setColorValue} value={values.color} />
+				</>
+			)}
+			{controlTemplate(
+				'bgcolor',
+				{ sm: 2, xs: 3 },
+				<>
+					<label>Background</label>
+					<ColorInputField
+						definition={{ default: 0x000000 }}
+						setValue={setBackgroundColorValue}
+						value={values.bgcolor}
+					/>
+				</>
+			)}
+		</>
 	)
 }

--- a/webui/src/Buttons/EditButton/FeedbackPanel.jsx
+++ b/webui/src/Buttons/EditButton/FeedbackPanel.jsx
@@ -1,4 +1,4 @@
-import { CAlert, CButton, CForm, CFormGroup, CLabel } from '@coreui/react'
+import { CAlert, CButton, CForm, CFormGroup } from '@coreui/react'
 import { faSort, faTrash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
@@ -300,7 +300,7 @@ function FeedbackManageStyles({ bankFeedbacksChanged, feedbackSpec, feedback, pa
 				<CForm>
 					<MyErrorBoundary>
 						<CFormGroup>
-							<label>Select properties</label>
+							<label>Change style properties</label>
 							<DropdownInputField
 								multiple={true}
 								definition={{ default: ['color', 'bgcolor'], choices: choices }}

--- a/webui/src/Buttons/EditButton/FeedbackPanel.jsx
+++ b/webui/src/Buttons/EditButton/FeedbackPanel.jsx
@@ -1,4 +1,4 @@
-import { CButton, CForm } from '@coreui/react'
+import { CAlert, CButton, CForm, CFormGroup, CLabel } from '@coreui/react'
 import { faSort, faTrash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
@@ -8,6 +8,8 @@ import Select from 'react-select'
 import { ActionTableRowOption } from './Table'
 import { useDrag, useDrop } from 'react-dnd'
 import { GenericConfirmModal } from '../../Components/GenericConfirmModal'
+import { DropdownInputField } from '../../Components'
+import { ButtonStyleConfigFields } from './ButtonStyleConfig'
 
 export const FeedbacksPanel = function ({
 	page,
@@ -120,11 +122,14 @@ export const FeedbacksPanel = function ({
 						<FeedbackTableRow
 							key={a?.id ?? i}
 							index={i}
+							page={page}
+							bank={bank}
 							feedback={a}
 							setValue={setValue}
 							doDelete={doDelete}
 							dragId={dragId}
 							moveCard={moveCard}
+							bankFeedbacksChanged={setFeedbacks}
 						/>
 					))}
 				</tbody>
@@ -135,7 +140,7 @@ export const FeedbacksPanel = function ({
 	)
 }
 
-function FeedbackTableRow({ feedback, index, dragId, moveCard, setValue, doDelete }) {
+function FeedbackTableRow({ feedback, page, bank, index, dragId, moveCard, setValue, doDelete, bankFeedbacksChanged }) {
 	const context = useContext(CompanionContext)
 
 	const innerDelete = useCallback(() => doDelete(feedback.id), [feedback.id, doDelete])
@@ -242,10 +247,149 @@ function FeedbackTableRow({ feedback, index, dragId, moveCard, setValue, doDelet
 							{options.length === 0 ? 'Nothing to configure' : ''}
 						</CForm>
 					</div>
+					<FeedbackStyles
+						feedbackSpec={feedbackSpec}
+						feedback={feedback}
+						page={page}
+						bank={bank}
+						bankFeedbacksChanged={bankFeedbacksChanged}
+					/>
+					<FeedbackManageStyles
+						feedbackSpec={feedbackSpec}
+						feedback={feedback}
+						page={page}
+						bank={bank}
+						bankFeedbacksChanged={bankFeedbacksChanged}
+					/>
 				</div>
 			</td>
 		</tr>
 	)
+}
+
+function FeedbackManageStyles({ bankFeedbacksChanged, feedbackSpec, feedback, page, bank }) {
+	const context = useContext(CompanionContext)
+
+	const setSelected = useCallback(
+		(selected) => {
+			socketEmit(context.socket, 'bank_update_feedback_style_selection', [page, bank, feedback.id, selected])
+				.then(([_page, _bank, bankFeedbacks]) => {
+					bankFeedbacksChanged(bankFeedbacks)
+				})
+				.catch((e) => {
+					// TODO
+				})
+		},
+		[context.socket, page, bank, feedback.id, bankFeedbacksChanged]
+	)
+
+	if (feedbackSpec.type === 'boolean') {
+		const choices = [
+			{ id: 'text', label: 'Text' },
+			{ id: 'size', label: 'Font Size' },
+			{ id: 'png64', label: 'PNG' },
+			{ id: 'alignment', label: 'Text Alignment' },
+			{ id: 'pngalignment', label: 'PNG Alignment' },
+			{ id: 'color', label: 'Color' },
+			{ id: 'bgcolor', label: 'Background' },
+		]
+		const currentValue = Object.keys(feedback.style || {})
+
+		return (
+			<div className="cell-styles-manage">
+				<CForm>
+					<MyErrorBoundary>
+						<CFormGroup>
+							<label>Select properties</label>
+							<DropdownInputField
+								multiple={true}
+								definition={{ default: ['color', 'bgcolor'], choices: choices }}
+								setValue={setSelected}
+								value={currentValue}
+							/>
+						</CFormGroup>
+					</MyErrorBoundary>
+				</CForm>
+			</div>
+		)
+	} else {
+		return ''
+	}
+}
+
+function FeedbackStyles({ feedbackSpec, feedback, page, bank, bankFeedbacksChanged }) {
+	const context = useContext(CompanionContext)
+
+	const setValue = useCallback(
+		(key, value) => {
+			socketEmit(context.socket, 'bank_update_feedback_style_set', [page, bank, feedback.id, key, value])
+				.then(([_page, _bank, bankFeedbacks]) => {
+					bankFeedbacksChanged(bankFeedbacks)
+				})
+				.catch((e) => {
+					console.error('Failed to update feedback style', e)
+				})
+		},
+		[context.socket, page, bank, feedback.id, bankFeedbacksChanged]
+	)
+	const [pngError, setPngError] = useState(null)
+	const clearPngError = useCallback(() => setPngError(null), [])
+	const setPng = useCallback(
+		(data) => {
+			setPngError(null)
+			socketEmit(context.socket, 'bank_update_feedback_style_set_png', [page, bank, feedback.id, data])
+				.then(([_page, _bank, bankFeedbacks]) => {
+					setPngError(null)
+					bankFeedbacksChanged(bankFeedbacks)
+				})
+				.catch((e) => {
+					console.error('Failed to upload png', e)
+					setPngError('Failed to set png')
+				})
+		},
+		[context.socket, page, bank, feedback.id, bankFeedbacksChanged]
+	)
+
+	if (feedbackSpec.type === 'boolean') {
+		const currentStyle = feedback.style || {}
+
+		const FeedbackStyleControlWrapper = (id, props, contents) => {
+			if (id in currentStyle) {
+				return (
+					<MyErrorBoundary>
+						<CFormGroup>{contents}</CFormGroup>
+					</MyErrorBoundary>
+				)
+			} else {
+				return ''
+			}
+		}
+
+		return (
+			<div className="cell-styles">
+				<CForm>
+					{pngError ? (
+						<CAlert color="warning" closeButton>
+							{pngError}
+						</CAlert>
+					) : (
+						''
+					)}
+
+					<ButtonStyleConfigFields
+						values={currentStyle}
+						setValueInner={setValue}
+						setPng={setPng}
+						setPngError={clearPngError}
+						controlTemplate={FeedbackStyleControlWrapper}
+					/>
+					{Object.keys(currentStyle).length === 0 ? 'Feedback has no effect. Try adding a property to override' : ''}
+				</CForm>
+			</div>
+		)
+	} else {
+		return ''
+	}
 }
 
 function AddFeedbackDropdown({ onSelect }) {

--- a/webui/src/scss/_button-edit.scss
+++ b/webui/src/scss/_button-edit.scss
@@ -66,6 +66,19 @@ table.feedback-table {
 			grid-row: 1 / 4;
 			grid-column: 2;
 		}
+
+		.cell-styles {
+			grid-row: 5;
+			grid-column: 2;
+
+			.png-browse {
+				display: block;
+			}
+		}
+		.cell-styles-manage {
+			grid-row: 5;
+			grid-column: 1;
+		}
 	}
 
 	// Give a border the bottom of the table. based on the table.td rule from coreui


### PR DESCRIPTION
Fixes #1543

Feedbacks are currently responsible for returning an object of the style properties that they should change. This means it is not easily possible to choose what properties a feedback will change.

With this change, feedbacks can state that they will instead return a boolean value (the existing flow is called advanced, as it is still useful for advanced feedbacks such as showing a generated png).
These 'boolean' feedbacks then have their styling effect managed by core. The ui can dynamically change the properties being set based on what the user selects.

![image](https://user-images.githubusercontent.com/1327476/115449414-b1bd0d00-a212-11eb-8b88-4f458ce07980.png)
(ui might want some attention to make it pretty, I have gone for functional and easy to implement.

## Module feedback definition
### Before
![image](https://user-images.githubusercontent.com/1327476/115449994-4aec2380-a213-11eb-8b40-85aff9f4ab5e.png)

### After
![image](https://user-images.githubusercontent.com/1327476/115449903-2ee88200-a213-11eb-8a3d-1a033fa9432f.png)


This is a start towards some of the ideas in https://github.com/bitfocus/companion/issues/1205