### PR TITLE
fix: improve UI scaling on bigger screens + minor tweeks

### DIFF
--- a/webui/src/Buttons/Variables.jsx
+++ b/webui/src/Buttons/Variables.jsx
@@ -69,7 +69,7 @@ function VariablesList({ selectedInstanceLabel, setInstance }) {
 	const doBack = useCallback(() => setInstance(null), [setInstance])
 
 	return (
-		<div>
+		<div className="variables-panel">
 			<h5>
 				<CButton color="primary" size="sm" onClick={doBack}>
 					Back

--- a/webui/src/scss/_bank.scss
+++ b/webui/src/scss/_bank.scss
@@ -51,14 +51,6 @@
 
 		-webkit-user-drag: none;
 	}
-
-	// // For bigger screens, like 1440p and 4K, alow scaling of the buttons
-	// @include media-breakpoint-up('xl') {
-	// 	img {
-	// 		max-width: none;
-	// 		max-height: none;
-	// 	}
-	// }
 }
 
 .button-page-input {

--- a/webui/src/scss/_bank.scss
+++ b/webui/src/scss/_bank.scss
@@ -38,8 +38,9 @@
 	}
 
 	img {
-		max-width: 72px;
-		max-height: 72px;
+		// Commented out to alow scaling in a uniform way, instead of streatching
+		// max-width: 72px;
+		// max-height: 72px;
 		width: 100%;
 		height: 100%;
 		object-fit: contain;
@@ -50,6 +51,14 @@
 
 		-webkit-user-drag: none;
 	}
+
+	// // For bigger screens, like 1440p and 4K, alow scaling of the buttons
+	// @include media-breakpoint-up('xl') {
+	// 	img {
+	// 		max-width: none;
+	// 		max-height: none;
+	// 	}
+	// }
 }
 
 .button-page-input {

--- a/webui/src/scss/_instances.scss
+++ b/webui/src/scss/_instances.scss
@@ -45,6 +45,7 @@
 
 .variables-table {
 	word-break: break-all;
+	margin-top: 20px;
 }
 
 .instances-panel {

--- a/webui/src/scss/_instances.scss
+++ b/webui/src/scss/_instances.scss
@@ -43,9 +43,14 @@
 	cursor: ns-resize;
 }
 
+.variables-panel {
+	.variables-table {
+		margin-top: 20px;
+	}
+}
+
 .variables-table {
 	word-break: break-all;
-	margin-top: 20px;
 }
 
 .instances-panel {

--- a/webui/src/scss/_layout.scss
+++ b/webui/src/scss/_layout.scss
@@ -138,7 +138,7 @@ body {
 }
 
 // For bigger screens, like 1440p and 4K, alow scaling
-@media only screen and (min-width: 1900px) {
+@media only screen and (min-width: 2000px) {
 	.tab-content {
 		max-width: 100%;
 	}

--- a/webui/src/scss/_layout.scss
+++ b/webui/src/scss/_layout.scss
@@ -62,7 +62,7 @@ body {
 		position: relative;
 	}
 
-	max-width: 1500px;
+	max-width: 1900px;
 	min-height: 300px;
 	max-height: 100%;
 }
@@ -133,6 +133,27 @@ body {
 					overflow-y: scroll;
 				}
 			}
+		}
+	}
+}
+
+// For bigger screens, like 1440p and 4K, alow scaling
+@media only screen and (min-width: 1900px) {
+	.tab-content {
+		max-width: 100%;
+	}
+
+	.col-xl-6 {
+		max-width: 100%;
+	}
+
+	.split-panels {
+		> .primary-panel {
+			flex: 0 0 40%;
+		}
+
+		> .secondary-panel {
+			flex: 0 0 60%;
 		}
 	}
 }

--- a/webui/src/scss/_log.scss
+++ b/webui/src/scss/_log.scss
@@ -4,7 +4,7 @@
 	height: 100%;
 
 	.log-panel {
-		margin-top: 5px;
+		margin-top: 10px;
 		font-size: 0.85em;
 		overflow-y: scroll;
 		line-height: 1.25em;

--- a/webui/src/scss/_presets.scss
+++ b/webui/src/scss/_presets.scss
@@ -8,6 +8,7 @@
 	grid-auto-rows: 1fr;
 
 	align-content: stretch;
+	padding-top: 10px;
 
 	@include media-breakpoint-down('xs') {
 		grid-template-columns: repeat(2, 1fr);


### PR DESCRIPTION
Hi, I got kinda tired of the UI only using half of my screen and did this to make it scale out on bigger screens, it changes at 1900px wide, so would b very close to the same on smaller screens, with the only difference being a bit of padding/margin form buttons like the "back" in variables and presets. And the "streamdeck" analogue in the buttons tab scales uniformly instead of only in with after a certain size.

I would not call this perfect but for me at least it feels better than how it is currently, it's mostly the way the icon for what button you are editing that annoys me a bit with this change, with how it hangs all the way to the right, but I could not figure out how to hover it over the "browse" button.

Please take a look and feel free to change it if need be, but scaling on screens bigger than 1200px should be a thing, as it becomes quite small and crowded with all the empty space on the right, and a lot of scrolling because actions cant be in a single line.

-McHauge

