### PR TITLE
backport: lib/db load, recovery, and save interval changes

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -89,7 +89,7 @@ class Database {
 			//this.save()
 		})
 
-		this.load()
+		this.loadSync()
 
 		// db defaults
 		if (this.store.userconfig === undefined) {
@@ -128,12 +128,22 @@ class Database {
 		this.dirty = false
 		this.lastsave = Date.now()
 
-		if (withBackup === true && fs.existsSync(this.cfgFile) && fs.readFileSync(this.cfgFile, 'utf8').trim().length > 0) {
+		if (withBackup === true) {
 			try {
-				await fs.copy(this.cfgFile, this.cfgBakFile)
-				this.debug(`${this.name}_save`, `backup written`)
+				const file = await fs.readFile(this.cfgFile, 'utf8')
+
+				if (file.trim().length > 0) {
+					JSON.parse(file) // just want to see if a parse error is thrown so we don't back up a corrupted db
+
+					try {
+						await fs.copy(this.cfgFile, this.cfgBakFile)
+						this.debug(`${this.name}_save`, `backup written`)
+					} catch (err) {
+						this.debug(`${this.name}_save`, `Error making backup copy: ${err}`)
+					}
+				}
 			} catch (err) {
-				this.debug(`${this.name}_save`, `Error making backup copy: ${err}`)
+				this.debug(`${this.name}_save`, `Error checking db file for backup: ${err}`)
 			}
 		}
 
@@ -213,7 +223,7 @@ class Database {
 	 * Attempt to load the database from disk
 	 * @access protected
 	 */
-	load() {
+	loadSync() {
 		if (fs.existsSync(this.cfgFile)) {
 			this.debug(this.cfgFile, 'exists. trying to read')
 
@@ -231,7 +241,7 @@ class Database {
 						'warn',
 						`${this.name} was empty.  Attempting to recover the configuration.`
 					)
-					this.loadBackup(this.cfgBakFile)
+					this.loadBackupSync(this.cfgBakFile)
 				}
 			} catch (e) {
 				try {
@@ -247,11 +257,11 @@ class Database {
 					this.debug(`${this.name}_load`, `Error making or deleting corrupted backup: ${err}`)
 				}
 
-				this.loadBackup(this.cfgBakFile)
+				this.loadBackupSync(this.cfgBakFile)
 			}
 		} else if (fs.existsSync(this.cfgBakFile)) {
 			this.system.emit('log', this.name, 'warn', `${this.name} is missing.  Attempting to recover the configuration.`)
-			this.loadBackup(this.cfgBakFile)
+			this.loadBackupSync(this.cfgBakFile)
 		} else {
 			this.debug(this.cfgFile, `doesn't exist. loading defaults`, this.defaults)
 			this.loadDefaults()
@@ -264,7 +274,7 @@ class Database {
 	 * Attempt to load the backup file from disk as a recovery
 	 * @access protected
 	 */
-	loadBackup() {
+	loadBackupSync() {
 		if (fs.existsSync(this.cfgBakFile)) {
 			this.debug(this.cfgBakFile, 'exists. trying to read')
 			let data = fs.readFileSync(this.cfgBakFile, 'utf8')

--- a/lib/db.js
+++ b/lib/db.js
@@ -55,7 +55,7 @@ class Database {
 	 * @param {EventEmitter} system - the application's event emitter
 	 * @param {string} cfgDir - the directory the flat file will be saved
 	 */
-	 constructor(system, cfgDir) {
+	constructor(system, cfgDir) {
 		this.system = system
 		this.cfgDir = cfgDir
 		this.cfgFile = path.join(cfgDir, this.name)

--- a/lib/db.js
+++ b/lib/db.js
@@ -15,181 +15,374 @@
  *
  */
 
-var debug = require('debug')('lib/db')
-var fs = require('fs-extra')
-var path = require('path')
-
-/**
-	Simpel KVS som forventer at all data har plass i ram.
-
-	Events: (system objektet)
-		* db_loaded(data) - Alle data
-		* db_saved(err) - kommandoen db_save ble fullført (eller feilet)
-
-	Svarer på events: (system objektet)
-		* db_set(key, value) - Sett key til value
-		* db_get(key, cb) - Hent verdi til key i store, emitter svar til 'cb'
-		* db_get_multiple([key1,key2], cb) - Henter verdier til flere keys, returnerer som array til 'cb'
-		* db_save - Lagrer db fra minne til fil. Svarer med db_saved. (se over)
-*/
-
-var lastsave = 0
-var saveInterval = 4000 // Minimum 4 seconds between each save
-var dirty = false
-var saving = false
+const fs = require('fs-extra')
+const path = require('path')
+const { cloneDeep } = require('lodash')
 
 module.exports = exports = function (system, cfgDir) {
-	return new db(system, cfgDir)
+	return new Database(system, cfgDir)
 }
 
-function db(system, cfgDir) {
-	debug('new(db)')
-	var self = this
-	self.system = system
-	self.db = {}
+/**
+ * The class that manages the applications's main database
+ *
+ * @author Håkon Nessjøen <haakon@bitfocus.io>
+ * @author Keith Rocheck <keith.rocheck@gmail.com>
+ * @author Julian Waller <me@julusian.co.uk>
+ * @author William Viker <william@bitfocus.io>
+ * @since 1.0.4
+ */
+class Database {
+	static SaveInterval = 4000
 
-	var pathDb = path.join(cfgDir, 'db')
-	var pathDbTmp = path.join(cfgDir, 'db.tmp')
-	var pathDbBak = path.join(cfgDir, 'db.bak')
+	cfgBakFile = null
+	cfgCorruptFile = null
+	cfgDir = null
+	cfgFile = null
+	cfgTmpFile = null
+	debug = require('debug')('lib/db')
+	defaults = {}
+	dirty = false
+	lastsave = Date.now()
+	name = 'db'
+	saveInterval = null
+	saving = false
+	store = {}
+	system = null
 
-	try {
-		var data = fs.readFileSync(pathDb)
+	/**
+	 * Create a new application flat file DB controller
+	 * @param {EventEmitter} system - the application's event emitter
+	 * @param {string} cfgDir - the directory the flat file will be saved
+	 */
+	 constructor(system, cfgDir) {
+		this.system = system
+		this.cfgDir = cfgDir
+		this.cfgFile = path.join(cfgDir, this.name)
+		this.cfgBakFile = path.join(cfgDir, this.name + '.bak')
+		this.cfgCorruptFile = path.join(cfgDir, this.name + '.corrupt')
+		this.cfgTmpFile = path.join(cfgDir, this.name + '.tmp')
+		this.saveInterval = Database.SaveInterval
 
-		self.db = JSON.parse(data)
-		debug('db loaded')
+		this.system.on('db_dirty', this.setDirty.bind(this))
 
-		var changed_after_load = false
+		this.system.on('db_all', (cb) => {
+			if (typeof cb == 'function') {
+				cb(this.getAll())
+			}
+		})
+
+		this.system.on('db_set', this.setKey.bind(this))
+
+		this.system.on('db_del', this.deleteKey.bind(this))
+
+		this.system.on('db_set_multiple', this.setKeys.bind(this))
+
+		this.system.on('db_get', (key, cb) => {
+			if (typeof cb == 'function') {
+				cb(this.getKey(key))
+			}
+		})
+
+		this.system.on('db_save', () => {
+			// Not wired ... interval has control
+			//this.save()
+		})
+
+		this.load()
+
 		// db defaults
-		if (self.db.userconfig === undefined) {
-			self.db.userconfig = {}
-			changed_after_load = true
+		if (this.store.userconfig === undefined) {
+			this.store.userconfig = {}
+			this.setDirty()
 		}
 
 		// is page up 1->2 or 2->1?
-		if (self.db.userconfig.page_direction_flipped === undefined) {
-			self.db.userconfig.page_direction_flipped = false
-			changed_after_load = true
-		}
-
-		system.emit('db_loaded', self.db)
-
-		if (changed_after_load === true) {
-			debug('config changed by default values after load, saving.')
-			system.emit('db_save')
-		}
-	} catch (err) {
-		if (err.code == 'ENOENT') {
-			debug('readFile(db)', 'Couldnt read db, loading {}')
-			system.emit('db_loaded', {})
-		} else {
-			throw err
+		if (this.store.userconfig.page_direction_flipped === undefined) {
+			this.store.userconfig.page_direction_flipped = false
+			this.setDirty()
 		}
 	}
 
-	system.on('db_all', function (cb) {
-		debug('db_all(): returning all database values')
-		if (typeof cb == 'function') {
-			cb(self.db)
+	/**
+	 * Delete a key/value pair
+	 * @param {string} key - the key to be delete
+	 * @access public
+	 */
+	deleteKey(key) {
+		this.debug(`${this.name}_del (${key})`)
+		if (key !== undefined) {
+			delete this.store[key]
+			this.setDirty()
 		}
-	})
+	}
 
-	system.on('db_set', function (key, value) {
-		debug('db_set(' + key + ', ' + value + ')')
-		self.db[key] = value
-	})
+	/**
+	 * Save the database to file making a `FILE.bak` version then moving it into place
+	 * @async
+	 * @param {boolean} [withBackup = true] - can be set to <code>false</code> if the current file should not be moved to `FILE.bak`
+	 * @access protected
+	 */
+	async doSave(withBackup) {
+		const jsonSave = JSON.stringify(this.store)
+		this.dirty = false
+		this.lastsave = Date.now()
 
-	system.on('db_del', function (key) {
-		debug('db_del(' + key + ')')
-		delete self.db[key]
-	})
-
-	system.on('db_set_multiple', function (keyvalueobj) {
-		debug('db_set_multiple:')
-		for (var key in keyvalueobj) {
-			debug('db_set(' + key + ',' + keyvalueobj[key] + ')')
-			self.db[key] = keyvalueobj[key]
-		}
-	})
-
-	system.on('db_get', function (key, cb) {
-		debug('db_get(' + key + ')')
-		cb(self.db[key])
-	})
-	system.on('db_get_multiple', function (keys, cb) {
-		if (typeof keys != 'object' || typeof keys.length == 'undefined') {
-			throw new Error('keys is not an array')
-		}
-		cb(
-			keys.map(function (key) {
-				return self.db[key]
-			})
-		)
-	})
-
-	async function doSave() {
-		const jsonStr = JSON.stringify(self.db)
-
-		try {
-			await fs.copy(pathDb, pathDbBak)
-		} catch (err) {
-			debug('db_save', 'Error making backup of config: ' + err)
+		if (withBackup === true && fs.existsSync(this.cfgFile) && fs.readFileSync(this.cfgFile, 'utf8').trim().length > 0) {
+			try {
+				await fs.copy(this.cfgFile, this.cfgBakFile)
+				this.debug(`${this.name}_save`, `backup written`)
+			} catch (err) {
+				this.debug(`${this.name}_save`, `Error making backup copy: ${err}`)
+			}
 		}
 
 		try {
-			await fs.writeFile(pathDbTmp, jsonStr)
+			await fs.writeFile(this.cfgTmpFile, jsonSave)
 		} catch (err) {
-			debug('db_save', 'Error saving: ' + err)
+			this.debug(`${this.name}_save`, `Error saving: ${err}`)
 			throw 'Error saving: ' + err
 		}
 
-		debug('db_save', 'written')
+		this.debug(`${this.name}_save`, 'written')
 
 		try {
-			await fs.rename(pathDbTmp, pathDb)
+			await fs.rename(this.cfgTmpFile, this.cfgFile)
 		} catch (err) {
-			debug('db_save', 'Error renaming db.tmp: ' + err)
-			throw 'Error renaming db.tmp: ' + err
+			this.debug('db_save', `Error renaming ${this.name}.tmp: ` + err)
+			throw `Error renaming ${this.name}.tmp: ` + err
 		}
 
-		debug('db_save', 'renamed')
-		system.emit('db_saved', null)
+		this.debug(`${this.name}_save`, 'renamed')
+		this.system.emit('db_saved', null)
 	}
 
-	system.on('db_save', function () {
-		if (!saving && Date.now() - lastsave > saveInterval) {
-			debug('db_save', 'begin')
+	/**
+	 * Get the entire database
+	 * @param {boolean} [clone = false] - <code>true</code> if a clone is needed instead of a link
+	 * @returns {Object[]} the database
+	 * @access public
+	 */
+	getAll(clone = false) {
+		let out
+		this.debug(`${this.name}_all`)
 
-			dirty = false
-			lastsave = Date.now()
-			saving = true
+		if (clone === true) {
+			out = cloneDeep(this.store)
+		} else {
+			out = this.store
+		}
 
-			doSave()
+		return out
+	}
+
+	/**
+	 * @returns {string} the directory of the flat file
+	 * @access public
+	 */
+	getCfgDir() {
+		return this.cfgDir
+	}
+
+	/**
+	 * Get a value from the database
+	 * @param {string} key - the key to be retrieved
+	 * @param {?Object[]} defaultValue - the default value to use if the key doesn't exist
+	 * @param {boolean} [clone = false] - <code>true</code> if a clone is needed instead of a link
+	 * @access public
+	 */
+	getKey(key, defaultValue, clone = false) {
+		let out
+		this.debug(`${this.name}_get(${key})`)
+
+		if (this.store[key] === undefined && defaultValue !== undefined) {
+			this.store[key] = defaultValue
+			this.setDirty()
+		}
+
+		if (clone === true) {
+			out = cloneDeep(this.store[key])
+		} else {
+			out = this.store[key]
+		}
+
+		return out
+	}
+
+	/**
+	 * Attempt to load the database from disk
+	 * @access protected
+	 */
+	load() {
+		if (fs.existsSync(this.cfgFile)) {
+			this.debug(this.cfgFile, 'exists. trying to read')
+
+			try {
+				let data = fs.readFileSync(this.cfgFile, 'utf8')
+
+				if (data.trim().length > 0) {
+					this.store = JSON.parse(data)
+					this.debug('parsed JSON')
+					this.system.emit(`${this.name}_loaded`, this.store)
+				} else {
+					this.system.emit(
+						'log',
+						this.name,
+						'warn',
+						`${this.name} was empty.  Attempting to recover the configuration.`
+					)
+					this.loadBackup(this.cfgBakFile)
+				}
+			} catch (e) {
+				try {
+					fs.copyFileSync(this.cfgFile, this.cfgCorruptFile)
+					this.system.emit(
+						'log',
+						this.name,
+						'error',
+						`${this.name} could not be parsed.  A copy has been saved to ${this.cfgCorruptFile}.`
+					)
+					fs.rmSync(this.cfgFile)
+				} catch (err) {
+					this.debug(`${this.name}_load`, `Error making or deleting corrupted backup: ${err}`)
+				}
+
+				this.loadBackup(this.cfgBakFile)
+			}
+		} else if (fs.existsSync(this.cfgBakFile)) {
+			this.system.emit('log', this.name, 'warn', `${this.name} is missing.  Attempting to recover the configuration.`)
+			this.loadBackup(this.cfgBakFile)
+		} else {
+			this.debug(this.cfgFile, `doesn't exist. loading defaults`, this.defaults)
+			this.loadDefaults()
+		}
+
+		this.setSaveCycle()
+	}
+
+	/**
+	 * Attempt to load the backup file from disk as a recovery
+	 * @access protected
+	 */
+	loadBackup() {
+		if (fs.existsSync(this.cfgBakFile)) {
+			this.debug(this.cfgBakFile, 'exists. trying to read')
+			let data = fs.readFileSync(this.cfgBakFile, 'utf8')
+
+			try {
+				if (data.trim().length > 0) {
+					this.store = JSON.parse(data)
+					this.debug('parsed JSON')
+					this.system.emit('log', this.name, 'warn', `${this.name}.bak has been used to recover the configuration.`)
+					this.system.emit(`${this.name}_loaded`, this.store)
+					this.save(false)
+				} else {
+					this.system.emit('log', this.name, 'warn', `${this.name} was empty.  Creating a new db.`)
+					this.loadDefaults()
+				}
+			} catch (e) {
+				throw e
+			}
+		} else {
+			throw 'Could not load database file'
+		}
+	}
+
+	/**
+	 * Save the defaults since a file could not be found/loaded/parses
+	 * @access protected
+	 */
+	loadDefaults() {
+		this.store = cloneDeep(this.defaults)
+		this.save()
+	}
+
+	/**
+	 * Save the database to file
+	 * @param {boolean} [withBackup = true] - can be set to `false` if the current file should not be moved to `FILE.bak`
+	 * @access protected
+	 */
+	save(withBackup = true) {
+		if (this.saving === false) {
+			this.debug('db_save', 'begin')
+			this.saving = true
+
+			this.doSave(withBackup)
 				.catch((err) => {
 					try {
-						self.system.emit('log', 'CORE(cb)', 'error', err)
+						this.system.emit('log', this.name, 'error', err)
 					} catch (err2) {
-						// make sure to not throw an error here
-						debug('db_save', 'Error reporting save failure: ' + err2)
+						this.debug('db_save', 'Error reporting save failue: ' + err2)
 					}
 				})
 				.then(() => {
 					// This will run even if the catch caught an error
-					saving = false
+					this.saving = false
 				})
-		} else {
-			dirty = true
 		}
-	})
+	}
 
-	// Do a save sometime within the next 10 seconds
-	system.on('db_dirty', function () {
-		dirty = true
-	})
-
-	// If last db_save was not handeled because of throttling, do it now
-	setInterval(function () {
-		if (Date.now() - lastsave > saveInterval && dirty) {
-			system.emit('db_save')
+	/**
+	 * Execute a save if the database is dirty
+	 * @access public
+	 */
+	saveImmediate() {
+		if (this.dirty === true) {
+			this.save()
 		}
-	}, 4000)
+	}
+
+	/**
+	 * Register that there are changes in the database that need to be saved as soon as possible
+	 * @access public
+	 */
+	setDirty() {
+		this.dirty = true
+	}
+
+	/**
+	 * Save/update a key/value pair to the database
+	 * @param {(number|string)} key - the key to save under
+	 * @param {Object} value - the object to save
+	 * @access public
+	 */
+	setKey(key, value) {
+		this.debug(`${this.name}_set(${key}, ${value})`)
+
+		if (key !== undefined) {
+			this.store[key] = value
+			this.setDirty()
+		}
+	}
+
+	/**
+	 * Save/update multiple key/value pairs to the database
+	 * @param {Array.<(number|string),Object>} keyvalueobj - the key to save under
+	 * @access public
+	 */
+	setKeys(keyvalueobj) {
+		this.debug(`${this.name}_set_multiple:`)
+
+		if (keyvalueobj !== undefined && typeof keyvalueobj == 'object' && keyvalueobj.length > 0) {
+			for (let key in keyvalueobj) {
+				this.debug(`${this.name}_set(${key}, ${keyvalueobj[key]})`)
+				this.store[key] = keyvalueobj[key]
+			}
+
+			this.setDirty()
+		}
+	}
+
+	/**
+	 * Setup the save cycle interval
+	 * @access protected
+	 */
+	setSaveCycle() {
+		this.saveCycle = setInterval(() => {
+			// See if the database is dirty and needs to be saved
+			if (Date.now() - this.lastsave > this.saveInterval && this.dirty) {
+				this.save()
+			}
+		}, this.saveInterval)
+	}
 }


### PR DESCRIPTION
This backports from [feat/registry](https://github.com/bitfocus/companion/tree/feat/registry) various updates to `lib/db`, including:

- ES6 refactor
- Disabling `db_save` in favor of a save interval and `dirty` flag
- Add an auto-recovery of `db.bak` if `db` is corrupt or missing
- Attempts to save a `db.corrupt` copy if corruption is detected
- Adds `fs` checks for both `db` and `db.bak` to support those operations

This class was fairly rigorously tested a ways back.  I ran a small collection of tests and the functionality seems to work as tested earlier.  Changes made in [22c1e4](https://github.com/bitfocus/companion/commit/22c14e9f37a9667296c795039be55c025fbca069#diff-69f9a48e7478eb5df50c35b61f5638a078f274a604fff85d69732c2651ef8b47) have been incorporated