### PR TITLE
feat: Implement fillImage retries for elgato-mini and elgator-xl

### DIFF
--- a/lib/usb/elgato-mini.js
+++ b/lib/usb/elgato-mini.js
@@ -20,13 +20,18 @@ var debug = require('debug')('lib/usb/elgato_mini')
 var elgato_base = require('./elgato-base')
 var sharp = require('sharp')
 var image_write_queue = require('./image-write-queue')
+var setTimeoutPromise = util.promisify(setTimeout);
 
 function elgato_mini(system, devicepath) {
 	var self = this
 
 	elgato_base.apply(this, [system, devicepath, 'Elgato Streamdeck Mini'])
 
-	self.write_queue = new image_write_queue(function (key, buffer) {
+	var image_filler = function(key, buffer, attempts) {
+		// null/undefined => 0
+		attempts = ~~attempts
+		attempts++
+
 		return sharp(buffer, { raw: { width: 72, height: 72, channels: 3 } })
 			.resize(80, 80)
 			.raw()
@@ -41,10 +46,17 @@ function elgato_mini(system, devicepath) {
 				}
 			})
 			.catch(function (e) {
-				self.system.emit('log', 'device(' + self.serialnumber + ')', 'debug', `fillImage failed: ${e}`)
-				self.system.emit('elgatodm_remove_device', self.devicepath)
+				if (attempts > 2) {
+					self.system.emit('log', 'device(' + self.serialnumber + ')', 'debug', `fillImage final attempt failed: ${e}`)
+					self.system.emit('elgatodm_remove_device', self.devicepath)
+				} else {
+					self.system.emit('log', 'device(' + self.serialnumber + ')', 'debug', `fillImage attempt ${attempts} failed: ${e}`)
+					return setTimeoutPromise(20).then(() => image_filler(key, buffer, attempts))
+				}
 			})
-	})
+	}
+
+	self.write_queue = new image_write_queue(image_filler)
 
 	return self
 }

--- a/lib/usb/elgato-mini.js
+++ b/lib/usb/elgato-mini.js
@@ -27,36 +27,36 @@ function elgato_mini(system, devicepath) {
 
 	elgato_base.apply(this, [system, devicepath, 'Elgato Streamdeck Mini'])
 
-	var image_filler = function(key, buffer, attempts) {
-		// null/undefined => 0
-		attempts = ~~attempts
-		attempts++
+	self.write_queue = new image_write_queue(async function (key, buffer) {
+		let newbuffer
+		try {
+			newbuffer = await sharp(buffer, { raw: { width: 72, height: 72, channels: 3 } })
+				.resize(80, 80)
+				.raw()
+				.toBuffer()
+		} catch (e) {
+			self.system.emit('log', 'device(' + self.serialnumber + ')', 'debug', `scale image failed: ${e}`)
+			self.system.emit('elgatodm_remove_device', self.devicepath)
+			return
+		}
 
-		return sharp(buffer, { raw: { width: 72, height: 72, channels: 3 } })
-			.resize(80, 80)
-			.raw()
-			.toBuffer()
-			.catch(function (e) {
-				self.system.emit('log', 'device(' + self.serialnumber + ')', 'debug', `scale image failed: ${e}`)
-				self.system.emit('elgatodm_remove_device', self.devicepath)
-			})
-			.then(function (newbuffer) {
-				if (newbuffer) {
-					self.streamDeck.fillImage(key, newbuffer)
-				}
-			})
-			.catch(function (e) {
-				if (attempts > 2) {
-					self.system.emit('log', 'device(' + self.serialnumber + ')', 'debug', `fillImage final attempt failed: ${e}`)
-					self.system.emit('elgatodm_remove_device', self.devicepath)
+		let attempts = 0
+		while (true) {
+			attempts++
+			try {
+				self.streamDeck.fillImage(key, newbuffer)
+			} catch (e) {
+				self.system.emit('log', 'device(' + self.serialnumber + ')', 'debug', `fillImage attempt ${attempts} failed: ${e}`)
+				if (attempts < 3) {
+					await setTimeoutPromise(20)
+					continue
 				} else {
-					self.system.emit('log', 'device(' + self.serialnumber + ')', 'debug', `fillImage attempt ${attempts} failed: ${e}`)
-					return setTimeoutPromise(20).then(() => image_filler(key, buffer, attempts))
+					self.system.emit('elgatodm_remove_device', self.devicepath)
 				}
-			})
-	}
-
-	self.write_queue = new image_write_queue(image_filler)
+			}
+			break
+		}
+	})
 
 	return self
 }

--- a/lib/usb/elgato-mini.js
+++ b/lib/usb/elgato-mini.js
@@ -40,21 +40,18 @@ function elgato_mini(system, devicepath) {
 			return
 		}
 
-		let attempts = 0
-		while (true) {
-			attempts++
+		const maxAttempts = 3;
+		for (let attempts = 1; attempts <= maxAttempts; attempts++) {
 			try {
 				self.streamDeck.fillImage(key, newbuffer)
 			} catch (e) {
 				self.system.emit('log', 'device(' + self.serialnumber + ')', 'debug', `fillImage attempt ${attempts} failed: ${e}`)
-				if (attempts < 3) {
-					await setTimeoutPromise(20)
-					continue
-				} else {
+				if (attempts == maxAttempts) {
 					self.system.emit('elgatodm_remove_device', self.devicepath)
+					return
 				}
+				await setTimeoutPromise(20)
 			}
-			break
 		}
 	})
 

--- a/lib/usb/elgato-xl.js
+++ b/lib/usb/elgato-xl.js
@@ -40,21 +40,18 @@ function elgato_xl(system, devicepath) {
 			return
 		}
 
-		let attempts = 0
-		while (true) {
-			attempts++
+		const maxAttempts = 3;
+		for (let attempts = 1; attempts <= maxAttempts; attempts++) {
 			try {
 				self.streamDeck.fillImage(key, newbuffer)
 			} catch (e) {
 				self.system.emit('log', 'device(' + self.serialnumber + ')', 'debug', `fillImage attempt ${attempts} failed: ${e}`)
-				if (attempts < 3) {
-					await setTimeoutPromise(20)
-					continue
-				} else {
+				if (attempts == maxAttempts) {
 					self.system.emit('elgatodm_remove_device', self.devicepath)
+					return
 				}
+				await setTimeoutPromise(20)
 			}
-			break
 		}
 	})
 

--- a/lib/usb/elgato-xl.js
+++ b/lib/usb/elgato-xl.js
@@ -20,13 +20,18 @@ var debug = require('debug')('lib/usb/elgato_xl')
 var elgato_base = require('./elgato-base')
 var sharp = require('sharp')
 var image_write_queue = require('./image-write-queue')
+var setTimeoutPromise = util.promisify(setTimeout);
 
 function elgato_xl(system, devicepath) {
 	var self = this
 
 	elgato_base.apply(this, [system, devicepath, 'Elgato Streamdeck XL'])
 
-	self.write_queue = new image_write_queue(function (key, buffer) {
+	var image_filler = function(key, buffer, attempts) {
+		// null/undefined => 0
+		attempts = ~~attempts
+		attempts++
+
 		return sharp(buffer, { raw: { width: 72, height: 72, channels: 3 } })
 			.resize(96, 96)
 			.raw()
@@ -41,10 +46,17 @@ function elgato_xl(system, devicepath) {
 				}
 			})
 			.catch(function (e) {
-				self.system.emit('log', 'device(' + self.serialnumber + ')', 'debug', `fillImage failed: ${e}`)
-				self.system.emit('elgatodm_remove_device', self.devicepath)
+				if (attempts > 2) {
+					self.system.emit('log', 'device(' + self.serialnumber + ')', 'debug', `fillImage final attempt failed: ${e}`)
+					self.system.emit('elgatodm_remove_device', self.devicepath)
+				} else {
+					self.system.emit('log', 'device(' + self.serialnumber + ')', 'debug', `fillImage attempt ${attempts} failed: ${e}`)
+					return setTimeoutPromise(20).then(() => image_filler(key, buffer, attempts))
+				}
 			})
-	})
+	}
+
+	self.write_queue = new image_write_queue(image_filler)
 
 	return self
 }

--- a/lib/usb/elgato-xl.js
+++ b/lib/usb/elgato-xl.js
@@ -27,42 +27,42 @@ function elgato_xl(system, devicepath) {
 
 	elgato_base.apply(this, [system, devicepath, 'Elgato Streamdeck XL'])
 
-	var image_filler = function(key, buffer, attempts) {
-		// null/undefined => 0
-		attempts = ~~attempts
-		attempts++
+	self.write_queue = new image_write_queue(async function (key, buffer) {
+		let newbuffer
+		try {
+			newbuffer = await sharp(buffer, { raw: { width: 72, height: 72, channels: 3 } })
+				.resize(96, 96)
+				.raw()
+				.toBuffer()
+		} catch (e) {
+			self.system.emit('log', 'device(' + self.serialnumber + ')', 'debug', `scale image failed: ${e}`)
+			self.system.emit('elgatodm_remove_device', self.devicepath)
+			return
+		}
 
-		return sharp(buffer, { raw: { width: 72, height: 72, channels: 3 } })
-			.resize(96, 96)
-			.raw()
-			.toBuffer()
-			.catch(function (e) {
-				self.system.emit('log', 'device(' + self.serialnumber + ')', 'debug', `scale image failed: ${e}`)
-				self.system.emit('elgatodm_remove_device', self.devicepath)
-			})
-			.then(function (newbuffer) {
-				if (newbuffer) {
-					self.streamDeck.fillImage(key, newbuffer)
-				}
-			})
-			.catch(function (e) {
-				if (attempts > 2) {
-					self.system.emit('log', 'device(' + self.serialnumber + ')', 'debug', `fillImage final attempt failed: ${e}`)
-					self.system.emit('elgatodm_remove_device', self.devicepath)
+		let attempts = 0
+		while (true) {
+			attempts++
+			try {
+				self.streamDeck.fillImage(key, newbuffer)
+			} catch (e) {
+				self.system.emit('log', 'device(' + self.serialnumber + ')', 'debug', `fillImage attempt ${attempts} failed: ${e}`)
+				if (attempts < 3) {
+					await setTimeoutPromise(20)
+					continue
 				} else {
-					self.system.emit('log', 'device(' + self.serialnumber + ')', 'debug', `fillImage attempt ${attempts} failed: ${e}`)
-					return setTimeoutPromise(20).then(() => image_filler(key, buffer, attempts))
+					self.system.emit('elgatodm_remove_device', self.devicepath)
 				}
-			})
-	}
-
-	self.write_queue = new image_write_queue(image_filler)
+			}
+			break
+		}
+	})
 
 	return self
 }
 elgato_xl.device_type = 'StreamDeck XL'
 
-elgato_xl.prototype.draw = function (key, buffer, ts) {
+elgato_xl.prototype.draw = function (key, buffer) {
 	var self = this
 
 	buffer = self.handleBuffer(buffer)


### PR DESCRIPTION
The standard lib/usb/elgato.js has a mechanism for retrying the `fillImage` call a couple of times before giving up on the USB device. This Pull Request applies that retry to the elgato-mini and elgato-xl.

The original retry logic was added as a result of a discussion on Issue https://github.com/bitfocus/companion/issues/313#issuecomment-524150012
In our use case, we had our Mini disconnect from its RPi4 when several image updates were made in quick succession. After running for a month now, we've seen debug logs where it would have disconnected before, but with the patched code it continues working just fine.
Note: I've tested with a Mini but not the XL since I don't have an XL but the code is otherwise identical.