### PR TITLE
feat: allow modules to batch variables updates

### DIFF
--- a/instance_skel.d.ts
+++ b/instance_skel.d.ts
@@ -86,6 +86,7 @@ declare abstract class InstanceSkel<TConfig> {
 	setPresetDefinitions(presets: CompanionPreset[]): void
 
 	setVariable(variableId: string, value: string): void
+	setVariables(variables: { [variableId: string]: string }): void
 	getVariable(variableId: string, cb: (value: string) => void): void
 	/** Recheck all feedbacks of the given types. eg `self.checkFeedbacks('bank_style', 'bank_text')` or `self.checkFeedbacks` */
 	checkFeedbacks(...feedbackTypes: string[]): void

--- a/instance_skel.d.ts
+++ b/instance_skel.d.ts
@@ -85,8 +85,11 @@ declare abstract class InstanceSkel<TConfig> {
 	setFeedbackDefinitions(feedbacks: CompanionFeedbacks): void
 	setPresetDefinitions(presets: CompanionPreset[]): void
 
-	setVariable(variableId: string, value: string): void
-	setVariables(variables: { [variableId: string]: string }): void
+	/** Set the value of a variable. Pass undefined to unset it */
+	setVariable(variableId: string, value: string | undefined): void
+	/** Set the value of multiple variable. Use undefined to unset values */
+	setVariables(variables: { [variableId: string]: string | undefined }): void
+	/** Get the value of a variable from this instance */
 	getVariable(variableId: string, cb: (value: string) => void): void
 	/** Recheck all feedbacks of the given types. eg `self.checkFeedbacks('bank_style', 'bank_text')` or `self.checkFeedbacks` */
 	checkFeedbacks(...feedbackTypes: string[]): void

--- a/instance_skel.js
+++ b/instance_skel.js
@@ -260,6 +260,14 @@ instance.prototype.setVariable = function (variable, value) {
 	self.system.emit('variable_instance_set', self, variable, value)
 }
 
+instance.prototype.setVariables = function (variables) {
+	var self = this
+
+	if (typeof variables === 'object') {
+		self.system.emit('variable_instance_set_many', self, variables)
+	}
+}
+
 instance.prototype.getVariable = function (variable, cb) {
 	var self = this
 

--- a/instance_skel.js
+++ b/instance_skel.js
@@ -295,11 +295,6 @@ instance.prototype.setFeedbackDefinitions = function (feedbacks) {
 instance.prototype.setPresetDefinitions = function (presets) {
 	var self = this
 
-	// Because RegExp.escape did not become a standard somehow
-	function escape(str) {
-		return str.replace(/[-[\]{}()*+?.,\\/^$|#\s]/g, '\\$&')
-	}
-
 	/*
 	 * Clean up variable references: $(instance:variable)
 	 * since the name of the instance is dynamic. We don't want to
@@ -309,15 +304,14 @@ instance.prototype.setPresetDefinitions = function (presets) {
 		var bank = presets[i].bank
 		var fixtext = bank.text
 		if (bank !== undefined && fixtext !== undefined) {
-			if (fixtext.match(/\$\(/)) {
-				var matches,
-					reg = /\$\(([^:)]+):([^)]+)\)/g
+			if (fixtext.includes('$(')) {
+				let matches
+				const reg = /\$\(([^:)]+):([^)]+)\)/g
 
 				while ((matches = reg.exec(fixtext)) !== null) {
 					if (matches[1] !== undefined) {
 						if (matches[2] !== undefined) {
-							reg2 = new RegExp('\\$\\(' + escape(matches[1]) + ':' + escape(matches[2]) + '\\)')
-							bank.text = bank.text.replace(reg2, '$(' + self.label + ':' + matches[2] + ')')
+							bank.text = bank.text.replace(matches[0], '$(' + self.label + ':' + matches[2] + ')')
 						}
 					}
 				}

--- a/lib/bank.js
+++ b/lib/bank.js
@@ -186,16 +186,22 @@ function bank(system) {
 	})
 
 	/* Variable jiu jitsu */
-	system.on('variable_changed', function (label, variable) {
-		var reg = new RegExp('\\$\\(' + label + ':' + variable + '\\)')
+	system.on('variables_changed', function (changed_variables, removed_variables) {
+		const all_changed_variables = [...removed_variables, ...Object.keys(changed_variables)]
+		// var reg = new RegExp('\\$\\(' + label + ':' + variable + '\\)')
 
 		for (var page in self.config) {
 			for (var bank in self.config[page]) {
 				var data = self.config[page][bank]
 
-				if (data.text !== undefined && data.text.match(reg)) {
-					debug('variable changed in bank ' + page + '.' + bank)
-					system.emit('graphics_bank_invalidate', page, bank)
+				if (data.text !== undefined) {
+					for (const variable of all_changed_variables) {
+						if (data.text.includes(`$(${variable})`)) {
+							debug('variable changed in bank ' + page + '.' + bank)
+							system.emit('graphics_bank_invalidate', page, bank)
+							break
+						}
+					}
 				}
 			}
 		}

--- a/lib/bank.js
+++ b/lib/bank.js
@@ -158,15 +158,20 @@ function bank(system) {
 			/* Fix pre-v1.1.0 and pre-v2.0.0 config for banks */
 			for (var page in self.config) {
 				for (var bank in self.config[page]) {
-					if (
-						self.config[page][bank].style !== undefined &&
-						self.config[page][bank].style.match(/^bigtext|smalltext$/)
-					) {
-						self.config[page][bank].size = self.config[page][bank].style == 'smalltext' ? 'small' : 'large'
-						self.config[page][bank].style = 'png'
-					}
-					if (self.config[page][bank].style !== undefined && self.config[page][bank].style == 'text') {
-						self.config[page][bank].style = 'png'
+					if (self.config[page][bank].style !== undefined) {
+						switch (self.config[page][bank].style) {
+							case 'text':
+								self.config[page][bank].style = 'png'
+								break
+							case 'bigtext':
+								self.config[page][bank].style = 'png'
+								self.config[page][bank].size = 'large'
+								break
+							case 'smalltext':
+								self.config[page][bank].style = 'png'
+								self.config[page][bank].size = 'small'
+								break
+						}
 					}
 				}
 			}

--- a/lib/bank.js
+++ b/lib/bank.js
@@ -188,7 +188,6 @@ function bank(system) {
 	/* Variable jiu jitsu */
 	system.on('variables_changed', function (changed_variables, removed_variables) {
 		const all_changed_variables = [...removed_variables, ...Object.keys(changed_variables)]
-		// var reg = new RegExp('\\$\\(' + label + ':' + variable + '\\)')
 
 		for (var page in self.config) {
 			for (var bank in self.config[page]) {

--- a/lib/variable.js
+++ b/lib/variable.js
@@ -226,7 +226,6 @@ variable.prototype.variables_changed = function (changed_variables, removed_vari
 	if (Object.keys(changed_variables).length > 0 || removed_variables.length > 0) {
 		self.system.emit('variables_changed', changed_variables, removed_variables)
 
-		// TODO - implement on client
 		io.emit('variables_set', changed_variables, removed_variables)
 	}
 }

--- a/lib/variable.js
+++ b/lib/variable.js
@@ -67,7 +67,11 @@ function variable(system) {
 	})
 
 	system.on('variable_instance_set', function (instance, variable, value) {
-		self.set_variable(instance.label, variable, value)
+		self.set_variables(instance.label, { [variable]: value })
+	})
+
+	system.on('variable_instance_set_many', function (instance, variables) {
+		self.set_variables(instance.label, variables)
 	})
 
 	system.on('variable_rename_callback', function (str, fromlabel, tolabel, cb) {
@@ -99,17 +103,19 @@ function variable(system) {
 			self.variables[labelTo] = {}
 		}
 		if (self.variables[labelFrom] !== undefined) {
+			const changed_variables = {}
+			const removed_variables = []
+
+			system.emit('bank_rename_variables', labelFrom, labelTo)
 			for (var variable in self.variables[labelFrom]) {
-				system.emit('bank_rename_variables', labelFrom, labelTo)
 				self.variables[labelTo][variable] = self.variables[labelFrom][variable]
 				delete self.variables[labelFrom][variable]
-				io.emit('variable_set', labelFrom + ':' + variable, undefined)
 
-				// In case variables exists in banks from before
-				self.system.emit('variable_changed', labelTo, variable, self.variables[labelTo][variable])
-				io.emit('variable_set', labelTo + ':' + variable, self.variables[labelTo][variable])
+				removed_variables.push(`${labelFrom}:${variable}`)
+				changed_variables[`${labelTo}:${variable}`] = self.variables[labelTo][variable]
 			}
 			delete self.variables[labelFrom]
+			self.variables_changed(changed_variables, removed_variables)
 		}
 
 		if (self.variable_definitions[labelFrom] !== undefined) {
@@ -130,26 +136,22 @@ function variable(system) {
 					delete self.variables[info.label]
 					io.emit('variable_instance_definitions_set', info.label, [])
 
-					// Reset banks
-					for (var i = 0; i < keys.length; ++i) {
-						// Force update
-						self.system.emit('variable_changed', info.label, keys[i], undefined)
-					}
+					const removed_variables = keys.map((l) => `${info.label}:${l}`)
+					self.variables_changed({}, removed_variables)
 				}
 			})
 		}
 	})
 
 	system.on('instance_delete', function (id, label) {
-		io.emit('variable_instance_definitions_set', label, [])
-
 		if (label !== undefined) {
 			if (self.variables[label] !== undefined) {
+				const removed_variables = []
 				for (var variable in self.variables[label]) {
 					self.variables[label][variable] = undefined
-					self.system.emit('variable_changed', label, variable, undefined)
-					io.emit('variable_set', label + ':' + variable, undefined)
+					removed_variables.push(`${label}:${variable}`)
 				}
+				self.variables_changed({}, removed_variables)
 			}
 
 			delete self.variable_definitions[label]
@@ -199,24 +201,40 @@ function variable(system) {
 	return self
 }
 
-variable.prototype.set_variable = function (label, variable, value) {
+variable.prototype.set_variables = function (label, variables) {
 	var self = this
 
 	if (self.variables[label] === undefined) {
 		self.variables[label] = {}
 	}
 
-	if (self.variables[label][variable] != value) {
-		self.variables[label][variable] = value
+	const changed_variables = {}
+	for (const variable in variables) {
+		const value = variables[variable]
 
-		self.system.emit('variable_changed', label, variable, value)
+		if (self.variables[label][variable] != value) {
+			self.variables[label][variable] = value
 
-		// Skip debug if it's just internal:time_* spamming.
-		if (!(label === 'internal' && variable.match(/^time_/))) {
-			debug('Variable $(' + label + ':' + variable + ') is "' + value + '"')
+			changed_variables[`${label}:${variable}`] = value
+
+			// Skip debug if it's just internal:time_* spamming.
+			if (!(label === 'internal' && variable.match(/^time_/))) {
+				debug('Variable $(' + label + ':' + variable + ') is "' + value + '"')
+			}
 		}
+	}
 
-		io.emit('variable_set', label + ':' + variable, value)
+	self.variables_changed(changed_variables, [])
+}
+
+variable.prototype.variables_changed = function (changed_variables, removed_variables) {
+	var self = this
+
+	if (Object.keys(changed_variables).length > 0 || removed_variables.length > 0) {
+		self.system.emit('variables_changed', changed_variables, removed_variables)
+
+		// TODO - implement on client
+		io.emit('variables_set', changed_variables, removed_variables)
 	}
 }
 

--- a/lib/variable.js
+++ b/lib/variable.js
@@ -81,15 +81,14 @@ function variable(system) {
 		}
 		var fixtext = str
 
-		if (fixtext.match(/\$\(/)) {
-			var matches,
-				reg = /\$\(([^:)]+):([^)]+)\)/g
+		if (fixtext.includes('$(')) {
+			const reg = /\$\(([^:)]+):([^)]+)\)/g
 
+			let matches
 			while ((matches = reg.exec(fixtext)) !== null) {
 				if (matches[1] !== undefined && matches[1] == fromlabel) {
 					if (matches[2] !== undefined) {
-						reg2 = new RegExp('\\$\\(' + escape(matches[1]) + ':' + escape(matches[2]) + '\\)')
-						str = str.replace(reg2, '$(' + tolabel + ':' + matches[2] + ')')
+						str = str.replace(matches[0], '$(' + tolabel + ':' + matches[2] + ')')
 					}
 				}
 			}
@@ -161,30 +160,24 @@ function variable(system) {
 		}
 	})
 
-	function escapereg(str) {
-		return str.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')
-	}
-
 	// Everybody stand back. I know regular expressions. - xckd #208 /ck/kc/
 	system.on('variable_parse', function (string, cb) {
-		var vars,
-			matches,
-			reg = /\$\([^:$)]+:[^)$]+\)/
-
 		if (string === undefined) {
 			return cb(undefined)
 		}
 
-		while ((vars = reg.exec(string))) {
-			matches = vars[0].match(/\$\(([^:)]+):([^)]+)\)/)
+		const reg = /\$\(([^:$)]+):([^)$]+)\)/
+
+		let matches
+		while ((matches = reg.exec(string))) {
 			if (self.variables[matches[1]] !== undefined) {
 				if (self.variables[matches[1]][matches[2]] !== undefined) {
-					string = string.replace(new RegExp(escapereg(matches[0])), self.variables[matches[1]][matches[2]])
+					string = string.replace(matches[0], self.variables[matches[1]][matches[2]])
 				} else {
-					string = string.replace(new RegExp(escapereg(matches[0])), '$NA')
+					string = string.replace(matches[0], '$NA')
 				}
 			} else {
-				string = string.replace(new RegExp(escapereg(matches[0])), '$NA')
+				string = string.replace(matches[0], '$NA')
 			}
 		}
 		cb(string)
@@ -218,7 +211,7 @@ variable.prototype.set_variables = function (label, variables) {
 			changed_variables[`${label}:${variable}`] = value
 
 			// Skip debug if it's just internal:time_* spamming.
-			if (!(label === 'internal' && variable.match(/^time_/))) {
+			if (!(label === 'internal' && variable.startsWith('time_'))) {
 				debug('Variable $(' + label + ':' + variable + ') is "' + value + '"')
 			}
 		}

--- a/lib/variable.js
+++ b/lib/variable.js
@@ -202,13 +202,18 @@ variable.prototype.set_variables = function (label, variables) {
 	}
 
 	const changed_variables = {}
+	const removed_variables = []
 	for (const variable in variables) {
 		const value = variables[variable]
 
 		if (self.variables[label][variable] != value) {
 			self.variables[label][variable] = value
 
-			changed_variables[`${label}:${variable}`] = value
+			if (value === undefined) {
+				removed_variables.push(`${label}:${variable}`)
+			} else {
+				changed_variables[`${label}:${variable}`] = value
+			}
 
 			// Skip debug if it's just internal:time_* spamming.
 			if (!(label === 'internal' && variable.startsWith('time_'))) {
@@ -217,7 +222,7 @@ variable.prototype.set_variables = function (label, variables) {
 		}
 	}
 
-	self.variables_changed(changed_variables, [])
+	self.variables_changed(changed_variables, removed_variables)
 }
 
 variable.prototype.variables_changed = function (changed_variables, removed_variables) {

--- a/webui/src/ContextData.jsx
+++ b/webui/src/ContextData.jsx
@@ -68,9 +68,14 @@ export function ContextData({ socket, children }) {
 					wait: 500,
 				}
 			)
-			const updateVariableValue = (key, value) => {
+			const updateVariableValue = (changed_variables, removed_variables) => {
 				// Don't commit to state immediately, run through a debounce to rate limit the renders
-				variablesQueue[key] = value
+				for (const [key, value] of Object.entries(changed_variables)) {
+					variablesQueue[key] = value
+				}
+				for (const variable of removed_variables) {
+					variablesQueue[variable] = undefined
+				}
 				persistVariableValues()
 			}
 
@@ -78,7 +83,7 @@ export function ContextData({ socket, children }) {
 			socket.emit('instances_get')
 
 			socket.on('variable_instance_definitions_set', updateVariableDefinitions)
-			socket.on('variable_set', updateVariableValue)
+			socket.on('variables_set', updateVariableValue)
 
 			socket.on('actions', setActions)
 			socket.emit('get_actions')
@@ -89,7 +94,7 @@ export function ContextData({ socket, children }) {
 			return () => {
 				socket.off('instances_get:result', setInstances)
 				socket.off('variable_instance_definitions_set', updateVariableDefinitions)
-				socket.off('variable_set', updateVariableValue)
+				socket.off('variables_set', updateVariableValue)
 				socket.off('actions', setActions)
 				socket.off('feedback_get_definitions:result', setFeedbacks)
 			}


### PR DESCRIPTION
This lets us reduce the number of events a bit, as the changes get passed around in a single lump.

It also reduces the number of list iterations we do, and lets some invalidations be batched.


Also, I looked over all the regexps in use, and stripped a lot of them back to basic string operations as they are sufficient and will be more perfomant