### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
 		"companion-module-barco-imagepro": "github:bitfocus/companion-module-barco-imagepro#v1.0.1",
 		"companion-module-barco-matrixpro": "github:bitfocus/companion-module-barco-matrixpro#v1.1.0",
 		"companion-module-barco-pds": "github:bitfocus/companion-module-barco-pds#v1.1.5",
-		"companion-module-barco-pulse": "github:bitfocus/companion-module-barco-pulse#1.1.2",
+		"companion-module-barco-pulse": "github:bitfocus/companion-module-barco-pulse#v1.1.2",
 		"companion-module-bbc-raven": "github:bitfocus/companion-module-bbc-raven#v1.0.0",
 		"companion-module-behringer-wing": "github:bitfocus/companion-module-behringer-wing#v1.0.3",
 		"companion-module-behringer-x32": "github:bitfocus/companion-module-behringer-x32#v2.6.0",


### PR DESCRIPTION
While `npm install`ing on a freshly installed Mac OS X 10.15.7, I ran into the issue that the tag name for barco-pulse has a `v` in front of it, that is not mentioned in the `package.json` file.