### PR TITLE
feat: add userconfig interfaces to instance_skel

### DIFF
--- a/instance_skel.d.ts
+++ b/instance_skel.d.ts
@@ -108,6 +108,8 @@ declare abstract class InstanceSkel<TConfig> {
 	setVariables(variables: { [variableId: string]: string | undefined }): void
 	/** Get the value of a variable from this instance */
 	getVariable(variableId: string, cb: (value: string) => void): void
+	/** Get the value of a userconfig setting */
+	getUserSetting(settingId: string, cb: (value: any) => void): void
 	/** Recheck all feedbacks of the given types. eg `self.checkFeedbacks('bank_style', 'bank_text')` or `self.checkFeedbacks` */
 	checkFeedbacks(...feedbackTypes: string[]): void
 	/** Recheck all feedbacks of the given ids. eg `self.checkFeedbacksById('vvbta3jtaD', 'Ba_1C3NF3q')` */

--- a/instance_skel.d.ts
+++ b/instance_skel.d.ts
@@ -116,7 +116,7 @@ declare abstract class InstanceSkel<TConfig> {
 	/** Get the value of a userconfig setting */
 	getUserSetting(settingId: string, cb: (value: any) => void): void
 	/** Subscribe to changes for a userconfig setting */
-	subscribeUserSetting(key: string, cb: (value: any) => void): void
+	subscribeUserSetting(settingId: string, cb: (value: any) => void): void
 	/** Manually clear/stop all user setting subscriptions */
 	clearUserSettingSubscriptions(): void
 

--- a/instance_skel.d.ts
+++ b/instance_skel.d.ts
@@ -108,12 +108,17 @@ declare abstract class InstanceSkel<TConfig> {
 	setVariables(variables: { [variableId: string]: string | undefined }): void
 	/** Get the value of a variable from this instance */
 	getVariable(variableId: string, cb: (value: string) => void): void
-	/** Get the value of a userconfig setting */
-	getUserSetting(settingId: string, cb: (value: any) => void): void
 	/** Recheck all feedbacks of the given types. eg `self.checkFeedbacks('bank_style', 'bank_text')` or `self.checkFeedbacks` */
 	checkFeedbacks(...feedbackTypes: string[]): void
 	/** Recheck all feedbacks of the given ids. eg `self.checkFeedbacksById('vvbta3jtaD', 'Ba_1C3NF3q')` */
 	checkFeedbacksById(...feedbackIds: string[]): void
+
+	/** Get the value of a userconfig setting */
+	getUserSetting(settingId: string, cb: (value: any) => void): void
+	/** Subscribe to changes for a userconfig setting */
+	subscribeUserSetting(key: string, cb: (value: any) => void): void
+	/** Manually clear/stop all user setting subscriptions */
+	clearUserSettingSubscriptions(): void
 
 	/**
 	 * Parse a string to replace any variable references with their values.

--- a/instance_skel.js
+++ b/instance_skel.js
@@ -304,6 +304,12 @@ instance.prototype.getVariable = function (variable, cb) {
 	self.system.emit('variable_get', self.label, variable, cb)
 }
 
+instance.prototype.getUserSetting = function (key, cb) {
+	var self = this
+
+	self.system.emit('get_userconfig_key', key, cb)
+}
+
 instance.prototype.parseVariables = function (string, cb) {
 	var self = this
 

--- a/lib/feedback.js
+++ b/lib/feedback.js
@@ -108,6 +108,18 @@ function feedback(system) {
 		self.system.emit('feedback_save')
 	})
 
+	system.on('feedback_check_all', function () {
+		if (self.feedbacks !== undefined && Array.isArray(self.feedbacks)) {
+			for (var page in self.feedbacks) {
+				if (Array.isArray(self.feedbacks[page])) {
+					for (var bank in self.feedbacks) {
+						system.emit('feedback_check_bank', page, bank)
+					}
+				}
+			}
+		}
+	})
+
 	system.on('feedback_subscribe_bank', function (page, bank) {
 		if (self.feedbacks[page] !== undefined && self.feedbacks[page][bank] !== undefined) {
 			// find all instance-ids in feedbacks for bank

--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -103,7 +103,11 @@ function graphics(_system) {
 		if (key == 'remove_topbar') {
 			self.remove_topbar = val
 			debug('Topbar removed')
-			self.generate(true)
+			// Delay redrawing to give instances a chance to adjust
+			setTimeout(() => {
+				system.emit('feedback_check_all')
+				self.generate(true)
+			}, 1000)
 		}
 	})
 
@@ -173,7 +177,6 @@ graphics.prototype.generate = function (invalidate) {
 graphics.prototype.drawBankImage = function (c, page, bank) {
 	var self = this
 	var img
-	var notStatic = page === undefined || bank === undefined
 
 	self.style[page + '_' + bank] = c.style
 
@@ -243,22 +246,6 @@ graphics.prototype.drawBankImage = function (c, page, bank) {
 		self.system.emit('graphics_set_bank_bg', page, bank, 0)
 	}
 
-	if (!notStatic) {
-		system.emit('action_bank_status_get', page, bank, function (status) {
-			var colors = [0, img.rgb(255, 127, 0), img.rgb(255, 0, 0)]
-
-			if (status > 0) {
-				img.boxFilled(62, 2, 70, 10, colors[status])
-			}
-		})
-
-		system.emit('action_running_get', page, bank, function (status) {
-			if (status) {
-				img.drawLetter(55, 3, 'play', img.rgb(0, 255, 0), 'icon')
-			}
-		})
-	}
-
 	if (c.style == 'png' || c.style == 'text') {
 		if (c.png64 !== undefined && c.png64 !== null) {
 			try {
@@ -271,7 +258,10 @@ graphics.prototype.drawBankImage = function (c, page, bank) {
 					: img.drawFromPNGdata(data, 0, 14, 72, 58, halign, valign)
 			} catch (e) {
 				img.boxFilled(0, 14, 71, 57, 0)
-				img.drawAlignedText(2, 18, 68, 52, 'PNG ERROR', img.rgb(255, 0, 0), 0, 2, 1, 'center', 'center')
+				self.remove_topbar
+					? img.drawAlignedText(2, 2, 68, 68, 'PNG ERROR', img.rgb(255, 0, 0), 0, 2, 1, 'center', 'center')
+					: img.drawAlignedText(2, 18, 68, 52, 'PNG ERROR', img.rgb(255, 0, 0), 0, 2, 1, 'center', 'center')
+				self.drawTopbar(img, c, page, bank)
 				return img
 			}
 		} else {
@@ -299,9 +289,18 @@ graphics.prototype.drawBankImage = function (c, page, bank) {
 
 		/* raw image buffers */
 		if (c.img64 !== undefined) {
-			self.remove_topbar
-				? img.drawPixelBuffer(0, 0, 72, 72, c.img64, 'base64')
-				: img.drawPixelBuffer(0, 14, 72, 58, c.img64, 'base64')
+			try {
+				self.remove_topbar
+					? img.drawPixelBuffer(0, 0, 72, 72, c.img64, 'base64')
+					: img.drawPixelBuffer(0, 14, 72, 58, c.img64, 'base64')
+			} catch (e) {
+				img.boxFilled(0, 14, 71, 57, 0)
+				self.remove_topbar
+					? img.drawAlignedText(2, 2, 68, 68, 'IMAGE\\nDRAW\\nERROR', img.rgb(255, 0, 0), 0, 2, 1, 'center', 'center')
+					: img.drawAlignedText(2, 18, 68, 52, 'IMAGE\\nDRAW\\nERROR', img.rgb(255, 0, 0), 0, 2, 1, 'center', 'center')
+				self.drawTopbar(img, c, page, bank)
+				return img
+			}
 		}
 	}
 
@@ -332,6 +331,15 @@ graphics.prototype.drawBankImage = function (c, page, bank) {
 		}
 	}
 
+	self.drawTopbar(img, c, page, bank)
+
+	return img
+}
+
+graphics.prototype.drawTopbar = function (img, c, page, bank) {
+	var self = this
+	var notStatic = page === undefined || bank === undefined
+
 	if (page === undefined) {
 		// Preview (no page/bank)
 
@@ -353,7 +361,21 @@ graphics.prototype.drawBankImage = function (c, page, bank) {
 		}
 	}
 
-	return img
+	if (!notStatic) {
+		self.system.emit('action_bank_status_get', page, bank, function (status) {
+			var colors = [0, img.rgb(255, 127, 0), img.rgb(255, 0, 0)]
+
+			if (status > 0) {
+				img.boxFilled(62, 2, 70, 10, colors[status])
+			}
+		})
+
+		self.system.emit('action_running_get', page, bank, function (status) {
+			if (status) {
+				img.drawLetter(55, 3, 'play', img.rgb(0, 255, 0), 'icon')
+			}
+		})
+	}
 }
 
 graphics.prototype.drawBank = function (page, bank) {

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -81,9 +81,9 @@ function instance(system) {
 		self.system.emit('log', 'instance(' + id + ')', 'info', 'instance deleted')
 
 		if (self.active[id] !== undefined) {
-			if (self.active[id].destroy !== undefined && typeof self.active[id].destroy == 'function') {
+			if (self.active[id]._destroy !== undefined && typeof self.active[id]._destroy == 'function') {
 				try {
-					self.active[id].destroy()
+					self.active[id]._destroy()
 				} catch (e) {
 					self.system.emit('log', 'instance(' + id + ')', 'debug', 'Error while deleting instance: ' + e.message)
 				}
@@ -112,11 +112,11 @@ function instance(system) {
 			for (var id in self.active) {
 				if (
 					self.active[id] !== undefined &&
-					self.active[id].destroy !== undefined &&
-					typeof self.active[id].destroy == 'function'
+					self.active[id]._destroy !== undefined &&
+					typeof self.active[id]._destroy == 'function'
 				) {
 					try {
-						self.active[id].destroy()
+						self.active[id]._destroy()
 					} catch (e) {
 						self.system.emit(
 							'log',
@@ -422,11 +422,11 @@ function instance(system) {
 			if (state === false) {
 				if (
 					self.active[id] !== undefined &&
-					self.active[id].destroy !== undefined &&
-					typeof self.active[id].destroy == 'function'
+					self.active[id]._destroy !== undefined &&
+					typeof self.active[id]._destroy == 'function'
 				) {
 					try {
-						self.active[id].destroy()
+						self.active[id]._destroy()
 					} catch (e) {
 						self.system.emit('log', 'instance(' + id + ')', 'warn', 'Error disabling instance: ' + e.message)
 					}
@@ -502,7 +502,7 @@ instance.prototype.upgrade_instance_config_partial = function (
 
 	const package_info = self.package_info[instance_type]
 	const package_name = package_info ? package_info.name : instance_type
-	var debug = require('debug')('instance:' + package_name + ':' + id)
+	var debug = require('debug')('instance/' + package_name + '/' + id)
 
 	debug(`upgrade_instance_config_partial(${package_name}): starting`)
 

--- a/lib/userconfig.js
+++ b/lib/userconfig.js
@@ -16,7 +16,6 @@
  */
 
 var debug = require('debug')('lib/userconfig')
-var system
 
 function userconfig(system) {
 	var self = this
@@ -37,6 +36,10 @@ function userconfig(system) {
 
 	system.on('get_userconfig', function (cb) {
 		cb(self.userconfig)
+	})
+
+	system.on('get_userconfig_key', function (key, cb) {
+		cb(self.userconfig[key])
 	})
 
 	system.emit('io_get', function (io) {


### PR DESCRIPTION
The "Remove Topbar" feature introduced some issues for modules dynamically drawing the canvas in feedbacks and injecting a raw pixel buffer for rasterization (e.g. `shure-wireless` and `studiocoast-vmix`).  The modules needed the ability to get and subscribe to the `remove_topbar` setting to change raster dimensions and placements.  This also required some changes/fixes to the remove topbar implementation to accommodate.

New `instance_skel` functions:

- `getUserSetting(key, cb)`  - get the value of a userconfig setting, returned via callback
- `subscribeUserSetting(key, cb)` - same as get but will provide return via callback whenever the setting changes
- `clearUserSettingSubscriptions()` - manually clear/stop all user setting subscriptions
- (there is additional 'behind the scenes' implementation in `instance_skel`, including a `destroy()` wrapper that executes the clear)

Other changes:

- Topbar rasterizing was moved to a function so it can be called at the end of drawing like normal or during a png64 or img64 exception so that it is always present
- Added img64 rendering try-catch
- Added `get_userconfig_key` system call to do the single setting fetch
- Added `feedback_check_all` system call
- Added run of `feedback_check_all` in `lib/graphics` on remove topbar change prior to re-rendering all banks; moving both to a 1s delay so modules can make adjustments

Sample use-case is in `shure-wireless` [here](https://github.com/bitfocus/companion-module-shure-wireless/commit/0d7e0ca8b5bff6b98328d16c51e33fd46df7348a)