### PR TITLE
Use button offset for Streamdeck Mini

### DIFF
--- a/lib/usb/common.js
+++ b/lib/usb/common.js
@@ -30,6 +30,9 @@ common.prototype.toDeviceKey = function (key) {
 		return key
 	}
 
+	// adjust column for mini
+	key -= self.streamDeck.MODEL == 'mini' ? 1 : 0
+
 	if (key % global.MAX_BUTTONS_PER_ROW > self.keysPerRow) {
 		return -1
 	}
@@ -51,6 +54,9 @@ common.prototype.toGlobalKey = function (key) {
 
 	var rows = Math.floor(key / self.keysPerRow)
 	var col = key % self.keysPerRow
+
+	// adjust column for mini
+	col += self.streamDeck.MODEL == 'mini' ? 1 : 0
 
 	return rows * global.MAX_BUTTONS_PER_ROW + col
 }


### PR DESCRIPTION
When a Streamdeck Mini (6 button) controller is attached, this adjusts the buttons to start at column 2 so they will match the 'mask' displayed in the GUI.