### PR TITLE
feat: rewrite satellite api

### DIFF
--- a/app.js
+++ b/app.js
@@ -184,6 +184,7 @@ system.ready = function (logToFile) {
 	var loadsave = require('./lib/loadsave')(system)
 	var preset = require('./lib/preset')(system)
 	var satellite = require('./lib/satellite_server')(system)
+	var satellitev2 = require('./lib/satellite/satellite_server_v2')(system)
 	var ws_api = require('./lib/ws_api')(system)
 	var help = require('./lib/help')(system)
 

--- a/lib/device.js
+++ b/lib/device.js
@@ -323,7 +323,7 @@ device.prototype.drawPage = function () {
 		self.data = graphics.getImagesForPage(self.page)
 
 		for (var i in self.data) {
-			self.panel.draw(i, self.data[i].buffer)
+			self.panel.draw(Number(i), self.data[i].buffer)
 		}
 	} else {
 		/* TODO: We should move this to the device module */

--- a/lib/elgato_dm.js
+++ b/lib/elgato_dm.js
@@ -23,7 +23,7 @@ var usb = require('./usb')
 var elgatoEmulator = require('./elgato_emulator')
 var elgatoPluginDevice = require('./elgato_plugin')
 var satelliteDevice = require('./satellite_device')
-var preview = require('./preview')
+var satelliteDeviceV2 = require('./satellite/satellite_device_v2')
 var system
 
 HID.setDriverType('libusb')
@@ -284,6 +284,11 @@ elgatoDM.prototype.addDevice = function (device, type) {
 		self.updateDevicesList()
 	} else if (type === 'satellite_device') {
 		instances[device.path] = new satelliteDevice(system, device.path, device)
+		instances[device.path].deviceHandler = new deviceHandler(system, instances[device.path])
+
+		self.updateDevicesList()
+	} else if (type === 'satellite_device2') {
+		instances[device.path] = new satelliteDeviceV2(system, device)
 		instances[device.path].deviceHandler = new deviceHandler(system, instances[device.path])
 
 		self.updateDevicesList()

--- a/lib/elgato_dm.js
+++ b/lib/elgato_dm.js
@@ -172,44 +172,42 @@ elgatoDM.prototype.refreshDevices = function (cb) {
 	function scanUSB() {
 		debug('USB: checking devices (blocking call)')
 		var devices = HID.devices()
-		for (var i = 0; i < devices.length; ++i) {
-			;(function (device) {
-				if (
-					!ignoreStreamDeck &&
-					device.vendorId === 0x0fd9 &&
-					device.productId === 0x0060 &&
-					instances[device.path] === undefined
-				) {
-					self.addDevice(device, 'elgato')
-				} else if (
-					!ignoreStreamDeck &&
-					device.vendorId === 0x0fd9 &&
-					device.productId === 0x0063 &&
-					instances[device.path] === undefined
-				) {
-					self.addDevice(device, 'elgato-mini')
-				} else if (
-					!ignoreStreamDeck &&
-					device.vendorId === 0x0fd9 &&
-					device.productId === 0x006c &&
-					instances[device.path] === undefined
-				) {
-					self.addDevice(device, 'elgato-xl')
-				} else if (
-					!ignoreStreamDeck &&
-					device.vendorId === 0x0fd9 &&
-					device.productId === 0x006d &&
-					instances[device.path] === undefined
-				) {
-					self.addDevice(device, 'elgato-v2')
-				} else if (device.vendorId === 0xffff && device.productId === 0x1f40 && instances[device.path] === undefined) {
-					self.addDevice(device, 'infinitton')
-				} else if (device.vendorId === 0xffff && device.productId === 0x1f41 && instances[device.path] === undefined) {
-					self.addDevice(device, 'infinitton')
-				} else if (device.vendorId === 1523 && device.interface === 0) {
-					self.addDevice(device, 'xkeys')
-				}
-			})(devices[i])
+		for (const device of devices) {
+			if (
+				!ignoreStreamDeck &&
+				device.vendorId === 0x0fd9 &&
+				device.productId === 0x0060 &&
+				instances[device.path] === undefined
+			) {
+				self.addDevice(device, 'elgato')
+			} else if (
+				!ignoreStreamDeck &&
+				device.vendorId === 0x0fd9 &&
+				device.productId === 0x0063 &&
+				instances[device.path] === undefined
+			) {
+				self.addDevice(device, 'elgato-mini')
+			} else if (
+				!ignoreStreamDeck &&
+				device.vendorId === 0x0fd9 &&
+				device.productId === 0x006c &&
+				instances[device.path] === undefined
+			) {
+				self.addDevice(device, 'elgato-xl')
+			} else if (
+				!ignoreStreamDeck &&
+				device.vendorId === 0x0fd9 &&
+				device.productId === 0x006d &&
+				instances[device.path] === undefined
+			) {
+				self.addDevice(device, 'elgato-v2')
+			} else if (device.vendorId === 0xffff && device.productId === 0x1f40 && instances[device.path] === undefined) {
+				self.addDevice(device, 'infinitton')
+			} else if (device.vendorId === 0xffff && device.productId === 0x1f41 && instances[device.path] === undefined) {
+				self.addDevice(device, 'infinitton')
+			} else if (device.vendorId === 1523 && device.interface === 0) {
+				self.addDevice(device, 'xkeys')
+			}
 		}
 		debug('USB: done')
 

--- a/lib/elgato_emulator.js
+++ b/lib/elgato_emulator.js
@@ -94,7 +94,6 @@ function elgatoEmulator(_system, devicepath) {
 
 	common.apply(this, arguments)
 }
-elgatoEmulator.device_type = 'StreamDeck Emulator'
 
 // Manual inherit
 for (var key in common.prototype) {
@@ -171,16 +170,7 @@ elgatoEmulator.prototype.clearKey = function (keyIndex) {
 
 	self.keys[keyIndex] = Buffer.alloc(15552)
 
-	io.emit('clearKey', keyIndex)
-}
-
-elgatoEmulator.prototype.clearAllKeys = function () {
-	var self = this
-
-	for (var i = 0; i < global.MAX_BUTTONS; ++i) {
-		self.keys[keyIndex] = Buffer.alloc(15552)
-		io.emit('clearKey', keyIndex)
-	}
+	io.emit('emul_clearKey', keyIndex)
 }
 
 elgatoEmulator.prototype.setBrightness = function (value) {

--- a/lib/elgato_plugin.js
+++ b/lib/elgato_plugin.js
@@ -38,7 +38,6 @@ function elgatoPlugin(_system, devicepath) {
 
 	self.devicepath = devicepath
 	self.keys = {}
-	self.device_type = 'StreamDeck Plugin'
 	self.config = ['orientation', 'page']
 	self.keysPerRow = 8
 	self.keysTotal = 32
@@ -92,7 +91,6 @@ function elgatoPlugin(_system, devicepath) {
 		}
 	}
 }
-elgatoPlugin.device_type = 'StreamDeck Plugin'
 
 util.inherits(elgatoPlugin, EventEmitter)
 
@@ -178,18 +176,6 @@ elgatoPlugin.prototype.fillImage = function (keyIndex, imageBuffer) {
 		self.socket.apicommand('fillImage', { keyIndex: keyIndex, data: imageBuffer })
 	} else {
 		//debug('trying to emit to nonexistaant socket: ', self.id);
-	}
-}
-
-elgatoPlugin.prototype.clearKey = function (keyIndex) {
-	var self = this
-
-	self.keys[keyIndex] = Buffer.alloc(15552)
-
-	if (self.socket !== undefined) {
-		self.socket.apicommand('fillImage', { keyIndex: keyIndex, data: self.keys[keyIndex] })
-	} else {
-		debug('trying to emit to nonexistaant socket: ', self.id)
 	}
 }
 

--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -39,6 +39,7 @@ function graphics(_system) {
 	self.page = {}
 	self.style = {}
 	self.pincodebuffer = {}
+	self.lastdrawproperties = {}
 
 	system.on('graphics_bank_invalidate', self.invalidateBank.bind(self))
 	system.on('graphics_indicate_push', self.indicatePush.bind(self))
@@ -64,6 +65,10 @@ function graphics(_system) {
 
 	system.on('action_bank_status_set', function (page, bank, status) {
 		self.invalidateBank(page, bank)
+	})
+
+	system.on('graphics_bank_draw_properties', function (page, bank, cb) {
+		cb(self.lastdrawproperties[page + '_' + bank])
 	})
 
 	system.on('graphics_page_controls_invalidated', function (page) {
@@ -198,6 +203,9 @@ graphics.prototype.drawBankImage = function (c, page, bank) {
 		img = new Image(72, 72)
 	}
 
+	// clear the lastdrawproperties, it gets set again if it was used
+	delete self.lastdrawproperties[page + '_' + bank]
+
 	// special button types
 	if (c.style == 'pageup') {
 		img.backgroundColor(img.rgb(15, 15, 15))
@@ -243,6 +251,8 @@ graphics.prototype.drawBankImage = function (c, page, bank) {
 			img.drawAlignedText(0, 0, 72, 72, pagename, colorWhite, '18', 2, 0, 'center', 'center')
 		}
 	} else if (c.style) {
+		self.lastdrawproperties[page + '_' + bank] = c
+
 		// handle upgrade from pre alignment-support configuration
 		if (c.alignment === undefined) {
 			c.alignment = 'center:center'
@@ -361,6 +371,8 @@ graphics.prototype.drawBank = function (page, bank) {
 
 		img.drawTextLine(2, 3, page + '.' + bank, img.rgb(50, 50, 50), 0)
 		img.horizontalLine(13, img.rgb(30, 30, 30))
+
+		delete self.lastdrawproperties[page + '_' + bank]
 	}
 
 	return img

--- a/lib/satellite/satellite_device_v2.js
+++ b/lib/satellite/satellite_device_v2.js
@@ -44,11 +44,6 @@ function satellite_device_v2(system, deviceInfo) {
 		brightness: 100,
 	}
 
-	self.keyColorChanged = self.keyColorChanged.bind(self)
-	if (self.streamColors) {
-		self.system.on('graphics_set_bank_bg', self.keyColorChanged)
-	}
-
 	system.on(deviceInfo.path + '_button', function (key, state) {
 		self.doButton(key, state)
 	})
@@ -60,16 +55,6 @@ function satellite_device_v2(system, deviceInfo) {
 
 util.inherits(satellite_device_v2, EventEmitter)
 
-satellite_device_v2.prototype.keyColorChanged = function (page, bank, bgcolor) {
-	var self = this
-
-	if (self.socket !== undefined && self.deviceHandler && self.deviceHandler.page == page) {
-		// convert color to hex
-		const color = bgcolor.toString(16).padStart(6, '0')
-		self.socket.write(`KEY-COLOR DEVICEID=${self.deviceId} KEY=${bank} COLOR=#${color}\n`)
-	}
-}
-
 satellite_device_v2.prototype.begin = function () {
 	var self = this
 
@@ -79,7 +64,6 @@ satellite_device_v2.prototype.begin = function () {
 satellite_device_v2.prototype.quit = function () {
 	var self = this
 	self.system.removeAllListeners(self.devicepath + '_button')
-	self.system.off('graphics_set_bank_bg', self.keyColorChanged)
 }
 
 satellite_device_v2.prototype.draw = function (key, buffer) {
@@ -93,10 +77,23 @@ satellite_device_v2.prototype.draw = function (key, buffer) {
 	const keyIndex2 = self.toDeviceKey(key)
 	if (keyIndex2 === -1) return
 
-	if (self.socket !== undefined && self.streamBitmaps) {
-		buffer = self.handleBuffer(buffer)
+	if (self.socket !== undefined) {
+		if (self.streamBitmaps) {
+			buffer = self.handleBuffer(buffer)
 
-		self.socket.write(`KEY-DRAW DEVICEID=${self.deviceId} KEY=${keyIndex2} DATA=${buffer.toString('base64')}\n`)
+			self.socket.write(`KEY-DRAW DEVICEID=${self.deviceId} KEY=${keyIndex2} DATA=${buffer.toString('base64')}\n`)
+		}
+		if (self.streamColors && self.deviceHandler) {
+			system.emit('graphics_bank_draw_properties', self.deviceHandler.page, key + 1, function (style) {
+				if (self.socket !== undefined) {
+					// convert color to hex
+					const bgcolor = style ? style.bgcolor : 0
+					const color = bgcolor.toString(16).padStart(6, '0')
+
+					self.socket.write(`KEY-COLOR DEVICEID=${self.deviceId} KEY=${keyIndex2} COLOR=#${color}\n`)
+				}
+			})
+		}
 	}
 
 	return true

--- a/lib/satellite/satellite_device_v2.js
+++ b/lib/satellite/satellite_device_v2.js
@@ -1,0 +1,179 @@
+/*
+ * This file is part of the Companion project
+ * Copyright (c) 2019 Bitfocus AS
+ * Authors: Håkon Nessjøen <haakon@bitfocus.io>, William Viker <william@bitfocus.io>
+ *
+ * This program is free software.
+ * You should have received a copy of the MIT licence as well as the Bitfocus
+ * Individual Contributor License Agreement for companion along with
+ * this program.
+ *
+ * You can be released from the requirements of the license by purchasing
+ * a commercial license. Buying such a license is mandatory as soon as you
+ * develop commercial activities involving the Companion software without
+ * disclosing the source code of your own applications.
+ *
+ */
+const { EventEmitter } = require('events')
+const util = require('util')
+const debug = require('debug')('lib/satellite_device')
+
+function satellite_device_v2(system, deviceInfo) {
+	var self = this
+
+	self.system = system
+	EventEmitter.call(self)
+
+	self.type = deviceInfo.productName
+	self.deviceId = deviceInfo.deviceId
+	self.serialnumber = deviceInfo.path
+	self.id = deviceInfo.path
+	self.keysPerRow = deviceInfo.keysPerRow
+	self.keysTotal = deviceInfo.keysTotal
+	self.socket = deviceInfo.socket
+	self.streamBitmaps = deviceInfo.streamBitmaps
+	self.streamColors = deviceInfo.streamColors
+
+	debug('Adding Satellite device')
+
+	self.devicepath = deviceInfo.path
+	self.config = ['orientation', 'brightness', 'page']
+
+	self._config = {
+		rotation: 0,
+		brightness: 100,
+	}
+
+	self.keyColorChanged = self.keyColorChanged.bind(self)
+	if (self.streamColors) {
+		self.system.on('graphics_set_bank_bg', self.keyColorChanged)
+	}
+
+	system.on(deviceInfo.path + '_button', function (key, state) {
+		self.doButton(key, state)
+	})
+
+	setImmediate(() => {
+		system.emit('elgato_ready', self.devicepath)
+	})
+}
+
+util.inherits(satellite_device_v2, EventEmitter)
+
+satellite_device_v2.prototype.keyColorChanged = function (page, bank, bgcolor) {
+	var self = this
+
+	if (self.socket !== undefined && self.deviceHandler && self.deviceHandler.page == page) {
+		// convert color to hex
+		const color = bgcolor.toString(16).padStart(6, '0')
+		self.socket.write(`KEY-COLOR DEVICEID=${self.deviceId} KEY=${bank} COLOR=#${color}\n`)
+	}
+}
+
+satellite_device_v2.prototype.begin = function () {
+	var self = this
+
+	self.setBrightness(self._config.brightness)
+}
+
+satellite_device_v2.prototype.quit = function () {
+	var self = this
+	self.system.removeAllListeners(self.devicepath + '_button')
+	self.system.off('graphics_set_bank_bg', self.keyColorChanged)
+}
+
+satellite_device_v2.prototype.draw = function (key, buffer) {
+	var self = this
+
+	if (buffer === undefined || buffer.length != 15552) {
+		debug('buffer was not 15552, but ', buffer.length)
+		return false
+	}
+
+	const keyIndex2 = self.toDeviceKey(key)
+	if (keyIndex2 === -1) return
+
+	if (self.socket !== undefined && self.streamBitmaps) {
+		buffer = self.handleBuffer(buffer)
+
+		self.socket.write(`KEY-DRAW DEVICEID=${self.deviceId} KEY=${keyIndex2} DATA=${buffer.toString('base64')}\n`)
+	}
+
+	return true
+}
+
+satellite_device_v2.prototype.doButton = function (key, state) {
+	var self = this
+
+	const keyIndex2 = this.toGlobalKey(key)
+
+	self.system.emit('elgato_click', self.devicepath, keyIndex2, state)
+}
+
+satellite_device_v2.prototype.clearDeck = function () {
+	var self = this
+	debug('elgato.prototype.clearDeck()')
+	if (self.socket !== undefined) {
+		self.socket.write(`CLEAR-DECK DEVICEID=${self.deviceId}\n`)
+	} else {
+		debug('trying to emit to nonexistaant socket: ', self.id)
+	}
+}
+
+/* elgato-streamdeck functions */
+
+satellite_device_v2.prototype.setConfig = function (config) {
+	var self = this
+
+	if (self._config.rotation != config.rotation && config.rotation !== undefined) {
+		self._config.rotation = config.rotation
+		self.system.emit('device_redraw', self.devicepath)
+	}
+
+	if (self._config.brightness != config.brightness && config.brightness !== undefined) {
+		self._config.brightness = config.brightness
+		self.setBrightness(config.brightness)
+	}
+
+	if (self.deviceHandler) {
+		// Custom override, page should have been inside the deviceconfig object
+		if (config.page !== undefined) {
+			self.deviceHandler.page = config.page
+			self.deviceHandler.updatePagedevice()
+		}
+	}
+
+	self._config = config
+
+	if (self.deviceHandler) {
+		self.deviceconfig = config
+		self.deviceHandler.updatedConfig()
+	}
+}
+
+satellite_device_v2.prototype.setBrightness = function (value) {
+	var self = this
+
+	debug('brightness: ' + value)
+	if (self.socket !== undefined) {
+		self.socket.write(`BRIGHTNESS DEVICEID=${self.deviceId} VALUE=${value}\n`)
+	}
+}
+
+// Steal rotation code from usb/common
+var common = require('../usb/common')
+util.inherits(satellite_device_v2, common)
+
+satellite_device_v2.prototype.getConfig = function (cb) {
+	var self = this
+
+	debug('getConfig')
+
+	if (typeof cb == 'function') {
+		cb(self._config)
+	}
+
+	return self._config
+}
+
+module.exports = satellite_device_v2

--- a/lib/satellite/satellite_server_v2.js
+++ b/lib/satellite/satellite_server_v2.js
@@ -162,13 +162,18 @@ class satelliteServerV2 {
 
 		const existing = Object.entries(this.devices).find(([internalId, dev]) => dev.id === id)
 		if (existing) {
-			// // Reuse the existing, to avoid duplicates issues
-			// setImmediate(() => {
-			// 	system.emit('elgato_ready', id)
-			// })
-			// return existing[0]
-			socket.write(`ADD-DEVICE ERROR Device already exists\n`)
-			return
+			if (existing[1].socket === socket) {
+				socket.write(`ADD-DEVICE ERROR Device already added\n`)
+				return
+			} else {
+				// // Reuse the existing, to avoid duplicates issues
+				// setImmediate(() => {
+				// 	system.emit('elgato_ready', id)
+				// })
+				// return existing[0]
+				socket.write(`ADD-DEVICE ERROR Device exists elsewhere\n`)
+				return
+			}
 		}
 
 		this.devices[id] = {

--- a/lib/satellite/satellite_server_v2.js
+++ b/lib/satellite/satellite_server_v2.js
@@ -1,0 +1,264 @@
+/*
+ * This file is part of the Companion project
+ * Copyright (c) 2018 Bitfocus AS
+ * Authors: Håkon Nessjøen <haakon@bitfocus.io>, William Viker <william@bitfocus.io>
+ *
+ * This program is free software.
+ * You should have received a copy of the MIT licence as well as the Bitfocus
+ * Individual Contributor License Agreement for companion along with
+ * this program.
+ *
+ * You can be released from the requirements of the license by purchasing
+ * a commercial license. Buying such a license is mandatory as soon as you
+ * develop commercial activities involving the Companion software without
+ * disclosing the source code of your own applications.
+ *
+ */
+const debug = require('debug')('lib/satellite_server')
+const net = require('net')
+
+function isFalsey(val) {
+	return val.toLowerCase() == 'false' || val == '0'
+}
+
+function parseLineParameters(line) {
+	// https://newbedev.com/javascript-split-string-by-space-but-ignore-space-in-quotes-notice-not-to-split-by-the-colon-too
+	const fragments = line.match(/\\?.|^$/g).reduce(
+		(p, c) => {
+			if (c === '"') {
+				p.quote ^= 1
+			} else if (!p.quote && c === ' ') {
+				p.a.push('')
+			} else {
+				p.a[p.a.length - 1] += c.replace(/\\(.)/, '$1')
+			}
+			return p
+		},
+		{ a: [''] }
+	).a
+
+	const res = {}
+
+	for (const fragment of fragments) {
+		const [key, value] = fragment.split('=')
+		res[key] = value === undefined ? true : value
+	}
+
+	return res
+}
+
+class satelliteServerV2 {
+	constructor(system) {
+		this.system = system
+		this.clients = []
+		this.devices = {}
+
+		this.buildNumber = 'Unknown'
+		this.system.emit('skeleton-info-info', (info) => {
+			// Assume this happens synchronously
+			this.buildNumber = info.appBuild
+		})
+
+		this.elgatoDM = require('../elgato_dm')(system)
+
+		this.server = net.createServer((socket) => {
+			socket.name = socket.remoteAddress + ':' + socket.remotePort
+
+			this.initSocket(socket)
+		})
+		this.server.on('error', function (e) {
+			debug('listen-socket error: ', e)
+		})
+
+		try {
+			this.server.listen(37134)
+		} catch (e) {
+			debug('ERROR opening port 37134 for companion satellite devices')
+		}
+	}
+
+	initSocket(socket) {
+		debug(`new connection from ${socket.name}`)
+
+		let receivebuffer = ''
+		socket.on('data', (data) => {
+			receivebuffer += data.toString()
+
+			var i = 0,
+				line = '',
+				offset = 0
+			while ((i = receivebuffer.indexOf('\n', offset)) !== -1) {
+				line = receivebuffer.substr(offset, i - offset)
+				offset = i + 1
+				this.handleCommand(socket, line.toString().replace(/\r/, ''))
+			}
+			receivebuffer = receivebuffer.substr(offset)
+		})
+
+		socket.on('error', (e) => {
+			debug('socket error:', e)
+		})
+
+		socket.on('close', () => {
+			for (let key in this.devices) {
+				if (this.devices[key].socket === socket) {
+					this.elgatoDM.removeDevice(this.devices[key].id)
+					system.removeAllListeners(this.devices[key].id + '_button')
+					delete this.devices[key]
+				}
+			}
+
+			socket.removeAllListeners('data')
+			socket.removeAllListeners('close')
+		})
+
+		socket.write(`BEGIN Companion Version=${this.buildNumber}\n`)
+	}
+
+	handleCommand(socket, line) {
+		debug(`received "${line}" from ${socket.name}`)
+
+		const i = line.indexOf(' ')
+		const cmd = i === -1 ? line : line.slice(0, i)
+		const body = i === -1 ? '' : line.slice(i + 1)
+		const params = parseLineParameters(body)
+		switch (cmd.toUpperCase()) {
+			case 'ADD-DEVICE':
+				this.addDevice(socket, params)
+				break
+			case 'REMOVE-DEVICE':
+				this.removeDevice(socket, params)
+				break
+			case 'KEY-PRESS':
+				this.keyPress(socket, params)
+				break
+			case 'PING':
+				socket.write(`PONG ${body}\n`)
+				break
+			case 'PONG':
+				// Nothing to do
+				// TODO - track timeouts?
+				break
+			case 'QUIT':
+				socket.destroy()
+				break
+			default:
+				socket.write(`ERROR Unknown command "${cmd.toUpperCase()}"\n`)
+		}
+	}
+
+	addDevice(socket, params) {
+		if (!params.DEVICEID) {
+			socket.write(`ADD-DEVICE ERROR Missing DEVICEID\n`)
+			return
+		}
+		if (!params.PRODUCT_NAME) {
+			socket.write(`ADD-DEVICE ERROR Missing PRODUCT_NAME\n`)
+			return
+		}
+
+		const id = `satellite-${params.DEVICEID}`
+		debug(`add device "${id}" for ${socket.remoteAddress}`)
+
+		const existing = Object.entries(this.devices).find(([internalId, dev]) => dev.id === id)
+		if (existing) {
+			// // Reuse the existing, to avoid duplicates issues
+			// setImmediate(() => {
+			// 	system.emit('elgato_ready', id)
+			// })
+			// return existing[0]
+			socket.write(`ADD-DEVICE ERROR Device already exists\n`)
+			return
+		}
+
+		this.devices[id] = {
+			id: id,
+			socket: socket,
+		}
+
+		const keysTotal = params.KEYS_TOTAL ? parseInt(params.KEYS_TOTAL) : global.MAX_BUTTONS
+		if (isNaN(keysTotal) || keysTotal > global.MAX_BUTTONS || keysTotal <= 0) {
+			socket.write(`ADD-DEVICE ERROR Invalid KEYS_TOTAL\n`)
+			return
+		}
+
+		const keysPerRow = params.KEYS_PER_ROW ? parseInt(params.KEYS_PER_ROW) : global.MAX_BUTTONS_PER_ROW
+		if (isNaN(keysPerRow) || keysPerRow > global.MAX_BUTTONS || keysPerRow <= 0) {
+			socket.write(`ADD-DEVICE ERROR Invalid KEYS_PER_ROW\n`)
+			return
+		}
+
+		const streamBitmaps = params.BITMAPS === undefined || !isFalsey(params.BITMAPS)
+		const streamColors = params.COLORS !== undefined && !isFalsey(params.COLORS)
+
+		this.elgatoDM.addDevice(
+			{
+				path: id,
+				keysTotal: keysTotal,
+				keysPerRow: keysPerRow,
+				socket: socket,
+				deviceId: params.DEVICEID,
+				productName: params.PRODUCT_NAME,
+				streamBitmaps: streamBitmaps,
+				streamColors: streamColors,
+			},
+			'satellite_device2'
+		)
+
+		socket.write(`ADD-DEVICE OK ${params.DEVICEID}\n`)
+	}
+
+	removeDevice(socket, params) {
+		if (!params.DEVICEID) {
+			socket.write(`REMOVE-DEVICE ERROR Missing DEVICEID\n`)
+			return
+		}
+
+		const id = `satellite-${params.DEVICEID}`
+		const device = this.devices[id]
+		if (device && device.socket === socket) {
+			this.system.removeAllListeners(id + '_button')
+			this.elgatoDM.removeDevice(id)
+			delete this.devices[id]
+			socket.write(`REMOVE-DEVICE OK ${params.DEVICEID}\n`)
+		} else {
+			socket.write(`REMOVE-DEVICE ERROR Device not found\n`)
+		}
+	}
+
+	keyPress(socket, params) {
+		if (!params.DEVICEID) {
+			socket.write(`KEY-PRESS ERROR Missing DEVICEID\n`)
+			return
+		}
+		if (!params.KEY) {
+			socket.write(`KEY-PRESS ERROR Missing KEY\n`)
+			return
+		}
+		if (!params.PRESSED) {
+			socket.write(`KEY-PRESS ERROR Missing PRESSED\n`)
+			return
+		}
+
+		const key = parseInt(params.KEY)
+		if (isNaN(key) || key > global.MAX_BUTTONS || key <= 0) {
+			socket.write(`KEY-PRESS ERROR Invalid KEY\n`)
+			return
+		}
+
+		const pressed = !isFalsey(params.PRESSED)
+
+		const id = `satellite-${params.DEVICEID}`
+		const device = this.devices[id]
+		if (device && device.socket === socket) {
+			this.system.emit(id + '_button', key, pressed)
+			socket.write(`KEY-PRESS OK\n`)
+		} else {
+			socket.write(`KEY-PRESS ERROR Device not found KEY\n`)
+		}
+	}
+}
+
+exports = module.exports = function (_system) {
+	return new satelliteServerV2(_system)
+}

--- a/lib/satellite_device.js
+++ b/lib/satellite_device.js
@@ -36,7 +36,6 @@ function satellite(system, devicepath, deviceInfo) {
 	debug('Adding Satellite device')
 
 	self.devicepath = devicepath
-	self.device_type = 'Satellite device'
 	self.config = ['orientation', 'brightness', 'page']
 
 	self._config = {
@@ -64,7 +63,6 @@ function satellite(system, devicepath, deviceInfo) {
 
 	self.clearImage = new Image(72, 72)
 }
-satellite.device_type = 'Satellite device'
 
 util.inherits(satellite, EventEmitter)
 

--- a/lib/satellite_server.js
+++ b/lib/satellite_server.js
@@ -24,7 +24,6 @@ var elgatoDM
 function satelliteServer(_system) {
 	var self = this
 
-	self.ready = true
 	self.system = system = _system
 	self.clients = []
 	self.devices = {}

--- a/lib/usb/elgato-base.js
+++ b/lib/usb/elgato-base.js
@@ -51,7 +51,6 @@ function elgato_base(system, devicepath, type) {
 	self.info = {
 		type: `${type} device`,
 		devicepath: devicepath,
-		device_type: 'StreamDeck',
 		config: ['brightness', 'orientation', 'page'],
 		keysPerRow: self.streamDeck.KEY_COLUMNS,
 		keysTotal: self.streamDeck.NUM_KEYS,

--- a/lib/usb/elgato-mini.js
+++ b/lib/usb/elgato-mini.js
@@ -62,7 +62,6 @@ function elgato_mini(system, devicepath) {
 
 	return self
 }
-elgato_mini.device_type = 'StreamDeck Mini'
 
 elgato_mini.prototype.draw = function (key, buffer) {
 	var self = this

--- a/lib/usb/elgato-xl.js
+++ b/lib/usb/elgato-xl.js
@@ -62,7 +62,6 @@ function elgato_xl(system, devicepath) {
 
 	return self
 }
-elgato_xl.device_type = 'StreamDeck XL'
 
 elgato_xl.prototype.draw = function (key, buffer) {
 	var self = this

--- a/lib/usb/elgato.js
+++ b/lib/usb/elgato.js
@@ -26,7 +26,6 @@ function elgato(system, devicepath) {
 
 	return self
 }
-elgato.device_type = 'StreamDeck'
 
 elgato.prototype.draw = function (key, buffer, attempts) {
 	var self = this

--- a/lib/usb/infinitton.js
+++ b/lib/usb/infinitton.js
@@ -25,7 +25,6 @@ function infinitton(system, devicepath) {
 
 	self.info = {}
 	self.type = self.info.type = 'Infinitton iDisplay device'
-	self.info.device_type = 'Infinitton'
 	self.info.config = ['brightness', 'orientation', 'page']
 	self.info.keysPerRow = 5
 	self.info.keysTotal = 15
@@ -96,7 +95,6 @@ function infinitton(system, devicepath) {
 	return self
 }
 util.inherits(infinitton, common)
-infinitton.device_type = 'Infinitton'
 
 infinitton.prototype.getConfig = function () {
 	var self = this

--- a/lib/usb/xkeys.js
+++ b/lib/usb/xkeys.js
@@ -34,10 +34,8 @@ class xkeys {
 		this._analogStates = {}
 		this.map = []
 		this.mapReverse = []
-		this.device_type = 'Xkeys'
 		this.info = {}
 		this.type = this.info.type = 'XKeys device'
-		this.info.device_type = 'XKeys'
 		this.info.config = ['brightness', 'page', 'enable_device']
 		this.info.keysPerRow = 10
 		this.info.keysTotal = 80


### PR DESCRIPTION
This is a rewrite of the satellite api used by https://github.com/julusian/companion-remote
The existing api has been there since 1.4.0, but until 2.1.1 it had a few breaking bugs:
* limited to 15 keys
* devices could be leaked when clients disconnect
* companion could crash when devices were removed

Additionally, the api is quite hard to use. It is binary encoded data, which makes adding new functionality without breaking clients very difficult. And when implementing a client you have to make sure to encode with the correct endianness and byte packing.

To improve on this, I propose replacing it with a text based protocol. While this does make the protocol less efficient on bandwidth, I dont think it is enough to be a problem and it makes implementation and maintenance of the protocol much simpler.
For 2.2 I propose we run with both apis. This will allow for minimal breakage for users using the existing api. In 2.3 we should remove the old satellite api

## API spec
The server by default runs on port 16622, but this may become configurable in the future. You should make sure to support alternate ports to allow for future compatibility as well as firewalls or router port forwarding.  
Each message is presented as a line, with a `\n` or `\r\n` terminator.  
Messages follow the general format of `COMMAND-NAME ARG1=VAL1 ARG2 ARG3="VAL3 with spaces"\n`. Note the `ARG2` which is shorthand for `ARG2=true`  
Key numbers are in the range of 0-31.  


Upon connection you will receive `BEGIN Companion Version=2.2.0-d9008309-3449` stating the build of companion you are connected to. This should not be relied on to be meaningful to your application, but can be presented as information to the user, or to aid debugging.

### Messages to send
Upon receiving an unknown command, the server will respond with the format `ERROR MESSAGE="Unknown command: SOMETHING"`  
Known commands will get either a success or error response like the following:
* `COMMAND-NAME ERROR MESSAGE="Some text here"\n`
* `COMMAND-NAME OK\n`
* `COMMAND-NAME OK ARG1=arg1\n`

#### Close connection
`QUIT`
Close the connection, removing all registered devices

#### Ping/pong
`PING payload`
Check the server is alive, with an arbitrary payload
Responds with `PONG payload`

#### Adding a satellite device
`ADD-DEVICE DEVICEID=00000 PRODUCT_NAME="Satellite Streamdeck"`
* DEVICEID should be a unique identifier for the hardware device. such as a serialnumber, or mac address.
* PRODUCT_NAME is the name of the product to show in the Surfaces table in the UI

Optional parameters:
* KEYS_TOTAL - number of keys the device has. Must be in the range 1-32 (default 32)
* KEYS_PER_ROW - number of keys per row. Must be in the range 1-8 (default 8)
* BITMAPS - true/false whether you want to be streamed bitmaps for display on the buttons (default true)
* COLORS - true/false whether you want to be streamed colors for display on the buttons (default false)

#### Removing a satellite device
`REMOVE-DEVICE DEVICEID=00000`
* DEVICEID the unique identifier used to add the device

#### Pressing a key
`KEY-PRESS DEVICEID=00000 KEY=0 PRESSED=true`
* DEVICEID the unique identifier used to add the device
* KEY number of the key which is pressed/released
* PRESSED true/false whether the key is pressed

### Messages to receive
No responses are expected to these, and to do so will result in an error.

#### Ping/pong
`PING payload`
The server is checking you are still alive, with an arbitrary payload
You must respond with `PONG payload`

#### Pixel buffer for key
`KEY-DRAW DEVICEID=00000 KEY=0 DATA=abcabcabc`
* DEVICEID the unique identifier of the device
* KEY number of the key which the pixel buffer is for
* DATA base64 encoded pixel data. Currently 72x72 pixels of 8bit RGB (this may be configurable in the future)
Note: this is only sent for devices which were added where `BITMAPS` was true

#### Color change for key
`KEY-COLOR DEVICEID=00000 KEY=0 COLOR=#00ff00`
* DEVICEID the unique identifier of the device
* KEY number of the key which the pixel buffer is for
* COLOR hex encoded 8bit RGB color for the key
Note: this is only sent for devices which were added where `COLORS` was true

#### Reset all keys to black
`KEYS-CLEAR DEVICEID=00000`
* DEVICEID the unique identifier of the device

#### Change brightness
`BRIGHTNESS DEVICEID=00000 VALUE=100`
* DEVICEID the unique identifier of the device
* VALUE brightness number in range 0-100

