### PR TITLE
Correct X-keys XK-4 and XK-16 product IDs

### DIFF
--- a/lib/usb/xkeys_products.js
+++ b/lib/usb/xkeys_products.js
@@ -31,7 +31,7 @@ exports.models = [
 	{
 		// This has not been tested
 		identifier: 'XK-4',
-		productId: [1127, 1128, 1129, 1253, 1049],
+		productId: [1127, 1128, 1129, 1253],
 		columns: 4,
 		rows: 1,
 		hasPS: false, // unknown
@@ -76,7 +76,7 @@ exports.models = [
 	{
 		// This has not been tested
 		identifier: 'XK-16',
-		productId: [1269, 1270, 1050, 1051, 1251],
+		productId: [1049, 1050, 1051, 1251],
 		columns: 4,
 		rows: 4, // not really rows, but the data comes like that (it is physically one row)
 		hasPS: false, // unknown


### PR DESCRIPTION
My XK-16 Stick (ID 1049) was being detected as an XK-4 due to incorrect product IDs. I’ve verified the IDs from the ‘X-keys XK-16 XK-8 XK-4 Stick Data Report.htm‘ file in the [HID reports](https://xkeys.com/software/developer/developerhiddatareports.html).