### PR TITLE
feat: ember+ service control

### DIFF
--- a/lib/server_emberplus.js
+++ b/lib/server_emberplus.js
@@ -29,6 +29,24 @@ function server_emberplus(system) {
 		self.companion_info = info
 	})
 
+	system.on('set_userconfig_key', (key, val) => {
+		if (key !== 'emberplus_enabled') {
+			return
+		}
+
+		self.config['emberplus_enabled'] = val
+
+		try {
+			if (val === true) {
+				self.init()
+			} else {
+				self.server.discard()
+			}
+		} catch (e) {
+			console.log('Error listening/stopping ember+', e)
+		}
+	})
+
 	system.on('graphics_indicate_push', function (page, bank, state, deviceid) {
 		if (deviceid === 'emberplus') {
 			return
@@ -46,8 +64,8 @@ function server_emberplus(system) {
 	})
 
 	system.on('graphics_bank_invalidate', function (page, bank) {
-		self.system.emit('log', `Updating ${page}.${bank} label ${self.banks[page][bank].text}`)
 		if (self.server) {
+			self.system.emit('log', `Updating ${page}.${bank} label ${self.banks[page][bank].text}`)
 			var path = '0.1.' + page + '.' + bank + '.1'
 			var node = self.server.getElementByPath(path)
 
@@ -58,7 +76,17 @@ function server_emberplus(system) {
 		}
 	})
 
-	self.init()
+	system.emit('get_userconfig', (obj) => {
+		self.config = obj
+
+		if (self.config['emberplus_enabled'] === true) {
+			try {
+				self.init()
+			} catch (e) {
+				console.log('Error listening for ember+', e)
+			}
+		}
+	})
 }
 
 server_emberplus.prototype.getPages = function () {

--- a/lib/userconfig.js
+++ b/lib/userconfig.js
@@ -42,6 +42,8 @@ const default_config = {
 
 	rosstalk_enabled: false,
 
+	emberplus_enabled: false,
+
 	artnet_enabled: false,
 	artnet_universe: 1,
 	artnet_channel: 1,
@@ -132,6 +134,8 @@ userconfig.prototype.ensure_listen_ports_are_defined = function () {
 
 				osc_enabled: true,
 				osc_listen_port: 12321,
+
+				emberplus_enabled: true,
 			}
 
 			// check if these fields have already been defined

--- a/webui/src/UserConfig.jsx
+++ b/webui/src/UserConfig.jsx
@@ -327,6 +327,26 @@ function UserConfigTable() {
 				</tr>
 				<tr>
 					<td colSpan="2" className="settings-category">
+						Ember+
+					</td>
+				</tr>
+				<tr>
+					<td>Ember+ Listener</td>
+					<td>
+						<div className="form-check form-check-inline mr-1">
+							<CInputCheckbox
+								id="userconfig_emberplus_enabled"
+								checked={config.emberplus_enabled}
+								onChange={(e) => setValue('emberplus_enabled', e.currentTarget.checked)}
+							/>
+							<label className="form-check-label" htmlFor="userconfig_emberplus_enabled">
+								Enabled
+							</label>
+						</div>
+					</td>
+				</tr>
+				<tr>
+					<td colSpan="2" className="settings-category">
 						Artnet Listener
 					</td>
 				</tr>


### PR DESCRIPTION
As a follow-up to #1644, the Ember+ service was not setup to be enabled via the settings page.  This adds that functionality.  Since the in place upgrade was designed to run once, this will disable the module for beta users since the merge on June 29, but will react appropriately for upgrades after a public release.