### PR TITLE
feat: Add http methods PATCH and DELETE to REST client

### DIFF
--- a/lib/rest.js
+++ b/lib/rest.js
@@ -151,8 +151,6 @@ function rest(system) {
 			})
 	})
 
-
-
 	return self
 }
 

--- a/lib/rest.js
+++ b/lib/rest.js
@@ -99,6 +99,60 @@ function rest(system) {
 			})
 	})
 
+	system.on('rest_patch', function (url, data, cb, extra_headers, extra_args) {
+		debug('making request:', url, data)
+
+		var client = new Client(extra_args)
+
+		var args = {
+			data: data,
+			headers: { 'Content-Type': 'application/json' },
+		}
+
+		if (extra_headers !== undefined) {
+			for (var header in extra_headers) {
+				args.headers[header] = extra_headers[header]
+			}
+		}
+
+		client
+			.patch(url, args, function (data, response) {
+				cb(null, { data: data, response: response })
+			})
+			.on('error', function (error) {
+				debug('error response:', error)
+				cb(true, { error: error })
+			})
+	})
+
+	system.on('rest_delete', function (url, data, cb, extra_headers, extra_args) {
+		debug('making request:', url, data)
+
+		var client = new Client(extra_args)
+
+		var args = {
+			data: data,
+			headers: { 'Content-Type': 'application/json' },
+		}
+
+		if (extra_headers !== undefined) {
+			for (var header in extra_headers) {
+				args.headers[header] = extra_headers[header]
+			}
+		}
+
+		client
+			.delete(url, args, function (data, response) {
+				cb(null, { data: data, response: response })
+			})
+			.on('error', function (error) {
+				debug('error response:', error)
+				cb(true, { error: error })
+			})
+	})
+
+
+
 	return self
 }
 


### PR DESCRIPTION
Adding these HTTP methods as some REST APIs rely on them (for example Airtable) and can't be used properly with the methods missing.
This is used in https://github.com/bitfocus/companion-module-generic-http/pull/11