### PR TITLE
feat: add ability to set custom DEBUG when DEVELOPER flag is set

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,7 +15,7 @@
  *
  */
 
-if (process.env.DEVELOPER !== undefined) {
+if (process.env.DEVELOPER !== undefined && process.env.DEBUG === undefined) {
 	process.env['DEBUG'] = '*,-websocket*,-express*,-engine*,-socket.io*,-send*,-db,-NRC*,-follow-redirects'
 }
 


### PR DESCRIPTION
When the `DEVELOPER` flag is set, only set a default value for
`DEBUG` when one has not already been set.

Resolves #1784

Signed-off-by: Johnny Estilles <johnny@estilles.com>