### PR TITLE
feat(webui): reduce minimum image size to 36x36

### DIFF
--- a/webui/src/Buttons/EditButton/ButtonStyleConfig.jsx
+++ b/webui/src/Buttons/EditButton/ButtonStyleConfig.jsx
@@ -165,7 +165,7 @@ export function ButtonStyleConfigFields({ values, setValueInner, setPng, setPngE
 						<PNGInputField
 							onSelect={setPng}
 							onError={setPngError}
-							definition={{ min: { width: 72, height: 58 }, max: { width: 72, height: 58 } }}
+							definition={{ min: { width: 36, height: 36 }, max: { width: 72, height: 58 } }}
 						/>
 						{clearPng ? (
 							<CButton color="danger" disabled={!values.png64} onClick={clearPng}>


### PR DESCRIPTION
This change reduces the minimum image sizes from 72x58 to 36x36.
Existing code already handles smaller images will. Images smaller
than 72x58 (down to 36x36) will be displayed as-is, without
resizing or padding.

Resolves #1774

Signed-off-by: Johnny Estilles <johnny@estilles.com>