### PR TITLE
allow for other content type headers

### DIFF
--- a/lib/rest.js
+++ b/lib/rest.js
@@ -53,8 +53,11 @@ function rest(system) {
 		var client = new Client(extra_args)
 
 		var args = {
-			data: data,
-			headers: { 'Content-Type': 'application/json' },
+			data: data
+		}
+
+		if (!extra_headers['Content-Type']) {
+			args.headers['Content-Type'] = 'application/json'
 		}
 
 		if (extra_headers !== undefined) {


### PR DESCRIPTION
Doesn't assume the content type is going to be application/json unless a content-type header is not specified