### PR TITLE
feat: add conditional config field display

### DIFF
--- a/instance_skel_types.d.ts
+++ b/instance_skel_types.d.ts
@@ -111,6 +111,7 @@ export interface CompanionInputField {
 	type: 'text' | 'textinput' | 'textwithvariables' | 'dropdown' | 'colorpicker' | 'number' | 'checkbox'
 	label: string
 	tooltip?: string
+	isVisible?: () => boolean
 }
 export interface CompanionInputFieldText extends CompanionInputField {
 	type: 'text'

--- a/instance_skel_types.d.ts
+++ b/instance_skel_types.d.ts
@@ -111,7 +111,7 @@ export interface CompanionInputField {
 	type: 'text' | 'textinput' | 'textwithvariables' | 'dropdown' | 'colorpicker' | 'number' | 'checkbox'
 	label: string
 	tooltip?: string
-	isVisible?: () => boolean
+	isVisible?: (config: { [id: string]: InputValue }) => boolean
 }
 export interface CompanionInputFieldText extends CompanionInputField {
 	type: 'text'

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -697,7 +697,16 @@ instance.prototype.connect = function (client) {
 				width: 12,
 			},
 			...(self.active[id].config_fields() || []),
-		]
+		].map((field) => {
+			// serialize `isVisible` if it exists
+			if (typeof field.isVisible === 'function') {
+				return {
+					...field,
+					isVisible: field.isVisible.toString(),
+				}
+			}
+			return field
+		})
 
 		sendResult(answer, 'instance_edit:result', id, configFields, self.store.db[id])
 
@@ -706,25 +715,6 @@ instance.prototype.connect = function (client) {
 		}
 
 		self.system.emit('instance_save')
-	})
-
-	client.on('instance_check_visibility', function (id, instanceConfig, answer) {
-		const configFields = self.active[id].config_fields()
-		let visibility = {}
-
-		if (instanceConfig) {
-			visibility = configFields.reduce((result, field) => {
-				if (typeof field.isVisible === 'function') {
-					return {
-						...result,
-						[field.id]: field.isVisible(instanceConfig),
-					}
-				}
-				return result
-			}, {})
-		}
-
-		sendResult(answer, 'instance_check_visibility:result', visibility)
 	})
 
 	client.on('instance_config_put', function (id, config, answer) {

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -708,6 +708,25 @@ instance.prototype.connect = function (client) {
 		self.system.emit('instance_save')
 	})
 
+	client.on('instance_check_visibility', function (id, instanceConfig, answer) {
+		const configFields = self.active[id].config_fields()
+		let visibility = {}
+
+		if (instanceConfig) {
+			visibility = configFields.reduce((result, field) => {
+				if (typeof field.isVisible === 'function') {
+					return {
+						...result,
+						[field.id]: field.isVisible(instanceConfig),
+					}
+				}
+				return result
+			}, {})
+		}
+
+		sendResult(answer, 'instance_check_visibility:result', visibility)
+	})
+
 	client.on('instance_config_put', function (id, config, answer) {
 		for (var inst in self.store.db) {
 			if (inst != id && self.store.db[inst].label == config.label) {

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -699,11 +699,14 @@ instance.prototype.connect = function (client) {
 			...(self.active[id].config_fields() || []),
 		].map((field) => {
 			// serialize `isVisible` if it exists
-			if (typeof field.isVisible === 'function') {
-				return {
-					...field,
-					isVisible: field.isVisible.toString(),
+			if ('isVisible' in field) {
+				if (typeof field.isVisible === 'function') {
+					return {
+						...field,
+						isVisible: field.isVisible.toString(),
+					}
 				}
+				delete field.isVisible
 			}
 			return field
 		})

--- a/webui/src/Instances/InstanceEditPanel.jsx
+++ b/webui/src/Instances/InstanceEditPanel.jsx
@@ -16,6 +16,8 @@ export const InstanceEditPanel = memo(function InstanceEditPanel({ instanceId, d
 	const [instanceConfig, setInstanceConfig] = useState(null)
 	const [validFields, setValidFields] = useState(null)
 
+	const [fieldVisibility, setFieldVisibility] = useState({})
+
 	const doCancel = useCallback(() => {
 		doConfigureInstance(null)
 		setConfigFields([])
@@ -96,6 +98,12 @@ export const InstanceEditPanel = memo(function InstanceEditPanel({ instanceId, d
 		}))
 	}, [])
 
+	useEffect(() => {
+		socketEmit(context.socket,'instance_check_visibility', [instanceId, instanceConfig]).then(([visibility]) => {
+			setFieldVisibility(visibility)
+		})
+	}, [context.socket, instanceId, instanceConfig])
+
 	const moduleInfo = context.modules[instanceConfig?.instance_type] ?? {}
 	const dataReady = instanceConfig && configFields && validFields
 	return (
@@ -115,7 +123,12 @@ export const InstanceEditPanel = memo(function InstanceEditPanel({ instanceId, d
 				{instanceId && dataReady
 					? configFields.map((field, i) => {
 							return (
-								<CCol key={i} className={`fieldtype-${field.type}`} sm={field.width}>
+								<CCol
+									key={i}
+									className={`fieldtype-${field.type}`}
+									sm={field.width}
+									style={{ display: fieldVisibility[field.id] === false ? 'none' : null }}
+								>
 									<label>{field.label}</label>
 									<ConfigField
 										definition={field}

--- a/webui/src/Instances/InstanceEditPanel.jsx
+++ b/webui/src/Instances/InstanceEditPanel.jsx
@@ -99,7 +99,7 @@ export const InstanceEditPanel = memo(function InstanceEditPanel({ instanceId, d
 	}, [])
 
 	useEffect(() => {
-		socketEmit(context.socket,'instance_check_visibility', [instanceId, instanceConfig]).then(([visibility]) => {
+		socketEmit(context.socket, 'instance_check_visibility', [instanceId, instanceConfig]).then(([visibility]) => {
 			setFieldVisibility(visibility)
 		})
 	}, [context.socket, instanceId, instanceConfig])

--- a/webui/src/Instances/InstanceEditPanel.jsx
+++ b/webui/src/Instances/InstanceEditPanel.jsx
@@ -106,7 +106,6 @@ export const InstanceEditPanel = memo(function InstanceEditPanel({ instanceId, d
 	useEffect(() => {
 		const visibility = {}
 
-		console.log(configFields, instanceConfig)
 		if (configFields === null || instanceConfig === null) {
 			return
 		}

--- a/webui/src/Instances/InstanceEditPanel.jsx
+++ b/webui/src/Instances/InstanceEditPanel.jsx
@@ -117,6 +117,10 @@ export const InstanceEditPanel = memo(function InstanceEditPanel({ instanceId, d
 		}
 
 		setFieldVisibility(visibility)
+
+		return () => {
+			setFieldVisibility({})
+		}
 	}, [configFields, instanceConfig])
 
 	const moduleInfo = context.modules[instanceConfig?.instance_type] ?? {}

--- a/webui/src/util.jsx
+++ b/webui/src/util.jsx
@@ -49,9 +49,9 @@ export function sandbox(serializedFn) {
 
 	return function (config) {
 		// create a sandboxed/proxy version of the context passed to the function
-		const configProxy = new Proxy(config, proxyHandlers)
+		const configProxy = new Proxy({ config }, proxyHandlers)
 		// call scoped function with context that only includes config
-		return scopedFn({ config: configProxy })
+		return scopedFn(configProxy)
 	}
 }
 

--- a/webui/src/util.jsx
+++ b/webui/src/util.jsx
@@ -46,16 +46,6 @@ const freezePrototypes = () => {
 	Object.freeze(Symbol.prototype)
 
 	// prevent constructors of async/generator functions to bypass sandbox
-	const blockedProperty = {
-		value: null,
-		configurable: false,
-		writable: false,
-	}
-
-	Object.defineProperty(async function () {}.constructor.prototype, 'constructor', blockedProperty)
-	Object.defineProperty(async function* () {}.constructor.prototype, 'constructor', blockedProperty)
-	Object.defineProperty(function* () {}.constructor.prototype, 'constructor', blockedProperty)
-
 	Object.freeze(async function () {}.__proto__)
 	Object.freeze(async function* () {}.__proto__)
 	Object.freeze(function* () {}.__proto__)

--- a/webui/src/util.jsx
+++ b/webui/src/util.jsx
@@ -96,6 +96,8 @@ export function sandbox(serializedFn) {
 		}
 	`
 
+	freezePrototypes()
+
 	try {
 		// eslint-disable-next-line no-new-func
 		const scopedFn = new Function('catchAllProxy', src)


### PR DESCRIPTION
Conditionally display configuration fields based on the value(s) of other configuration fields.

A optional option `isVisible` can be assigned a function which receives the current `instanceConfig` to determine visibilty returning a Boolean. For backwards compatibility, if `isVisible` is not present the config field will always be displayed.

In the example below:
- the `version` field is always displayed
- the `community` field is only displayed when `version` is `v1` or `v2c` 
- the `engineID` field is only displayed when `version` is `v3`

```JavaScript
			{
				type: 'dropdown',
				id: 'version',
				label: 'SNMP Version',
				width: 6,
				choices: [
					{ id: 'v1', label: 'SNMP v1' },
					{ id: 'v2c', label: 'SNMP v2c' },
					{ id: 'v3', label: 'SNMP v3' },
				],
				default: 'v1',
				require: true,
			},
			{
				type: 'textinput',
				id: 'community',
				width: 6,
				label: 'Community',
				default: 'companion',
				isVisible: ({ version }) => version === 'v1' || version === 'v2c',
			},
			{
				type: 'textinput',
				id: 'engineID',
				width: 6,
				label: 'Engine ID',
				default: '',
				isVisible: ({ version }) => version === 'v3',
			},

```

Signed-off-by: Johnny Estilles <johnny@estilles.com>