### PR TITLE
module: Upgraded tesmart-hdmimatrix v1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -431,7 +431,7 @@
 		"companion-module-teracom-tcw181b": "github:bitfocus/companion-module-teracom-tcw181b#v1.0.2",
 		"companion-module-teradek-vidiu": "github:bitfocus/companion-module-teradek-vidiu#v1.0.2",
 		"companion-module-tesla-smart": "github:bitfocus/companion-module-tesla-smart#v1.0.3",
-		"companion-module-tesmart-hdmimatrix": "github:bitfocus/companion-module-tesmart-hdmimatrix#v1.0.0",
+		"companion-module-tesmart-hdmimatrix": "github:bitfocus/companion-module-tesmart-hdmimatrix#v1.0.1",
 		"companion-module-thelightingcontroller": "github:bitfocus/companion-module-thelightingcontroller#v1.1.2",
 		"companion-module-thingm-blink1": "github:bitfocus/companion-module-thingm-blink1#v1.2.3",
 		"companion-module-tow-mixeffect": "github:bitfocus/companion-module-tow-mixeffect#v1.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2874,9 +2874,9 @@ commist@^1.0.0:
   version "1.0.3"
   resolved "https://codeload.github.com/bitfocus/companion-module-tesla-smart/tar.gz/2f19dbedc1d69285eaf0c9388ba141841ef5424a"
 
-"companion-module-tesmart-hdmimatrix@github:bitfocus/companion-module-tesmart-hdmimatrix#v1.0.0":
+"companion-module-tesmart-hdmimatrix@github:bitfocus/companion-module-tesmart-hdmimatrix#v1.0.1":
   version "1.0.0"
-  resolved "https://codeload.github.com/bitfocus/companion-module-tesmart-hdmimatrix/tar.gz/96b661e0462ffa922592cbb2f06021636bd58fed"
+  resolved "https://codeload.github.com/bitfocus/companion-module-tesmart-hdmimatrix/tar.gz/db7d7015f72b1541794aa0249032c000c5787399"
 
 "companion-module-thelightingcontroller@github:bitfocus/companion-module-thelightingcontroller#v1.1.2":
   version "1.1.2"


### PR DESCRIPTION
Fixes discrepancy between module name in manifest and repo name

Signed-off-by: Johnny Estilles <johnny@estilles.com>