### PR TITLE
chore(tools): check manifest/module names match

### DIFF
--- a/tools/verify-module-build.mjs
+++ b/tools/verify-module-build.mjs
@@ -46,6 +46,9 @@ for (const folder of possibleModuleFolders) {
 
 			if (!pkgJson.main) throw new Error(`Missing main in package.json`)
 
+			if (folder !== `companion-module-${pkgJson.name}`)
+				throw new Error(`Name in package.json (${pkgJson.name}) doesn't match folder name`)
+
 			const mainPath = path.join(appPath, 'node_modules', folder, pkgJson.main)
 			if (!fs.existsSync(mainPath)) throw new Error('Missing entrypoint')
 


### PR DESCRIPTION
I noticed modules do not load if the name on the manifest doesn't match the name of the repository/folder. (e.g. bitfocus/companion-module-tesmart-hdmimatrix#2)

This PR adds this check to the `verify-module-build.js` script.

Signed-off-by: Johnny Estilles <johnny@estilles.com>