### PR TITLE
Add `isVisibile` to action/feedback options

### DIFF
--- a/instance_skel.js
+++ b/instance_skel.js
@@ -177,6 +177,26 @@ instance.prototype.addUpgradeScript = function () {
 	)
 }
 
+instance.prototype.serializeIsVisibleFn = function (options = []) {
+	return options.map((option) => {
+		if ('isVisible' in option) {
+			if (typeof option.isVisible === 'function') {
+				return {
+					...option,
+					isVisibleFn: option.isVisible.toString(),
+					isVisible: undefined,
+				}
+			}
+		}
+
+		// ignore any existing `isVisibleFn` to avoid code injection
+		return {
+			...option,
+			isVisibleFn: undefined,
+		}
+	})
+}
+
 instance.prototype.setActions = function (actions) {
 	var self = this
 
@@ -185,19 +205,7 @@ instance.prototype.setActions = function (actions) {
 	} else {
 		actions = Object.fromEntries(
 			Object.entries(actions).map(([id, action]) => {
-				action.options = action.options?.map((option) => {
-					if ('isVisible' in option) {
-						if (typeof option.isVisible === 'function') {
-							return {
-								...option,
-								isVisibleFn: option.isVisible.toString(),
-							}
-						}
-					}
-					// ignore any existing `isVisibleFn` to avoid code injection
-					delete option.isVisibleFn
-					return option
-				})
+				action.options = self.serializeIsVisibleFn(action.options)
 				return [id, action]
 			})
 		)
@@ -248,19 +256,7 @@ instance.prototype.setFeedbackDefinitions = function (feedbacks) {
 	} else {
 		feedbacks = Object.fromEntries(
 			Object.entries(feedbacks).map(([id, feedback]) => {
-				feedback.options = feedback.options?.map((option) => {
-					if ('isVisible' in option) {
-						if (typeof option.isVisible === 'function') {
-							return {
-								...option,
-								isVisibleFn: option.isVisible.toString(),
-							}
-						}
-					}
-					// ignore any existing `isVisibleFn` to avoid code injection
-					delete option.isVisibleFn
-					return option
-				})
+				feedback.options = self.serializeIsVisibleFn(feedback.options)
 				return [id, feedback]
 			})
 		)

--- a/instance_skel.js
+++ b/instance_skel.js
@@ -180,28 +180,28 @@ instance.prototype.addUpgradeScript = function () {
 instance.prototype.setActions = function (actions) {
 	var self = this
 
-	actions = Object.fromEntries(
-		Object.entries(actions).map(([id, action]) => {
-			action.options = action.options?.map((option) => {
-				if ('isVisible' in option) {
-					if (typeof option.isVisible === 'function') {
-						return {
-							...option,
-							isVisibleFn: option.isVisible.toString(),
-						}
-					}
-				}
-				// ignore any existing `isVisibleFn` to avoid code injection
-				delete option.isVisibleFn
-				return option
-			})
-			return [id, action]
-		})
-	)
-
 	if (actions === undefined) {
 		self._actionDefinitions = {}
 	} else {
+		actions = Object.fromEntries(
+			Object.entries(actions).map(([id, action]) => {
+				action.options = action.options?.map((option) => {
+					if ('isVisible' in option) {
+						if (typeof option.isVisible === 'function') {
+							return {
+								...option,
+								isVisibleFn: option.isVisible.toString(),
+							}
+						}
+					}
+					// ignore any existing `isVisibleFn` to avoid code injection
+					delete option.isVisibleFn
+					return option
+				})
+				return [id, action]
+			})
+		)
+
 		self._actionDefinitions = actions
 	}
 

--- a/instance_skel.js
+++ b/instance_skel.js
@@ -19,6 +19,7 @@ var util = require('util')
 var debug = require('debug')('lib/instance_skel')
 var image = require('./lib/image')
 var icons = require('./lib/resources/icons')
+var { serializeIsVisibleFn } = require('./lib/resources/util')
 
 function instance(system, id, config) {
 	var self = this
@@ -177,27 +178,6 @@ instance.prototype.addUpgradeScript = function () {
 	)
 }
 
-// NOTE: *** This is a internal method. DO NOT call or override. ***
-instance.prototype.serializeIsVisibleFn = function (options = []) {
-	return options.map((option) => {
-		if ('isVisible' in option) {
-			if (typeof option.isVisible === 'function') {
-				return {
-					...option,
-					isVisibleFn: option.isVisible.toString(),
-					isVisible: undefined,
-				}
-			}
-		}
-
-		// ignore any existing `isVisibleFn` to avoid code injection
-		return {
-			...option,
-			isVisibleFn: undefined,
-		}
-	})
-}
-
 instance.prototype.setActions = function (actions) {
 	var self = this
 
@@ -206,7 +186,7 @@ instance.prototype.setActions = function (actions) {
 	} else {
 		actions = Object.fromEntries(
 			Object.entries(actions).map(([id, action]) => {
-				action.options = self.serializeIsVisibleFn(action.options)
+				action.options = serializeIsVisibleFn(action.options)
 				return [id, action]
 			})
 		)
@@ -257,7 +237,7 @@ instance.prototype.setFeedbackDefinitions = function (feedbacks) {
 	} else {
 		feedbacks = Object.fromEntries(
 			Object.entries(feedbacks).map(([id, feedback]) => {
-				feedback.options = self.serializeIsVisibleFn(feedback.options)
+				feedback.options = serializeIsVisibleFn(feedback.options)
 				return [id, feedback]
 			})
 		)

--- a/instance_skel.js
+++ b/instance_skel.js
@@ -180,6 +180,25 @@ instance.prototype.addUpgradeScript = function () {
 instance.prototype.setActions = function (actions) {
 	var self = this
 
+	actions = Object.fromEntries(
+		Object.entries(actions).map(([id, action]) => {
+			action.options = action.options?.map((option) => {
+				if ('isVisible' in option) {
+					if (typeof option.isVisible === 'function') {
+						return {
+							...option,
+							isVisibleFn: option.isVisible.toString(),
+						}
+					}
+				}
+				// ignore any existing `isVisibleFn` to avoid code injection
+				delete option.isVisibleFn
+				return option
+			})
+			return [id, action]
+		})
+	)
+
 	if (actions === undefined) {
 		self._actionDefinitions = {}
 	} else {

--- a/instance_skel.js
+++ b/instance_skel.js
@@ -246,6 +246,25 @@ instance.prototype.setFeedbackDefinitions = function (feedbacks) {
 	if (feedbacks === undefined) {
 		self._feedbackDefinitions = {}
 	} else {
+		feedbacks = Object.fromEntries(
+			Object.entries(feedbacks).map(([id, feedback]) => {
+				feedback.options = feedback.options?.map((option) => {
+					if ('isVisible' in option) {
+						if (typeof option.isVisible === 'function') {
+							return {
+								...option,
+								isVisibleFn: option.isVisible.toString(),
+							}
+						}
+					}
+					// ignore any existing `isVisibleFn` to avoid code injection
+					delete option.isVisibleFn
+					return option
+				})
+				return [id, feedback]
+			})
+		)
+
 		self._feedbackDefinitions = feedbacks
 	}
 

--- a/instance_skel.js
+++ b/instance_skel.js
@@ -177,6 +177,7 @@ instance.prototype.addUpgradeScript = function () {
 	)
 }
 
+// NOTE: *** This is a internal method. DO NOT call or override. ***
 instance.prototype.serializeIsVisibleFn = function (options = []) {
 	return options.map((option) => {
 		if ('isVisible' in option) {

--- a/instance_skel_types.d.ts
+++ b/instance_skel_types.d.ts
@@ -111,7 +111,7 @@ export interface CompanionInputField {
 	type: 'text' | 'textinput' | 'textwithvariables' | 'dropdown' | 'colorpicker' | 'number' | 'checkbox'
 	label: string
 	tooltip?: string
-	isVisible?: (config: { [id: string]: InputValue }) => boolean
+	isVisible?: (options: { [key: string]: InputValue | undefined }) => boolean
 }
 export interface CompanionInputFieldText extends CompanionInputField {
 	type: 'text'
@@ -197,7 +197,6 @@ export interface CompanionFeedbackBase<TRes> {
 	) => TRes
 	subscribe?: (feedback: CompanionFeedbackEvent) => void
 	unsubscribe?: (feedback: CompanionFeedbackEvent) => void
-	isVisible?: (config: { [id: string]: InputValue }) => boolean
 }
 export interface CompanionFeedbackBoolean extends CompanionFeedbackBase<boolean> {
 	type: 'boolean'

--- a/instance_skel_types.d.ts
+++ b/instance_skel_types.d.ts
@@ -197,6 +197,7 @@ export interface CompanionFeedbackBase<TRes> {
 	) => TRes
 	subscribe?: (feedback: CompanionFeedbackEvent) => void
 	unsubscribe?: (feedback: CompanionFeedbackEvent) => void
+	isVisible?: (config: { [id: string]: InputValue }) => boolean
 }
 export interface CompanionFeedbackBoolean extends CompanionFeedbackBase<boolean> {
 	type: 'boolean'

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -703,11 +703,12 @@ instance.prototype.connect = function (client) {
 				if (typeof field.isVisible === 'function') {
 					return {
 						...field,
-						isVisible: field.isVisible.toString(),
+						isVisibleFn: field.isVisible.toString(),
 					}
 				}
-				delete field.isVisible
 			}
+			// ignore any existing `isVisibleFn` to avoid code injection
+			delete field.isVisibleFn
 			return field
 		})
 

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -19,6 +19,7 @@ var debug = require('debug')('lib/instance')
 var shortid = require('shortid')
 var fs = require('fs')
 var image = require('./image')
+var { serializeIsVisibleFn } = require('./resources/util')
 
 function instance(system) {
 	var self = this
@@ -689,7 +690,7 @@ instance.prototype.connect = function (client) {
 			return
 		}
 
-		const configFields = [
+		const configFields = serializeIsVisibleFn([
 			{
 				type: 'textinput',
 				id: 'label',
@@ -697,20 +698,7 @@ instance.prototype.connect = function (client) {
 				width: 12,
 			},
 			...(self.active[id].config_fields() || []),
-		].map((field) => {
-			// serialize `isVisible` if it exists
-			if ('isVisible' in field) {
-				if (typeof field.isVisible === 'function') {
-					return {
-						...field,
-						isVisibleFn: field.isVisible.toString(),
-					}
-				}
-			}
-			// ignore any existing `isVisibleFn` to avoid code injection
-			delete field.isVisibleFn
-			return field
-		})
+		])
 
 		sendResult(answer, 'instance_edit:result', id, configFields, self.store.db[id])
 

--- a/lib/resources/util.js
+++ b/lib/resources/util.js
@@ -1,0 +1,24 @@
+// NOTE: *** This is a internal method. DO NOT call or override. ***
+const serializeIsVisibleFn = (options = []) => {
+	return options.map((option) => {
+		if ('isVisible' in option) {
+			if (typeof option.isVisible === 'function') {
+				return {
+					...option,
+					isVisibleFn: option.isVisible.toString(),
+					isVisible: undefined,
+				}
+			}
+		}
+
+		// ignore any existing `isVisibleFn` to avoid code injection
+		return {
+			...option,
+			isVisibleFn: undefined,
+		}
+	})
+}
+
+module.exports = {
+	serializeIsVisibleFn,
+}

--- a/webui/src/Buttons/ButtonGrid.jsx
+++ b/webui/src/Buttons/ButtonGrid.jsx
@@ -192,10 +192,10 @@ export const ButtonsGridPanel = memo(function ButtonsPage({
 					You can navigate between pages using the arrow buttons, or by clicking the page number, typing in a number,
 					and pressing 'Enter' on your keyboard.
 				</CAlert>
-				
+
 				<CAlert color="info">
-					You can use common key commands such as copy, paste, and cut to move buttons around. You can also 
-					press the delete or backspace key with any button highlighted to delete it.
+					You can use common key commands such as copy, paste, and cut to move buttons around. You can also press the
+					delete or backspace key with any button highlighted to delete it.
 				</CAlert>
 			</div>
 		</KeyReceiver>

--- a/webui/src/Buttons/EditButton/ActionsPanel.jsx
+++ b/webui/src/Buttons/EditButton/ActionsPanel.jsx
@@ -240,6 +240,8 @@ function ActionTableRow({ action, index, dragId, setValue, doDelete, doDelay, mo
 
 	const [optionVisibility, setOptionVisibility] = useState({})
 
+	const actionSpec = actionsContext[action.label]
+
 	const ref = useRef(null)
 	const [, drop] = useDrop({
 		accept: dragId,
@@ -294,19 +296,17 @@ function ActionTableRow({ action, index, dragId, setValue, doDelete, doDelay, mo
 	preview(drop(ref))
 
 	useEffect(() => {
-		const actionSpec = actionsContext[action.label]
 		const options = actionSpec?.options ?? []
 
 		for (const option of options) {
-			if (typeof option.isVisibleFn === 'string') {
+			if (typeof option.isVisibleFn === 'string' && typeof option.isVisible !== 'function') {
 				option.isVisible = sandbox(option.isVisibleFn)
 			}
 		}
-	}, [actionsContext, action])
+	}, [actionSpec])
 
 	useEffect(() => {
 		const visibility = {}
-		const actionSpec = actionsContext[action.label]
 		const options = actionSpec?.options ?? []
 
 		if (options === null || action === null) {
@@ -324,7 +324,7 @@ function ActionTableRow({ action, index, dragId, setValue, doDelete, doDelay, mo
 		return () => {
 			setOptionVisibility({})
 		}
-	}, [actionsContext, action])
+	}, [actionSpec, action])
 
 	if (!action) {
 		// Invalid action, so skip
@@ -335,7 +335,6 @@ function ActionTableRow({ action, index, dragId, setValue, doDelete, doDelay, mo
 	// const module = instance ? context.modules[instance.instance_type] : undefined
 	const instanceLabel = instance?.label ?? action.instance
 
-	const actionSpec = actionsContext[action.label]
 	const options = actionSpec?.options ?? []
 
 	let name = ''

--- a/webui/src/Buttons/EditButton/ActionsPanel.jsx
+++ b/webui/src/Buttons/EditButton/ActionsPanel.jsx
@@ -383,7 +383,7 @@ function ActionTableRow({ action, index, dragId, setValue, doDelete, doDelay, mo
 										actionId={action.id}
 										value={(action.options || {})[opt.id]}
 										setValue={setValue}
-										visibility={optionVisibility[opt.id] === false ? 'none' : null}
+										visibility={optionVisibility[opt.id]}
 									/>
 								</MyErrorBoundary>
 							))}

--- a/webui/src/Buttons/EditButton/FeedbackPanel.jsx
+++ b/webui/src/Buttons/EditButton/FeedbackPanel.jsx
@@ -260,14 +260,12 @@ export function FeedbackEditor({ feedback, setValue, innerDelete, setSelectedSty
 	useEffect(() => {
 		const options = feedbackSpec?.options ?? []
 
-		console.log({ options })
-
 		for (const option of options) {
 			if (typeof option.isVisibleFn === 'string') {
 				option.isVisible = sandbox(option.isVisibleFn)
 			}
 		}
-	}, [feedbackSpec, feedback])
+	}, [feedbackSpec])
 
 	useEffect(() => {
 		const visibility = {}

--- a/webui/src/Buttons/EditButton/FeedbackPanel.jsx
+++ b/webui/src/Buttons/EditButton/FeedbackPanel.jsx
@@ -316,7 +316,7 @@ export function FeedbackEditor({ feedback, setValue, innerDelete, setSelectedSty
 								actionId={feedback.id}
 								value={(feedback.options || {})[opt.id]}
 								setValue={setValue}
-								visibility={optionVisibility[opt.id] === false ? 'none' : null}
+								visibility={optionVisibility[opt.id]}
 							/>
 						</MyErrorBoundary>
 					))}

--- a/webui/src/Buttons/EditButton/Table.jsx
+++ b/webui/src/Buttons/EditButton/Table.jsx
@@ -58,7 +58,7 @@ export function ActionTableRowOption({ actionId, option, value, setValue, visibi
 	}
 
 	return (
-		<CFormGroup style={{ display: visibility }}>
+		<CFormGroup style={{ display: visibility ? null : 'none' }}>
 			<CLabel>{option.label}</CLabel>
 			{control}
 		</CFormGroup>

--- a/webui/src/Buttons/EditButton/Table.jsx
+++ b/webui/src/Buttons/EditButton/Table.jsx
@@ -9,7 +9,7 @@ import {
 	TextWithVariablesInputField,
 } from '../../Components'
 
-export function ActionTableRowOption({ actionId, option, value, setValue }) {
+export function ActionTableRowOption({ actionId, option, value, setValue, visibility }) {
 	const setValue2 = useCallback((val) => setValue(actionId, option.id, val), [actionId, option.id, setValue])
 
 	if (!option) {
@@ -58,7 +58,7 @@ export function ActionTableRowOption({ actionId, option, value, setValue }) {
 	}
 
 	return (
-		<CFormGroup>
+		<CFormGroup style={{ display: visibility }}>
 			<CLabel>{option.label}</CLabel>
 			{control}
 		</CFormGroup>

--- a/webui/src/Buttons/EditButton/Table.jsx
+++ b/webui/src/Buttons/EditButton/Table.jsx
@@ -58,7 +58,7 @@ export function ActionTableRowOption({ actionId, option, value, setValue, visibi
 	}
 
 	return (
-		<CFormGroup style={{ display: visibility === false ?  'none' : null }}>
+		<CFormGroup style={{ display: visibility === false ? 'none' : null }}>
 			<CLabel>{option.label}</CLabel>
 			{control}
 		</CFormGroup>

--- a/webui/src/Buttons/EditButton/Table.jsx
+++ b/webui/src/Buttons/EditButton/Table.jsx
@@ -58,7 +58,7 @@ export function ActionTableRowOption({ actionId, option, value, setValue, visibi
 	}
 
 	return (
-		<CFormGroup style={{ display: visibility ? null : 'none' }}>
+		<CFormGroup style={{ display: visibility === false ?  'none' : null }}>
 			<CLabel>{option.label}</CLabel>
 			{control}
 		</CFormGroup>

--- a/webui/src/Instances/InstanceEditPanel.jsx
+++ b/webui/src/Instances/InstanceEditPanel.jsx
@@ -62,8 +62,8 @@ export const InstanceEditPanel = memo(function InstanceEditPanel({ instanceId, d
 						validFields[field.id] = true
 
 						// deserialize `isVisible` with a sandbox/proxy version
-						if (typeof field.isVisible === 'string') {
-							field.isVisible = sandbox(field.isVisible)
+						if (typeof field.isVisibleFn === 'string') {
+							field.isVisible = sandbox(field.isVisibleFn)
 						}
 					}
 


### PR DESCRIPTION
This is the next phase of my "conditional visibility" project. This PR includes:

- A slight refactoring of the `isVisible` implementation for config fields.
  In the original implementation the `isVisible` property was overwritten with a serialized copy of the function. I wasn't happy with that, so instead I now add and `isVisibleFn` property which is the serialized copy of `isVisible`.
- Add `isVisible` to action options
- Add `isVisible` to feedback options

Because instance configs are slightly different from actions/feedbacks under the hood, this implementation is slightly different than the visibility implementation for config fields, but it is functionally equivalent for all intents and purposes.

#### Sample Usage
The `isVisible` function receives a copy of the action state. The function then returns a boolean indicating the desired visibility.

```JavaScript
action.testAction = {
  label: 'Some Action',
  options: [
    {
      type: 'dropdown',
      label: 'Option 1',
      id: 'opt1',
      choices: [
        { id: 'yes', label: 'Yes' },
        { id: 'no', label: 'No' },
      ],
      default: 'yes',
    },
    {
      type: 'textinput',
      label: 'Option 2',
      id: 'opt2',
      default: '',
      isVisible: (action) => action.options.opt1 === 'yes',
    },
  ],
}