### PR TITLE
feat: config field to enable the elgato plugin instead of scanning for local devices

### DIFF
--- a/app.js
+++ b/app.js
@@ -185,7 +185,13 @@ system.ready = function (logToFile) {
 	var preset = require('./lib/preset')(system)
 	var satelliteLegacy = require('./lib/satellite/satellite_server_legacy')(system)
 	var satellite = require('./lib/satellite/satellite_server')(system)
-	var ws_api = require('./lib/ws_api')(system)
+	var elgato_plugin_server
+	system.emit('get_userconfig_key', 'elgato_plugin_enable', function(enabled) {
+		if (enabled) {
+			// Only enable if box was ticked at startup
+			elgato_plugin_server = require('./lib/elgato_plugin_server')(system)
+		}
+	})
 	var help = require('./lib/help')(system)
 	var metrics = require('./lib/metrics')(system)
 

--- a/app.js
+++ b/app.js
@@ -185,13 +185,7 @@ system.ready = function (logToFile) {
 	var preset = require('./lib/preset')(system)
 	var satelliteLegacy = require('./lib/satellite/satellite_server_legacy')(system)
 	var satellite = require('./lib/satellite/satellite_server')(system)
-	var elgato_plugin_server
-	system.emit('get_userconfig_key', 'elgato_plugin_enable', function(enabled) {
-		if (enabled) {
-			// Only enable if box was ticked at startup
-			elgato_plugin_server = require('./lib/elgato_plugin_server')(system)
-		}
-	})
+	var elgato_plugin_server = require('./lib/elgato_plugin_server')(system)
 	var help = require('./lib/help')(system)
 	var metrics = require('./lib/metrics')(system)
 

--- a/lib/elgato_dm.js
+++ b/lib/elgato_dm.js
@@ -20,8 +20,8 @@ var HID = require('node-hid')
 var findProcess = require('find-process')
 var deviceHandler = require('./device')
 var usb = require('./usb')
-var elgatoEmulator = require('./elgato_emulator')
-var elgatoPluginDevice = require('./elgato_plugin')
+var elgatoEmulator = require('./elgato_emulator_device')
+var elgatoPluginDevice = require('./elgato_plugin_device')
 var satelliteDeviceLegacy = require('./satellite/satellite_device_legacy')
 var satelliteDevice = require('./satellite/satellite_device')
 var system
@@ -155,9 +155,12 @@ elgatoDM.prototype.updateDevicesList = function (socket) {
 
 elgatoDM.prototype.refreshDevices = function (cb) {
 	var self = this
-	var ignoreStreamDeck = false
+	var streamDeckSoftwareRunning = false
+	var streamdeckDisabled = !!self.config.elgato_plugin_enable
 
 	function scanUSB() {
+		var ignoreStreamDeck = streamDeckSoftwareRunning || streamdeckDisabled
+
 		debug('USB: checking devices (blocking call)')
 		var devices = HID.devices()
 		for (const device of devices) {
@@ -210,25 +213,25 @@ elgatoDM.prototype.refreshDevices = function (cb) {
 		debug('USB: done')
 
 		if (typeof cb === 'function') {
-			if (ignoreStreamDeck) {
-				cb('Not scanning for Stream Deck devices as the stream deck app is running')
+			if (streamdeckDisabled) {
+				cb('Ignoring Stream Decks devices as the plugin has been enabled')
+			} else if (ignoreStreamDeck) {
+				cb('Ignoring Stream Decks devices as the stream deck app is running')
 			} else {
 				cb()
 			}
 		}
 	}
 
-	// Make sure we don't try to take over stream deck devices when the stream deck application
-	// is running on windows.
-	ignoreStreamDeck = false
-
 	try {
-		if (process.platform === 'win32') {
+		// Make sure we don't try to take over stream deck devices when the stream deck application
+		// is running on windows.
+		if (!streamdeckDisabled && process.platform === 'win32') {
 			findProcess('name', 'Stream Deck')
 				.then(function (list) {
 					if (typeof list === 'object' && list.length > 0) {
-						ignoreStreamDeck = true
-						debug('Not scanning for Stream Deck devices because we are on windows, and the stream deck app is running')
+						streamDeckSoftwareRunning = true
+						debug('Elgato software detected, ignoring stream decks')
 					}
 
 					scanUSB()

--- a/lib/elgato_emulator_device.js
+++ b/lib/elgato_emulator_device.js
@@ -17,14 +17,14 @@
 
 var EventEmitter = require('events').EventEmitter
 var util = require('util')
-var debug = require('debug')('lib/elgato_emulator')
+var debug = require('debug')('lib/elgato_emulator_device')
 var path = require('path')
 var common = require('./usb/common')
 
 var system
 var io
 
-function elgatoEmulator(_system, devicepath) {
+function elgatoEmulatorDevice(_system, devicepath) {
 	var self = this
 
 	system = _system
@@ -88,15 +88,15 @@ function elgatoEmulator(_system, devicepath) {
 
 // Manual inherit
 for (var key in common.prototype) {
-	elgatoEmulator.prototype[key] = common.prototype[key]
+	elgatoEmulatorDevice.prototype[key] = common.prototype[key]
 }
 
-util.inherits(elgatoEmulator, EventEmitter)
+util.inherits(elgatoEmulatorDevice, EventEmitter)
 
-elgatoEmulator.prototype.begin = function () {}
-elgatoEmulator.prototype.quit = function () {}
+elgatoEmulatorDevice.prototype.begin = function () {}
+elgatoEmulatorDevice.prototype.quit = function () {}
 
-elgatoEmulator.prototype.draw = function (key, buffer, style) {
+elgatoEmulatorDevice.prototype.draw = function (key, buffer, style) {
 	var self = this
 
 	if (buffer === undefined || buffer.length != 15552) {
@@ -112,7 +112,7 @@ elgatoEmulator.prototype.draw = function (key, buffer, style) {
 	return true
 }
 
-elgatoEmulator.prototype.mapButton = function (input) {
+elgatoEmulatorDevice.prototype.mapButton = function (input) {
 	var self = this
 	var map = '7 6 5 4 3 2 1 0 15 14 13 12 11 10 9 8 23 22 21 20 19 18 17 16 31 30 29 28 27 26 25 24'.split(/ /)
 	var devkey = self.toDeviceKey(input)
@@ -123,7 +123,7 @@ elgatoEmulator.prototype.mapButton = function (input) {
 	return parseInt(map[devkey])
 }
 
-elgatoEmulator.prototype.reverseButton = function (input) {
+elgatoEmulatorDevice.prototype.reverseButton = function (input) {
 	var self = this
 
 	var map = '7 6 5 4 3 2 1 0 15 14 13 12 11 10 9 8 23 22 21 20 19 18 17 16 31 30 29 28 27 26 25 24'.split(/ /)
@@ -134,7 +134,7 @@ elgatoEmulator.prototype.reverseButton = function (input) {
 	return
 }
 
-elgatoEmulator.prototype.clearDeck = function () {
+elgatoEmulatorDevice.prototype.clearDeck = function () {
 	var self = this
 	debug('elgato.prototype.clearDeck()')
 	for (var x = 0; x < self.keysTotal; x++) {
@@ -144,7 +144,7 @@ elgatoEmulator.prototype.clearDeck = function () {
 
 /* elgato-streamdeck functions */
 
-elgatoEmulator.prototype.fillImage = function (keyIndex, imageBuffer) {
+elgatoEmulatorDevice.prototype.fillImage = function (keyIndex, imageBuffer) {
 	var self = this
 
 	if (imageBuffer.length !== 15552) {
@@ -156,7 +156,7 @@ elgatoEmulator.prototype.fillImage = function (keyIndex, imageBuffer) {
 	io.emit('emul_fillImage', keyIndex, imageBuffer)
 }
 
-elgatoEmulator.prototype.clearKey = function (keyIndex) {
+elgatoEmulatorDevice.prototype.clearKey = function (keyIndex) {
 	var self = this
 
 	self.keys[keyIndex] = Buffer.alloc(15552)
@@ -164,4 +164,4 @@ elgatoEmulator.prototype.clearKey = function (keyIndex) {
 	io.emit('emul_clearKey', keyIndex)
 }
 
-module.exports = elgatoEmulator
+module.exports = elgatoEmulatorDevice

--- a/lib/elgato_plugin_device.js
+++ b/lib/elgato_plugin_device.js
@@ -16,14 +16,14 @@
  */
 var EventEmitter = require('events').EventEmitter
 var util = require('util')
-var debug = require('debug')('lib/elgato_plugin')
+var debug = require('debug')('lib/elgato_plugin_device')
 var path = require('path')
 
 var system
 var express
 var io
 
-function elgatoPlugin(_system, devicepath) {
+function elgatoPluginDevice(_system, devicepath) {
 	var self = this
 
 	self.system = system = _system
@@ -82,16 +82,16 @@ function elgatoPlugin(_system, devicepath) {
 	})
 }
 
-util.inherits(elgatoPlugin, EventEmitter)
+util.inherits(elgatoPluginDevice, EventEmitter)
 
-elgatoPlugin.prototype.begin = function () {}
+elgatoPluginDevice.prototype.begin = function () {}
 
-elgatoPlugin.prototype.quit = function () {
+elgatoPluginDevice.prototype.quit = function () {
 	socket.removeAllListeners('keyup')
 	socket.removeAllListeners('keydown')
 }
 
-elgatoPlugin.prototype.draw = function (key, buffer, style) {
+elgatoPluginDevice.prototype.draw = function (key, buffer, style) {
 	var self = this
 
 	if (buffer === undefined || buffer.length != 15552) {
@@ -108,7 +108,7 @@ elgatoPlugin.prototype.draw = function (key, buffer, style) {
 	return true
 }
 
-elgatoPlugin.prototype.clearDeck = function () {
+elgatoPluginDevice.prototype.clearDeck = function () {
 	var self = this
 	debug('elgato.prototype.clearDeck()')
 	self.clearAllKeys()
@@ -116,7 +116,7 @@ elgatoPlugin.prototype.clearDeck = function () {
 
 /* elgato-streamdeck functions */
 
-elgatoPlugin.prototype.setConfig = function (config, cb) {
+elgatoPluginDevice.prototype.setConfig = function (config, cb) {
 	var self = this
 
 	let redraw = false
@@ -130,7 +130,7 @@ elgatoPlugin.prototype.setConfig = function (config, cb) {
 	cb(redraw)
 }
 
-elgatoPlugin.prototype.fillImage = function (keyIndex, imageBuffer) {
+elgatoPluginDevice.prototype.fillImage = function (keyIndex, imageBuffer) {
 	var self = this
 
 	if (imageBuffer.length !== 15552) {
@@ -144,7 +144,7 @@ elgatoPlugin.prototype.fillImage = function (keyIndex, imageBuffer) {
 	}
 }
 
-elgatoPlugin.prototype.clearAllKeys = function () {
+elgatoPluginDevice.prototype.clearAllKeys = function () {
 	var self = this
 
 	const emptyBuffer = Buffer.alloc(72 * 72 * 3)
@@ -160,6 +160,6 @@ elgatoPlugin.prototype.clearAllKeys = function () {
 
 // Steal rotation code from usb/common
 var common = require('./usb/common')
-elgatoPlugin.prototype.handleBuffer = common.prototype.handleBuffer
+elgatoPluginDevice.prototype.handleBuffer = common.prototype.handleBuffer
 
-module.exports = elgatoPlugin
+module.exports = elgatoPluginDevice

--- a/lib/elgato_plugin_server.js
+++ b/lib/elgato_plugin_server.js
@@ -16,13 +16,13 @@
  */
 
 var system
-var debug = require('debug')('lib/ws_api')
+var debug = require('debug')('lib/elgato_plugin_server')
 var WebSocketServer = require('websocket').server
 var http = require('http')
 var graphics
 var elgatoDM
 
-function wsapi(_system) {
+function elgatoPluginServer(_system) {
 	var self = this
 	system = _system
 
@@ -85,7 +85,7 @@ function socketCommand(command, args) {
 	this.sendUTF(JSON.stringify({ command: command, arguments: args }))
 }
 
-wsapi.prototype.initAPI1 = function (socket) {
+elgatoPluginServer.prototype.initAPI1 = function (socket) {
 	var self = this
 
 	debug('init api')
@@ -128,7 +128,7 @@ wsapi.prototype.initAPI1 = function (socket) {
 	})
 }
 
-wsapi.prototype.handleBankChanged = function (page, bank) {
+elgatoPluginServer.prototype.handleBankChanged = function (page, bank) {
 	var self = this
 
 	page = parseInt(page)
@@ -144,7 +144,7 @@ wsapi.prototype.handleBankChanged = function (page, bank) {
 	}
 }
 
-wsapi.prototype.initAPI2 = function (socket) {
+elgatoPluginServer.prototype.initAPI2 = function (socket) {
 	var self = this
 
 	debug('init api v2')
@@ -202,7 +202,7 @@ wsapi.prototype.initAPI2 = function (socket) {
 	})
 }
 
-wsapi.prototype.initSocket = function (socket) {
+elgatoPluginServer.prototype.initSocket = function (socket) {
 	var self = this
 
 	socket.apireply = socketResponse.bind(socket)
@@ -227,5 +227,5 @@ wsapi.prototype.initSocket = function (socket) {
 }
 
 exports = module.exports = function (system) {
-	return new wsapi(system)
+	return new elgatoPluginServer(system)
 }

--- a/lib/elgato_plugin_server.js
+++ b/lib/elgato_plugin_server.js
@@ -22,9 +22,9 @@ var http = require('http')
 var graphics
 var elgatoDM
 
-function elgatoPluginServer(_system) {
+function elgatoPluginServer(system) {
 	var self = this
-	system = _system
+	self.system = system
 
 	elgatoDM = require('./elgato_dm')(system)
 
@@ -38,15 +38,48 @@ function elgatoPluginServer(_system) {
 		self.handleBankChanged(page, button)
 	})
 
+	let user_config = {}
+	system.emit('db_get', 'userconfig', function (config) {
+		user_config = config || {}
+	})
+
+	if (user_config.elgato_plugin_enable) {
+		self.start_listening()
+	}
+
+	system.on('set_userconfig_key', function (key, value) {
+		if (key == 'elgato_plugin_enable') {
+			// start/stop listener
+			if (value && !self.http) {
+				self.start_listening()
+			} else if (!value && self.http) {
+				self.stop_listening()
+			}
+		}
+	})
+}
+
+elgatoPluginServer.prototype.start_listening = function () {
+	var self = this
+
+	if (self.http || self.ws) {
+		// cleanup an old server first
+		self.stop_listening()
+	}
+
+	const port = 28492
+
 	self.http = http.createServer(function (request, response) {
 		response.writeHead(404)
 		response.end('Not found')
 	})
 	self.http.on('error', function (err) {
-		debug('ERROR opening port 28492 for ws-api', err)
+		debug(`ERROR opening port ${port} for elgato plugin`, err)
+		self.system.emit('log', 'Elgato Plugin', 'error', `Couldn't bind to Elgato Plugin port ${port}`)
 	})
-	self.http.listen(28492, function () {
-		debug('ws-api ready')
+	self.http.listen(port, function () {
+		debug('elgato plugin ready')
+		self.system.emit('log', 'Elgato Plugin', 'info', `Listening for Elgato Plugin commands`)
 	})
 
 	self.ws = new WebSocketServer({
@@ -76,6 +109,23 @@ function elgatoPluginServer(_system) {
 			debug('Connection from ' + socket.remoteAddress + ' disconnected')
 		})
 	})
+}
+
+elgatoPluginServer.prototype.stop_listening = function () {
+	var self = this
+
+	debug(`Stopping eglato plugin server`)
+	self.system.emit('log', 'Elgato Plugin', 'info', `Stopping listening for Elgato Plugin commands`)
+
+	if (self.ws) {
+		self.ws.shutDown()
+		delete self.ws
+	}
+
+	if (self.http) {
+		self.http.close()
+		delete self.http
+	}
 }
 
 function socketResponse(command, args) {

--- a/lib/userconfig.js
+++ b/lib/userconfig.js
@@ -25,6 +25,7 @@ const default_config = {
 
 	emulator_control_enable: false,
 	xkeys_enable: true,
+	elgato_plugin_enable: false, // Also disables local streamdeck
 
 	pin_enable: false,
 	link_lockouts: false,

--- a/webui/src/UserConfig.jsx
+++ b/webui/src/UserConfig.jsx
@@ -133,7 +133,22 @@ function UserConfigTable() {
 					</td>
 				</tr>
 				<tr>
-					<td>Enable connected xkeys (Companion restart required)</td>
+					<td>Use Elgato Plugin for StreamDeck access (Requires Companion restart)</td>
+					<td>
+						<div className="form-check form-check-inline mr-1">
+							<CInputCheckbox
+								id="userconfig_elgato_plugin_enable"
+								checked={config.elgato_plugin_enable}
+								onChange={(e) => setValue('elgato_plugin_enable', e.currentTarget.checked)}
+							/>
+							<label className="form-check-label" htmlFor="userconfig_elgato_plugin_enable">
+								Enabled
+							</label>
+						</div>
+					</td>
+				</tr>
+				<tr>
+					<td>Enable connected xkeys (Requires Companion restart)</td>
 					<td>
 						<div className="form-check form-check-inline mr-1">
 							<CInputCheckbox


### PR DESCRIPTION
This should resolve some common issues from users who try the elgato plugin instead of native streamdeck support. eg #1795

The plugin api is now disabled by default. It has a userconfig field to enable it, and doing so will stop companion attempting to connect to streamdecks by itself.
So users will have to explicitly choose which way they want it to work.

There are still some edge cases where the two can fight, but this should solve the bulk of the cases and will resolve some of the issues observed at startup once it has already been setup.

I don't know how we can do this without blanket disabling the plugin for everyone, hopefully we are ok with that being done.

This can also be used to disable streamdeck loading #1771