### PR TITLE
Added info about key commands to buttons page

### DIFF
--- a/webui/src/Buttons/ButtonGrid.jsx
+++ b/webui/src/Buttons/ButtonGrid.jsx
@@ -192,6 +192,11 @@ export const ButtonsGridPanel = memo(function ButtonsPage({
 					You can navigate between pages using the arrow buttons, or by clicking the page number, typing in a number,
 					and pressing 'Enter' on your keyboard.
 				</CAlert>
+				
+				<CAlert color="info">
+					You can use common key commands such as copy, paste, and cut to move buttons around. You can also 
+					press the delete or backspace key with any button highlighted to delete it.
+				</CAlert>
 			</div>
 		</KeyReceiver>
 	)


### PR DESCRIPTION
I've been asked so many times about a faster way to copy, paste, and move buttons that I wanted to add a little bit to the UI to tell people about it.

I just added `You can also use common key commands such as copy, paste, and cut to move buttons around. You can even press the delete or backspace key with any button highlighted to delete it.` to the current `<CAlert>` on the buttons page.