### PR TITLE
Additional TCP type definitions

### DIFF
--- a/tcp.d.ts
+++ b/tcp.d.ts
@@ -15,11 +15,16 @@ declare class TCPClient extends EventEmitter {
 	constructor(
 		host: string,
 		port: number,
+		connected: boolean,
+		status: null | 0 | 1 | 2,
 		options?: {
 			/** default 2000 */
 			reconnect_interval?: number
 			/** default true */
 			reconnect?: boolean
+		},
+		socket?: {
+			connecting: boolean
 		}
 	)
 


### PR DESCRIPTION
There is the potential for an error if the a new TCP instance is created and then destroyed before the connection process even starts. This PR exposes some additional types to allow module developers to check the status to hopefully prevent that rare situation.