### PR TITLE
major: Add first-run configuration wizard

### DIFF
--- a/app.js
+++ b/app.js
@@ -196,6 +196,10 @@ system.ready = function (logToFile) {
 	system.on('exit', function () {
 		elgatoDM.quit()
 	})
+
+	setTimeout(function () {
+		system.emit('ip_rebind')
+	}, 2000)
 }
 
 exports = module.exports = system

--- a/lib/server_http.js
+++ b/lib/server_http.js
@@ -57,7 +57,6 @@ function server_http(system, express) {
 	system.emit('config_object', function (config) {
 		self.config = config
 		system.on('ip_rebind', self.listen_for_http)
-		self.listen_for_http()
 	})
 
 	return self

--- a/lib/userconfig.js
+++ b/lib/userconfig.js
@@ -20,6 +20,8 @@ var selfsigned = require('selfsigned')
 
 // The config for new installs
 const default_config = {
+	setup_wizard: 0,
+
 	page_direction_flipped: false,
 	page_plusminus: false,
 	remove_topbar: false,

--- a/lib/userconfig.js
+++ b/lib/userconfig.js
@@ -136,6 +136,7 @@ function userconfig(system) {
 			debug('socket ' + socket.id + ' connected')
 
 			socket.on('set_userconfig_key', self.set_userconfig_key.bind(self))
+			socket.on('set_userconfig_keys', self.set_userconfig_keys.bind(self))
 
 			socket.on('reset_userconfig_key', function (key) {
 				self.set_userconfig_key(key, default_config[key])

--- a/webui/src/App.jsx
+++ b/webui/src/App.jsx
@@ -132,6 +132,7 @@ export default function App() {
 }
 
 function AppMain({ connected, loadingComplete, loadingProgress, buttonGridHotPress }) {
+	const context = useContext(StaticContext)
 	const config = useContext(UserConfigContext)
 
 	const [showSidebar, setShowSidebar] = useState(true)
@@ -156,20 +157,20 @@ function AppMain({ connected, loadingComplete, loadingProgress, buttonGridHotPre
 
 	const setUnlockedInner = useCallback(() => {
 		setUnlocked(true)
-		if (config && !config?.v22_wizard) {
+		if (config && config?.setup_wizard < context.currentVersion) {
 			showWizard()
 		}
-	}, [config, showWizard])
+	}, [config, context.currentVersion, showWizard])
 
 	// If lockout is disabled, then we are logged in
 	useEffect(() => {
 		if (config && !config?.admin_lockout) {
 			setUnlocked(true)
-			if (!config?.v22_wizard) {
+			if (config?.setup_wizard < context.currentVersion) {
 				showWizard()
 			}
 		}
-	}, [config, showWizard])
+	}, [config, context.currentVersion, showWizard])
 
 	return (
 		<div className="c-app">
@@ -178,7 +179,7 @@ function AppMain({ connected, loadingComplete, loadingProgress, buttonGridHotPre
 			) : (
 				''
 			)}
-			<WizardModal ref={wizardModal} />
+			<WizardModal ref={wizardModal} currentVerson={context.currentVersion} />
 			<MySidebar show={showSidebar} showWizard={showWizard} />
 			<div className="c-wrapper">
 				<MyHeader toggleSidebar={toggleSidebar} setLocked={setLocked} canLock={canLock && unlocked} />

--- a/webui/src/App.jsx
+++ b/webui/src/App.jsx
@@ -147,17 +147,17 @@ function AppMain({ connected, loadingComplete, loadingProgress, buttonGridHotPre
 		}
 	}, [canLock])
 
+	const wizardModal = useRef()
+	const showWizard = useCallback(() => {
+		wizardModal.current.show()
+	}, [])
+
 	const setUnlockedInner = useCallback(() => {
 		setUnlocked(true)
 		if (config && !config?.v22_wizard) {
 			showWizard()
 		}
 	}, [config, showWizard])
-
-	const wizardModal = useRef()
-	const showWizard = useCallback(() => {
-		wizardModal.current.show()
-	}, [])
 
 	// If lockout is disabled, then we are logged in
 	useEffect(() => {

--- a/webui/src/App.jsx
+++ b/webui/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import React, { Suspense, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import {
 	CContainer,
 	CTabContent,
@@ -37,6 +37,7 @@ import { Triggers } from './Triggers'
 import { InstancesPage } from './Instances'
 import { ButtonsPage } from './Buttons'
 import { ContextData } from './ContextData'
+import { WizardModal } from './Wizard'
 import { Redirect, useLocation } from 'react-router-dom'
 import { useIdleTimer } from 'react-idle-timer'
 
@@ -150,12 +151,20 @@ function AppMain({ connected, loadingComplete, loadingProgress, buttonGridHotPre
 		setUnlocked(true)
 	}, [])
 
+	const wizardModal = useRef()
+	const showWizard = useCallback(() => {
+		wizardModal.current.show()
+	}, [])
+
 	// If lockout is disabled, then we are logged in
 	useEffect(() => {
 		if (config && !config?.admin_lockout) {
 			setUnlocked(true)
 		}
-	}, [config])
+		if (config && !config?.v22_wizard) {
+			showWizard()
+		}
+	}, [config, showWizard])
 
 	return (
 		<div className="c-app">
@@ -164,7 +173,8 @@ function AppMain({ connected, loadingComplete, loadingProgress, buttonGridHotPre
 			) : (
 				''
 			)}
-			<MySidebar show={showSidebar} />
+			<WizardModal ref={wizardModal} />
+			<MySidebar show={showSidebar} showWizard={showWizard} />
 			<div className="c-wrapper">
 				<MyHeader toggleSidebar={toggleSidebar} setLocked={setLocked} canLock={canLock && unlocked} />
 				<div className="c-body">

--- a/webui/src/App.jsx
+++ b/webui/src/App.jsx
@@ -149,8 +149,10 @@ function AppMain({ connected, loadingComplete, loadingProgress, buttonGridHotPre
 
 	const wizardModal = useRef()
 	const showWizard = useCallback(() => {
-		wizardModal.current.show()
-	}, [])
+		if (unlocked) {
+			wizardModal.current.show()
+		}
+	}, [unlocked])
 
 	const setUnlockedInner = useCallback(() => {
 		setUnlocked(true)

--- a/webui/src/App.jsx
+++ b/webui/src/App.jsx
@@ -149,7 +149,10 @@ function AppMain({ connected, loadingComplete, loadingProgress, buttonGridHotPre
 
 	const setUnlockedInner = useCallback(() => {
 		setUnlocked(true)
-	}, [])
+		if (config && !config?.v22_wizard) {
+			showWizard()
+		}
+	}, [config, showWizard])
 
 	const wizardModal = useRef()
 	const showWizard = useCallback(() => {
@@ -160,9 +163,9 @@ function AppMain({ connected, loadingComplete, loadingProgress, buttonGridHotPre
 	useEffect(() => {
 		if (config && !config?.admin_lockout) {
 			setUnlocked(true)
-		}
-		if (config && !config?.v22_wizard) {
-			showWizard()
+			if (!config?.v22_wizard) {
+				showWizard()
+			}
 		}
 	}, [config, showWizard])
 

--- a/webui/src/App.scss
+++ b/webui/src/App.scss
@@ -16,6 +16,7 @@
 @import 'scss/log';
 @import 'scss/presets';
 @import 'scss/settings';
+@import 'scss/wizard';
 
 @keyframes fadeIn {
 	from {

--- a/webui/src/ContextData.jsx
+++ b/webui/src/ContextData.jsx
@@ -136,6 +136,7 @@ export function ContextData({ socket, children }) {
 		notifier: notifierRef,
 		modules: modules,
 		moduleRedirects: moduleRedirects,
+		currentVersion: 22,
 	}
 
 	const steps = [

--- a/webui/src/Layout/Sidebar.jsx
+++ b/webui/src/Layout/Sidebar.jsx
@@ -5,6 +5,7 @@ import {
 	faComments,
 	faDollarSign,
 	faGamepad,
+	faHatWizard,
 	faInfo,
 	faMousePointer,
 	faTabletAlt,
@@ -13,7 +14,7 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useTranslation } from 'react-i18next'
 
-export function MySidebar({ show }) {
+export function MySidebar({ show, showWizard }) {
 	const { t } = useTranslation()
 
 	return (
@@ -30,6 +31,11 @@ export function MySidebar({ show }) {
 					</div>
 				</CSidebarBrand>
 
+				<CSidebarNavItem
+					icon={<FontAwesomeIcon className="c-sidebar-nav-icon" icon={faHatWizard} />}
+					name={t('Configuration Wizard')}
+					onClick={showWizard}
+				/>
 				<CSidebarNavItem
 					target="_new"
 					href="/emulator"

--- a/webui/src/Wizard/ApplyStep.jsx
+++ b/webui/src/Wizard/ApplyStep.jsx
@@ -3,7 +3,7 @@ import React from 'react'
 export function ApplyStep({ oldConfig, newConfig }) {
 	let changes = []
 
-	if (!oldConfig.v22_wizard || oldConfig.elgato_plugin_enable !== newConfig.elgato_plugin_enable) {
+	if (oldConfig.setup_wizard === 0 || oldConfig.elgato_plugin_enable !== newConfig.elgato_plugin_enable) {
 		changes.push(
 			newConfig.elgato_plugin_enable ? (
 				<li>Stream Deck hardware will access Companion via the Stream Deck software and the Companion plugin.</li>
@@ -17,145 +17,157 @@ export function ApplyStep({ oldConfig, newConfig }) {
 		)
 	}
 
-	if (!oldConfig.v22_wizard || oldConfig.xkeys_enable !== newConfig.xkeys_enable) {
+	if (oldConfig.setup_wizard === 0 || oldConfig.xkeys_enable !== newConfig.xkeys_enable) {
 		changes.push(
 			newConfig.xkeys_enable ? (
 				<li>X-keys hardware will be detected by Companion.</li>
 			) : (
-				<li>X-keys hardware will {oldConfig.v22_wizard ? 'no longer' : 'not'} be detected by Companion.</li>
+				<li>X-keys hardware will {oldConfig.setup_wizard > 0 ? 'no longer' : 'not'} be detected by Companion.</li>
 			)
 		)
 	}
 
-	if (oldConfig.tcp_enabled !== newConfig.tcp_enabled) {
-		changes.push(
-			newConfig.tcp_enabled ? (
-				<li style={{ color: 'green' }}>Enable TCP Listener</li>
-			) : (
-				<li style={{ color: 'red' }}>Disable TCP Listener</li>
-			)
-		)
-	}
 	if (
-		(!oldConfig.v22_wizard && newConfig.tcp_enabled && !oldConfig.tcp_enabled) ||
-		(newConfig.tcp_enabled && oldConfig.tcp_listen_port !== newConfig.tcp_listen_port)
+		oldConfig.setup_wizard === 0 &&
+		!newConfig.tcp_enabled &&
+		!newConfig.udp_enabled &&
+		!newConfig.osc_enabled &&
+		!newConfig.rosstalk_enabled &&
+		!newConfig.emberplus_enabled &&
+		!newConfig.artnet_enabled
 	) {
-		changes.push(
-			<li>
-				{oldConfig.v22_wizard || oldConfig.tcp_enabled ? 'Change' : 'Set'} TCP listen port to{' '}
-				{newConfig.tcp_listen_port}
-			</li>
-		)
-	}
-
-	if (oldConfig.udp_enabled !== newConfig.udp_enabled) {
-		changes.push(
-			newConfig.udp_enabled ? (
-				<li style={{ color: 'green' }}>Enable TCP Listener</li>
-			) : (
-				<li style={{ color: 'red' }}>Disable TCP Listener</li>
+		changes.push(<li>No remote control services will be enabled.</li>)
+	} else {
+		if (oldConfig.tcp_enabled !== newConfig.tcp_enabled) {
+			changes.push(
+				newConfig.tcp_enabled ? (
+					<li style={{ color: 'green' }}>Enable TCP Listener</li>
+				) : (
+					<li style={{ color: 'red' }}>Disable TCP Listener</li>
+				)
 			)
-		)
-	}
-	if (
-		(!oldConfig.v22_wizard && newConfig.udp_enabled && !oldConfig.udp_enabled) ||
-		(newConfig.udp_enabled && oldConfig.udp_listen_port !== newConfig.udp_listen_port)
-	) {
-		changes.push(
-			<li>
-				{oldConfig.v22_wizard || oldConfig.udp_enabled ? 'Change' : 'Set'} UDP listen port to{' '}
-				{newConfig.udp_listen_port}
-			</li>
-		)
-	}
-
-	if (oldConfig.osc_enabled !== newConfig.osc_enabled) {
-		changes.push(
-			newConfig.osc_enabled ? (
-				<li style={{ color: 'green' }}>Enable OSC Listener</li>
-			) : (
-				<li style={{ color: 'red' }}>Disable OSC Listener</li>
+		}
+		if (
+			(oldConfig.setup_wizard === 0 && newConfig.tcp_enabled && !oldConfig.tcp_enabled) ||
+			(newConfig.tcp_enabled && oldConfig.tcp_listen_port !== newConfig.tcp_listen_port)
+		) {
+			changes.push(
+				<li>
+					{oldConfig.setup_wizard > 0 || oldConfig.tcp_enabled ? 'Change' : 'Set'} TCP listen port to{' '}
+					{newConfig.tcp_listen_port}
+				</li>
 			)
-		)
-	}
-	if (
-		(!oldConfig.v22_wizard && newConfig.osc_enabled && !oldConfig.osc_enabled) ||
-		(newConfig.osc_enabled && oldConfig.osc_listen_port !== newConfig.osc_listen_port)
-	) {
-		changes.push(
-			<li>
-				{oldConfig.v22_wizard || oldConfig.osc_enabled ? 'Change' : 'Set'} OSC listen port to{' '}
-				{newConfig.osc_listen_port}
-			</li>
-		)
-	}
+		}
 
-	if (oldConfig.rosstalk_enabled !== newConfig.rosstalk_enabled) {
-		changes.push(
-			newConfig.rosstalk_enabled ? (
-				<li style={{ color: 'green' }}>Enable Rosstalk Listener</li>
-			) : (
-				<li style={{ color: 'red' }}>Disable Rosstalk Listener</li>
+		if (oldConfig.udp_enabled !== newConfig.udp_enabled) {
+			changes.push(
+				newConfig.udp_enabled ? (
+					<li style={{ color: 'green' }}>Enable TCP Listener</li>
+				) : (
+					<li style={{ color: 'red' }}>Disable TCP Listener</li>
+				)
 			)
-		)
-	}
-
-	if (oldConfig.emberplus_enabled !== newConfig.emberplus_enabled) {
-		changes.push(
-			newConfig.emberplus_enabled ? (
-				<li style={{ color: 'green' }}>Enable Ember+ Listener</li>
-			) : (
-				<li style={{ color: 'red' }}>Disable Ember+ Listener</li>
+		}
+		if (
+			(oldConfig.setup_wizard === 0 && newConfig.udp_enabled && !oldConfig.udp_enabled) ||
+			(newConfig.udp_enabled && oldConfig.udp_listen_port !== newConfig.udp_listen_port)
+		) {
+			changes.push(
+				<li>
+					{oldConfig.setup_wizard > 0 || oldConfig.udp_enabled ? 'Change' : 'Set'} UDP listen port to{' '}
+					{newConfig.udp_listen_port}
+				</li>
 			)
-		)
-	}
+		}
 
-	if (oldConfig.artnet_enabled !== newConfig.artnet_enabled) {
-		changes.push(
-			newConfig.artnet_enabled ? (
-				<li style={{ color: 'green' }}>Enable Artnet Listener</li>
-			) : (
-				<li style={{ color: 'red' }}>Disable Artnet Listener</li>
+		if (oldConfig.osc_enabled !== newConfig.osc_enabled) {
+			changes.push(
+				newConfig.osc_enabled ? (
+					<li style={{ color: 'green' }}>Enable OSC Listener</li>
+				) : (
+					<li style={{ color: 'red' }}>Disable OSC Listener</li>
+				)
 			)
-		)
-	}
-	if (
-		(!oldConfig.v22_wizard && newConfig.artnet_enabled && !oldConfig.artnet_enabled) ||
-		(newConfig.artnet_enabled && oldConfig.artnet_universe !== newConfig.artnet_universe)
-	) {
-		changes.push(
-			<li>
-				{oldConfig.v22_wizard || oldConfig.artnet_enabled ? 'Change' : 'Set'} Artnet Universe to{' '}
-				{newConfig.artnet_universe}
-			</li>
-		)
-	}
-	if (
-		(!oldConfig.v22_wizard && newConfig.artnet_enabled && !oldConfig.artnet_enabled) ||
-		(newConfig.artnet_enabled && oldConfig.artnet_channel !== newConfig.artnet_channel)
-	) {
-		changes.push(
-			<li>
-				{oldConfig.v22_wizard || oldConfig.artnet_enabled ? 'Change' : 'Set'} Artnet Channel to{' '}
-				{newConfig.artnet_channel}
-			</li>
-		)
+		}
+		if (
+			(oldConfig.setup_wizard === 0 && newConfig.osc_enabled && !oldConfig.osc_enabled) ||
+			(newConfig.osc_enabled && oldConfig.osc_listen_port !== newConfig.osc_listen_port)
+		) {
+			changes.push(
+				<li>
+					{oldConfig.setup_wizard > 0 || oldConfig.osc_enabled ? 'Change' : 'Set'} OSC listen port to{' '}
+					{newConfig.osc_listen_port}
+				</li>
+			)
+		}
+
+		if (oldConfig.rosstalk_enabled !== newConfig.rosstalk_enabled) {
+			changes.push(
+				newConfig.rosstalk_enabled ? (
+					<li style={{ color: 'green' }}>Enable Rosstalk Listener</li>
+				) : (
+					<li style={{ color: 'red' }}>Disable Rosstalk Listener</li>
+				)
+			)
+		}
+
+		if (oldConfig.emberplus_enabled !== newConfig.emberplus_enabled) {
+			changes.push(
+				newConfig.emberplus_enabled ? (
+					<li style={{ color: 'green' }}>Enable Ember+ Listener</li>
+				) : (
+					<li style={{ color: 'red' }}>Disable Ember+ Listener</li>
+				)
+			)
+		}
+
+		if (oldConfig.artnet_enabled !== newConfig.artnet_enabled) {
+			changes.push(
+				newConfig.artnet_enabled ? (
+					<li style={{ color: 'green' }}>Enable Artnet Listener</li>
+				) : (
+					<li style={{ color: 'red' }}>Disable Artnet Listener</li>
+				)
+			)
+		}
+		if (
+			(oldConfig.setup_wizard === 0 && newConfig.artnet_enabled && !oldConfig.artnet_enabled) ||
+			(newConfig.artnet_enabled && oldConfig.artnet_universe !== newConfig.artnet_universe)
+		) {
+			changes.push(
+				<li>
+					{oldConfig.setup_wizard > 0 || oldConfig.artnet_enabled ? 'Change' : 'Set'} Artnet Universe to{' '}
+					{newConfig.artnet_universe}
+				</li>
+			)
+		}
+		if (
+			(oldConfig.setup_wizard === 0 && newConfig.artnet_enabled && !oldConfig.artnet_enabled) ||
+			(newConfig.artnet_enabled && oldConfig.artnet_channel !== newConfig.artnet_channel)
+		) {
+			changes.push(
+				<li>
+					{oldConfig.setup_wizard > 0 || oldConfig.artnet_enabled ? 'Change' : 'Set'} Artnet Channel to{' '}
+					{newConfig.artnet_channel}
+				</li>
+			)
+		}
 	}
 
-	if (!oldConfig.v22_wizard || oldConfig.admin_lockout !== newConfig.admin_lockout) {
+	if (oldConfig.setup_wizard === 0 || oldConfig.admin_lockout !== newConfig.admin_lockout) {
 		changes.push(
 			newConfig.admin_lockout ? (
-				<li>This admin interface will {oldConfig.v22_wizard ? 'now' : ''} be password protected.</li>
+				<li>This admin interface will {oldConfig.setup_wizard > 0 ? 'now' : ''} be password protected.</li>
 			) : (
 				<li>This admin interface will not be password protected.</li>
 			)
 		)
 	}
 	if (
-		(!oldConfig.v22_wizard && newConfig.admin_lockout) ||
+		(oldConfig.setup_wizard === 0 && newConfig.admin_lockout) ||
 		(newConfig.admin_lockout && oldConfig.admin_password !== newConfig.admin_password)
 	) {
-		oldConfig.v22_wizard
+		oldConfig.setup_wizard > 0
 			? changes.push(
 					<li>
 						Change admin password from {oldConfig.admin_password === '' ? '(none)' : `'${oldConfig.admin_password}'`} to{' '}
@@ -165,10 +177,10 @@ export function ApplyStep({ oldConfig, newConfig }) {
 			: changes.push(<li>Set admin password to '{newConfig.admin_password}'.</li>)
 	}
 	if (
-		(!oldConfig.v22_wizard && newConfig.admin_lockout) ||
+		(oldConfig.setup_wizard === 0 && newConfig.admin_lockout) ||
 		(newConfig.admin_lockout && oldConfig.admin_timeout !== newConfig.admin_timeout)
 	) {
-		oldConfig.v22_wizard
+		oldConfig.setup_wizard > 0
 			? changes.push(
 					<li>
 						Change admin GUI timeout from{' '}
@@ -184,13 +196,13 @@ export function ApplyStep({ oldConfig, newConfig }) {
 	}
 
 	if (changes.length === 0) {
-		changes.push(<li>No changes to the configuration will be made</li>)
+		changes.push(<li>No changes to the configuration will be made.</li>)
 	}
 
 	return (
 		<div>
 			<h5>Review Settings</h5>
-			<p>The following configuration settings will be applied:</p>
+			<p>The following configuration {oldConfig.setup_wizard > 0 ? 'settings' : 'changes'} will be applied:</p>
 			<ul>{changes}</ul>
 		</div>
 	)

--- a/webui/src/Wizard/ApplyStep.jsx
+++ b/webui/src/Wizard/ApplyStep.jsx
@@ -20,9 +20,9 @@ export function ApplyStep({ oldConfig, newConfig }) {
 	if (!oldConfig.v22_wizard || oldConfig.xkeys_enable !== newConfig.xkeys_enable) {
 		changes.push(
 			newConfig.xkeys_enable ? (
-				<li>X-keys hardware will {oldConfig.v22_wizard ? 'no longer' : 'not'} be detected by Companion.</li>
-			) : (
 				<li>X-keys hardware will be detected by Companion.</li>
+			) : (
+				<li>X-keys hardware will {oldConfig.v22_wizard ? 'no longer' : 'not'} be detected by Companion.</li>
 			)
 		)
 	}

--- a/webui/src/Wizard/ApplyStep.jsx
+++ b/webui/src/Wizard/ApplyStep.jsx
@@ -11,7 +11,7 @@ export function ApplyStep({ oldConfig, newConfig }) {
 				<li>
 					Stream Deck hardware will be detected by Companion natively.
 					<br />
-					The Stream Deck software must be closed for this to work.
+					<span style={{ color: 'red' }}>The Stream Deck software must be closed for this to work.</span>
 				</li>
 			)
 		)

--- a/webui/src/Wizard/ApplyStep.jsx
+++ b/webui/src/Wizard/ApplyStep.jsx
@@ -1,0 +1,197 @@
+import React from 'react'
+
+export function ApplyStep({ oldConfig, newConfig }) {
+	let changes = []
+
+	if (!oldConfig.v22_wizard || oldConfig.elgato_plugin_enable !== newConfig.elgato_plugin_enable) {
+		changes.push(
+			newConfig.elgato_plugin_enable ? (
+				<li>Stream Deck hardware will access Companion via the Stream Deck software and the Companion plugin.</li>
+			) : (
+				<li>
+					Stream Deck hardware will be detected by Companion natively.
+					<br />
+					The Stream Deck software must be closed for this to work.
+				</li>
+			)
+		)
+	}
+
+	if (!oldConfig.v22_wizard || oldConfig.xkeys_enable !== newConfig.xkeys_enable) {
+		changes.push(
+			newConfig.xkeys_enable ? (
+				<li>X-keys hardware will {oldConfig.v22_wizard ? 'no longer' : 'not'} be detected by Companion.</li>
+			) : (
+				<li>X-keys hardware will be detected by Companion.</li>
+			)
+		)
+	}
+
+	if (oldConfig.tcp_enabled !== newConfig.tcp_enabled) {
+		changes.push(
+			newConfig.tcp_enabled ? (
+				<li style={{ color: 'green' }}>Enable TCP Listener</li>
+			) : (
+				<li style={{ color: 'red' }}>Disable TCP Listener</li>
+			)
+		)
+	}
+	if (
+		(!oldConfig.v22_wizard && newConfig.tcp_enabled && !oldConfig.tcp_enabled) ||
+		(newConfig.tcp_enabled && oldConfig.tcp_listen_port !== newConfig.tcp_listen_port)
+	) {
+		changes.push(
+			<li>
+				{oldConfig.v22_wizard || oldConfig.tcp_enabled ? 'Change' : 'Set'} TCP listen port to{' '}
+				{newConfig.tcp_listen_port}
+			</li>
+		)
+	}
+
+	if (oldConfig.udp_enabled !== newConfig.udp_enabled) {
+		changes.push(
+			newConfig.udp_enabled ? (
+				<li style={{ color: 'green' }}>Enable TCP Listener</li>
+			) : (
+				<li style={{ color: 'red' }}>Disable TCP Listener</li>
+			)
+		)
+	}
+	if (
+		(!oldConfig.v22_wizard && newConfig.udp_enabled && !oldConfig.udp_enabled) ||
+		(newConfig.udp_enabled && oldConfig.udp_listen_port !== newConfig.udp_listen_port)
+	) {
+		changes.push(
+			<li>
+				{oldConfig.v22_wizard || oldConfig.udp_enabled ? 'Change' : 'Set'} UDP listen port to{' '}
+				{newConfig.udp_listen_port}
+			</li>
+		)
+	}
+
+	if (oldConfig.osc_enabled !== newConfig.osc_enabled) {
+		changes.push(
+			newConfig.osc_enabled ? (
+				<li style={{ color: 'green' }}>Enable OSC Listener</li>
+			) : (
+				<li style={{ color: 'red' }}>Disable OSC Listener</li>
+			)
+		)
+	}
+	if (
+		(!oldConfig.v22_wizard && newConfig.osc_enabled && !oldConfig.osc_enabled) ||
+		(newConfig.osc_enabled && oldConfig.osc_listen_port !== newConfig.osc_listen_port)
+	) {
+		changes.push(
+			<li>
+				{oldConfig.v22_wizard || oldConfig.osc_enabled ? 'Change' : 'Set'} OSC listen port to{' '}
+				{newConfig.osc_listen_port}
+			</li>
+		)
+	}
+
+	if (oldConfig.rosstalk_enabled !== newConfig.rosstalk_enabled) {
+		changes.push(
+			newConfig.rosstalk_enabled ? (
+				<li style={{ color: 'green' }}>Enable Rosstalk Listener</li>
+			) : (
+				<li style={{ color: 'red' }}>Disable Rosstalk Listener</li>
+			)
+		)
+	}
+
+	if (oldConfig.emberplus_enabled !== newConfig.emberplus_enabled) {
+		changes.push(
+			newConfig.emberplus_enabled ? (
+				<li style={{ color: 'green' }}>Enable Ember+ Listener</li>
+			) : (
+				<li style={{ color: 'red' }}>Disable Ember+ Listener</li>
+			)
+		)
+	}
+
+	if (oldConfig.artnet_enabled !== newConfig.artnet_enabled) {
+		changes.push(
+			newConfig.artnet_enabled ? (
+				<li style={{ color: 'green' }}>Enable Artnet Listener</li>
+			) : (
+				<li style={{ color: 'red' }}>Disable Artnet Listener</li>
+			)
+		)
+	}
+	if (
+		(!oldConfig.v22_wizard && newConfig.artnet_enabled && !oldConfig.artnet_enabled) ||
+		(newConfig.artnet_enabled && oldConfig.artnet_universe !== newConfig.artnet_universe)
+	) {
+		changes.push(
+			<li>
+				{oldConfig.v22_wizard || oldConfig.artnet_enabled ? 'Change' : 'Set'} Artnet Universe to{' '}
+				{newConfig.artnet_universe}
+			</li>
+		)
+	}
+	if (
+		(!oldConfig.v22_wizard && newConfig.artnet_enabled && !oldConfig.artnet_enabled) ||
+		(newConfig.artnet_enabled && oldConfig.artnet_channel !== newConfig.artnet_channel)
+	) {
+		changes.push(
+			<li>
+				{oldConfig.v22_wizard || oldConfig.artnet_enabled ? 'Change' : 'Set'} Artnet Channel to{' '}
+				{newConfig.artnet_channel}
+			</li>
+		)
+	}
+
+	if (!oldConfig.v22_wizard || oldConfig.admin_lockout !== newConfig.admin_lockout) {
+		changes.push(
+			newConfig.admin_lockout ? (
+				<li>This admin interface will {oldConfig.v22_wizard ? 'now' : ''} be password protected.</li>
+			) : (
+				<li>This admin interface will not be password protected.</li>
+			)
+		)
+	}
+	if (
+		(!oldConfig.v22_wizard && newConfig.admin_lockout) ||
+		(newConfig.admin_lockout && oldConfig.admin_password !== newConfig.admin_password)
+	) {
+		oldConfig.v22_wizard
+			? changes.push(
+					<li>
+						Change admin password from {oldConfig.admin_password == '' ? '(none)' : `'${oldConfig.admin_password}'`} to{' '}
+						'{newConfig.admin_password}'.
+					</li>
+			  )
+			: changes.push(<li>Set admin password to '{newConfig.admin_password}'.</li>)
+	}
+	if (
+		(!oldConfig.v22_wizard && newConfig.admin_lockout) ||
+		(newConfig.admin_lockout && oldConfig.admin_timeout !== newConfig.admin_timeout)
+	) {
+		oldConfig.v22_wizard
+			? changes.push(
+					<li>
+						Change admin GUI timeout from{' '}
+						{oldConfig.admin_timeout === '0' ? 'none' : oldConfig.admin_timeout + ' minutes'} to{' '}
+						{newConfig.admin_timeout === '0' ? 'none' : newConfig.admin_timeout + ' minutes'}.
+					</li>
+			  )
+			: changes.push(
+					<li>
+						Set admin GUI timeout to {newConfig.admin_timeout === '0' ? 'none' : newConfig.admin_timeout + ' minutes'}.
+					</li>
+			  )
+	}
+
+	if (changes.length === 0) {
+		changes.push(<li>No changes to the configuration will be made</li>)
+	}
+
+	return (
+		<div>
+			<h5>Review Settings</h5>
+			<p>The following configuration settings will be applied:</p>
+			<ul>{changes}</ul>
+		</div>
+	)
+}

--- a/webui/src/Wizard/ApplyStep.jsx
+++ b/webui/src/Wizard/ApplyStep.jsx
@@ -158,7 +158,7 @@ export function ApplyStep({ oldConfig, newConfig }) {
 		oldConfig.v22_wizard
 			? changes.push(
 					<li>
-						Change admin password from {oldConfig.admin_password == '' ? '(none)' : `'${oldConfig.admin_password}'`} to{' '}
+						Change admin password from {oldConfig.admin_password === '' ? '(none)' : `'${oldConfig.admin_password}'`} to{' '}
 						'{newConfig.admin_password}'.
 					</li>
 			  )

--- a/webui/src/Wizard/BeginStep.jsx
+++ b/webui/src/Wizard/BeginStep.jsx
@@ -4,8 +4,8 @@ export function BeginStep() {
 	return (
 		<div>
 			<p style={{ marginTop: 0 }}>
-				Whether you are a new user or upgrading, there are a number of settings you should review before using Companion.
-				This wizard will walk you through the following configuration settings:
+				Whether you are a new user or upgrading, there are a number of settings you should review before using
+				Companion. This wizard will walk you through the following configuration settings:
 			</p>
 			<ol>
 				<li>USB Surface Detection Configuration</li>

--- a/webui/src/Wizard/BeginStep.jsx
+++ b/webui/src/Wizard/BeginStep.jsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+export function BeginStep() {
+	return (
+		<div>
+			<p style={{ marginTop: 0 }}>
+				Whether you are a new user or upgrading, there are a number of settings you should review before using Companion.
+				This wizard will walk you through the following configuration settings:
+			</p>
+			<ol>
+				<li>USB Surface Detection Configuration</li>
+				<li>Remote Control Services</li>
+				<li>Admin GUI Password</li>
+			</ol>
+		</div>
+	)
+}

--- a/webui/src/Wizard/FinishStep.jsx
+++ b/webui/src/Wizard/FinishStep.jsx
@@ -12,7 +12,7 @@ export function FinishStep({ oldConfig, newConfig }) {
 			</p>
 			<ol>
 				<li>
-					Review the 'Surfaces' tab and ensure the USB devices you have plugged in are detected for use.&nbsp;
+					Review the 'Surfaces' tab and ensure the USB devices you have plugged in are detected for use.{' '}
 					{newConfig.elgato_plugin_enable
 						? 'Please note that Stream Deck devices will not appear since they are configured for the Stream Deck software.'
 						: ''}

--- a/webui/src/Wizard/FinishStep.jsx
+++ b/webui/src/Wizard/FinishStep.jsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { CAlert } from '@coreui/react'
+
+export function FinishStep({ oldConfig, newConfig }) {
+	return (
+		<div>
+			<h4>Congratulations!</h4>
+			<p style={{ fontWeight: 'bold' }}>
+				Companion is now configured and ready for use.
+				<br />
+				Your next steps are:
+			</p>
+			<ol>
+				<li>
+					Review the 'Surfaces' tab and ensure the USB devices you have plugged in are detected for use.&nbsp;
+					{newConfig.elgato_plugin_enable
+						? 'Please note that Stream Deck devices will not appear since they are configured for the Stream Deck software.'
+						: ''}
+				</li>
+				<li>Go to the 'Conections' tab to configure the devices you'd like to control.</li>
+				<li>
+					Go to the 'Buttons' tab to program buttons to control your devices.
+					<br />
+					<span style={{ fontStyle: 'italic' }}>
+						Helpful hint: many devices have 'Presets' (pre-configured buttons) that you can drag and drop onto the
+						surfaces.
+					</span>
+				</li>
+			</ol>
+			{(newConfig.elgato_plugin_enable && oldConfig.elgato_plugin_enable !== newConfig.elgato_plugin_enable) ||
+			(!newConfig.xkeys_enable && oldConfig.xkeys_enable !== newConfig.xkeys_enable) ? (
+				<CAlert color="danger">
+					After completing this wizard a restart of Companion is required to apply your USB detection settings. You will
+					need to do this manually.
+				</CAlert>
+			) : (
+				''
+			)}
+		</div>
+	)
+}

--- a/webui/src/Wizard/PasswordStep.jsx
+++ b/webui/src/Wizard/PasswordStep.jsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import { CAlert, CInput, CInputCheckbox, CLabel } from '@coreui/react'
+
+export function PasswordStep({ config, setValue }) {
+	return (
+		<div>
+			<h5>Admin GUI Password</h5>
+			<p>
+				Optionally, you can restrict this interface using a password. This is intended to keep normal users from
+				stumbling upon the settings and changing things. It will not keep out someone determined to bypass it.
+			</p>
+			<CAlert color="danger">This does not make an installation more secure!</CAlert>
+			<div className="indent3">
+				<div className="form-check form-check-inline mr-1">
+					<CInputCheckbox
+						id="userconfig_admin_lockout"
+						checked={config.admin_lockout}
+						onChange={(e) => setValue('admin_lockout', e.currentTarget.checked)}
+					/>
+					<CLabel htmlFor="userconfig_admin_lockout">Enable Admin Password</CLabel>
+				</div>
+				{config.admin_lockout ? (
+					<div className="indent2, group">
+						<div className="col-left">Password</div>
+						<div className="col-right">
+							<div className="form-check form-check-inline mr-1">
+								<CInput
+									type="text"
+									value={config.admin_password}
+									onChange={(e) => setValue('admin_password', e.currentTarget.value)}
+								/>
+							</div>
+						</div>
+						<br />
+						<div className="col-left">
+							Session Timeout
+							<br />
+							(minutes, 0 for none)
+						</div>
+						<div className="col-right">
+							<div className="form-check form-check-inline mr-1">
+								<CInput
+									type="number"
+									value={config.admin_timeout}
+									min={0}
+									step={1}
+									onChange={(e) => setValue('admin_timeout', e.currentTarget.value)}
+								/>
+							</div>
+						</div>
+					</div>
+				) : (
+					''
+				)}
+			</div>
+		</div>
+	)
+}

--- a/webui/src/Wizard/ServicesStep.jsx
+++ b/webui/src/Wizard/ServicesStep.jsx
@@ -7,7 +7,8 @@ export function ServicesStep({ config, setValue }) {
 			<h5>Remote Control Services</h5>
 			<p>
 				In addition to USB hardware, Companion is able to be controlled over the network by various different methods.
-				Since these expose Companion to control via your network, it is only recommended to enable the services you need.
+				Since these expose Companion to control via your network, it is only recommended to enable the services you
+				need.
 			</p>
 			<div className="indent3">
 				<div className="form-check form-check-inline mr-1">

--- a/webui/src/Wizard/ServicesStep.jsx
+++ b/webui/src/Wizard/ServicesStep.jsx
@@ -1,0 +1,150 @@
+import React from 'react'
+import { CInput, CInputCheckbox, CLabel } from '@coreui/react'
+
+export function ServicesStep({ config, setValue }) {
+	return (
+		<div>
+			<h5>Remote Control Services</h5>
+			<p>
+				In addition to USB hardware, Companion is able to be controlled over the network by various different methods.
+				Since these expose Companion to control via your network, it is only recommended to enable the services you need.
+			</p>
+			<div className="indent3">
+				<div className="form-check form-check-inline mr-1">
+					<CInputCheckbox
+						id="userconfig_tcp_enabled"
+						checked={config.tcp_enabled}
+						onChange={(e) => setValue('tcp_enabled', e.currentTarget.checked)}
+					/>
+					<CLabel htmlFor="userconfig_tcp_enabled">TCP Raw Socket</CLabel>
+				</div>
+				{config.tcp_enabled ? (
+					<div className="indent2, group">
+						<div className="col-left">Listen Port</div>
+						<div className="col-right">
+							<div className="form-check form-check-inline mr-1">
+								<CInput
+									type="number"
+									value={config.tcp_listen_port}
+									onChange={(e) => setValue('tcp_listen_port', e.currentTarget.value)}
+								/>
+							</div>
+						</div>
+					</div>
+				) : (
+					''
+				)}
+			</div>
+			<div className="indent3">
+				<div className="form-check form-check-inline mr-1">
+					<CInputCheckbox
+						id="userconfig_udp_enabled"
+						checked={config.udp_enabled}
+						onChange={(e) => setValue('udp_enabled', e.currentTarget.checked)}
+					/>
+					<CLabel htmlFor="userconfig_udp_enabled">UDP Raw Socket</CLabel>
+				</div>
+				{config.udp_enabled ? (
+					<div className="indent2, group">
+						<div className="col-left">Listen Port</div>
+						<div className="col-right">
+							<div className="form-check form-check-inline mr-1">
+								<CInput
+									type="number"
+									value={config.udp_listen_port}
+									onChange={(e) => setValue('udp_listen_port', e.currentTarget.value)}
+								/>
+							</div>
+						</div>
+					</div>
+				) : (
+					''
+				)}
+			</div>
+			<div className="indent3">
+				<div className="form-check form-check-inline mr-1">
+					<CInputCheckbox
+						id="userconfig_osc_enabled"
+						checked={config.osc_enabled}
+						onChange={(e) => setValue('osc_enabled', e.currentTarget.checked)}
+					/>
+					<CLabel htmlFor="userconfig_osc_enabled">Open Sound Control (OSC)</CLabel>
+				</div>
+				{config.osc_enabled ? (
+					<div className="indent2, group">
+						<div className="col-left">Listen Port</div>
+						<div className="col-right">
+							<div className="form-check form-check-inline mr-1">
+								<CInput
+									type="number"
+									value={config.osc_listen_port}
+									onChange={(e) => setValue('osc_listen_port', e.currentTarget.value)}
+								/>
+							</div>
+						</div>
+					</div>
+				) : (
+					''
+				)}
+			</div>
+			<div className="indent3">
+				<div className="form-check form-check-inline mr-1">
+					<CInputCheckbox
+						id="userconfig_rosstalk_enabled"
+						checked={config.rosstalk_enabled}
+						onChange={(e) => setValue('rosstalk_enabled', e.currentTarget.checked)}
+					/>
+					<CLabel htmlFor="userconfig_rosstalk_enabled">RossTalk</CLabel>
+				</div>
+			</div>
+			<div className="indent3">
+				<div className="form-check form-check-inline mr-1">
+					<CInputCheckbox
+						id="userconfig_emberplus_enabled"
+						checked={config.emberplus_enabled}
+						onChange={(e) => setValue('emberplus_enabled', e.currentTarget.checked)}
+					/>
+					<CLabel htmlFor="userconfig_emberplus_enabled">Ember+</CLabel>
+				</div>
+			</div>
+			<div className="indent3">
+				<div className="form-check form-check-inline mr-1">
+					<CInputCheckbox
+						id="userconfig_artnet_enabled"
+						checked={config.artnet_enabled}
+						onChange={(e) => setValue('artnet_enabled', e.currentTarget.checked)}
+					/>
+					<CLabel htmlFor="userconfig_artnet_enabled">Artnet</CLabel>
+				</div>
+				{config.artnet_enabled ? (
+					<div className="indent2, group">
+						<div className="col-left">Universe (first is 0)</div>
+						<div className="col-right">
+							<div className="form-check form-check-inline mr-1">
+								<CInput
+									type="number"
+									value={config.artnet_universe}
+									onChange={(e) => setValue('artnet_universe', e.currentTarget.value)}
+								/>
+							</div>
+						</div>
+						<br />
+						<div className="col-left">Channel</div>
+						<div className="col-right">
+							<div className="form-check form-check-inline mr-1">
+								<CInput
+									type="number"
+									value={config.artnet_channel}
+									onChange={(e) => setValue('artnet_channel', e.currentTarget.value)}
+								/>
+							</div>
+						</div>
+					</div>
+				) : (
+					''
+				)}
+			</div>
+			<p>You can change these later and review how to use them on the 'Settings' tab in the GUI.</p>
+		</div>
+	)
+}

--- a/webui/src/Wizard/SurfacesStep.jsx
+++ b/webui/src/Wizard/SurfacesStep.jsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { CInputCheckbox, CInputRadio, CLabel } from '@coreui/react'
+
+export function SurfacesStep({ config, setValue }) {
+	return (
+		<div>
+			<h5>USB Surface Detection Configuration</h5>
+			<p className='indent3'>Stream Deck USB Hardware</p>
+			<div className='indent3'>
+				<div className="form-check form-check-inline mr-1">
+					<CInputRadio
+						id="userconfig_elgato_plugin_disable"
+						checked={!config.elgato_plugin_enable}
+						onChange={(e) => setValue('elgato_plugin_enable', false)}
+					/>
+					<CLabel htmlFor="userconfig_elgato_plugin_disable">
+						Use Companion natively (requires Stream Deck software to be closed)
+					</CLabel>
+				</div>
+			</div>
+			<div className='indent3'>
+				<div className="form-check form-check-inline mr-1">
+					<CInputRadio
+						id="userconfig_elgato_plugin_enable"
+						checked={config.elgato_plugin_enable}
+						onChange={(e) => setValue('elgato_plugin_enable', true)}
+					/>
+					<CLabel htmlFor="userconfig_elgato_plugin_enable">Use Stream Deck software via Companion plugin</CLabel>
+				</div>
+			</div>
+
+			<p className='indent3'>X-keys USB Keypads</p>
+			<div className='indent3'>
+				<div className="form-check form-check-inline mr-1">
+					<CInputCheckbox
+						id="userconfig_xkeys_enable"
+						checked={config.xkeys_enable}
+						onChange={(e) => setValue('xkeys_enable', e.currentTarget.checked)}
+					/>
+					<CLabel htmlFor="userconfig_xkeys_enable">Enable</CLabel>
+				</div>
+			</div>
+		</div>
+	)
+}

--- a/webui/src/Wizard/SurfacesStep.jsx
+++ b/webui/src/Wizard/SurfacesStep.jsx
@@ -5,8 +5,8 @@ export function SurfacesStep({ config, setValue }) {
 	return (
 		<div>
 			<h5>USB Surface Detection Configuration</h5>
-			<p className='indent3'>Stream Deck USB Hardware</p>
-			<div className='indent3'>
+			<p className="indent3">Stream Deck USB Hardware</p>
+			<div className="indent3">
 				<div className="form-check form-check-inline mr-1">
 					<CInputRadio
 						id="userconfig_elgato_plugin_disable"
@@ -18,7 +18,7 @@ export function SurfacesStep({ config, setValue }) {
 					</CLabel>
 				</div>
 			</div>
-			<div className='indent3'>
+			<div className="indent3">
 				<div className="form-check form-check-inline mr-1">
 					<CInputRadio
 						id="userconfig_elgato_plugin_enable"
@@ -29,8 +29,8 @@ export function SurfacesStep({ config, setValue }) {
 				</div>
 			</div>
 
-			<p className='indent3'>X-keys USB Keypads</p>
-			<div className='indent3'>
+			<p className="indent3">X-keys USB Keypads</p>
+			<div className="indent3">
 				<div className="form-check form-check-inline mr-1">
 					<CInputCheckbox
 						id="userconfig_xkeys_enable"

--- a/webui/src/Wizard/index.jsx
+++ b/webui/src/Wizard/index.jsx
@@ -1,0 +1,160 @@
+import React, { forwardRef, useCallback, useContext, useImperativeHandle, useState } from 'react'
+import { CAlert, CButton, CForm, CModal, CModalBody, CModalFooter, CModalHeader } from '@coreui/react'
+import { StaticContext, socketEmit } from '../util'
+import { BeginStep } from './BeginStep'
+import { SurfacesStep } from './SurfacesStep'
+import { ServicesStep } from './ServicesStep'
+import { PasswordStep } from './PasswordStep'
+import { ApplyStep } from './ApplyStep'
+import { FinishStep } from './FinishStep'
+
+export const WizardModal = forwardRef(function WizardModal(_props, ref) {
+	const context = useContext(StaticContext)
+	const [currentStep, setCurrentStep] = useState(1)
+	const maxSteps = 6 // can use useState in the future if the number of steps needs to be dynamic
+	const applyStep = 5 // can use useState in the future if the number of steps needs to be dynamic
+	const [startConfig, setStartConfig] = useState(null)
+	const [oldConfig, setOldConfig] = useState(null)
+	const [newConfig, setNewConfig] = useState(null)
+	const [error, setError] = useState(null)
+
+	const getConfig = useCallback(() => {
+		socketEmit(context.socket, 'get_userconfig_all', [])
+			.then(([config]) => {
+				setStartConfig(config)
+				setOldConfig(config)
+				setNewConfig(config)
+			})
+			.catch((e) => {
+				setError('Could not load configuration for wizard.  Please close and try again.')
+				console.error('Failed to load user config', e)
+			})
+	}, [context.socket])
+
+	const [show, setShow] = useState(false)
+
+	const doClose = useCallback(() => {
+		context.socket.emit('set_userconfig_key', 'v22_wizard', true)
+		setShow(false)
+	}, [context.socket])
+
+	const doNextStep = useCallback(() => {
+		let newStep = currentStep
+		// Make sure step is set to something reasonable
+		if (newStep >= maxSteps - 1) {
+			newStep = maxSteps
+		} else {
+			newStep = newStep + 1
+		}
+
+		setCurrentStep(newStep)
+	}, [currentStep, maxSteps])
+
+	const doPrevStep = useCallback(() => {
+		let newStep = currentStep
+		if (newStep <= 1) {
+			newStep = 1
+		} else {
+			newStep = newStep - 1
+		}
+
+		setCurrentStep(newStep)
+	}, [currentStep])
+
+	const doSave = useCallback(
+		(e) => {
+			e.preventDefault()
+
+			let saveConfig = {}
+
+			for (const id in oldConfig) {
+				if (oldConfig[id] !== newConfig[id]) {
+					saveConfig[id] = newConfig[id]
+				}
+			}
+
+			context.socket.emit('set_userconfig_keys', saveConfig)
+
+			setOldConfig(newConfig)
+
+			doNextStep()
+		},
+		[context.socket, newConfig, oldConfig, doNextStep]
+	)
+
+	const setValue = (key, value) => {
+		setNewConfig((oldState) => ({
+			...oldState,
+			[key]: value,
+		}))
+	}
+
+	useImperativeHandle(
+		ref,
+		() => ({
+			show() {
+				getConfig()
+				setCurrentStep(1)
+				setShow(true)
+			},
+		}),
+		[getConfig]
+	)
+
+	let nextButton
+	switch (currentStep) {
+		case 5:
+			nextButton = (
+				<CButton color="primary" onClick={doSave}>
+					Apply
+				</CButton>
+			)
+			break
+		case 6:
+			nextButton = (
+				<CButton color="primary" onClick={doClose}>
+					Finish
+				</CButton>
+			)
+			break
+		default:
+			nextButton = (
+				<CButton color="primary" onClick={doNextStep}>
+					Next
+				</CButton>
+			)
+	}
+
+	return (
+		<CModal show={show} onClose={doClose} className={'wizard'}>
+			<CForm onSubmit={doSave} className={'edit-button-panel'}>
+				<CModalHeader>
+					<h2>
+						<img src="/img/brand/icon.png" height="30" alt="logo" />
+						Welcome to Companion
+					</h2>
+				</CModalHeader>
+				<CModalBody>
+					{error ? <CAlert color="danger">{error}</CAlert> : ''}
+					{currentStep === 1 && !error ? <BeginStep /> : ''}
+					{currentStep === 2 && !error ? <SurfacesStep config={newConfig} setValue={setValue} /> : ''}
+					{currentStep === 3 && !error ? <ServicesStep config={newConfig} setValue={setValue} /> : ''}
+					{currentStep === 4 && !error ? <PasswordStep config={newConfig} setValue={setValue} /> : ''}
+					{currentStep === 5 && !error ? <ApplyStep oldConfig={oldConfig} newConfig={newConfig} /> : ''}
+					{currentStep === 6 && !error ? <FinishStep oldConfig={startConfig} newConfig={newConfig} /> : ''}
+				</CModalBody>
+				<CModalFooter>
+					{currentStep <= applyStep && (
+						<CButton color="secondary" onClick={doClose}>
+							Cancel
+						</CButton>
+					)}
+					<CButton color="secondary" disabled={currentStep === 1} onClick={doPrevStep}>
+						Previous
+					</CButton>
+					{nextButton}
+				</CModalFooter>
+			</CForm>
+		</CModal>
+	)
+})

--- a/webui/src/Wizard/index.jsx
+++ b/webui/src/Wizard/index.jsx
@@ -17,6 +17,7 @@ export const WizardModal = forwardRef(function WizardModal(_props, ref) {
 	const [oldConfig, setOldConfig] = useState(null)
 	const [newConfig, setNewConfig] = useState(null)
 	const [error, setError] = useState(null)
+	const [clear, setClear] = useState(true)
 
 	const getConfig = useCallback(() => {
 		socketEmit(context.socket, 'get_userconfig_all', [])
@@ -36,6 +37,7 @@ export const WizardModal = forwardRef(function WizardModal(_props, ref) {
 	const doClose = useCallback(() => {
 		context.socket.emit('set_userconfig_key', 'v22_wizard', true)
 		setShow(false)
+		setClear(true)
 	}, [context.socket])
 
 	const doNextStep = useCallback(() => {
@@ -93,12 +95,15 @@ export const WizardModal = forwardRef(function WizardModal(_props, ref) {
 		ref,
 		() => ({
 			show() {
-				getConfig()
-				setCurrentStep(1)
+				if (clear) {
+					getConfig()
+					setCurrentStep(1)
+				}
 				setShow(true)
+				setClear(false)
 			},
 		}),
-		[getConfig]
+		[getConfig, clear]
 	)
 
 	let nextButton

--- a/webui/src/Wizard/index.jsx
+++ b/webui/src/Wizard/index.jsx
@@ -35,10 +35,10 @@ export const WizardModal = forwardRef(function WizardModal(_props, ref) {
 	const [show, setShow] = useState(false)
 
 	const doClose = useCallback(() => {
-		context.socket.emit('set_userconfig_key', 'v22_wizard', true)
+		context.socket.emit('set_userconfig_key', 'setup_wizard', context.currentVersion)
 		setShow(false)
 		setClear(true)
-	}, [context.socket])
+	}, [context])
 
 	const doNextStep = useCallback(() => {
 		let newStep = currentStep

--- a/webui/src/scss/_wizard.scss
+++ b/webui/src/scss/_wizard.scss
@@ -1,0 +1,59 @@
+.wizard div.col-left {
+	width: 30%;
+	display: inline-block;
+	font-size: 0.85em;
+	font-weight: 700;
+}
+
+.wizard div.col-right {
+	width: 40%;
+	display: inline-block;
+	margin: 0.25em 0;
+}
+
+.wizard div.group {
+	margin: 0 0 0.5em 0.25em;
+}
+
+.wizard div.indent1 {
+	margin-left: 0.5em;
+}
+
+.wizard div.indent2 {
+	margin-left: 1em;
+}
+
+.wizard div.indent3 {
+	margin-left: 1.5em;
+}
+
+.wizard p.indent3 {
+	margin-left: 1.5em;
+	font-weight: bold;
+}
+
+.wizard h2 {
+	margin: 0;
+}
+
+.wizard h2 img {
+	padding-right: 0.5em;
+	margin-top: -0.1em;
+}
+
+.wizard h4 {
+	margin: 0 0 0.5rem 0;
+}
+
+.wizard h5 {
+	margin: 0;
+}
+
+.wizard p {
+	margin-top: 1rem;
+	margin-bottom: 0.5rem;
+}
+
+.wizard li {
+	font-size: 1em;
+}


### PR DESCRIPTION
This feature adds a one-time configuration wizard as a modal popup for new installs and upgrades.  If it detects the lack of a `userconfig` setting called `v22_wizard` it will run and if the wizard is successfully completed or canceled out that setting is set to `true`.  A button has been added to the sidebar to manually launch the wizard.  It is non-destructive, meaning there is a confirmation step before it applies changes and can be canceled up to that point.
![image](https://user-images.githubusercontent.com/749812/155888029-2d6b2997-c40a-4cab-a7a6-51cf4d929def.png)

#### Welcome
Simple welcome step indicates new and upgrade users should step through and review the settings.
![image](https://user-images.githubusercontent.com/749812/155887619-fe81423a-51c5-429a-9bac-602b7390215f.png)

#### USB Surface Detection Settings
Provides plain language on if the Elgato Plugin should be enabled or not, as well as the option for X-keys support.
![image](https://user-images.githubusercontent.com/749812/155887681-8cbd9867-2119-41a8-b9fd-99a12bc42485.png)

#### Remote Control Services
Provides enable checkboxes for all of the listeners and displays dependent settings for the enabled settings.
![image](https://user-images.githubusercontent.com/749812/155887763-f8c6e47b-4168-429f-8499-fee486bab7f7.png)

#### Admin GUI Password
Provides the settings for configuring an admin password.
@Julusian I need a little help here.  I couldn't figure out a way to disable the `Next` button if this is enabled but no password is entered.
![image](https://user-images.githubusercontent.com/749812/155887806-8b091f73-817a-413c-897a-bc5a6c3a01e9.png)

#### Review Changes
Provides a summary of how the environment will be configured.  The language does adapt a little bit based on this being a first run or a manual run.
![image](https://user-images.githubusercontent.com/749812/155887851-0db7a0d6-9627-4b92-8610-eff3e0c97f40.png)

#### Finish
After applying the changes it displays information on next steps including a notification to restart Companion should the changes made to USB detection require it.
![image](https://user-images.githubusercontent.com/749812/155887915-6fd146d6-7a89-47fc-bacd-522b13eaf55b.png)

I tested this fairly thoroughly.  @willosof you're welcome to fancy up the UI.  I did the best I could.
