### PR TITLE
feat: Add healthcheck and expose Satellite API port in Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,7 @@
+.dockerignore
 node_modules
 */node_modules
-module-local-dev/*/node_modules
-module-local-dev/*/.git
+module-local-dev
 *.log
 electron-output
 webui/build

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,8 @@ RUN apt update && apt install -y curl && \
 ENV COMPANION_CONFIG_BASEDIR /companion
 RUN mkdir $COMPANION_CONFIG_BASEDIR && chown node:node $COMPANION_CONFIG_BASEDIR
 USER node
+# Export both web and Satellite API ports
+EXPOSE 8000 16622
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 CMD [ "curl", "-fSsq", "http://localhost:8000/" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,12 +38,17 @@ FROM node:14-bullseye-slim
 WORKDIR /app
 COPY --from=companion-builder /app/	/app/
 
+# Install curl for the health check
+RUN apt update && apt install -y curl && \
+    rm -rf /var/lib/apt/lists/*
+
 # Create config directory and set correct permissions
 # Once docker mounts the volume, the directory will be owned by node:node
 ENV COMPANION_CONFIG_BASEDIR /companion
 RUN mkdir $COMPANION_CONFIG_BASEDIR && chown node:node $COMPANION_CONFIG_BASEDIR
 USER node
-EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 CMD [ "curl", "-fSsq", "http://localhost:8000/" ]
 
 # Bind to 0.0.0.0, as access should be scoped down by how the port is exposed from docker
 ENTRYPOINT ["./headless_ip.js", "0.0.0.0"]


### PR DESCRIPTION
This PR does the following:
1. It adds a healthcheck to the Dockerfile so that the container is marked as healthy/unhealthy. This is useful when running it as a swarm service so that it gets automatically restarted.
2. Expose the Satellite API port. As per Docker best practices, all open ports should be documented in the Dockerfile so that they are available for discovery to other tools and by other users
3. Minor cleanups to the `.dockerignore` file