### PR TITLE
feat: add support export and show config folder

### DIFF
--- a/app.js
+++ b/app.js
@@ -25,6 +25,7 @@ global.MAX_BUTTONS_PER_ROW = 8
 var EventEmitter = require('events')
 var system = new EventEmitter()
 var fs = require('fs')
+var path = require('path')
 var debug = require('debug')('app')
 var mkdirp = require('mkdirp')
 var stripAnsi = require('strip-ansi')
@@ -138,7 +139,7 @@ system.ready = function (logToFile) {
 				var writestring = logbuffer.join('\n')
 				logbuffer = []
 				logwriting = true
-				fs.appendFile('./companion.log', writestring + '\n', function (err) {
+				fs.appendFile(path.join(cfgDir, 'companion.log'), writestring + '\n', function (err) {
 					if (err) {
 						console.log('log write error', err)
 					}

--- a/electron.js
+++ b/electron.js
@@ -10,6 +10,8 @@ var exec = require('child_process').exec
 const { init, showReportDialog, configureScope } = require('@sentry/electron')
 const systeminformation = require('systeminformation')
 
+let configDir
+
 // Ensure there isn't another instance of companion running already
 var lock = app.requestSingleInstanceLock()
 if (!lock) {
@@ -174,7 +176,7 @@ function createWindow() {
 	})
 
 	try {
-		let configDir = app.getPath('appData')
+		configDir = app.getPath('appData')
 		if (process.env.COMPANION_CONFIG_BASEDIR !== undefined) {
 			configDir = process.env.COMPANION_CONFIG_BASEDIR
 		}
@@ -224,6 +226,12 @@ function createTray() {
 	)
 	menu.append(
 		new electron.MenuItem({
+			label: 'Show config folder',
+			click: showConfigFolder,
+		})
+	)
+	menu.append(
+		new electron.MenuItem({
 			label: 'Quit',
 			click: trayQuit,
 		})
@@ -263,6 +271,14 @@ function trayQuit() {
 
 function scanUsb() {
 	system.emit('devices_reenumerate')
+}
+
+function showConfigFolder() {
+	try {
+		electron.shell.showItemInFolder(path.join(configDir, 'companion', 'db'))
+	} catch (e) {
+		electron.dialog.showErrorBox('File Error', 'Could not open config directory.')
+	}
 }
 
 function toggleWindow() {

--- a/lib/loadsave.js
+++ b/lib/loadsave.js
@@ -22,6 +22,7 @@ var shortid = require('shortid')
 var debug = require('debug')('lib/loadsave')
 var os = require('os')
 var _ = require('lodash')
+var archiver = require('archiver')
 
 function loadsave(_system) {
 	var self = this
@@ -843,6 +844,57 @@ function loadsave(_system) {
 
 				done()
 			})
+		}
+
+		if ((match = req.url.match(/^\/support_export/))) {
+			// Export support zip
+			const archive = archiver('zip', { zlib: { level: 9 } })
+
+			archive.on('error', function (err) {
+				console.log(err)
+			})
+
+			//on stream closed we can end the request
+			archive.on('end', function () {
+				debug('Archive wrote %d bytes', archive.pointer())
+			})
+
+			//set the archive name
+			res.attachment(os.hostname() + '_companion-config_' + getTimestamp() + '.zip')
+
+			//this is the streaming magic
+			archive.pipe(res)
+
+			self.system.emit('configdir_get', function (_cfgDir) {
+				archive.glob(
+					'*',
+					{
+						cwd: _cfgDir,
+						nodir: true,
+					},
+					{}
+				)
+			})
+
+			self.system.emit('log_get', function (logs) {
+				let out = `"Date","Module","Type","Log"\r\n`
+
+				for (let id in logs) {
+					let log = logs[id]
+					out += `${new Date(log[0]).toISOString()},"${log[1]}","${log[2]}","${log[3]}"\r\n`
+				}
+
+				archive.append(out, { name: 'log.csv' })
+			})
+
+			self.system.emit('db_all', function (_db) {
+				try {
+					let out = JSON.stringify(_db)
+					archive.append(out, { name: 'db.ram' })
+				} catch (e) {}
+			})
+
+			archive.finalize()
 		}
 	})
 }

--- a/webui/src/LogPanel.jsx
+++ b/webui/src/LogPanel.jsx
@@ -87,6 +87,17 @@ export const LogPanel = memo(function LogPanel() {
 						>
 							<FontAwesomeIcon icon={faFileExport} /> Export log
 						</CButton>
+						<CButton
+							color="light"
+							style={{
+								marginLeft: 10,
+							}}
+							size="sm"
+							href={`/int/support_export`}
+							target="_new"
+						>
+							<FontAwesomeIcon icon={faFileExport} /> Export support bundle
+						</CButton>
 					</div>
 				</CCol>
 			</CRow>

--- a/webui/src/LogPanel.jsx
+++ b/webui/src/LogPanel.jsx
@@ -1,15 +1,17 @@
-import React, { memo, useCallback, useContext, useEffect, useState } from 'react'
+import React, { memo, useCallback, useContext, useEffect, useRef, useState } from 'react'
 import { CButton, CButtonGroup, CCol, CRow } from '@coreui/react'
 import { StaticContext } from './util'
 import shortid from 'shortid'
 import dayjs from 'dayjs'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faFileExport } from '@fortawesome/free-solid-svg-icons'
+import { GenericConfirmModal } from './Components/GenericConfirmModal'
 
 export const LogPanel = memo(function LogPanel() {
 	const context = useContext(StaticContext)
 	const [config, setConfig] = useState(() => loadConfig())
 	const [history, setHistory] = useState([])
+	const exportRef = useRef()
 
 	// on 'Mount' setup
 	useEffect(() => {
@@ -52,73 +54,87 @@ export const LogPanel = memo(function LogPanel() {
 			[key]: !oldConfig[key],
 		}))
 	}, [])
+
 	const doToggleWarn = useCallback(() => doToggleConfig('warn'), [doToggleConfig])
 	const doToggleInfo = useCallback(() => doToggleConfig('info'), [doToggleConfig])
 	const doToggleDebug = useCallback(() => doToggleConfig('debug'), [doToggleConfig])
 
+	const exportSupportModal = useCallback(() => {
+		exportRef.current.show(
+			'Export Support Bundle',
+			'Are you sure you want to export your configuration and logs?  This may contain sensitive information, such as connection information to online services.  It is not recommended to post this publicly, rather you should send it privately to the necessary party.',
+			'Export',
+			() => {
+				window.open('/int/support_export')
+			}
+		)
+	}, [])
+
 	return (
-		<div className="log-page">
-			<CRow>
-				<CCol lg={12} className="log-buttons">
-					<CButtonGroup>
-						<CButton color="warning" size="sm" onClick={doToggleWarn} style={{ opacity: config.warn ? 1 : 0.2 }}>
-							Warning
-						</CButton>
-						<CButton color="info" size="sm" onClick={doToggleInfo} style={{ opacity: config.info ? 1 : 0.2 }}>
-							Info
-						</CButton>
-						<CButton color="secondary" size="sm" onClick={doToggleDebug} style={{ opacity: config.debug ? 1 : 0.2 }}>
-							Debug
-						</CButton>
-					</CButtonGroup>
+		<>
+			<GenericConfirmModal ref={exportRef} />
+			<div className="log-page">
+				<CRow>
+					<CCol lg={12} className="log-buttons">
+						<CButtonGroup>
+							<CButton color="warning" size="sm" onClick={doToggleWarn} style={{ opacity: config.warn ? 1 : 0.2 }}>
+								Warning
+							</CButton>
+							<CButton color="info" size="sm" onClick={doToggleInfo} style={{ opacity: config.info ? 1 : 0.2 }}>
+								Info
+							</CButton>
+							<CButton color="secondary" size="sm" onClick={doToggleDebug} style={{ opacity: config.debug ? 1 : 0.2 }}>
+								Debug
+							</CButton>
+						</CButtonGroup>
 
-					<div className="float-right">
-						<CButton color="danger" size="sm" onClick={doClearLog} style={{ opacity: history.length > 0 ? 1 : 0.2 }}>
-							Clear log
-						</CButton>
-						<CButton
-							color="light"
-							style={{
-								marginLeft: 10,
-							}}
-							size="sm"
-							href={`/int/log_export`}
-							target="_new"
-						>
-							<FontAwesomeIcon icon={faFileExport} /> Export log
-						</CButton>
-						<CButton
-							color="light"
-							style={{
-								marginLeft: 10,
-							}}
-							size="sm"
-							href={`/int/support_export`}
-							target="_new"
-						>
-							<FontAwesomeIcon icon={faFileExport} /> Export support bundle
-						</CButton>
-					</div>
-				</CCol>
-			</CRow>
+						<div className="float-right">
+							<CButton color="danger" size="sm" onClick={doClearLog} style={{ opacity: history.length > 0 ? 1 : 0.2 }}>
+								Clear log
+							</CButton>
+							<CButton
+								color="light"
+								style={{
+									marginLeft: 10,
+								}}
+								size="sm"
+								href={`/int/log_export`}
+								target="_new"
+							>
+								<FontAwesomeIcon icon={faFileExport} /> Export log
+							</CButton>
+							<CButton
+								color="light"
+								style={{
+									marginLeft: 10,
+								}}
+								onClick={exportSupportModal}
+								size="sm"
+							>
+								<FontAwesomeIcon icon={faFileExport} /> Export support bundle
+							</CButton>
+						</div>
+					</CCol>
+				</CRow>
 
-			<CRow className="log-panel">
-				<CCol lg={12}>
-					{history.map((h) => {
-						if (h.level === 'error' || config[h.level]) {
-							const time_format = dayjs(h.time).format('YY.MM.DD HH:mm:ss')
-							return (
-								<div key={h.id} className={`log-line log-type-${h.level}`}>
-									{time_format} <strong>{h.source}</strong>: <span className="log-message">{h.message}</span>
-								</div>
-							)
-						} else {
-							return ''
-						}
-					})}
-				</CCol>
-			</CRow>
-		</div>
+				<CRow className="log-panel">
+					<CCol lg={12}>
+						{history.map((h) => {
+							if (h.level === 'error' || config[h.level]) {
+								const time_format = dayjs(h.time).format('YY.MM.DD HH:mm:ss')
+								return (
+									<div key={h.id} className={`log-line log-type-${h.level}`}>
+										{time_format} <strong>{h.source}</strong>: <span className="log-message">{h.message}</span>
+									</div>
+								)
+							} else {
+								return ''
+							}
+						})}
+					</CCol>
+				</CRow>
+			</div>
+		</>
 	)
 })
 


### PR DESCRIPTION
Adds "Show config folder" to the tray menu and "Export support bundle" to the log tab.

Minor change to headless that `companion.log` writes to the config directory instead of executable path so it can be included in the export.

![image](https://user-images.githubusercontent.com/749812/160683499-48be9c07-f037-4756-9fe3-dd019068e137.png)
![image](https://user-images.githubusercontent.com/749812/160683562-5490af36-44ed-4311-b2bc-266e7d29fa29.png)
