### PR TITLE
feat: report client wrappers which do not have an error handler

### DIFF
--- a/tcp.js
+++ b/tcp.js
@@ -126,14 +126,12 @@ function tcp(host, port, options) {
 	// Let caller install event handlers first
 	setImmediate(self.connect.bind(self))
 
-	if (process.env.DEVELOPER) {
-		setTimeout(() => {
-			if (!self.destroyed && self.listenerCount('error')) {
-				// The socket is active and has no listeners. Log an error for the module devs!
-				console.error(`Danger: TCP client for ${self.host}:${self.port} is missing an error handler!`)
-			}
-		}, 5000)
-	}
+	setTimeout(() => {
+		if (!self.destroyed && self.listenerCount('error')) {
+			// The socket is active and has no listeners. Log an error for the module devs!
+			console.error(`Danger: TCP client for ${self.host}:${self.port} is missing an error handler!`)
+		}
+	}, 5000)
 
 	return self
 }

--- a/tcp.js
+++ b/tcp.js
@@ -50,6 +50,7 @@ function tcp(host, port, options) {
 
 	EventEmitter.call(this)
 
+	self.destroyed = false
 	self.status = undefined
 	self.host = host
 	self.port = port
@@ -125,6 +126,15 @@ function tcp(host, port, options) {
 	// Let caller install event handlers first
 	setImmediate(self.connect.bind(self))
 
+	if (process.env.DEVELOPER) {
+		setTimeout(() => {
+			if (!self.destroyed && self.listenerCount('error')) {
+				// The socket is active and has no listeners. Log an error for the module devs!
+				console.error(`Danger: TCP client for ${self.host}:${self.port} is missing an error handler!`)
+			}
+		}, 5000)
+	}
+
 	return self
 }
 util.inherits(tcp, EventEmitter)
@@ -177,6 +187,8 @@ tcp.prototype.write = tcp.prototype.send = function (message, cb) {
 
 tcp.prototype.destroy = function () {
 	var self = this
+
+	self.destroyed = true
 
 	if (self.try_timer !== undefined) {
 		clearTimeout(self.try_timer)

--- a/telnet.js
+++ b/telnet.js
@@ -155,14 +155,12 @@ function telnetStreamer(host, port, options) {
 	// Let caller install event handlers first
 	setImmediate(self.connect.bind(self))
 
-	if (process.env.DEVELOPER) {
-		setTimeout(() => {
-			if (!self.destroyed && self.listenerCount('error')) {
-				// The socket is active and has no listeners. Log an error for the module devs!
-				console.error(`Danger: Telnet client for ${self.host}:${self.port} is missing an error handler!`)
-			}
-		}, 5000)
-	}
+	setTimeout(() => {
+		if (!self.destroyed && self.listenerCount('error')) {
+			// The socket is active and has no listeners. Log an error for the module devs!
+			console.error(`Danger: Telnet client for ${self.host}:${self.port} is missing an error handler!`)
+		}
+	}, 5000)
 
 	return self
 }

--- a/udp.js
+++ b/udp.js
@@ -101,14 +101,12 @@ function udp(host, port, options) {
 	udp_sockets.push(self.socket)
 	debug(udp_sockets.length + ' UDP sockets in use (+1)')
 
-	if (process.env.DEVELOPER) {
-		setTimeout(() => {
-			if (!self.destroyed && self.listenerCount('error')) {
-				// The socket is active and has no listeners. Log an error for the module devs!
-				console.error(`Danger: UDP socket for ${self.host}:${self.port} is missing an error handler!`)
-			}
-		}, 5000)
-	}
+	setTimeout(() => {
+		if (!self.destroyed && self.listenerCount('error')) {
+			// The socket is active and has no listeners. Log an error for the module devs!
+			console.error(`Danger: UDP socket for ${self.host}:${self.port} is missing an error handler!`)
+		}
+	}, 5000)
 
 	return self
 }


### PR DESCRIPTION
Various modules have forgotten to add error handlers to the udp/tcp wrappers we provide. This means that when they throw an error it will either crash companion or trigger the blocking error dialog.

To help mitigate this, we could add a check like this to log if a socket has been created and has no error handler setup.
I havent tested this yet.

Do all module devs run the 'dev' versions of commands? I know one who doesn't becuase the console is too noisy with internal logging. We might want to look at reducing the logging at the same time, or adding a 'module-dev' level of logging.