### PR TITLE
feat: browse and bulk add actions/feedbacks to button

### DIFF
--- a/webui/src/Buttons/EditButton/ActionsPanel.jsx
+++ b/webui/src/Buttons/EditButton/ActionsPanel.jsx
@@ -3,9 +3,17 @@ import { faSort, faTrash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { NumberInputField } from '../../Components'
-import { ActionsContext, StaticContext, InstancesContext, MyErrorBoundary, socketEmit, sandbox } from '../../util'
+import {
+	ActionsContext,
+	StaticContext,
+	InstancesContext,
+	MyErrorBoundary,
+	socketEmit,
+	sandbox,
+	useMountEffect,
+} from '../../util'
 import update from 'immutability-helper'
-import Select from 'react-select'
+import Select, { createFilter } from 'react-select'
 import { ActionTableRowOption } from './Table'
 import { useDrag, useDrop } from 'react-dnd'
 import { GenericConfirmModal } from '../../Components/GenericConfirmModal'
@@ -217,9 +225,38 @@ export function ActionsPanelInner({
 		[emitOrder, setActions]
 	)
 
+	const [recentActions, setRecentActions] = useState([])
+	useMountEffect(() => {
+		try {
+			// Load from localStorage at startup
+			const recent = JSON.parse(window.localStorage.getItem('recent_actions') || '[]')
+			if (Array.isArray(recent)) {
+				setRecentActions(recent)
+			}
+		} catch (e) {
+			setRecentActions([])
+		}
+	})
+
+	const addAction2 = useCallback(
+		(actionType) => {
+			setRecentActions((existing) => {
+				const newActions = [actionType, ...existing.filter((v) => v !== actionType)]
+
+				window.localStorage.setItem('recent_actions', JSON.stringify(newActions))
+
+				return newActions
+			})
+
+			addAction(actionType)
+		},
+		[addAction]
+	)
+
 	return (
 		<>
-			<AddActionsModal ref={addActionsRef} addAction={addAction} />
+			<AddActionsModal ref={addActionsRef} addAction={addAction2} />
+
 			<table className="table action-table">
 				<tbody>
 					{actions.map((a, i) => (
@@ -239,7 +276,7 @@ export function ActionsPanelInner({
 			</table>
 
 			<div className="add-dropdown-wrapper">
-				<AddActionDropdown onSelect={addAction} placeholder={addPlaceholder} />
+				<AddActionDropdown onSelect={addAction2} placeholder={addPlaceholder} recentActions={recentActions} />
 				<CButton color="primary" variant="outline" onClick={showAddModal}>
 					Browse
 				</CButton>
@@ -415,7 +452,24 @@ function ActionTableRow({ action, isOnBank, index, dragId, setValue, doDelete, d
 	)
 }
 
-function AddActionDropdown({ onSelect, placeholder }) {
+const baseFilter = createFilter()
+const filterOptions = (candidate, input) => {
+	if (input) {
+		return !candidate.data.isRecent && baseFilter(candidate, input)
+	} else {
+		return candidate.data.isRecent
+	}
+}
+
+const noOptionsMessage = ({ inputValue }) => {
+	if (inputValue) {
+		return 'No actions found'
+	} else {
+		return 'No recently used actions'
+	}
+}
+
+function AddActionDropdown({ onSelect, placeholder, recentActions }) {
 	const instancesContext = useContext(InstancesContext)
 	const actionsContext = useContext(ActionsContext)
 
@@ -424,11 +478,34 @@ function AddActionDropdown({ onSelect, placeholder }) {
 		for (const [instanceId, instanceActions] of Object.entries(actionsContext)) {
 			for (const [actionId, action] of Object.entries(instanceActions || {})) {
 				const instanceLabel = instancesContext[instanceId]?.label ?? instanceId
-				options.push({ value: `${instanceId}:${actionId}`, label: `${instanceLabel}: ${action.label}` })
+				options.push({
+					isRecent: false,
+					value: `${instanceId}:${actionId}`,
+					label: `${instanceLabel}: ${action.label}`,
+				})
 			}
 		}
+
+		const recents = []
+		for (const actionType of recentActions) {
+			const [instanceId, actionId] = actionType.split(':', 2)
+			const actionInfo = actionsContext[instanceId]?.[actionId]
+			if (actionInfo) {
+				const instanceLabel = instancesContext[instanceId]?.label ?? instanceId
+				recents.push({
+					isRecent: true,
+					value: `${instanceId}:${actionId}`,
+					label: `${instanceLabel}: ${actionInfo.label}`,
+				})
+			}
+		}
+		options.push({
+			label: 'Recently Used',
+			options: recents,
+		})
+
 		return options
-	}, [actionsContext, instancesContext])
+	}, [actionsContext, instancesContext, recentActions])
 
 	const innerChange = useCallback(
 		(e) => {
@@ -448,7 +525,8 @@ function AddActionDropdown({ onSelect, placeholder }) {
 			placeholder={placeholder}
 			value={null}
 			onChange={innerChange}
-			// components={{ Option: CustomOption }}
+			filterOption={filterOptions}
+			noOptionsMessage={noOptionsMessage}
 		/>
 	)
 }

--- a/webui/src/Buttons/EditButton/ActionsPanel.jsx
+++ b/webui/src/Buttons/EditButton/ActionsPanel.jsx
@@ -241,7 +241,7 @@ export function ActionsPanelInner({
 	const addAction2 = useCallback(
 		(actionType) => {
 			setRecentActions((existing) => {
-				const newActions = [actionType, ...existing.filter((v) => v !== actionType)]
+				const newActions = [actionType, ...existing.filter((v) => v !== actionType)].slice(0, 20)
 
 				window.localStorage.setItem('recent_actions', JSON.stringify(newActions))
 

--- a/webui/src/Buttons/EditButton/ActionsPanel.jsx
+++ b/webui/src/Buttons/EditButton/ActionsPanel.jsx
@@ -9,6 +9,7 @@ import Select from 'react-select'
 import { ActionTableRowOption } from './Table'
 import { useDrag, useDrop } from 'react-dnd'
 import { GenericConfirmModal } from '../../Components/GenericConfirmModal'
+import { AddActionsModal } from './AddModal'
 
 export function ActionsPanel({
 	page,
@@ -118,6 +119,13 @@ export function ActionsPanelInner({
 	emitOrder,
 	addAction,
 }) {
+	const addActionsRef = useRef(null)
+	const showAddModal = useCallback(() => {
+		if (addActionsRef.current) {
+			addActionsRef.current.show()
+		}
+	}, [])
+
 	const setValue = useCallback(
 		(actionId, key, val) => {
 			// The server doesn't repond to our change, so we assume it was ok
@@ -211,6 +219,7 @@ export function ActionsPanelInner({
 
 	return (
 		<>
+			<AddActionsModal ref={addActionsRef} addAction={addAction} />
 			<table className="table action-table">
 				<tbody>
 					{actions.map((a, i) => (
@@ -229,7 +238,12 @@ export function ActionsPanelInner({
 				</tbody>
 			</table>
 
-			<AddActionDropdown onSelect={addAction} placeholder={addPlaceholder} />
+			<div className="add-dropdown-wrapper">
+				<AddActionDropdown onSelect={addAction} placeholder={addPlaceholder} />
+				<CButton color="primary" variant="outline" onClick={showAddModal}>
+					Browse
+				</CButton>
+			</div>
 		</>
 	)
 }
@@ -434,6 +448,7 @@ function AddActionDropdown({ onSelect, placeholder }) {
 			placeholder={placeholder}
 			value={null}
 			onChange={innerChange}
+			// components={{ Option: CustomOption }}
 		/>
 	)
 }

--- a/webui/src/Buttons/EditButton/AddModal.jsx
+++ b/webui/src/Buttons/EditButton/AddModal.jsx
@@ -1,0 +1,308 @@
+import {
+	CAlert,
+	CButton,
+	CCard,
+	CCardBody,
+	CCardHeader,
+	CCollapse,
+	CInput,
+	CModal,
+	CModalBody,
+	CModalFooter,
+	CModalHeader,
+} from '@coreui/react'
+import React, { forwardRef, useCallback, useContext, useImperativeHandle, useMemo, useState } from 'react'
+import { ActionsContext, FeedbacksContext, InstancesContext } from '../../util'
+
+export const AddActionsModal = forwardRef(function AddActionsModal({ addAction }, ref) {
+	const actions = useContext(ActionsContext)
+	const instances = useContext(InstancesContext)
+
+	const [selected, setSelected] = useState({})
+	const [show, setShow] = useState(false)
+
+	const doClose = useCallback(() => setShow(false), [])
+	const onClosed = useCallback(() => {
+		setSelected({})
+		setFilter('')
+	}, [])
+	const doAdd = useCallback(() => {
+		for (const [id, count] of Object.entries(selected)) {
+			for (let i = 0; i < count; i++) {
+				addAction(id, i)
+			}
+		}
+
+		setShow(false)
+	}, [selected, addAction])
+
+	useImperativeHandle(
+		ref,
+		() => ({
+			show() {
+				setShow(true)
+				setSelected({})
+			},
+		}),
+		[]
+	)
+
+	const [expanded, setExpanded] = useState({})
+	const toggle = useCallback((id) => {
+		setExpanded((oldVal) => {
+			return {
+				...oldVal,
+				[id]: !oldVal[id],
+			}
+		})
+	}, [])
+	const [filter, setFilter] = useState('')
+
+	const setSelected2 = useCallback(
+		(id, val) => {
+			setSelected((oldVal) => ({
+				...oldVal,
+				[id]: val,
+			}))
+		},
+		[setSelected]
+	)
+
+	const addEnabled = useMemo(() => {
+		return !!Object.values(selected).find((v) => typeof v === 'number' && v > 0)
+	}, [selected])
+
+	return (
+		<CModal show={show} onClose={doClose} onClosed={onClosed} size="lg" scrollable={true}>
+			<CModalHeader closeButton>
+				<h5>Browse Actions</h5>
+			</CModalHeader>
+			<CModalHeader>
+				<CInput
+					type="text"
+					placeholder="Search ..."
+					onChange={(e) => setFilter(e.currentTarget.value)}
+					value={filter}
+					style={{ fontSize: '1.2em' }}
+				/>
+			</CModalHeader>
+			<CModalBody>
+				{Object.entries(actions).map(([instanceId, items]) => (
+					<InstanceCollapse
+						instanceId={instanceId}
+						instanceInfo={instances[instanceId]}
+						items={items}
+						itemName="actions"
+						expanded={!!filter || expanded[instanceId]}
+						filter={filter}
+						doToggle={toggle}
+						selected={selected}
+						setSelected={setSelected2}
+					/>
+				))}
+			</CModalBody>
+			<CModalFooter>
+				<CButton color="secondary" onClick={doClose}>
+					Cancel
+				</CButton>
+				<CButton color="primary" onClick={doAdd} disabled={!addEnabled}>
+					Add
+				</CButton>
+			</CModalFooter>
+		</CModal>
+	)
+})
+
+export const AddFeedbacksModal = forwardRef(function AddFeedbacksModal({ addFeedback }, ref) {
+	const feedbacks = useContext(FeedbacksContext)
+	const instances = useContext(InstancesContext)
+
+	const [selected, setSelected] = useState({})
+	const [show, setShow] = useState(false)
+
+	const doClose = useCallback(() => setShow(false), [])
+	const onClosed = useCallback(() => {
+		setSelected({})
+		setFilter('')
+	}, [])
+	const doAdd = useCallback(() => {
+		for (const [id, count] of Object.entries(selected)) {
+			for (let i = 0; i < count; i++) {
+				addFeedback(id, i)
+			}
+		}
+
+		setShow(false)
+	}, [selected, addFeedback])
+
+	useImperativeHandle(
+		ref,
+		() => ({
+			show() {
+				setShow(true)
+				setSelected({})
+			},
+		}),
+		[]
+	)
+
+	const [expanded, setExpanded] = useState({})
+	const toggle = useCallback((id) => {
+		setExpanded((oldVal) => {
+			return {
+				...oldVal,
+				[id]: !oldVal[id],
+			}
+		})
+	}, [])
+	const [filter, setFilter] = useState('')
+
+	const setSelected2 = useCallback(
+		(id, val) => {
+			setSelected((oldVal) => ({
+				...oldVal,
+				[id]: val,
+			}))
+		},
+		[setSelected]
+	)
+
+	const addEnabled = useMemo(() => {
+		return !!Object.values(selected).find((v) => typeof v === 'number' && v > 0)
+	}, [selected])
+
+	return (
+		<CModal show={show} onClose={doClose} onClosed={onClosed} size="lg" scrollable={true}>
+			<CModalHeader closeButton>
+				<h5>Browse Feedbacks</h5>
+			</CModalHeader>
+			<CModalHeader>
+				<CInput
+					type="text"
+					placeholder="Search ..."
+					onChange={(e) => setFilter(e.currentTarget.value)}
+					value={filter}
+					style={{ fontSize: '1.2em' }}
+				/>
+			</CModalHeader>
+			<CModalBody>
+				{Object.entries(feedbacks).map(([instanceId, items]) => (
+					<InstanceCollapse
+						instanceId={instanceId}
+						instanceInfo={instances[instanceId]}
+						items={items}
+						itemName="feedbacks"
+						expanded={!!filter || expanded[instanceId]}
+						filter={filter}
+						doToggle={toggle}
+						selected={selected}
+						setSelected={setSelected2}
+					/>
+				))}
+			</CModalBody>
+			<CModalFooter>
+				<CButton color="secondary" onClick={doClose}>
+					Cancel
+				</CButton>
+				<CButton color="primary" onClick={doAdd} disabled={!addEnabled}>
+					Add
+				</CButton>
+			</CModalFooter>
+		</CModal>
+	)
+})
+
+function InstanceCollapse({
+	instanceId,
+	instanceInfo,
+	items,
+	itemName,
+	expanded,
+	filter,
+	doToggle,
+	selected,
+	setSelected,
+}) {
+	const doToggle2 = useCallback(() => doToggle(instanceId), [doToggle, instanceId])
+
+	const candidates = useMemo(() => {
+		try {
+			const regexp = new RegExp(filter, 'i')
+
+			const res = []
+			for (const [id, info] of Object.entries(items)) {
+				if (info.label.match(regexp)) {
+					const fullId = `${instanceId}:${id}`
+					res.push({
+						...info,
+						fullId: fullId,
+					})
+				}
+			}
+
+			return res
+		} catch (e) {
+			console.error('Failed to compile candidates list:', e)
+
+			return [
+				<CAlert color="warning" role="alert">
+					Failed to build list of {itemName}:
+					<br />
+					{e}
+				</CAlert>,
+			]
+		}
+	}, [items, filter, instanceId, itemName])
+
+	if (Object.keys(items).length === 0) {
+		// Hide card if there are no actions which match
+		return ''
+	} else {
+		return (
+			<CCard className={'add-browse-card'}>
+				<CCardHeader onClick={doToggle2}>{instanceInfo?.label || instanceId}</CCardHeader>
+				<CCollapse show={expanded}>
+					<CCardBody>
+						{candidates.length > 0 ? (
+							<table class="table">
+								{candidates.map((info) => (
+									<AddRow
+										key={info.fullId}
+										info={info}
+										id={info.fullId}
+										selected={selected[info.fullId]}
+										setSelected={setSelected}
+									/>
+								))}
+							</table>
+						) : (
+							<p className="no-entries">No {itemName} match the search</p>
+						)}
+					</CCardBody>
+				</CCollapse>
+			</CCard>
+		)
+	}
+}
+
+function AddRow({ info, selected, id, setSelected }) {
+	const setSelected2 = useCallback(
+		(e) => {
+			setSelected(id, Number(e.currentTarget.value))
+		},
+		[setSelected, id]
+	)
+	return (
+		<tr>
+			{/* <p>{id}</p> */}
+			<td>
+				<span className="item-label">{info.label}</span>
+				<br />
+				{info.description || ''}
+			</td>
+			<td className="add-count">
+				<CInput type="number" min={0} step={1} value={selected ?? 0} onChange={setSelected2} />
+			</td>
+		</tr>
+	)
+}

--- a/webui/src/Buttons/EditButton/AddModal.jsx
+++ b/webui/src/Buttons/EditButton/AddModal.jsx
@@ -18,30 +18,19 @@ export const AddActionsModal = forwardRef(function AddActionsModal({ addAction }
 	const actions = useContext(ActionsContext)
 	const instances = useContext(InstancesContext)
 
-	const [selected, setSelected] = useState({})
 	const [show, setShow] = useState(false)
 
 	const doClose = useCallback(() => setShow(false), [])
 	const onClosed = useCallback(() => {
-		setSelected({})
 		setFilter('')
 	}, [])
-	const doAdd = useCallback(() => {
-		for (const [id, count] of Object.entries(selected)) {
-			for (let i = 0; i < count; i++) {
-				addAction(id, i)
-			}
-		}
-
-		setShow(false)
-	}, [selected, addAction])
 
 	useImperativeHandle(
 		ref,
 		() => ({
 			show() {
 				setShow(true)
-				setSelected({})
+				setFilter('')
 			},
 		}),
 		[]
@@ -57,20 +46,6 @@ export const AddActionsModal = forwardRef(function AddActionsModal({ addAction }
 		})
 	}, [])
 	const [filter, setFilter] = useState('')
-
-	const setSelected2 = useCallback(
-		(id, val) => {
-			setSelected((oldVal) => ({
-				...oldVal,
-				[id]: val,
-			}))
-		},
-		[setSelected]
-	)
-
-	const addEnabled = useMemo(() => {
-		return !!Object.values(selected).find((v) => typeof v === 'number' && v > 0)
-	}, [selected])
 
 	return (
 		<CModal show={show} onClose={doClose} onClosed={onClosed} size="lg" scrollable={true}>
@@ -96,17 +71,13 @@ export const AddActionsModal = forwardRef(function AddActionsModal({ addAction }
 						expanded={!!filter || expanded[instanceId]}
 						filter={filter}
 						doToggle={toggle}
-						selected={selected}
-						setSelected={setSelected2}
+						doAdd={addAction}
 					/>
 				))}
 			</CModalBody>
 			<CModalFooter>
 				<CButton color="secondary" onClick={doClose}>
-					Cancel
-				</CButton>
-				<CButton color="primary" onClick={doAdd} disabled={!addEnabled}>
-					Add
+					Done
 				</CButton>
 			</CModalFooter>
 		</CModal>
@@ -117,30 +88,19 @@ export const AddFeedbacksModal = forwardRef(function AddFeedbacksModal({ addFeed
 	const feedbacks = useContext(FeedbacksContext)
 	const instances = useContext(InstancesContext)
 
-	const [selected, setSelected] = useState({})
 	const [show, setShow] = useState(false)
 
 	const doClose = useCallback(() => setShow(false), [])
 	const onClosed = useCallback(() => {
-		setSelected({})
 		setFilter('')
 	}, [])
-	const doAdd = useCallback(() => {
-		for (const [id, count] of Object.entries(selected)) {
-			for (let i = 0; i < count; i++) {
-				addFeedback(id, i)
-			}
-		}
-
-		setShow(false)
-	}, [selected, addFeedback])
 
 	useImperativeHandle(
 		ref,
 		() => ({
 			show() {
 				setShow(true)
-				setSelected({})
+				setFilter('')
 			},
 		}),
 		[]
@@ -156,20 +116,6 @@ export const AddFeedbacksModal = forwardRef(function AddFeedbacksModal({ addFeed
 		})
 	}, [])
 	const [filter, setFilter] = useState('')
-
-	const setSelected2 = useCallback(
-		(id, val) => {
-			setSelected((oldVal) => ({
-				...oldVal,
-				[id]: val,
-			}))
-		},
-		[setSelected]
-	)
-
-	const addEnabled = useMemo(() => {
-		return !!Object.values(selected).find((v) => typeof v === 'number' && v > 0)
-	}, [selected])
 
 	return (
 		<CModal show={show} onClose={doClose} onClosed={onClosed} size="lg" scrollable={true}>
@@ -195,34 +141,20 @@ export const AddFeedbacksModal = forwardRef(function AddFeedbacksModal({ addFeed
 						expanded={!!filter || expanded[instanceId]}
 						filter={filter}
 						doToggle={toggle}
-						selected={selected}
-						setSelected={setSelected2}
+						doAdd={addFeedback}
 					/>
 				))}
 			</CModalBody>
 			<CModalFooter>
 				<CButton color="secondary" onClick={doClose}>
-					Cancel
-				</CButton>
-				<CButton color="primary" onClick={doAdd} disabled={!addEnabled}>
-					Add
+					Done
 				</CButton>
 			</CModalFooter>
 		</CModal>
 	)
 })
 
-function InstanceCollapse({
-	instanceId,
-	instanceInfo,
-	items,
-	itemName,
-	expanded,
-	filter,
-	doToggle,
-	selected,
-	setSelected,
-}) {
+function InstanceCollapse({ instanceId, instanceInfo, items, itemName, expanded, filter, doToggle, doAdd }) {
 	const doToggle2 = useCallback(() => doToggle(instanceId), [doToggle, instanceId])
 
 	const candidates = useMemo(() => {
@@ -266,13 +198,7 @@ function InstanceCollapse({
 						{candidates.length > 0 ? (
 							<table class="table">
 								{candidates.map((info) => (
-									<AddRow
-										key={info.fullId}
-										info={info}
-										id={info.fullId}
-										selected={selected[info.fullId]}
-										setSelected={setSelected}
-									/>
+									<AddRow key={info.fullId} info={info} id={info.fullId} doAdd={doAdd} />
 								))}
 							</table>
 						) : (
@@ -285,13 +211,9 @@ function InstanceCollapse({
 	}
 }
 
-function AddRow({ info, selected, id, setSelected }) {
-	const setSelected2 = useCallback(
-		(e) => {
-			setSelected(id, Number(e.currentTarget.value))
-		},
-		[setSelected, id]
-	)
+function AddRow({ info, id, doAdd }) {
+	const doAdd2 = useCallback(() => doAdd(id), [doAdd, id])
+
 	return (
 		<tr>
 			{/* <p>{id}</p> */}
@@ -300,8 +222,10 @@ function AddRow({ info, selected, id, setSelected }) {
 				<br />
 				{info.description || ''}
 			</td>
-			<td className="add-count">
-				<CInput type="number" min={0} step={1} value={selected ?? 0} onChange={setSelected2} />
+			<td>
+				<CButton color="primary" onClick={doAdd2}>
+					Add
+				</CButton>
 			</td>
 		</tr>
 	)

--- a/webui/src/Buttons/EditButton/FeedbackPanel.jsx
+++ b/webui/src/Buttons/EditButton/FeedbackPanel.jsx
@@ -100,7 +100,7 @@ export const FeedbacksPanel = function ({
 	const addFeedback = useCallback(
 		(feedbackType) => {
 			setRecentFeedbacks((existing) => {
-				const newActions = [feedbackType, ...existing.filter((v) => v !== feedbackType)]
+				const newActions = [feedbackType, ...existing.filter((v) => v !== feedbackType)].slice(0, 20)
 
 				window.localStorage.setItem('recent_feedbacks', JSON.stringify(newActions))
 

--- a/webui/src/Buttons/EditButton/FeedbackPanel.jsx
+++ b/webui/src/Buttons/EditButton/FeedbackPanel.jsx
@@ -10,6 +10,7 @@ import { useDrag, useDrop } from 'react-dnd'
 import { GenericConfirmModal } from '../../Components/GenericConfirmModal'
 import { DropdownInputField } from '../../Components'
 import { ButtonStyleConfigFields } from './ButtonStyleConfig'
+import { AddFeedbacksModal } from './AddModal'
 
 export const FeedbacksPanel = function ({
 	page,
@@ -28,6 +29,13 @@ export const FeedbacksPanel = function ({
 	const [feedbacks, setFeedbacks] = useState([])
 
 	const confirmModal = useRef()
+
+	const addFeedbacksRef = useRef(null)
+	const showAddModal = useCallback(() => {
+		if (addFeedbacksRef.current) {
+			addFeedbacksRef.current.show()
+		}
+	}, [])
 
 	// Ensure the correct data is loaded
 	useEffect(() => {
@@ -116,6 +124,8 @@ export const FeedbacksPanel = function ({
 		<>
 			<GenericConfirmModal ref={confirmModal} />
 
+			<AddFeedbacksModal ref={addFeedbacksRef} addFeedback={addFeedback} />
+
 			<table className="table feedback-table">
 				<tbody>
 					{feedbacks.map((a, i) => (
@@ -135,7 +145,12 @@ export const FeedbacksPanel = function ({
 				</tbody>
 			</table>
 
-			<AddFeedbackDropdown onSelect={addFeedback} />
+			<div className="add-dropdown-wrapper">
+				<AddFeedbackDropdown onSelect={addFeedback} />
+				<CButton color="primary" variant="outline" onClick={showAddModal}>
+					Browse
+				</CButton>
+			</div>
 		</>
 	)
 }

--- a/webui/src/Triggers/EditModal.jsx
+++ b/webui/src/Triggers/EditModal.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useMemo, useState } from 'react'
+import React, { useCallback, useContext, useMemo, useRef, useState } from 'react'
 import {
 	CButton,
 	CCol,
@@ -18,6 +18,7 @@ import { AddFeedbackDropdown, FeedbackEditor } from '../Buttons/EditButton/Feedb
 import shortid from 'shortid'
 import { ActionsPanelInner } from '../Buttons/EditButton/ActionsPanel'
 import { CheckboxInputField } from '../Components'
+import { AddFeedbacksModal } from '../Buttons/EditButton/AddModal'
 
 function getPluginSpecDefaults(pluginOptions) {
 	const config = {}
@@ -211,6 +212,13 @@ export function TriggerEditModal({ doClose, doSave, item, plugins }) {
 function TriggerEditModalConfig({ pluginSpec, config, updateConfig }) {
 	const context = useContext(StaticContext)
 
+	const addFeedbacksRef = useRef(null)
+	const showAddModal = useCallback(() => {
+		if (addFeedbacksRef.current) {
+			addFeedbacksRef.current.show()
+		}
+	}, [])
+
 	if (pluginSpec.type === 'feedback' && !Array.isArray(config)) config = [config]
 
 	const updateInnerConfig = useCallback(
@@ -297,7 +305,14 @@ function TriggerEditModalConfig({ pluginSpec, config, updateConfig }) {
 					</tbody>
 				</table>
 
-				<AddFeedbackDropdown onSelect={addFeedbackSelect} booleanOnly recentFeedbacks={recentFeedbacks} />
+				<AddFeedbacksModal ref={addFeedbacksRef} addFeedback={addFeedbackSelect} />
+
+				<div className="add-dropdown-wrapper">
+					<AddFeedbackDropdown onSelect={addFeedbackSelect} booleanOnly recentFeedbacks={recentFeedbacks} />
+					<CButton color="primary" variant="outline" onClick={showAddModal}>
+						Browse
+					</CButton>
+				</div>
 			</>
 		)
 	}

--- a/webui/src/Triggers/EditModal.jsx
+++ b/webui/src/Triggers/EditModal.jsx
@@ -254,7 +254,7 @@ function TriggerEditModalConfig({ pluginSpec, config, updateConfig }) {
 	const addFeedbackSelect = useCallback(
 		(feedbackType) => {
 			setRecentFeedbacks((existing) => {
-				const newActions = [feedbackType, ...existing.filter((v) => v !== feedbackType)]
+				const newActions = [feedbackType, ...existing.filter((v) => v !== feedbackType)].slice(0, 20)
 
 				window.localStorage.setItem('recent_feedbacks', JSON.stringify(newActions))
 

--- a/webui/src/scss/_button-edit.scss
+++ b/webui/src/scss/_button-edit.scss
@@ -95,3 +95,46 @@ table.feedback-table {
 		}
 	}
 }
+
+.add-dropdown-wrapper {
+	display: grid;
+	grid-auto-flow: column;
+	grid-template-columns: 1fr auto;
+}
+
+.add-browse-card {
+	.card-header {
+		cursor: pointer;
+		font-weight: bold;
+		// background-color: #ccc;
+
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+
+	.card-body {
+		padding: 0;
+	}
+
+	.table {
+		margin-bottom: 0;
+
+		td {
+			vertical-align: middle;
+		}
+
+		.add-count {
+			width: 7rem;
+		}
+
+		.item-label {
+			font-weight: bold;
+		}
+	}
+
+	p.no-entries {
+		padding: 0.75rem;
+		margin: 0;
+	}
+}

--- a/webui/src/scss/_button-edit.scss
+++ b/webui/src/scss/_button-edit.scss
@@ -124,10 +124,6 @@ table.feedback-table {
 			vertical-align: middle;
 		}
 
-		.add-count {
-			width: 7rem;
-		}
-
 		.item-label {
 			font-weight: bold;
 		}


### PR DESCRIPTION
Closes #89

A browse button has been added next to each of the add dropdowns
![Screenshot from 2022-05-11 22-36-38](https://user-images.githubusercontent.com/1327476/167957655-4e9e01ed-c71e-4fe3-b39a-a05cd639e587.png)

This button opens a modal which lists all of the available actions/feedbacks, grouped by device. The devices are collapsible, making it possible to look through the items more easily.
![Screenshot from 2022-05-11 23-37-07](https://user-images.githubusercontent.com/1327476/167958841-e7be1bc5-dc9c-418c-bc15-925dd98535eb.png)

There is a search box provided, which will filter the actions/feedbacks shown. When 'Add' is clicked it will add one of that immediately. It can be clicked multiple times to add multiple
![Screenshot from 2022-05-11 23-37-39](https://user-images.githubusercontent.com/1327476/167958832-50a0207e-ba63-4f34-9bbd-72c08ba9efed.png)


Finally, the dropdown has been changed to show only the recently used entries. Once some input is provided it switches to searching all of the actions/feedbacks as before.
![Screenshot from 2022-05-11 recently used](https://user-images.githubusercontent.com/1327476/167957652-cb6f7e59-888a-4f8e-8477-7d6e0fdf066f.png)