### PR TITLE
Install dependencies of local dev modules in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,6 @@ RUN mv webui/build webui-build \
     && mkdir webui \
     && mv webui-build webui/build
 
-# TODO - module-local-dev dependencies
-
 # cleanup up some stuff that shouldnt be preserved
 RUN rm -R .git
 
@@ -52,5 +50,9 @@ EXPOSE 8000 16622
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 CMD [ "curl", "-fSsq", "http://localhost:8000/" ]
 
+# module-local-dev dependencies
+# Dependencies will be installed and cached once the container is started
+ENTRYPOINT [ "/app/module-dev-docker-entrypoint.sh" ]
+
 # Bind to 0.0.0.0, as access should be scoped down by how the port is exposed from docker
-ENTRYPOINT ["./headless_ip.js", "0.0.0.0"]
+CMD ["./headless_ip.js", "0.0.0.0"]

--- a/module-dev-docker-entrypoint.sh
+++ b/module-dev-docker-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+
+# Install dependencies for all local dev modules
+
+if [ -d /app/module-local-dev ]; then
+  echo "Installing dependencies for all local dev modules..."
+  for module in $(ls /app/module-local-dev/); do
+    cd /app/module-local-dev/$module
+    if [ -d node_modules ]; then
+      echo "Skipping installation of module $module dependencies, to force, remove its node_modules directory"
+    else
+      echo "Installing dependencies for module $module"
+      npm install
+    fi
+  done
+fi
+
+exec "$@"

--- a/module-dev-docker-entrypoint.sh
+++ b/module-dev-docker-entrypoint.sh
@@ -11,7 +11,7 @@ if [ -d /app/module-local-dev ]; then
       echo "Skipping installation of module $module dependencies, to force, remove its node_modules directory"
     else
       echo "Installing dependencies for module $module"
-      npm install
+      yarn install --prod
     fi
   done
 fi


### PR DESCRIPTION
Automatically install dependencies of local modules in docker. This also caches the dependencies so they will only be installed once. To enable this behaviour one should mount the local dev folder when running the container, example:

```bash
docker build . -t companion:dev # just once
docker run -it --rm -v $PWD/module-local-dev:/app/module-local-dev companion:dev
```

If no volumes are mounted as above, everything stays the same.