### PR TITLE
feat: learn button for actions and feedbacks

### DIFF
--- a/instance_skel.js
+++ b/instance_skel.js
@@ -193,6 +193,7 @@ instance.prototype.setActions = function (actions) {
 				if (action && action.options) {
 					action.options = serializeIsVisibleFn(action.options)
 				}
+				if (action?.learn) action.hasLearn = true
 				return [id, action]
 			})
 		)

--- a/instance_skel.js
+++ b/instance_skel.js
@@ -247,6 +247,7 @@ instance.prototype.setFeedbackDefinitions = function (feedbacks) {
 				if (feedback && feedback.options) {
 					feedback.options = serializeIsVisibleFn(feedback.options)
 				}
+				if (feedback?.learn) feedback.hasLearn = true
 				return [id, feedback]
 			})
 		)

--- a/instance_skel_types.d.ts
+++ b/instance_skel_types.d.ts
@@ -54,6 +54,10 @@ export interface CompanionBankPreset
 	style: 'png' | 'text' // 'text' for backwards compatability
 }
 
+export interface CompanionOptionValues {
+	[key: string]: InputValue | undefined
+}
+
 export interface CompanionAction {
 	label: string
 	description?: string
@@ -61,11 +65,19 @@ export interface CompanionAction {
 	callback?: (action: CompanionActionEvent, info: CompanionActionEventInfo | null) => void
 	subscribe?: (action: CompanionActionEvent) => void
 	unsubscribe?: (action: CompanionActionEvent) => void
+
+	/**
+	 * The user requested to 'learn' the values for this action.
+	 *
+	 */
+	learn?: (
+		action: CompanionActionEvent
+	) => CompanionOptionValues | undefined | Promise<CompanionOptionValues | undefined>
 }
 export interface CompanionActionEvent {
 	id: string
 	action: string
-	options: { [key: string]: InputValue | undefined }
+	options: CompanionOptionValues
 }
 
 export interface CompanionActionEventInfo {
@@ -84,7 +96,7 @@ export interface CompanionFeedbackEventInfo {
 export interface CompanionFeedbackEvent {
 	id: string
 	type: string
-	options: { [key: string]: InputValue | undefined }
+	options: CompanionOptionValues
 }
 export interface CompanionFeedbackResult {
 	color?: number
@@ -111,7 +123,7 @@ export interface CompanionInputField {
 	type: 'text' | 'textinput' | 'textwithvariables' | 'dropdown' | 'colorpicker' | 'number' | 'checkbox'
 	label: string
 	tooltip?: string
-	isVisible?: (options: { [key: string]: InputValue | undefined }) => boolean
+	isVisible?: (options: CompanionOptionValues) => boolean
 }
 export interface CompanionInputFieldText extends CompanionInputField {
 	type: 'text'
@@ -213,16 +225,16 @@ export interface CompanionPreset {
 	bank: CompanionBankPreset
 	feedbacks: Array<{
 		type: string
-		options: { [key: string]: InputValue | undefined }
+		options: CompanionOptionValues
 		style?: Partial<CompanionBankRequiredProps & CompanionBankAdditionalStyleProps>
 	}>
 	actions: Array<{
 		action: string
-		options: { [key: string]: InputValue | undefined }
+		options: CompanionOptionValues
 	}>
 	release_actions?: Array<{
 		action: string
-		options: { [key: string]: InputValue | undefined }
+		options: CompanionOptionValues
 	}>
 }
 
@@ -267,14 +279,14 @@ export interface CompanionMigrationAction {
 	readonly instance: string
 	label: string
 	action: string
-	options: { [key: string]: InputValue | undefined }
+	options: CompanionOptionValues
 }
 
 export interface CompanionMigrationFeedback {
 	readonly id: string
 	readonly instance_id: string
 	type: string
-	options: { [key: string]: InputValue | undefined }
+	options: CompanionOptionValues
 }
 
 export type OSCArgument = number | string | Uint8Array

--- a/instance_skel_types.d.ts
+++ b/instance_skel_types.d.ts
@@ -68,7 +68,6 @@ export interface CompanionAction {
 
 	/**
 	 * The user requested to 'learn' the values for this action.
-	 *
 	 */
 	learn?: (
 		action: CompanionActionEvent
@@ -209,6 +208,13 @@ export interface CompanionFeedbackBase<TRes> {
 	) => TRes
 	subscribe?: (feedback: CompanionFeedbackEvent) => void
 	unsubscribe?: (feedback: CompanionFeedbackEvent) => void
+
+	/**
+	 * The user requested to 'learn' the values for this feedback.
+	 */
+	learn?: (
+		feedback: CompanionFeedbackEvent
+	) => CompanionOptionValues | undefined | Promise<CompanionOptionValues | undefined>
 }
 export interface CompanionFeedbackBoolean extends CompanionFeedbackBase<boolean> {
 	type: 'boolean'

--- a/lib/action.js
+++ b/lib/action.js
@@ -18,6 +18,8 @@
 var debug = require('debug')('lib/action')
 var shortid = require('shortid')
 var jsonPatch = require('fast-json-patch')
+var _ = require('lodash')
+var pTimeout = require('p-timeout')
 
 function action(system) {
 	var self = this
@@ -779,6 +781,42 @@ function action(system) {
 					self.system.emit('action_save')
 				}
 			})
+
+			client.on('bank_action_learn', function (page, bank, action) {
+				var bp = self.bank_actions[page][bank]
+				if (bp !== undefined) {
+					for (var n in bp) {
+						var actionObj = bp[n]
+						if (actionObj !== undefined && actionObj.id === action) {
+							self.action_learn(actionObj).then((newOptions) => {
+								self.io.emit('bank_action_learn:result', action, newOptions)
+							})
+						}
+					}
+				}
+			})
+
+			client.on('bank_release_action_learn', function (page, bank, action) {
+				var bp = self.bank_release_actions[page][bank]
+				if (bp !== undefined) {
+					for (var n in bp) {
+						var actionObj = bp[n]
+						if (actionObj !== undefined && actionObj.id === action) {
+							self.action_learn(actionObj).then((newOptions) => {
+								self.io.emit('bank_release_action_learn:result', action, newOptions)
+							})
+						}
+					}
+				}
+			})
+
+			client.on('action_learn_single', function (actionObj, answer) {
+				if (actionObj !== undefined) {
+					self.action_learn(actionObj).then((newOptions) => {
+						answer(newOptions)
+					})
+				}
+			})
 		})
 	})
 
@@ -884,6 +922,45 @@ action.prototype.unsubscribeAction = function (action) {
 			// Run the unsubscribe function if needed
 			if (definition.unsubscribe !== undefined && typeof definition.unsubscribe == 'function') {
 				definition.unsubscribe(action)
+			}
+		}
+	}
+}
+
+action.prototype.action_learn = async function (action) {
+	var self = this
+
+	if (action !== undefined && action.action !== undefined && action.instance !== undefined) {
+		let instance = null
+		self.system.emit('instance_get', action.instance, function (_instance) {
+			instance = _instance
+		})
+
+		const definition = self.getActionDefinition(action.instance, action.action)
+		if (definition) {
+			// Run the unsubscribe function if needed
+			if (definition.learn !== undefined && typeof definition.learn == 'function') {
+				return Promise.resolve()
+					.then(async () => {
+						const pNewOptions = Promise.resolve(definition.learn(_.cloneDeep(action)))
+						const newOptions = await pTimeout(pNewOptions, 2000, 'timed out!')
+
+						if (!newOptions) throw new Error('No new options')
+
+						action.options = newOptions
+						self.system.emit('action_save')
+
+						return newOptions
+					})
+					.catch((e) => {
+						debug('instance(' + (instance?.label || action.instance) + '): Error learning action options: ' + e.message)
+						self.system.emit(
+							'log',
+							'instance(' + (instance?.label || action.instance) + ')',
+							'warn',
+							'Error learning action options: ' + e.message
+						)
+					})
 			}
 		}
 	}

--- a/lib/feedback.js
+++ b/lib/feedback.js
@@ -21,6 +21,7 @@ var debug = require('debug')('lib/feedback')
 var _ = require('lodash')
 var shortid = require('shortid')
 var jsonPatch = require('fast-json-patch')
+var pTimeout = require('p-timeout')
 
 function feedback(system) {
 	var self = this
@@ -547,6 +548,33 @@ function feedback(system) {
 				}
 			}
 		})
+
+		client.on('bank_feedback_learn', function (page, bank, id) {
+			var bp = self.feedbacks[page][bank]
+			if (bp !== undefined) {
+				for (var n in bp) {
+					var feedbackObj = bp[n]
+					if (feedbackObj !== undefined && feedbackObj.id === id) {
+						self.feedback_learn(feedbackObj).then((newOptions) => {
+							self.system.emit('feedback_check_bank', page, bank, {
+								instance_id: feedbackObj.instance_id,
+								feedback_ids: [feedbackObj.id],
+							})
+
+							self.io.emit('bank_feedback_learn:result', id, newOptions)
+						})
+					}
+				}
+			}
+		})
+
+		client.on('feedback_learn_single', function (feedbackObj, answer) {
+			if (feedbackObj !== undefined) {
+				self.feedback_learn(feedbackObj).then((newOptions) => {
+					answer(newOptions)
+				})
+			}
+		})
 	})
 }
 
@@ -649,6 +677,54 @@ feedback.prototype.setCachedStyle = function (page, bank, index, definition, fee
 		return true
 	} else {
 		return false
+	}
+}
+
+feedback.prototype.feedback_learn = async function (feedback) {
+	var self = this
+
+	if (feedback !== undefined && feedback.type !== undefined && feedback.instance_id !== undefined) {
+		let instance = null
+		self.system.emit('instance_get', feedback.instance_id, function (_instance) {
+			instance = _instance
+		})
+
+		if (
+			self.feedback_definitions[instance.id] !== undefined &&
+			self.feedback_definitions[instance.id][feedback.type] !== undefined
+		) {
+			const definition = self.feedback_definitions[instance.id][feedback.type]
+			// Run the unsubscribe function if needed
+			if (definition.learn !== undefined && typeof definition.learn == 'function') {
+				return Promise.resolve()
+					.then(async () => {
+						const pNewOptions = Promise.resolve(definition.learn(_.cloneDeep(feedback)))
+						const newOptions = await pTimeout(pNewOptions, 2000, 'timed out!')
+
+						if (!newOptions) throw new Error('No new options')
+
+						feedback.options = newOptions
+
+						self.system.emit('feedback_save')
+
+						return newOptions
+					})
+					.catch((e) => {
+						debug(
+							'instance(' +
+								(instance?.label || feedback.instance_id) +
+								'): Error learning feedback options: ' +
+								e.message
+						)
+						self.system.emit(
+							'log',
+							'instance(' + (instance?.label || feedback.instance_id) + ')',
+							'warn',
+							'Error learning feedback options: ' + e.message
+						)
+					})
+			}
+		}
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -537,6 +537,7 @@
 		"node-fetch": "^2.6.7",
 		"node-rest-client": "^3.1.1",
 		"osc": "^2.4.2",
+		"p-timeout": "^4.1.0",
 		"pngjs": "^3.3.3",
 		"rimraf": "^3.0.2",
 		"selfsigned": "^2.0.1",

--- a/webui/src/Buttons/EditButton/ActionsPanel.jsx
+++ b/webui/src/Buttons/EditButton/ActionsPanel.jsx
@@ -55,19 +55,21 @@ export function ActionsPanel({
 			})
 
 		const learnHandler = (actionId, actionOptions) => {
-			setActions((oldActions) => {
-				const index = oldActions.findIndex((a) => a.id === actionId)
-				if (index === -1) {
-					return oldActions
-				} else {
-					const newActions = [...oldActions]
-					newActions[index] = {
-						...newActions[index],
-						options: actionOptions,
+			if (actionId && actionOptions) {
+				setActions((oldActions) => {
+					const index = oldActions.findIndex((a) => a.id === actionId)
+					if (index === -1) {
+						return oldActions
+					} else {
+						const newActions = [...oldActions]
+						newActions[index] = {
+							...newActions[index],
+							options: actionOptions,
+						}
+						return newActions
 					}
-					return newActions
-				}
-			})
+				})
+			}
 		}
 
 		context.socket.on(`${learnCommand}:result`, learnHandler)

--- a/webui/src/Buttons/EditButton/index.jsx
+++ b/webui/src/Buttons/EditButton/index.jsx
@@ -177,6 +177,7 @@ export function EditButton({ page, bank, onKeyUp }) {
 								orderCommand="bank_update_action_option_order"
 								setDelay="bank_update_action_delay"
 								deleteCommand="bank_action_delete"
+								learnCommand="bank_action_learn"
 								addPlaceholder="+ Add key down/on action"
 								loadStatusKey={'downActions'}
 								setLoadStatus={addLoadStatus}
@@ -194,6 +195,7 @@ export function EditButton({ page, bank, onKeyUp }) {
 								orderCommand="bank_release_action_update_option_order"
 								setDelay="bank_update_release_action_delay"
 								deleteCommand="bank_release_action_delete"
+								learnCommand="bank_release_action_learn"
 								addPlaceholder="+ Add key up/off action"
 								loadStatusKey={'releaseActions'}
 								setLoadStatus={addLoadStatus}

--- a/webui/src/Triggers/EditModal.jsx
+++ b/webui/src/Triggers/EditModal.jsx
@@ -62,12 +62,6 @@ export function TriggerEditModal({ doClose, doSave, item, plugins }) {
 	const actionsRef = useRef()
 
 	const [config, setConfig] = useState({})
-	const updateConfig = useCallback((id, val) => {
-		setConfig((oldConfig) => ({
-			...oldConfig,
-			[id]: val,
-		}))
-	}, [])
 
 	useEffect(() => {
 		actionsRef.current = config.actions
@@ -110,6 +104,8 @@ export function TriggerEditModal({ doClose, doSave, item, plugins }) {
 			// hack
 			if (!item.actions) item.actions = []
 
+			if (item.type === 'feedback' && !Array.isArray(item.config)) item.config = [item.config]
+
 			setConfig(item)
 		} else if (plugins) {
 			const defaultPlugin = plugins.find((p) => p.type === 'feedback') ?? plugins[0]
@@ -132,10 +128,13 @@ export function TriggerEditModal({ doClose, doSave, item, plugins }) {
 	const addActionSelect = useCallback(
 		(actionType) => {
 			socketEmit(context.socket, 'action_get_defaults', [actionType]).then(([action]) => {
-				updateConfig('actions', [...config.actions, action])
+				setConfig((oldConfig) => ({
+					...oldConfig,
+					actions: [...oldConfig.actions, action],
+				}))
 			})
 		},
-		[context.socket, config, updateConfig]
+		[context.socket]
 	)
 
 	const doLearn = useCallback(
@@ -167,8 +166,22 @@ export function TriggerEditModal({ doClose, doSave, item, plugins }) {
 				}
 			}
 		},
-		[context.socket]
+		[context.socket, setActions]
 	)
+
+	const setTitle = useCallback((e) => {
+		setConfig((oldConfig) => ({
+			...oldConfig,
+			title: e.target.value,
+		}))
+	}, [])
+
+	const setRelativeDelays = useCallback((e) => {
+		setConfig((oldConfig) => ({
+			...oldConfig,
+			relative_delays: e,
+		}))
+	}, [])
 
 	return (
 		<CModal show={true} onClose={doClose} size="lg">
@@ -179,7 +192,7 @@ export function TriggerEditModal({ doClose, doSave, item, plugins }) {
 				<CModalBody>
 					<CFormGroup>
 						<label>Name</label>
-						<CInput required value={config.title} onChange={(e) => updateConfig('title', e.target.value)} />
+						<CInput required value={config.title} onChange={setTitle} />
 					</CFormGroup>
 
 					<legend>Condition</legend>
@@ -196,7 +209,7 @@ export function TriggerEditModal({ doClose, doSave, item, plugins }) {
 					</CFormGroup>
 
 					{pluginSpec?.options ? (
-						<TriggerEditModalConfig pluginSpec={pluginSpec} config={config.config} updateConfig={updateConfig} />
+						<TriggerEditModalConfig pluginSpec={pluginSpec} config={config.config} setConfig={setConfig} />
 					) : (
 						'Unknown type selected'
 					)}
@@ -220,7 +233,7 @@ export function TriggerEditModal({ doClose, doSave, item, plugins }) {
 								<CheckboxInputField
 									definition={{ default: false }}
 									value={config.relative_delays ?? false}
-									setValue={(e) => updateConfig('relative_delays', e)}
+									setValue={setRelativeDelays}
 								/>
 								&nbsp;
 							</p>
@@ -249,8 +262,13 @@ export function TriggerEditModal({ doClose, doSave, item, plugins }) {
 	)
 }
 
-function TriggerEditModalConfig({ pluginSpec, config, updateConfig }) {
+function TriggerEditModalConfig({ pluginSpec, config, setConfig }) {
 	const context = useContext(StaticContext)
+
+	const feedbacksRef = useRef(null)
+	useEffect(() => {
+		feedbacksRef.current = config
+	}, [config])
 
 	const addFeedbacksRef = useRef(null)
 	const showAddModal = useCallback(() => {
@@ -259,31 +277,41 @@ function TriggerEditModalConfig({ pluginSpec, config, updateConfig }) {
 		}
 	}, [])
 
-	if (pluginSpec.type === 'feedback' && !Array.isArray(config)) config = [config]
-
 	const updateInnerConfig = useCallback(
 		(id, val) => {
-			updateConfig('config', {
-				...config,
-				[id]: val,
-			})
-		},
-		[config, updateConfig]
-	)
-	const updateFeedbackOptionConfig = useCallback(
-		(index, id, val) => {
-			const newConfig = [...config]
-			console.log('set', newConfig[index].options, id, val)
-			newConfig[index] = {
-				...newConfig[index],
-				options: {
-					...newConfig[index].options,
+			setConfig((oldConfig) => ({
+				...oldConfig,
+				config: {
+					...oldConfig.config,
 					[id]: val,
 				},
-			}
-			updateConfig('config', newConfig)
+			}))
 		},
-		[config, updateConfig]
+		[setConfig]
+	)
+	const updateFeedbackOptionConfig = useCallback(
+		(feedbackId, id, val) => {
+			setConfig((oldConfig) => {
+				const newFeedbacks = oldConfig.config.map((fb) => {
+					if (fb.id === feedbackId) {
+						return {
+							...fb,
+							options: {
+								...fb.options,
+								[id]: val,
+							},
+						}
+					} else {
+						return fb
+					}
+				})
+				return {
+					...oldConfig,
+					config: newFeedbacks,
+				}
+			})
+		},
+		[setConfig]
 	)
 
 	const [recentFeedbacks, setRecentFeedbacks] = useState([])
@@ -310,17 +338,63 @@ function TriggerEditModalConfig({ pluginSpec, config, updateConfig }) {
 			})
 
 			socketEmit(context.socket, 'feedback_get_defaults', [feedbackType]).then(([fb]) => {
-				updateConfig('config', [...config, fb])
+				setConfig((oldConfig) => ({
+					...oldConfig,
+					config: [...oldConfig.config, fb],
+				}))
 			})
 		},
-		[context.socket, config, updateConfig]
+		[context.socket, setConfig]
 	)
 
-	const delRow = (i) => {
-		const config2 = [...config]
-		config2.splice(i, 1)
-		updateConfig('config', config2)
-	}
+	const delRow = useCallback(
+		(feedbackId) => {
+			setConfig((oldConfig) => {
+				const newFeedbacks = oldConfig.config.filter((fb) => fb.id !== feedbackId)
+
+				return {
+					...oldConfig,
+					config: newFeedbacks,
+				}
+			})
+		},
+		[setConfig]
+	)
+
+	const learnRow = useCallback(
+		(feedbackId) => {
+			if (feedbacksRef.current) {
+				const oldFeedback = feedbacksRef.current.find((fb) => fb.id === feedbackId)
+				if (oldFeedback) {
+					socketEmit(context.socket, 'feedback_learn_single', [oldFeedback])
+						.then(([newOptions]) => {
+							if (newOptions) {
+								setConfig((oldConfig) => {
+									const newFeedbacks = oldConfig.config.map((fb) => {
+										if (fb.id === feedbackId) {
+											return {
+												...fb,
+												options: newOptions,
+											}
+										} else {
+											return fb
+										}
+									})
+									return {
+										...oldConfig,
+										config: newFeedbacks,
+									}
+								})
+							}
+						})
+						.catch((e) => {
+							console.error('Learn failed', e)
+						})
+				}
+			}
+		},
+		[context.socket, setConfig]
+	)
 
 	// This is a bit of a hack:
 	if (pluginSpec.type === 'feedback') {
@@ -332,11 +406,11 @@ function TriggerEditModalConfig({ pluginSpec, config, updateConfig }) {
 							<tr key={i}>
 								<td>
 									<MyErrorBoundary>
-										<FeedbackEditor
-											isOnBank={false}
+										<FeedbackEditorRow
 											feedback={conf}
-											setValue={(id, k, v) => updateFeedbackOptionConfig(i, k, v)}
-											innerDelete={() => delRow(i)}
+											updateFeedbackOptionConfig={updateFeedbackOptionConfig}
+											delRow={delRow}
+											learnRow={learnRow}
 										/>
 									</MyErrorBoundary>
 								</td>
@@ -371,6 +445,25 @@ function TriggerEditModalConfig({ pluginSpec, config, updateConfig }) {
 				</CFormGroup>
 			))}
 		</>
+	)
+}
+
+function FeedbackEditorRow({ feedback, updateFeedbackOptionConfig, delRow, learnRow }) {
+	const innerDelete = useCallback(() => {
+		delRow(feedback.id)
+	}, [feedback.id, delRow])
+	const innerLearn = useCallback(() => {
+		learnRow(feedback.id)
+	}, [feedback.id, learnRow])
+
+	return (
+		<FeedbackEditor
+			isOnBank={false}
+			feedback={feedback}
+			setValue={updateFeedbackOptionConfig}
+			innerDelete={innerDelete}
+			innerLearn={innerLearn}
+		/>
 	)
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8577,6 +8577,11 @@ p-timeout@^3.2.0:
   dependencies:
     p-finally "^1.0.0"
 
+p-timeout@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-4.1.0.tgz#788253c0452ab0ffecf18a62dff94ff1bd09ca0a"
+  integrity sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==
+
 p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"


### PR DESCRIPTION
This lets modules define a `learn` callback for actions and feedbacks to help users fill in the properties.
![image](https://user-images.githubusercontent.com/1327476/174454626-2e5a132f-3e3a-402e-aabe-7695229cc518.png)

The idea is that instead of having to define the values inside of companion, you can set it up on the device and press learn to populate the current values into the action or feedback.

The methods take the same data as supplied to subscribe and unsubscribe, and the method is expected to return the new options object. Undefined/null is also valid if the method wishes to 'reject' the call.

For example, I have tested this with the `internal: Check variable value` feedback, so that it will populate the `Value` with the current value of the variable.

The bmd-atem module will benefit from this, as some of the supersource layouts are hard to define inside companion without a lot of trial and error. This will let users build their layouts in other software, and 'capture' those onto buttons in companion.