### PR TITLE
Set custom variable value using remote control protocols

### DIFF
--- a/docs/5_remote_control/http_remote_control.md
+++ b/docs/5_remote_control/http_remote_control.md
@@ -12,6 +12,8 @@ Remote triggering can be done by sending `HTTP` Requests to the same IP and port
   _Change text on a button_
 - `/style/bank/<page>/<bank>?size=<text size>`  
   _Change text size on a button (between the predefined values)_
+- `/set/custom-variable/?name=<name>&value=<value>`  
+  _Change custom variable value_
 - `/rescan`  
   _Make Companion rescan for newly attached USB surfaces_
 
@@ -25,3 +27,6 @@ Change the text of button 4 on page 2 to TEST:
 
 Change the text of button 4 on page 2 to TEST, background color to #ffffff, text color to #000000 and font size to 28px:  
 `/style/bank/2/4/?text=TEST&bgcolor=%23ffffff&color=%23000000&size=28px`
+
+Change custom variable "cue" to value "intro":  
+`/set/custom-variable/?name=cue&value=intro`

--- a/docs/5_remote_control/osc_control.md
+++ b/docs/5_remote_control/osc_control.md
@@ -14,6 +14,8 @@ Remote triggering can be done by sending OSC commands to port `12321`.
   _Change color of text on button_
 - `/style/text/ <page> <bank> <text>`  
   _Change text on a button_
+- `/set/custom-variable/<name> <value>`  
+  _Change custom variable value_
 - `/rescan 1`
   _Make Companion rescan for newly attached USB surfaces_
 
@@ -27,3 +29,6 @@ Change button background color of button 5 on page 1 to red
 
 Change the text of button 5 on page 1 to ONLINE  
 `/style/text/1/5 ONLINE`
+
+Change custom variable "cue" to value "intro":  
+`/set/custom-variable/cue intro`

--- a/docs/5_remote_control/tcp_udp.md
+++ b/docs/5_remote_control/tcp_udp.md
@@ -20,6 +20,8 @@ Remote triggering can be done by sending TCP (port `51234`) or UDP (port `51235`
   _Change text color on a button (#000000)_
 - `STYLE BANK <page> <bank> BGCOLOR <color HEX>`  
   _Change background color on a button (#000000)_
+- `SET-CUSTOM-VARIABLE "<name>" "<value>"`  
+  _Change custom variable value_
 - `RESCAN`
   _Make Companion rescan for newly attached USB surfaces_
 
@@ -30,3 +32,6 @@ Set the emulator surface to page 23:
 
 Press page 1 bank 2:  
 `BANK-PRESS 1 2`
+
+Change custom variable "cue" to value "intro":  
+`SET-CUSTOM-VARIABLE "cue" "intro"`

--- a/lib/server_api.js
+++ b/lib/server_api.js
@@ -130,6 +130,8 @@ function server_api(system) {
 			system.emit('log', 'TCP/UDP Server', 'debug', 'Rescanning USB')
 			system.emit('devices_reenumerate')
 			response_cb(null, '+OK')
+		} else if ((match = command.match(/^set-custom-variable "(.+)" "(.*)"\n?$/i))) {
+			system.emit('custom_variable_set_value', match[1], match[2]);
 		} else {
 			response_cb(true, '-ERR Syntax error')
 		}

--- a/lib/server_express.js
+++ b/lib/server_express.js
@@ -239,6 +239,25 @@ class CompanionExpress extends Express {
 			res.send(responseStatus)
 		})
 
+		this.get('^/set/custom-variable/', function (req, res) {
+			res.header('Access-Control-Allow-Origin', '*')
+			res.header('Access-Control-Allow-Methods', 'GET,OPTIONS')
+			res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization, Content-Length, X-Requested-With')
+
+			let responseStatus = 'ok'
+			if(req.query.name) {
+				if(req.query.value) {
+					debug('Got HTTP /set/custom-variable/', req.query.name, 'to value', req.query.value)
+					system.emit('custom_variable_set_value', req.query.name, req.query.value);
+				} else {
+					responseStatus = '"value" parameter is mandatory'
+				}
+			} else {
+				responseStatus = '"name" parameter is mandatory'
+			}
+			res.send(responseStatus)
+		})
+
 		/**
 		 * Electron doesn't handle serving files from inside the asar well. It unpacks them to a tmp dir, which can get cleaned up without it noticing
 		 * We don't want to ship hundreds of loose files, so instead we can serve them from a zip file

--- a/lib/server_osc.js
+++ b/lib/server_osc.js
@@ -212,6 +212,12 @@ server_osc.prototype.handle_message = function (message) {
 				self.system.emit('log', 'OSC Server', 'debug', 'Rescanning USB')
 				self.system.emit('devices_reenumerate')
 			}
+		} else if (message.address.match(/^\/set\/custom-variable\/.+$/)) {
+			var name = message.address.substring(21)
+			if (message.args.length > 0) {
+				debug('Got /set/custom-variable/', name, 'to value', message.args[0].value)
+				system.emit('custom_variable_set_value', name, message.args[0].value)
+			}
 		}
 	} catch (error) {
 		self.system.emit('log', 'osc', 'warn', 'OSC Error: ' + error)

--- a/webui/src/UserConfig.jsx
+++ b/webui/src/UserConfig.jsx
@@ -804,6 +804,16 @@ function RemoteControlInfo() {
 									<br />
 									<i>Change background color on a button (#000000)</i>
 								</li>
+								<li>
+									<code>SET-CUSTOM-VARIABLE</code> &quot;&lt;name&gt;&quot; &quot;&lt;value&gt;&quot;
+									<br />
+									<i>Change custom variable value</i>
+								</li>
+								<li>
+									<code>RESCAN</code>
+									<br />
+									<i>Make Companion rescan for newly attached USB surfaces</i>
+								</li>
 							</ul>
 
 							<p>
@@ -820,6 +830,12 @@ function RemoteControlInfo() {
 								Press page 1 button 2
 								<br />
 								<code>BANK-PRESS 1 2</code>
+							</p>
+
+							<p>
+								Change custom variable &quot;cue&quot; to value &quot;intro&quot;
+								<br />
+								<code>SET-CUSTOM-VARIABLE &quot;cue&quot; &quot;intro&quot;</code>
 							</p>
 						</MyErrorBoundary>
 					</CTabPane>
@@ -860,6 +876,16 @@ function RemoteControlInfo() {
 										<br />
 										<i>Change text size on a button (between the predefined values)</i>
 									</li>
+									<li>
+										<code>/set/custom-variable/?name=</code>&lt;name&gt;<code>&amp;value=</code>&lt;value&gt;
+										<br />
+										<i>Change custom variable value</i>
+									</li>
+									<li>
+										<code>/rescan</code>
+										<br />
+										<i>Make Companion rescan for newly attached USB surfaces</i>
+									</li>
 								</ul>
 							</p>
 
@@ -884,6 +910,12 @@ function RemoteControlInfo() {
 								font size to 28px
 								<br />
 								<code>/style/bank/2/4/?text=TEST&bgcolor=%23ffffff&color=%23000000&size=28px</code>
+							</p>
+
+							<p>
+								Change custom variable &quot;cue&quot; to value &quot;intro&quot;
+								<br />
+								<code>/set/custom-variable/?name=cue&amp;value=intro</code>
 							</p>
 						</MyErrorBoundary>
 					</CTabPane>
@@ -934,6 +966,16 @@ function RemoteControlInfo() {
 									<br />
 									<i>Change text on a button</i>
 								</li>
+								<li>
+									<code>/set/custom-variable/</code>&lt;name&gt; &lt;value&gt;
+									<br />
+									<i>Change custom variable value</i>
+								</li>
+								<li>
+									<code>/rescan</code> 1
+									<br />
+									<i>Make Companion rescan for newly attached USB surfaces</i>
+								</li>
 							</ul>
 
 							<p>
@@ -956,6 +998,12 @@ function RemoteControlInfo() {
 								Change the text of button 5 on page 1 to ONLINE
 								<br />
 								<code>/style/text/1/5 ONLINE</code>
+							</p>
+
+							<p>
+								Change custom variable &quot;cue&quot; to value &quot;intro&quot;
+								<br />
+								<code>/set/custom-variable/cue intro</code>
 							</p>
 						</MyErrorBoundary>
 					</CTabPane>


### PR DESCRIPTION
This PR will allow to set the value of a custom variable by using remote control protocols such as TCP/UDP/OSC/HTTP.
The variable must be already defined in Companion.

I choose che command syntax in a reasonable way but please let me know if it should be changed to something more meaningful or future-proof; below are my thoughts about the naming convention:

OSC and HTTP divides the "SET" part from "CUSTOM-VARIABLE" (i.e. /SET/CUSTOM-VARIABLE/) because if at any point in the future we need to add another "SET" command for something else we could maintain a reasonable syntax (i.e. /SET/OTHER-THING/. Maybe we should also change TCP/UDP to SET CUSTOM-VARIABLE instead of SET-CUSTOM-VARIABLE?

TCP/UDP syntax uses double quotes for name and value, allowing an easy parsing of them (both may include white spaces or special chars such as escaped double quotes).

HTTP syntax allows for easy GET requests, sending both the custom variable name and the value as parameters that could use URI encoding for special chars.

OSC syntax on the other hand includes the custom variable name as part of the address (/set/custom-variable/name_of_the_variable) and accepts any value (or the first element of multi-parameter message). I think this is easier to integrate in external software that may not have the ability to send multi-parameter OSC messages and also allows for arbitrary variable names, including the ones with forward slashes "/" or spaces.