### PR TITLE
button editor improvements

### DIFF
--- a/lib/Controls/Button/Base.js
+++ b/lib/Controls/Button/Base.js
@@ -124,6 +124,36 @@ export default class ButtonControlBase extends ControlBase {
 	}
 
 	/**
+	 * Duplicate an action on this control
+	 * @param {string} setId
+	 * @param {string} id
+	 * @returns {boolean} success
+	 * @access public
+	 */
+	actionDuplicate(setId, id) {
+		const action_set = this.action_sets[setId]
+		if (action_set) {
+			const index = action_set.findIndex((act) => act.id === id)
+			if (index !== -1) {
+				const actionItem = cloneDeep(action_set[index])
+				actionItem.id = nanoid()
+
+				this.action_sets[setId].splice(index + 1, 0, actionItem)
+
+				this.#actionSubscribe(actionItem)
+
+				this.commitChange(false)
+
+				this.checkButtonStatus()
+
+				return true
+			}
+		}
+
+		return false
+	}
+
+	/**
 	 * Learn the options for an action, by asking the instance for the current values
 	 * @param {string} setId the id of the action set
 	 * @param {string} id the id of the action

--- a/lib/Controls/Button/Base.js
+++ b/lib/Controls/Button/Base.js
@@ -449,6 +449,30 @@ export default class ButtonControlBase extends ControlBase {
 	}
 
 	/**
+	 * Duplicate an feedback on this control
+	 * @param {string} id
+	 * @returns {boolean} success
+	 * @access public
+	 */
+	feedbackDuplicate(id) {
+		const index = this.feedbacks.findIndex((fb) => fb.id === id)
+		if (index !== -1) {
+			const feedbackItem = cloneDeep(this.feedbacks[index])
+			feedbackItem.id = nanoid()
+
+			this.feedbacks.splice(index + 1, 0, feedbackItem)
+
+			this.#feedbackSubscribe(feedbackItem)
+
+			this.commitChange(false)
+
+			return true
+		}
+
+		return false
+	}
+
+	/**
 	 * Learn the options for a feedback, by asking the instance for the current values
 	 * @param {string} id the id of the feedback
 	 * @returns {boolean} success

--- a/lib/Controls/Button/Base.js
+++ b/lib/Controls/Button/Base.js
@@ -213,19 +213,22 @@ export default class ButtonControlBase extends ControlBase {
 	}
 
 	/**
-	 * Reorder an action in the list
-	 * @param {string} setId the action_set id
-	 * @param {number} oldIndex the index of the action to move
-	 * @param {number} newIndex the target index of the action
+	 * Reorder an action in the list or move between sets
+	 * @param {string} dragSetId the action_set id to remove from
+	 * @param {number} dragIndex the index of the action to move
+	 * @param {string} dropSetId the target action_set of the action
+	 * @param {number} dropIndex the target index of the action
 	 * @returns {boolean} success
 	 * @access public
 	 */
-	actionReorder(setId, oldIndex, newIndex) {
-		const action_set = this.action_sets[setId]
-		if (action_set) {
-			oldIndex = clamp(oldIndex, 0, action_set.length)
-			newIndex = clamp(newIndex, 0, action_set.length)
-			action_set.splice(newIndex, 0, ...action_set.splice(oldIndex, 1))
+	actionReorder(dragSetId, dragIndex, dropSetId, dropIndex) {
+		const fromSet = this.action_sets[dragSetId]
+		const toSet = this.action_sets[dropSetId]
+		if (fromSet && toSet) {
+			dragIndex = clamp(dragIndex, 0, fromSet.length)
+			dropIndex = clamp(dropIndex, 0, toSet.length)
+
+			toSet.splice(dropIndex, 0, ...fromSet.splice(dragIndex, 1))
 		}
 
 		this.commitChange()

--- a/lib/Controls/Controller.js
+++ b/lib/Controls/Controller.js
@@ -371,12 +371,12 @@ class ControlsController extends CoreBase {
 				throw new Error(`Control "${controlId}" does not support actions`)
 			}
 		})
-		client.onPromise('controls:action:reorder', (controlId, setId, oldIndex, newIndex) => {
+		client.onPromise('controls:action:reorder', (controlId, dragSetId, dragIndex, dropSetId, dropIndex) => {
 			const control = this.getControl(controlId)
 			if (!control) return false
 
 			if (typeof control.actionReorder === 'function') {
-				return control.actionReorder(setId, oldIndex, newIndex)
+				return control.actionReorder(dragSetId, dragIndex, dropSetId, dropIndex)
 			} else {
 				throw new Error(`Control "${controlId}" does not support actions`)
 			}

--- a/lib/Controls/Controller.js
+++ b/lib/Controls/Controller.js
@@ -328,6 +328,17 @@ class ControlsController extends CoreBase {
 			}
 		})
 
+		client.onPromise('controls:action:duplicate', (controlId, setId, id) => {
+			const control = this.getControl(controlId)
+			if (!control) return false
+
+			if (typeof control.actionDuplicate === 'function') {
+				return control.actionDuplicate(setId, id)
+			} else {
+				throw new Error(`Control "${controlId}" does not support actions`)
+			}
+		})
+
 		client.onPromise('controls:action:set-delay', (controlId, setId, id, delay) => {
 			const control = this.getControl(controlId)
 			if (!control) return false

--- a/lib/Controls/Controller.js
+++ b/lib/Controls/Controller.js
@@ -242,6 +242,17 @@ class ControlsController extends CoreBase {
 			}
 		})
 
+		client.onPromise('controls:feedback:duplicate', (controlId, id) => {
+			const control = this.getControl(controlId)
+			if (!control) return false
+
+			if (typeof control.feedbackDuplicate === 'function') {
+				return control.feedbackDuplicate(id)
+			} else {
+				throw new Error(`Control "${controlId}" does not support feedbacks`)
+			}
+		})
+
 		client.onPromise('controls:feedback:set-option', (controlId, id, key, value) => {
 			const control = this.getControl(controlId)
 			if (!control) return false

--- a/webui/src/Buttons/EditButton/ActionsPanel.jsx
+++ b/webui/src/Buttons/EditButton/ActionsPanel.jsx
@@ -87,10 +87,8 @@ export function ActionsPanel({ controlId, set, actions, dragId, addPlaceholder, 
 	)
 
 	const actionIds = useMemo(() => actions.map((act) => act.id), [actions])
-	const { collapsed, setPanelCollapsed, setAllCollapsed, setAllExpanded } = usePanelCollapseHelper(
-		`actions_${controlId}_${set}`,
-		actionIds
-	)
+	const { setPanelCollapsed, isPanelCollapsed, setAllCollapsed, setAllExpanded, canExpandAll, canCollapseAll } =
+		usePanelCollapseHelper(`actions_${controlId}_${set}`, actionIds)
 
 	return (
 		<>
@@ -103,7 +101,7 @@ export function ActionsPanel({ controlId, set, actions, dragId, addPlaceholder, 
 							size="sm"
 							onClick={setAllExpanded}
 							title="Expand all actions"
-							disabled={!collapsed.defaultCollapsed && Object.values(collapsed.ids || {}).every((v) => !v)}
+							disabled={!canExpandAll}
 						>
 							<FontAwesomeIcon icon={faExpandArrowsAlt} />
 						</CButton>{' '}
@@ -112,7 +110,7 @@ export function ActionsPanel({ controlId, set, actions, dragId, addPlaceholder, 
 							size="sm"
 							onClick={setAllCollapsed}
 							title="Collapse all actions"
-							disabled={collapsed.defaultCollapsed && Object.values(collapsed.ids || {}).every((v) => v)}
+							disabled={!canCollapseAll}
 						>
 							<FontAwesomeIcon icon={faCompressArrowsAlt} />
 						</CButton>
@@ -135,8 +133,8 @@ export function ActionsPanel({ controlId, set, actions, dragId, addPlaceholder, 
 				doReorder={emitOrder}
 				emitLearn={emitLearn}
 				addAction={addAction}
-				setActionCollapsed={setPanelCollapsed}
-				collapsed={collapsed}
+				setPanelCollapsed={setPanelCollapsed}
+				isPanelCollapsed={isPanelCollapsed}
 			/>
 		</>
 	)
@@ -155,8 +153,8 @@ export function ActionsPanelInner({
 	doReorder,
 	emitLearn,
 	addAction,
-	setActionCollapsed,
-	collapsed,
+	setPanelCollapsed,
+	isPanelCollapsed,
 }) {
 	const addActionsRef = useRef(null)
 	const showAddModal = useCallback(() => {
@@ -228,8 +226,8 @@ export function ActionsPanelInner({
 								doDelay={doSetDelay}
 								moveCard={doReorder}
 								doLearn={emitLearn}
-								setCollapsed={setActionCollapsed}
-								collapsed={collapsed?.ids?.[a.id] ?? collapsed.defaultCollapsed}
+								setCollapsed={setPanelCollapsed}
+								isCollapsed={isPanelCollapsed(a.id)}
 							/>
 						</MyErrorBoundary>
 					))}
@@ -257,7 +255,7 @@ function ActionTableRow({
 	doDelay,
 	moveCard,
 	doLearn,
-	collapsed,
+	isCollapsed,
 	setCollapsed,
 }) {
 	const instancesContext = useContext(InstancesContext)
@@ -400,7 +398,7 @@ function ActionTableRow({
 
 					<div className="cell-controls">
 						<CButtonGroup>
-							{collapsed ? (
+							{isCollapsed ? (
 								<CButton color="info" size="sm" onClick={doExpand} title="Expand action view">
 									<FontAwesomeIcon icon={faExpandArrowsAlt} />
 								</CButton>
@@ -418,7 +416,7 @@ function ActionTableRow({
 						</CButtonGroup>
 					</div>
 
-					{!collapsed ? (
+					{!isCollapsed ? (
 						<>
 							<div className="cell-description">{actionSpec?.description || ''}</div>
 

--- a/webui/src/Buttons/EditButton/CollapseHelper.jsx
+++ b/webui/src/Buttons/EditButton/CollapseHelper.jsx
@@ -1,0 +1,83 @@
+import { useCallback, useEffect, useState } from 'react'
+
+export function usePanelCollapseHelper(storageId, panelIds) {
+	const collapseStorageId = `companion_ui_collapsed_${storageId}`
+
+	const [collapsed, setCollapsed] = useState({})
+	useEffect(() => {
+		// Reload from storage whenever the storage key changes
+		const oldState = window.localStorage.getItem(collapseStorageId)
+		if (oldState) {
+			setCollapsed(JSON.parse(oldState))
+		} else {
+			setCollapsed({
+				defaultCollapsed: false,
+				ids: {},
+			})
+		}
+	}, [collapseStorageId])
+	// const panelIds = useMemo(() => panelIds.map((a) => a.id), [panelIds])
+	const setPanelCollapsed = useCallback(
+		(panelId, collapsed) => {
+			setCollapsed((oldState) => {
+				const newState = {
+					...oldState,
+					ids: {},
+				}
+
+				// preserve only the panels which exist
+				for (const id of panelIds) {
+					newState.ids[id] = oldState.ids[id]
+				}
+
+				// set the new one
+				newState.ids[panelId] = collapsed
+
+				window.localStorage.setItem(collapseStorageId, JSON.stringify(newState))
+				return newState
+			})
+		},
+		[collapseStorageId, panelIds]
+	)
+	const setAllCollapsed = useCallback(() => {
+		setCollapsed((oldState) => {
+			const newState = {
+				...oldState,
+				defaultCollapsed: true,
+				ids: {},
+			}
+
+			// set all to collapsed
+			for (const id of panelIds) {
+				newState.ids[id] = true
+			}
+
+			window.localStorage.setItem(collapseStorageId, JSON.stringify(newState))
+			return newState
+		})
+	}, [collapseStorageId, panelIds])
+	const setAllExpanded = useCallback(() => {
+		setCollapsed((oldState) => {
+			const newState = {
+				...oldState,
+				defaultCollapsed: false,
+				ids: {},
+			}
+
+			// set all to collapsed
+			for (const id of panelIds) {
+				newState.ids[id] = false
+			}
+
+			window.localStorage.setItem(collapseStorageId, JSON.stringify(newState))
+			return newState
+		})
+	}, [collapseStorageId, panelIds])
+
+	return {
+		collapsed,
+		setAllCollapsed,
+		setAllExpanded,
+		setPanelCollapsed,
+	}
+}

--- a/webui/src/Buttons/EditButton/CollapseHelper.jsx
+++ b/webui/src/Buttons/EditButton/CollapseHelper.jsx
@@ -16,7 +16,7 @@ export function usePanelCollapseHelper(storageId, panelIds) {
 			})
 		}
 	}, [collapseStorageId])
-	// const panelIds = useMemo(() => panelIds.map((a) => a.id), [panelIds])
+
 	const setPanelCollapsed = useCallback(
 		(panelId, collapsed) => {
 			setCollapsed((oldState) => {
@@ -74,10 +74,22 @@ export function usePanelCollapseHelper(storageId, panelIds) {
 		})
 	}, [collapseStorageId, panelIds])
 
+	const isPanelCollapsed = useCallback(
+		(panelId) => {
+			return collapsed?.ids?.[panelId] ?? collapsed?.defaultCollapsed
+		},
+		[collapsed]
+	)
+
+	const canExpandAll = collapsed.defaultCollapsed || !Object.values(collapsed.ids || {}).every((v) => !v)
+	const canCollapseAll = !collapsed.defaultCollapsed || !Object.values(collapsed.ids || {}).every((v) => v)
+
 	return {
-		collapsed,
 		setAllCollapsed,
 		setAllExpanded,
+		canExpandAll,
+		canCollapseAll,
 		setPanelCollapsed,
+		isPanelCollapsed,
 	}
 }

--- a/webui/src/Buttons/EditButton/FeedbackPanel.jsx
+++ b/webui/src/Buttons/EditButton/FeedbackPanel.jsx
@@ -1,5 +1,5 @@
 import { CAlert, CButton, CForm, CFormGroup, CButtonGroup } from '@coreui/react'
-import { faSort, faTrash, faCompressArrowsAlt, faExpandArrowsAlt } from '@fortawesome/free-solid-svg-icons'
+import { faSort, faTrash, faCompressArrowsAlt, faExpandArrowsAlt, faCopy } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import {
@@ -53,6 +53,15 @@ export const FeedbacksPanel = function ({ controlId, feedbacks, dragId, heading 
 				socketEmitPromise(socket, 'controls:feedback:remove', [controlId, feedbackId]).catch((e) => {
 					console.error(`Failed to delete feedback: ${e}`)
 				})
+			})
+		},
+		[socket, controlId]
+	)
+
+	const doDuplicate = useCallback(
+		(feedbackId) => {
+			socketEmitPromise(socket, 'controls:feedback:duplicate', [controlId, feedbackId]).catch((e) => {
+				console.error(`Failed to duplicate feedback: ${e}`)
 			})
 		},
 		[socket, controlId]
@@ -158,6 +167,7 @@ export const FeedbacksPanel = function ({ controlId, feedbacks, dragId, heading 
 								feedback={a}
 								setValue={setValue}
 								doDelete={doDelete}
+								doDuplicate={doDuplicate}
 								doLearn={doLearn}
 								dragId={dragId}
 								moveCard={moveCard}
@@ -187,6 +197,7 @@ function FeedbackTableRow({
 	moveCard,
 	setValue,
 	doDelete,
+	doDuplicate,
 	doLearn,
 	collapsed,
 	setCollapsed,
@@ -194,6 +205,7 @@ function FeedbackTableRow({
 	const socket = useContext(SocketContext)
 
 	const innerDelete = useCallback(() => doDelete(feedback.id), [feedback.id, doDelete])
+	const innerDuplicate = useCallback(() => doDuplicate(feedback.id), [feedback.id, doDuplicate])
 	const innerLearn = useCallback(() => doLearn(feedback.id), [doLearn, feedback.id])
 
 	const ref = useRef(null)
@@ -294,6 +306,7 @@ function FeedbackTableRow({
 					feedback={feedback}
 					setValue={setValue}
 					innerDelete={innerDelete}
+					innerDuplicate={innerDuplicate}
 					innerLearn={innerLearn}
 					setSelectedStyleProps={setSelectedStyleProps}
 					setStylePropsValue={setStylePropsValue}
@@ -311,6 +324,7 @@ export function FeedbackEditor({
 	isOnBank,
 	setValue,
 	innerDelete,
+	innerDuplicate,
 	innerLearn,
 	setSelectedStyleProps,
 	setStylePropsValue,
@@ -374,18 +388,18 @@ export function FeedbackEditor({
 			<div className="cell-controls">
 				<CButtonGroup>
 					{collapsed ? (
-						<CButton color="info" size="sm" onClick={doExpand} title="Expand action view">
+						<CButton color="info" size="sm" onClick={doExpand} title="Expand feedback view">
 							<FontAwesomeIcon icon={faExpandArrowsAlt} />
 						</CButton>
 					) : (
-						<CButton color="info" size="sm" onClick={doCollapse} title="Collapse action view">
+						<CButton color="info" size="sm" onClick={doCollapse} title="Collapse feedback view">
 							<FontAwesomeIcon icon={faCompressArrowsAlt} />
 						</CButton>
 					)}
-					{/* <CButton color="warning" size="sm" onClick={innerDuplicate} title="Duplicate action">
+					<CButton color="warning" size="sm" onClick={innerDuplicate} title="Duplicate feedback">
 						<FontAwesomeIcon icon={faCopy} />
-					</CButton> */}
-					<CButton color="danger" size="sm" onClick={innerDelete} title="Remove action">
+					</CButton>
+					<CButton color="danger" size="sm" onClick={innerDelete} title="Remove feedback">
 						<FontAwesomeIcon icon={faTrash} />
 					</CButton>
 				</CButtonGroup>

--- a/webui/src/Buttons/EditButton/FeedbackPanel.jsx
+++ b/webui/src/Buttons/EditButton/FeedbackPanel.jsx
@@ -219,27 +219,10 @@ function FeedbackTableRow({
 			if (dragIndex === hoverIndex) {
 				return
 			}
-			// Determine rectangle on screen
-			const hoverBoundingRect = ref.current?.getBoundingClientRect()
-			// Get vertical middle
-			const hoverMiddleY = (hoverBoundingRect.bottom - hoverBoundingRect.top) / 2
-			// Determine mouse position
-			const clientOffset = monitor.getClientOffset()
-			// Get pixels to the top
-			const hoverClientY = clientOffset.y - hoverBoundingRect.top
-			// Only perform the move when the mouse has crossed half of the items height
-			// When dragging downwards, only move when the cursor is below 50%
-			// When dragging upwards, only move when the cursor is above 50%
-			// Dragging downwards
-			if (dragIndex < hoverIndex && hoverClientY < hoverMiddleY) {
-				return
-			}
-			// Dragging upwards
-			if (dragIndex > hoverIndex && hoverClientY > hoverMiddleY) {
-				return
-			}
+
 			// Time to actually perform the action
 			moveCard(dragIndex, hoverIndex)
+
 			// Note: we're mutating the monitor item here!
 			// Generally it's better to avoid mutations,
 			// but it's good here for the sake of performance

--- a/webui/src/Buttons/EditButton/FeedbackPanel.jsx
+++ b/webui/src/Buttons/EditButton/FeedbackPanel.jsx
@@ -117,10 +117,8 @@ export const FeedbacksPanel = function ({ controlId, feedbacks, dragId, heading 
 	})
 
 	const feedbackIds = useMemo(() => feedbacks.map((fb) => fb.id), [feedbacks])
-	const { collapsed, setPanelCollapsed, setAllCollapsed, setAllExpanded } = usePanelCollapseHelper(
-		`feedbacks_${controlId}`,
-		feedbackIds
-	)
+	const { setPanelCollapsed, isPanelCollapsed, setAllCollapsed, setAllExpanded, canExpandAll, canCollapseAll } =
+		usePanelCollapseHelper(`feedbacks_${controlId}`, feedbackIds)
 
 	return (
 		<>
@@ -139,7 +137,7 @@ export const FeedbacksPanel = function ({ controlId, feedbacks, dragId, heading 
 							size="sm"
 							onClick={setAllExpanded}
 							title="Expand all feedbacks"
-							disabled={!collapsed.defaultCollapsed && Object.values(collapsed.ids || {}).every((v) => !v)}
+							disabled={!canExpandAll}
 						>
 							<FontAwesomeIcon icon={faExpandArrowsAlt} />
 						</CButton>{' '}
@@ -148,7 +146,7 @@ export const FeedbacksPanel = function ({ controlId, feedbacks, dragId, heading 
 							size="sm"
 							onClick={setAllCollapsed}
 							title="Collapse all feedbacks"
-							disabled={collapsed.defaultCollapsed && Object.values(collapsed.ids || {}).every((v) => v)}
+							disabled={!canCollapseAll}
 						>
 							<FontAwesomeIcon icon={faCompressArrowsAlt} />
 						</CButton>
@@ -172,7 +170,7 @@ export const FeedbacksPanel = function ({ controlId, feedbacks, dragId, heading 
 								dragId={dragId}
 								moveCard={moveCard}
 								setCollapsed={setPanelCollapsed}
-								collapsed={collapsed?.ids?.[a.id] ?? collapsed.defaultCollapsed}
+								isCollapsed={isPanelCollapsed(a.id)}
 							/>
 						</MyErrorBoundary>
 					))}
@@ -199,7 +197,7 @@ function FeedbackTableRow({
 	doDelete,
 	doDuplicate,
 	doLearn,
-	collapsed,
+	isCollapsed,
 	setCollapsed,
 }) {
 	const socket = useContext(SocketContext)
@@ -310,7 +308,7 @@ function FeedbackTableRow({
 					innerLearn={innerLearn}
 					setSelectedStyleProps={setSelectedStyleProps}
 					setStylePropsValue={setStylePropsValue}
-					collapsed={collapsed}
+					isCollapsed={isCollapsed}
 					doCollapse={doCollapse}
 					doExpand={doExpand}
 				/>
@@ -328,7 +326,7 @@ export function FeedbackEditor({
 	innerLearn,
 	setSelectedStyleProps,
 	setStylePropsValue,
-	collapsed,
+	isCollapsed,
 	doCollapse,
 	doExpand,
 }) {
@@ -387,7 +385,7 @@ export function FeedbackEditor({
 
 			<div className="cell-controls">
 				<CButtonGroup>
-					{collapsed ? (
+					{isCollapsed ? (
 						<CButton color="info" size="sm" onClick={doExpand} title="Expand feedback view">
 							<FontAwesomeIcon icon={faExpandArrowsAlt} />
 						</CButton>
@@ -405,7 +403,7 @@ export function FeedbackEditor({
 				</CButtonGroup>
 			</div>
 
-			{!collapsed ? (
+			{!isCollapsed ? (
 				<>
 					<div className="cell-description">{feedbackSpec?.description || ''}</div>
 

--- a/webui/src/Buttons/EditButton/index.jsx
+++ b/webui/src/Buttons/EditButton/index.jsx
@@ -327,9 +327,9 @@ function ActionsSection({ style, controlId, action_sets, runtimeProps }) {
 	if (style === 'press') {
 		return (
 			<>
-				<h4 className="mt-3">Press actions</h4>
 				<MyErrorBoundary>
 					<ActionsPanel
+						heading="Press actions"
 						controlId={controlId}
 						set={'down'}
 						dragId={'downAction'}
@@ -337,9 +337,9 @@ function ActionsSection({ style, controlId, action_sets, runtimeProps }) {
 						actions={action_sets['down']}
 					/>
 				</MyErrorBoundary>
-				<h4 className="mt-3">Release actions</h4>
 				<MyErrorBoundary>
 					<ActionsPanel
+						heading="Release actions"
 						controlId={controlId}
 						set={'up'}
 						dragId={'releaseAction'}
@@ -355,19 +355,21 @@ function ActionsSection({ style, controlId, action_sets, runtimeProps }) {
 			<>
 				<GenericConfirmModal ref={confirmRef} />
 				{keys.map((k, i) => (
-					<>
-						<h4 key={`heading_${k}`} className="mt-3">
-							Step {i + 1} actions
-							<CButtonGroup className="right">
+					<MyErrorBoundary>
+						<ActionsPanel
+							heading={`Step ${i + 1} actions`}
+							headingActions={[
 								<CButton
+									key="set-next"
 									color={runtimeProps.current_step_id === k ? 'success' : 'primary'}
 									size="sm"
 									disabled={runtimeProps.current_step_id === k}
 									onClick={() => setNextStep(k)}
 								>
 									Set Next
-								</CButton>
+								</CButton>,
 								<CButton
+									key="move-up"
 									color="warning"
 									title="Move step up"
 									size="sm"
@@ -375,8 +377,9 @@ function ActionsSection({ style, controlId, action_sets, runtimeProps }) {
 									onClick={() => swapSteps(k, keys[i - 1])}
 								>
 									<FontAwesomeIcon icon={faArrowUp} />
-								</CButton>
+								</CButton>,
 								<CButton
+									key="move-down"
 									color="warning"
 									title="Move step down"
 									size="sm"
@@ -384,8 +387,9 @@ function ActionsSection({ style, controlId, action_sets, runtimeProps }) {
 									onClick={() => swapSteps(k, keys[i + 1])}
 								>
 									<FontAwesomeIcon icon={faArrowDown} />
-								</CButton>
+								</CButton>,
 								<CButton
+									key="delete"
 									color="danger"
 									title="Delete step"
 									size="sm"
@@ -393,20 +397,16 @@ function ActionsSection({ style, controlId, action_sets, runtimeProps }) {
 									onClick={() => removeStep(k)}
 								>
 									<FontAwesomeIcon icon={faTrash} />
-								</CButton>
-							</CButtonGroup>
-						</h4>
-						<MyErrorBoundary>
-							<ActionsPanel
-								key={`panel_${k}`}
-								controlId={controlId}
-								set={k}
-								dragId={`${k}Action`}
-								addPlaceholder={`+ Add action to step ${i + 1}`}
-								actions={action_sets[k]}
-							/>
-						</MyErrorBoundary>
-					</>
+								</CButton>,
+							]}
+							key={`panel_${k}`}
+							controlId={controlId}
+							set={k}
+							dragId={`${k}Action`}
+							addPlaceholder={`+ Add action to step ${i + 1}`}
+							actions={action_sets[k]}
+						/>
+					</MyErrorBoundary>
 				))}
 				<br />
 				<p>

--- a/webui/src/Buttons/EditButton/index.jsx
+++ b/webui/src/Buttons/EditButton/index.jsx
@@ -250,9 +250,13 @@ export function EditButton({ controlId, onKeyUp }) {
 
 							{config.feedbacks ? (
 								<>
-									<h4 className="mt-3">Feedback</h4>
 									<MyErrorBoundary>
-										<FeedbacksPanel controlId={controlId} feedbacks={config.feedbacks} dragId={'feedback'} />
+										<FeedbacksPanel
+											heading={'Feedback'}
+											controlId={controlId}
+											feedbacks={config.feedbacks}
+											dragId={'feedback'}
+										/>
 									</MyErrorBoundary>
 								</>
 							) : (

--- a/webui/src/Triggers/EditModal.jsx
+++ b/webui/src/Triggers/EditModal.jsx
@@ -191,7 +191,7 @@ export function TriggerEditModal({ doClose, doSave, item, plugins }) {
 		[setActions]
 	)
 	const actionReorder = useCallback(
-		(dragIndex, hoverIndex) => {
+		(_dragSetId, dragIndex, _dropSetId, hoverIndex) => {
 			setActions((actions) => {
 				const dragCard = actions[dragIndex]
 				return update(actions, {
@@ -415,6 +415,7 @@ export function TriggerEditModal({ doClose, doSave, item, plugins }) {
 					<ActionsPanelInner
 						isOnBank={false}
 						dragId={'triggerAction'}
+						setId={0}
 						addPlaceholder="+ Add action"
 						actions={config.actions || []}
 						addAction={addActionSelect}

--- a/webui/src/Triggers/EditModal.jsx
+++ b/webui/src/Triggers/EditModal.jsx
@@ -272,10 +272,14 @@ export function TriggerEditModal({ doClose, doSave, item, plugins }) {
 	}, [])
 
 	const actionIds = useMemo(() => (config.actions || []).map((act) => act.id), [config.actions])
-	const { collapsed, setPanelCollapsed, setAllCollapsed, setAllExpanded } = usePanelCollapseHelper(
-		`trigger_actions_${item.id}`,
-		actionIds
-	)
+	const {
+		setPanelCollapsed: setActionPanelCollapsed,
+		isPanelCollapsed: isActionPanelCollapsed,
+		setAllCollapsed: setAllActionCollapsed,
+		setAllExpanded: setAllActionExpanded,
+		canExpandAll: canExpandAllAction,
+		canCollapseAll: canCollapseAllAction,
+	} = usePanelCollapseHelper(`trigger_actions_${item.id}`, actionIds)
 
 	const isFeedbackBased = pluginSpec?.type === 'feedback'
 	const feedbackIds = useMemo(() => {
@@ -286,10 +290,12 @@ export function TriggerEditModal({ doClose, doSave, item, plugins }) {
 		}
 	}, [config.config, isFeedbackBased])
 	const {
-		collapsed: feedbackCollapsed,
 		setPanelCollapsed: setFeedbackPanelCollapsed,
+		isPanelCollapsed: isFeedbackPanelCollapsed,
 		setAllCollapsed: setAllFeedbackCollapsed,
 		setAllExpanded: setAllFeedbackExpanded,
+		canExpandAll: canExpandAllFeedback,
+		canCollapseAll: canCollapseAllFeedback,
 	} = usePanelCollapseHelper(`feedbacks_${item.id}`, feedbackIds)
 
 	return (
@@ -314,9 +320,7 @@ export function TriggerEditModal({ doClose, doSave, item, plugins }) {
 										size="sm"
 										onClick={setAllFeedbackExpanded}
 										title="Expand all feedbacks"
-										disabled={
-											!feedbackCollapsed.defaultCollapsed && Object.values(feedbackCollapsed.ids || {}).every((v) => !v)
-										}
+										disabled={!canExpandAllFeedback}
 									>
 										<FontAwesomeIcon icon={faExpandArrowsAlt} />
 									</CButton>{' '}
@@ -325,9 +329,7 @@ export function TriggerEditModal({ doClose, doSave, item, plugins }) {
 										size="sm"
 										onClick={setAllFeedbackCollapsed}
 										title="Collapse all feedbacks"
-										disabled={
-											feedbackCollapsed.defaultCollapsed && Object.values(feedbackCollapsed.ids || {}).every((v) => v)
-										}
+										disabled={!canCollapseAllFeedback}
 									>
 										<FontAwesomeIcon icon={faCompressArrowsAlt} />
 									</CButton>
@@ -354,7 +356,7 @@ export function TriggerEditModal({ doClose, doSave, item, plugins }) {
 							pluginSpec={pluginSpec}
 							config={config.config}
 							setConfig={setConfig}
-							collapsed={feedbackCollapsed}
+							isPanelCollapsed={isFeedbackPanelCollapsed}
 							setPanelCollapsed={setFeedbackPanelCollapsed}
 						/>
 					) : (
@@ -369,18 +371,18 @@ export function TriggerEditModal({ doClose, doSave, item, plugins }) {
 								<CButton
 									color="info"
 									size="sm"
-									onClick={setAllExpanded}
+									onClick={setAllActionExpanded}
 									title="Expand all actions"
-									disabled={!collapsed.defaultCollapsed && Object.values(collapsed.ids || {}).every((v) => !v)}
+									disabled={!canExpandAllAction}
 								>
 									<FontAwesomeIcon icon={faExpandArrowsAlt} />
 								</CButton>{' '}
 								<CButton
 									color="info"
 									size="sm"
-									onClick={setAllCollapsed}
+									onClick={setAllActionCollapsed}
 									title="Collapse all actions"
-									disabled={collapsed.defaultCollapsed && Object.values(collapsed.ids || {}).every((v) => v)}
+									disabled={!canCollapseAllAction}
 								>
 									<FontAwesomeIcon icon={faCompressArrowsAlt} />
 								</CButton>
@@ -422,8 +424,8 @@ export function TriggerEditModal({ doClose, doSave, item, plugins }) {
 						doReorder={actionReorder}
 						doSetValue={actionSetValue}
 						emitLearn={doLearn}
-						collapsed={collapsed}
-						setActionCollapsed={setPanelCollapsed}
+						isPanelCollapsed={isActionPanelCollapsed}
+						setPanelCollapsed={setActionPanelCollapsed}
 					/>
 				</CModalBody>
 				<CModalFooter>
@@ -439,7 +441,7 @@ export function TriggerEditModal({ doClose, doSave, item, plugins }) {
 	)
 }
 
-function TriggerEditModalConfig({ pluginSpec, config, setConfig, collapsed, setPanelCollapsed }) {
+function TriggerEditModalConfig({ pluginSpec, config, setConfig, isPanelCollapsed, setPanelCollapsed }) {
 	const socket = useContext(SocketContext)
 
 	const feedbacksRef = useRef(null)
@@ -616,7 +618,7 @@ function TriggerEditModalConfig({ pluginSpec, config, setConfig, collapsed, setP
 											duplicateRow={duplicateRow}
 											learnRow={learnRow}
 											setCollapsed={setPanelCollapsed}
-											collapsed={collapsed?.ids?.[conf.id] ?? collapsed.defaultCollapsed}
+											isCollapsed={isPanelCollapsed(conf.id)}
 										/>
 									</MyErrorBoundary>
 								</td>
@@ -660,7 +662,7 @@ function FeedbackEditorRow({
 	delRow,
 	duplicateRow,
 	learnRow,
-	collapsed,
+	isCollapsed,
 	setCollapsed,
 }) {
 	const innerDelete = useCallback(() => {
@@ -688,7 +690,7 @@ function FeedbackEditorRow({
 			innerDelete={innerDelete}
 			innerDuplicate={innerDuplicate}
 			innerLearn={innerLearn}
-			collapsed={collapsed}
+			isCollapsed={isCollapsed}
 			doCollapse={doCollapse}
 			doExpand={doExpand}
 		/>

--- a/webui/src/Triggers/EditModal.jsx
+++ b/webui/src/Triggers/EditModal.jsx
@@ -540,6 +540,29 @@ function TriggerEditModalConfig({ pluginSpec, config, setConfig, collapsed, setP
 		},
 		[setConfig]
 	)
+	const duplicateRow = useCallback(
+		(feedbackId) => {
+			setConfig((oldConfig) => {
+				const oldIndex = oldConfig.config.findIndex((fb) => fb.id === feedbackId)
+				if (oldIndex !== -1) {
+					const newFeedbacks = [...oldConfig.config]
+
+					newFeedbacks.splice(oldIndex + 1, 0, {
+						...cloneDeep(oldConfig.config[oldIndex]),
+						id: nanoid(),
+					})
+
+					return {
+						...oldConfig,
+						config: newFeedbacks,
+					}
+				}
+
+				return oldConfig
+			})
+		},
+		[setConfig]
+	)
 
 	const learnRow = useCallback(
 		(feedbackId) => {
@@ -590,6 +613,7 @@ function TriggerEditModalConfig({ pluginSpec, config, setConfig, collapsed, setP
 											feedback={conf}
 											updateFeedbackOptionConfig={updateFeedbackOptionConfig}
 											delRow={delRow}
+											duplicateRow={duplicateRow}
 											learnRow={learnRow}
 											setCollapsed={setPanelCollapsed}
 											collapsed={collapsed?.ids?.[conf.id] ?? collapsed.defaultCollapsed}
@@ -630,10 +654,21 @@ function TriggerEditModalConfig({ pluginSpec, config, setConfig, collapsed, setP
 	)
 }
 
-function FeedbackEditorRow({ feedback, updateFeedbackOptionConfig, delRow, learnRow, collapsed, setCollapsed }) {
+function FeedbackEditorRow({
+	feedback,
+	updateFeedbackOptionConfig,
+	delRow,
+	duplicateRow,
+	learnRow,
+	collapsed,
+	setCollapsed,
+}) {
 	const innerDelete = useCallback(() => {
 		delRow(feedback.id)
 	}, [feedback.id, delRow])
+	const innerDuplicate = useCallback(() => {
+		duplicateRow(feedback.id)
+	}, [feedback.id, duplicateRow])
 	const innerLearn = useCallback(() => {
 		learnRow(feedback.id)
 	}, [feedback.id, learnRow])
@@ -651,6 +686,7 @@ function FeedbackEditorRow({ feedback, updateFeedbackOptionConfig, delRow, learn
 			feedback={feedback}
 			setValue={updateFeedbackOptionConfig}
 			innerDelete={innerDelete}
+			innerDuplicate={innerDuplicate}
 			innerLearn={innerLearn}
 			collapsed={collapsed}
 			doCollapse={doCollapse}

--- a/webui/src/scss/_button-edit.scss
+++ b/webui/src/scss/_button-edit.scss
@@ -30,6 +30,18 @@ table.feedback-table {
 		opacity: 0.5;
 	}
 
+	.actionlist-dropzone {
+		p {
+			border: 2px dashed #bbb;
+			border-radius: 5px;
+
+			text-align: center;
+
+			margin: 0;
+			padding: 0.75rem;
+		}
+	}
+
 	td.td-reorder {
 		padding-right: 0;
 		vertical-align: middle;

--- a/webui/src/scss/_button-edit.scss
+++ b/webui/src/scss/_button-edit.scss
@@ -48,6 +48,12 @@ table.feedback-table {
 			grid-column: 1;
 		}
 
+		.cell-controls {
+			grid-row: 1;
+			grid-column: 2;
+			text-align: right;
+		}
+
 		.cell-description {
 			grid-row: 2;
 			grid-column: 1;
@@ -68,7 +74,7 @@ table.feedback-table {
 		}
 
 		.cell-option {
-			grid-row: 1 / 5;
+			grid-row: 2 / 5;
 			grid-column: 2;
 		}
 

--- a/webui/src/scss/_common.scss
+++ b/webui/src/scss/_common.scss
@@ -11,7 +11,8 @@ h4 {
 }
 
 h4,
-h5 {
+h5,
+legend {
 	.btn-group {
 		float: right;
 	}


### PR DESCRIPTION
* actions and feedbacks can be collapsed/expanded to reduce screen usage
* actions and feedbacks can be duplicated
* actions can be dragged between sets (eg between down and up)

![image](https://user-images.githubusercontent.com/1327476/191078009-88f32ac8-9c34-4938-9867-041ab70349eb.png)
