### PR TITLE
feat: better encoders support for loupdeck-live

### DIFF
--- a/instance_skel.js
+++ b/instance_skel.js
@@ -373,9 +373,7 @@ instance.prototype.getAllActions = function () {
 	self.system.emit('actions_for_instance', self.id, function (_result) {
 		result = _result
 	})
-	self.system.emit('release_actions_for_instance', self.id, function (_result) {
-		result.push(..._result)
-	})
+
 	return result
 }
 

--- a/lib/action.js
+++ b/lib/action.js
@@ -518,6 +518,11 @@ function action(system) {
 			bank_config = config
 		})
 
+		if (!bank_config.rotary_actions) {
+			// skip execution as rotary actions disabled
+			return
+		}
+
 		var obj = self.bank_rotate_right_actions
 
 		// find release actions if the direction is up

--- a/lib/action.js
+++ b/lib/action.js
@@ -1173,6 +1173,18 @@ function action(system) {
 		}
 	})
 
+	self.system.on('clear_bank_rotary_actions', function (page, bank) {
+		if (self.bank_rotate_left_actions[page] === undefined) {
+			self.bank_rotate_left_actions[page] = {}
+		}
+		self.bank_rotate_left_actions[page][bank] = []
+
+		if (self.bank_rotate_right_actions[page] === undefined) {
+			self.bank_rotate_right_actions[page] = {}
+		}
+		self.bank_rotate_right_actions[page][bank] = []
+	})
+
 	self.system.on('bank_reset', function (page, bank) {
 		system.emit('action_unsubscribe_bank', page, bank)
 

--- a/lib/action.js
+++ b/lib/action.js
@@ -511,6 +511,34 @@ function action(system) {
 		})
 	})
 
+	self.system.on('bank_rotated', function (page, bank, direction, deviceid) {
+		var bank_config
+
+		system.emit('get_bank', page, bank, function (config) {
+			bank_config = config
+		})
+
+		var obj = self.bank_rotate_right_actions
+
+		// find release actions if the direction is up
+		if (direction === false) {
+			obj = self.bank_rotate_left_actions
+		}
+
+		if (obj[page] === undefined || obj[page][bank] === undefined || obj[page][bank].length === 0) {
+			return
+		}
+
+		debug('found actions')
+
+		const bankId = `${page}_${bank}`
+		system.emit('action_run_multiple', obj[page][bank], bankId, bank_config.relative_delay, {
+			deviceid: deviceid,
+			page: page,
+			bank: bank,
+		})
+	})
+
 	self.system.on('action_run_multiple', function (actions, groupId, relative_delay, run_source) {
 		// Handle whether the delays are absolute or relative.
 		var action_delay = 0

--- a/lib/action.js
+++ b/lib/action.js
@@ -201,6 +201,14 @@ function action(system) {
 		cb(self.bank_release_actions)
 	})
 
+	self.system.on('rotate_left_action_get_banks', function (cb) {
+		cb(self.bank_rotate_left_actions)
+	})
+
+	self.system.on('rotate_right_action_get_banks', function (cb) {
+		cb(self.bank_rotate_right_actions)
+	})
+
 	self.system.on('actions_for_instance', function (instance_id, cb) {
 		var actions = []
 		for (var page in self.bank_actions) {

--- a/lib/action.js
+++ b/lib/action.js
@@ -28,6 +28,8 @@ function action(system) {
 	self.action_definitions = {}
 	self.bank_actions = {}
 	self.bank_release_actions = {}
+	self.bank_rotate_left_actions = {}
+	self.bank_rotate_right_actions = {}
 	self.bank_status = {}
 	self.instance = {}
 	self.actions_running = new Set()
@@ -42,6 +44,17 @@ function action(system) {
 	self.system.emit('db_get', 'bank_release_actions', function (res) {
 		if (res !== undefined) {
 			self.bank_release_actions = res
+		}
+	})
+
+	self.system.emit('db_get', 'bank_rotate_left_actions', function (res) {
+		if (res !== undefined) {
+			self.bank_rotate_left_actions = res
+		}
+	})
+	self.system.emit('db_get', 'bank_rotate_right_actions', function (res) {
+		if (res !== undefined) {
+			self.bank_rotate_right_actions = res
 		}
 	})
 
@@ -91,12 +104,16 @@ function action(system) {
 
 		self.system.emit('db_set', 'bank_actions', self.bank_actions)
 		self.system.emit('db_set', 'bank_release_actions', self.bank_release_actions)
+		self.system.emit('db_set', 'bank_rotate_left_actions', self.bank_rotate_left_actions)
+		self.system.emit('db_set', 'bank_rotate_right_actions', self.bank_rotate_right_actions)
 		self.system.emit('db_save')
 	})
 
 	self.system.on('action_save', function () {
 		self.system.emit('db_set', 'bank_actions', self.bank_actions)
 		self.system.emit('db_set', 'bank_release_actions', self.bank_release_actions)
+		self.system.emit('db_set', 'bank_rotate_left_actions', self.bank_rotate_left_actions)
+		self.system.emit('db_set', 'bank_rotate_right_actions', self.bank_rotate_right_actions)
 		self.system.emit('db_save')
 		debug('saving')
 	})
@@ -137,6 +154,40 @@ function action(system) {
 			}
 		}
 
+		for (var page in self.bank_rotate_left_actions) {
+			for (var bank in self.bank_rotate_left_actions[page]) {
+				if (self.bank_rotate_left_actions[page][bank] !== undefined) {
+					for (var i = 0; i < self.bank_rotate_left_actions[page][bank].length; ++i) {
+						var action = self.bank_rotate_left_actions[page][bank][i]
+						if (action.instance == id) {
+							debug('Deleting rotate left action ' + i + ' from button ' + page + '.' + bank)
+							self.unsubscribeAction(self.bank_rotate_left_actions[page][bank][i])
+							self.bank_releasebank_rotate_left_actions_actions[page][bank].splice(i, 1)
+							self.system.emit('instance_status_check_bank', page, bank)
+							i--
+						}
+					}
+				}
+			}
+		}
+
+		for (var page in self.bank_rotate_right_actions) {
+			for (var bank in self.bank_rotate_right_actions[page]) {
+				if (self.bank_rotate_right_actions[page][bank] !== undefined) {
+					for (var i = 0; i < self.bank_rotate_right_actions[page][bank].length; ++i) {
+						var action = self.bank_rotate_right_actions[page][bank][i]
+						if (action.instance == id) {
+							debug('Deleting rotate right action ' + i + ' from button ' + page + '.' + bank)
+							self.unsubscribeAction(self.bank_rotate_right_actions[page][bank][i])
+							self.bank_rotate_right_actions[page][bank].splice(i, 1)
+							self.system.emit('instance_status_check_bank', page, bank)
+							i--
+						}
+					}
+				}
+			}
+		}
+
 		// Remove the definitions
 		delete self.action_definitions[id]
 		self.io.emit('action_instance_definitions_patch', id, null)
@@ -163,19 +214,6 @@ function action(system) {
 			}
 		}
 
-		self.system.emit('schedule_get_all_actions', function (_actions) {
-			for (const action of _actions) {
-				if (action.instance == instance_id) {
-					actions.push(action)
-				}
-			}
-		})
-
-		cb(actions)
-	})
-
-	self.system.on('release_actions_for_instance', function (instance_id, cb) {
-		var actions = []
 		for (var page in self.bank_release_actions) {
 			for (var bank in self.bank_release_actions[page]) {
 				for (var i in self.bank_release_actions[page][bank]) {
@@ -186,6 +224,37 @@ function action(system) {
 				}
 			}
 		}
+
+		for (var page in self.bank_rotate_left_actions) {
+			for (var bank in self.bank_rotate_left_actions[page]) {
+				for (var i in self.bank_rotate_left_actions[page][bank]) {
+					var action = self.bank_rotate_left_actions[page][bank][i]
+					if (action.instance == instance_id) {
+						actions.push(action)
+					}
+				}
+			}
+		}
+
+		for (var page in self.bank_rotate_right_actions) {
+			for (var bank in self.bank_rotate_right_actions[page]) {
+				for (var i in self.bank_rotate_right_actions[page][bank]) {
+					var action = self.bank_rotate_right_actions[page][bank][i]
+					if (action.instance == instance_id) {
+						actions.push(action)
+					}
+				}
+			}
+		}
+
+		self.system.emit('schedule_get_all_actions', function (_actions) {
+			for (const action of _actions) {
+				if (action.instance == instance_id) {
+					actions.push(action)
+				}
+			}
+		})
+
 		cb(actions)
 	})
 
@@ -239,6 +308,38 @@ function action(system) {
 				if (self.bank_release_actions[page] !== undefined && self.bank_release_actions[page][bank] !== undefined) {
 					for (var i = 0; i < self.bank_release_actions[page][bank].length; ++i) {
 						var action = self.bank_release_actions[page][bank][i]
+						if (action.instance == instance) {
+							checkBank(page, bank)
+						}
+					}
+				}
+			}
+		}
+
+		for (var page in self.bank_rotate_left_actions) {
+			for (var bank in self.bank_rotate_left_actions[page]) {
+				if (
+					self.bank_rotate_left_actions[page] !== undefined &&
+					self.bank_rotate_left_actions[page][bank] !== undefined
+				) {
+					for (var i = 0; i < self.bank_rotate_left_actions[page][bank].length; ++i) {
+						var action = self.bank_rotate_left_actions[page][bank][i]
+						if (action.instance == instance) {
+							checkBank(page, bank)
+						}
+					}
+				}
+			}
+		}
+
+		for (var page in self.bank_rotate_right_actions) {
+			for (var bank in self.bank_rotate_right_actions[page]) {
+				if (
+					self.bank_rotate_right_actions[page] !== undefined &&
+					self.bank_rotate_right_actions[page][bank] !== undefined
+				) {
+					for (var i = 0; i < self.bank_rotate_right_actions[page][bank].length; ++i) {
+						var action = self.bank_rotate_right_actions[page][bank][i]
 						if (action.instance == instance) {
 							checkBank(page, bank)
 						}
@@ -538,35 +639,39 @@ function action(system) {
 				answer(self.action_definitions)
 			})
 
-			client.on('bank_update_action_delay', function (page, bank, action, value) {
-				var bp = self.bank_actions[page][bank]
+			function setActionDelay(bp, action, value) {
 				if (bp !== undefined) {
 					for (var n in bp) {
 						var obj = bp[n]
 						if (obj !== undefined && obj.id === action) {
-							self.bank_actions[page][bank][n].delay = value
+							obj.delay = value
 							self.system.emit('action_save')
 						}
 					}
 				}
+			}
+
+			client.on('bank_update_action_delay', function (page, bank, action, value) {
+				var bp = self.bank_actions[page][bank]
+				setActionDelay(bp, action, value)
 			})
 
 			client.on('bank_update_release_action_delay', function (page, bank, action, value) {
 				var bp = self.bank_release_actions[page][bank]
-				if (bp !== undefined) {
-					for (var n in bp) {
-						var obj = bp[n]
-						if (obj !== undefined && obj.id === action) {
-							self.bank_release_actions[page][bank][n].delay = value
-							self.system.emit('action_save')
-						}
-					}
-				}
+				setActionDelay(bp, action, value)
 			})
 
-			client.on('bank_update_action_option', function (page, bank, action, option, value) {
-				debug('bank_update_action_option', page, bank, action, option, value)
-				var bp = self.bank_actions[page][bank]
+			client.on('bank_update_rotate_left_action_delay', function (page, bank, action, value) {
+				var bp = self.bank_rotate_left_actions[page][bank]
+				setActionDelay(bp, action, value)
+			})
+
+			client.on('bank_update_rotate_right_action_delay', function (page, bank, action, value) {
+				var bp = self.bank_rotate_right_actions[page][bank]
+				setActionDelay(bp, action, value)
+			})
+
+			function updateActionOption(bp, action, option, value) {
 				if (bp !== undefined) {
 					for (var n in bp) {
 						var obj = bp[n]
@@ -581,25 +686,30 @@ function action(system) {
 						}
 					}
 				}
+			}
+
+			client.on('bank_update_action_option', function (page, bank, action, option, value) {
+				debug('bank_update_action_option', page, bank, action, option, value)
+				var bp = self.bank_actions[page][bank]
+				updateActionOption(bp, action, option, value)
 			})
 
 			client.on('bank_release_action_update_option', function (page, bank, action, option, value) {
 				debug('bank_release_action_update_option', page, bank, action, option, value)
 				var bp = self.bank_release_actions[page][bank]
-				if (bp !== undefined) {
-					for (var n in bp) {
-						var obj = bp[n]
-						if (obj !== undefined && obj.id === action) {
-							self.unsubscribeAction(obj)
-							if (obj.options === undefined) {
-								obj.options = {}
-							}
-							obj.options[option] = value
-							self.subscribeAction(obj)
-							self.system.emit('action_save')
-						}
-					}
-				}
+				updateActionOption(bp, action, option, value)
+			})
+
+			client.on('bank_rotate_left_action_update_option', function (page, bank, action, option, value) {
+				debug('bank_rotate_left_action_update_option', page, bank, action, option, value)
+				var bp = self.bank_rotate_left_actions[page][bank]
+				updateActionOption(bp, action, option, value)
+			})
+
+			client.on('bank_rotate_right_action_update_option', function (page, bank, action, option, value) {
+				debug('bank_rotate_right_action_update_option', page, bank, action, option, value)
+				var bp = self.bank_rotate_right_actions[page][bank]
+				updateActionOption(bp, action, option, value)
 			})
 
 			client.on('action_get_defaults', function (action, answer) {
@@ -630,12 +740,10 @@ function action(system) {
 				answer(act)
 			})
 
-			client.on('bank_action_add', function (page, bank, action, answer) {
-				if (self.bank_actions[page] === undefined) self.bank_actions[page] = {}
-				if (self.bank_actions[page][bank] === undefined) self.bank_actions[page][bank] = []
-				var s = action.split(/:/)
+			function generateNewAction(action) {
+				const s = action.split(/:/)
 
-				var act = {
+				const act = {
 					id: shortid.generate(),
 					label: action,
 					instance: s[0],
@@ -657,6 +765,15 @@ function action(system) {
 						}
 					}
 				}
+
+				return act
+			}
+
+			client.on('bank_action_add', function (page, bank, action, answer) {
+				if (self.bank_actions[page] === undefined) self.bank_actions[page] = {}
+				if (self.bank_actions[page][bank] === undefined) self.bank_actions[page][bank] = []
+
+				const act = generateNewAction(action)
 
 				self.bank_actions[page][bank].push(act)
 				self.subscribeAction(act)
@@ -669,36 +786,48 @@ function action(system) {
 			client.on('bank_addReleaseAction', function (page, bank, action, answer) {
 				if (self.bank_release_actions[page] === undefined) self.bank_release_actions[page] = {}
 				if (self.bank_release_actions[page][bank] === undefined) self.bank_release_actions[page][bank] = []
-				var s = action.split(/:/)
 
-				var act = {
-					id: shortid.generate(),
-					label: action,
-					instance: s[0],
-					action: s[1],
-					options: {},
-				}
-
-				if (!self.instance.store.db[act.instance]) {
-					// Action is not valid
-					return
-				}
-
-				const definition = self.getActionDefinition(act.instance, act.action)
-				if (definition) {
-					if (definition.options !== undefined && definition.options.length > 0) {
-						for (var j in definition.options) {
-							var opt = definition.options[j]
-							act.options[opt.id] = opt.default
-						}
-					}
-				}
+				const act = generateNewAction(action)
 
 				self.bank_release_actions[page][bank].push(act)
 				self.subscribeAction(act)
 
 				system.emit('action_save')
 				sendResult(answer, 'bank_release_actions_get:result', page, bank, self.bank_release_actions[page][bank])
+				system.emit('instance_status_check_bank', page, bank)
+			})
+
+			client.on('bank_addRotateLeftAction', function (page, bank, action, answer) {
+				if (self.bank_rotate_left_actions[page] === undefined) self.bank_rotate_left_actions[page] = {}
+				if (self.bank_rotate_left_actions[page][bank] === undefined) self.bank_rotate_left_actions[page][bank] = []
+
+				const act = generateNewAction(action)
+
+				self.bank_rotate_left_actions[page][bank].push(act)
+				self.subscribeAction(act)
+
+				system.emit('action_save')
+				sendResult(answer, 'bank_rotate_left_actions_get:result', page, bank, self.bank_rotate_left_actions[page][bank])
+				system.emit('instance_status_check_bank', page, bank)
+			})
+
+			client.on('bank_addRotateRightAction', function (page, bank, action, answer) {
+				if (self.bank_rotate_right_actions[page] === undefined) self.bank_rotate_right_actions[page] = {}
+				if (self.bank_rotate_right_actions[page][bank] === undefined) self.bank_rotate_right_actions[page][bank] = []
+
+				const act = generateNewAction(action)
+
+				self.bank_rotate_right_actions[page][bank].push(act)
+				self.subscribeAction(act)
+
+				system.emit('action_save')
+				sendResult(
+					answer,
+					'bank_rotate_right_actions_get:result',
+					page,
+					bank,
+					self.bank_rotate_right_actions[page][bank]
+				)
 				system.emit('instance_status_check_bank', page, bank)
 			})
 
@@ -754,6 +883,64 @@ function action(system) {
 				system.emit('instance_status_check_bank', page, bank)
 			})
 
+			client.on('bank_rotate_left_action_delete', function (page, bank, id, answer) {
+				var ba = self.bank_rotate_left_actions[page][bank]
+
+				for (var n in ba) {
+					if (ba[n].id == id) {
+						self.unsubscribeAction(self.bank_rotate_left_actions[page][bank][n])
+						delete self.bank_rotate_left_actions[page][bank][n]
+						break
+					}
+				}
+
+				var cleanup = []
+
+				for (var n in ba) {
+					if (ba[n] !== null) {
+						cleanup.push(ba[n])
+					}
+				}
+
+				self.bank_rotate_left_actions[page][bank] = cleanup
+
+				system.emit('action_save')
+				sendResult(answer, 'bank_rotate_left_actions_get:result', page, bank, self.bank_rotate_left_actions[page][bank])
+				system.emit('instance_status_check_bank', page, bank)
+			})
+
+			client.on('bank_rotate_right_action_delete', function (page, bank, id, answer) {
+				var ba = self.bank_rotate_right_actions[page][bank]
+
+				for (var n in ba) {
+					if (ba[n].id == id) {
+						self.unsubscribeAction(self.bank_rotate_right_actions[page][bank][n])
+						delete self.bank_rotate_right_actions[page][bank][n]
+						break
+					}
+				}
+
+				var cleanup = []
+
+				for (var n in ba) {
+					if (ba[n] !== null) {
+						cleanup.push(ba[n])
+					}
+				}
+
+				self.bank_rotate_right_actions[page][bank] = cleanup
+
+				system.emit('action_save')
+				sendResult(
+					answer,
+					'bank_rotate_right_actions_get:result',
+					page,
+					bank,
+					self.bank_rotate_right_actions[page][bank]
+				)
+				system.emit('instance_status_check_bank', page, bank)
+			})
+
 			client.on('bank_actions_get', function (page, bank, answer) {
 				if (self.bank_actions[page] === undefined) self.bank_actions[page] = {}
 				if (self.bank_actions[page][bank] === undefined) self.bank_actions[page][bank] = []
@@ -766,20 +953,49 @@ function action(system) {
 				sendResult(answer, 'bank_release_actions_get:result', page, bank, self.bank_release_actions[page][bank])
 			})
 
-			client.on('bank_update_action_option_order', function (page, bank, old_index, new_index) {
-				var bp = self.bank_actions[page][bank]
+			client.on('bank_rotate_left_actions_get', function (page, bank, answer) {
+				if (self.bank_rotate_left_actions[page] === undefined) self.bank_rotate_left_actions[page] = {}
+				if (self.bank_rotate_left_actions[page][bank] === undefined) self.bank_rotate_left_actions[page][bank] = []
+				sendResult(answer, 'bank_rotate_left_actions_get:result', page, bank, self.bank_rotate_left_actions[page][bank])
+			})
+
+			client.on('bank_rotate_right_actions_get', function (page, bank, answer) {
+				if (self.bank_rotate_right_actions[page] === undefined) self.bank_rotate_right_actions[page] = {}
+				if (self.bank_rotate_right_actions[page][bank] === undefined) self.bank_rotate_right_actions[page][bank] = []
+				sendResult(
+					answer,
+					'bank_rotate_right_actions_get:result',
+					page,
+					bank,
+					self.bank_rotate_right_actions[page][bank]
+				)
+			})
+
+			function updateOrder(bp, old_index, new_index) {
 				if (bp !== undefined) {
 					bp.splice(new_index, 0, bp.splice(old_index, 1)[0])
 					self.system.emit('action_save')
 				}
+			}
+
+			client.on('bank_update_action_option_order', function (page, bank, old_index, new_index) {
+				var bp = self.bank_actions[page][bank]
+				updateOrder(bp, old_index, new_index)
 			})
 
 			client.on('bank_release_action_update_option_order', function (page, bank, old_index, new_index) {
 				var bp = self.bank_release_actions[page][bank]
-				if (bp !== undefined) {
-					bp.splice(new_index, 0, bp.splice(old_index, 1)[0])
-					self.system.emit('action_save')
-				}
+				updateOrder(bp, old_index, new_index)
+			})
+
+			client.on('bank_rotate_left_action_update_option_order', function (page, bank, old_index, new_index) {
+				var bp = self.bank_rotate_left_actions[page][bank]
+				updateOrder(bp, old_index, new_index)
+			})
+
+			client.on('bank_rotate_right_action_update_option_order', function (page, bank, old_index, new_index) {
+				var bp = self.bank_rotate_right_actions[page][bank]
+				updateOrder(bp, old_index, new_index)
 			})
 
 			client.on('bank_action_learn', function (page, bank, action) {
@@ -804,6 +1020,34 @@ function action(system) {
 						if (actionObj !== undefined && actionObj.id === action) {
 							self.action_learn(actionObj).then((newOptions) => {
 								self.io.emit('bank_release_action_learn:result', action, newOptions)
+							})
+						}
+					}
+				}
+			})
+
+			client.on('bank_rotate_left_action_learn', function (page, bank, action) {
+				var bp = self.bank_rotate_left_actions[page][bank]
+				if (bp !== undefined) {
+					for (var n in bp) {
+						var actionObj = bp[n]
+						if (actionObj !== undefined && actionObj.id === action) {
+							self.action_learn(actionObj).then((newOptions) => {
+								self.io.emit('bank_rotate_left_action_learn:result', action, newOptions)
+							})
+						}
+					}
+				}
+			})
+
+			client.on('bank_rotate_right_action_learn', function (page, bank, action) {
+				var bp = self.bank_rotate_right_actions[page][bank]
+				if (bp !== undefined) {
+					for (var n in bp) {
+						var actionObj = bp[n]
+						if (actionObj !== undefined && actionObj.id === action) {
+							self.action_learn(actionObj).then((newOptions) => {
+								self.io.emit('bank_rotate_right_action_learn:result', action, newOptions)
 							})
 						}
 					}
@@ -841,6 +1085,21 @@ function action(system) {
 				self.subscribeAction(self.bank_release_actions[page][bank][i])
 			}
 		}
+		if (self.bank_rotate_left_actions[page] !== undefined && self.bank_rotate_left_actions[page][bank] !== undefined) {
+			// find all instance-ids in release_actions for bank
+			for (var i in self.bank_rotate_left_actions[page][bank]) {
+				self.subscribeAction(self.bank_rotate_left_actions[page][bank][i])
+			}
+		}
+		if (
+			self.bank_rotate_right_actions[page] !== undefined &&
+			self.bank_rotate_right_actions[page][bank] !== undefined
+		) {
+			// find all instance-ids in release_actions for bank
+			for (var i in self.bank_rotate_right_actions[page][bank]) {
+				self.subscribeAction(self.bank_rotate_right_actions[page][bank][i])
+			}
+		}
 	})
 
 	system.on('action_unsubscribe_bank', function (page, bank) {
@@ -854,6 +1113,21 @@ function action(system) {
 			// find all instance-ids in release_actions for bank
 			for (var i in self.bank_release_actions[page][bank]) {
 				self.unsubscribeAction(self.bank_release_actions[page][bank][i])
+			}
+		}
+		if (self.bank_rotate_left_actions[page] !== undefined && self.bank_rotate_left_actions[page][bank] !== undefined) {
+			// find all instance-ids in release_actions for bank
+			for (var i in self.bank_rotate_left_actions[page][bank]) {
+				self.unsubscribeAction(self.bank_rotate_left_actions[page][bank][i])
+			}
+		}
+		if (
+			self.bank_rotate_right_actions[page] !== undefined &&
+			self.bank_rotate_right_actions[page][bank] !== undefined
+		) {
+			// find all instance-ids in release_actions for bank
+			for (var i in self.bank_rotate_right_actions[page][bank]) {
+				self.unsubscribeAction(self.bank_rotate_right_actions[page][bank][i])
 			}
 		}
 	})
@@ -871,7 +1145,17 @@ function action(system) {
 		}
 		self.bank_release_actions[page][bank] = []
 
-		debug('bank_reset()', page, bank, self.bank_actions[page][bank])
+		if (self.bank_rotate_left_actions[page] === undefined) {
+			self.bank_rotate_left_actions[page] = {}
+		}
+		self.bank_rotate_left_actions[page][bank] = []
+
+		if (self.bank_rotate_right_actions[page] === undefined) {
+			self.bank_rotate_right_actions[page] = {}
+		}
+		self.bank_rotate_right_actions[page][bank] = []
+
+		debug('bank_reset()', page, bank)
 
 		self.system.emit('action_save')
 	})

--- a/lib/bank.js
+++ b/lib/bank.js
@@ -278,6 +278,11 @@ function bank(system) {
 	})
 
 	system.on('bank_changefield', function (page, bank, key, val) {
+		// Cleanup any rotary actions that are now hidden/disabled
+		if (key === 'rotary_actions') {
+			system.emit('clear_bank_rotary_actions', page, bank)
+		}
+
 		self.config[page][bank][key] = val
 		system.emit('bank_update', self.config)
 		system.emit('graphics_bank_invalidate', page, bank)

--- a/lib/bank.js
+++ b/lib/bank.js
@@ -323,6 +323,11 @@ function bank(system) {
 			system.emit('bank_pressed', page, button, direction)
 		})
 
+		client.on('hot_rotate', function (page, button, direction) {
+			debug('being told from gui to hot rotate', page, button, direction)
+			system.emit('bank_rotated', page, button, direction)
+		})
+
 		client.on('bank_set_png', function (page, bank, dataurl, answer) {
 			if (!dataurl.match(/data:.*?image\/png/)) {
 				sendResult(answer, 'bank_set_png:result', 'error')
@@ -390,6 +395,7 @@ function bank(system) {
 			client.removeAllListeners('get_all_banks')
 			client.removeAllListeners('get_bank')
 			client.removeAllListeners('hot_press')
+			client.removeAllListeners('hot_rotate')
 			client.removeAllListeners('bank_set_png')
 			client.removeAllListeners('bank_changefield')
 			client.removeAllListeners('bank_copy')

--- a/lib/device.js
+++ b/lib/device.js
@@ -351,6 +351,47 @@ function device(_system, panel) {
 		}
 	}
 	system.on('elgato_click', self.on_elgato_click)
+	self.on_elgato_rotate = function (devicepath, key, state) {
+		if (devicepath != self.devicepath) {
+			return
+		}
+		if (!self.lockedout) {
+			self.lastinteraction = Date.now()
+			self.lockoutat = self.userconfig.pin_timeout * 1000 + Date.now()
+
+			// Translate key for offset
+			const xOffset = Math.min(Math.max(self.panelconfig.config.xOffset || 0, 0), self.panelinfo.xOffsetMax)
+			const yOffset = Math.min(Math.max(self.panelconfig.config.yOffset || 0, 0), self.panelinfo.yOffsetMax)
+
+			// Note: the maths looks inverted, but its already been through toGlobalKey
+			key = parseInt(key) + xOffset + yOffset * global.MAX_BUTTONS_PER_ROW
+
+			// var thispress = self.panel.serialnumber + '_' + self.page
+			// if (state) {
+			// 	self.lastpress = thispress
+			// 	self.lastpage = self.page
+			// } else if (thispress != self.lastpress) {
+			// 	// page changed on this device before button released
+			// 	// release the old page+bank
+			// 	system.emit('bank_pressed', self.lastpage, key + 1, false, self.panel.serialnumber)
+			// 	self.lastpress = ''
+			// 	return
+			// } else {
+			// 	self.lastpress = ''
+			// }
+
+			system.emit('bank_rotated', self.page, key + 1, state, self.panel.serialnumber)
+			system.emit(
+				'log',
+				'device(' + self.panel.serialnumber + ')',
+				'debug',
+				'Rotary ' + self.page + '.' + (key + 1) + ' rotated ' + (state ? 'right' : 'left')
+			)
+		} else {
+			// Ignore when locked out
+		}
+	}
+	system.on('elgato_rotate', self.on_elgato_rotate)
 
 	system.emit('bank_update_request')
 }

--- a/lib/device.js
+++ b/lib/device.js
@@ -538,6 +538,7 @@ device.prototype.unload = function () {
 	system.removeListener('graphics_bank_invalidated', self.on_bank_invalidated)
 	system.removeListener('elgato_ready', self.on_elgato_ready)
 	system.removeListener('elgato_click', self.on_elgato_click)
+	system.removeListener('elgato_rotate', self.on_elgato_rotate)
 	system.removeListener('lockoutall', self.lockoutAll)
 	system.removeListener('unlockoutall', self.unlockoutAll)
 	system.removeListener('lockout_device', self.lockoutDevice)

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -516,24 +516,13 @@ instance.prototype.upgrade_instance_config = function (id, instance_type) {
 	self.system.emit('actions_for_instance', id, function (_actions) {
 		actions = _actions
 	})
-	var release_actions = []
-	self.system.emit('release_actions_for_instance', id, function (_release_actions) {
-		release_actions = _release_actions
-	})
 	var feedbacks = []
 	self.system.emit('feedbacks_for_instance', id, function (_feedbacks) {
 		feedbacks = _feedbacks
 	})
 
 	const config = self.store.db[id]
-	const changed = self.upgrade_instance_config_partial(
-		id,
-		instance_type,
-		config._configIdx,
-		config,
-		[...actions, ...release_actions],
-		feedbacks
-	)
+	const changed = self.upgrade_instance_config_partial(id, instance_type, config._configIdx, config, actions, feedbacks)
 
 	// If anything was changed, update system and db
 	if (changed) {

--- a/lib/loadsave.js
+++ b/lib/loadsave.js
@@ -45,6 +45,14 @@ function loadsave(_system) {
 		self.bank_release_actions = bank_release_actions
 	})
 
+	system.emit('rotate_left_action_get_banks', function (bank_rotate_left_actions) {
+		self.bank_rotate_left_actions = bank_rotate_left_actions
+	})
+
+	system.emit('rotate_right_action_get_banks', function (bank_rotate_right_actions) {
+		self.bank_rotate_right_actions = bank_rotate_right_actions
+	})
+
 	system.emit('feedback_getall', function (feedbacks) {
 		self.feedbacks = feedbacks
 	})
@@ -61,6 +69,14 @@ function loadsave(_system) {
 
 		if (self.bank_release_actions[page] !== undefined) {
 			exp.release_actions = _.cloneDeep(self.bank_release_actions[page][bank])
+		}
+
+		if (self.bank_rotate_left_actions[page] !== undefined) {
+			exp.rotate_left_actions = _.cloneDeep(self.bank_rotate_left_actions[page][bank])
+		}
+
+		if (self.bank_rotate_right_actions[page] !== undefined) {
+			exp.rotate_right_actions = _.cloneDeep(self.bank_rotate_right_actions[page][bank])
 		}
 
 		if (self.feedbacks[page] !== undefined) {
@@ -324,6 +340,26 @@ function loadsave(_system) {
 						}
 
 						if (
+							data.rotate_left_actions !== undefined &&
+							data.rotate_left_actions[page] !== undefined &&
+							data.rotate_left_actions[page][bank] !== undefined
+						) {
+							obj.rotate_left_actions = data.rotate_left_actions[page][bank]
+						} else {
+							obj.rotate_left_actions = []
+						}
+
+						if (
+							data.rotate_right_actions !== undefined &&
+							data.rotate_right_actions[page] !== undefined &&
+							data.rotate_right_actions[page][bank] !== undefined
+						) {
+							obj.rotate_right_actions = data.rotate_right_actions[page][bank]
+						} else {
+							obj.rotate_right_actions = []
+						}
+
+						if (
 							data.feedbacks !== undefined &&
 							data.feedbacks[page] !== undefined &&
 							data.feedbacks[page][bank] !== undefined
@@ -365,6 +401,8 @@ function loadsave(_system) {
 					data.config = data.config[frompage]
 					data.actions = data.actions === undefined ? {} : data.actions[frompage]
 					data.release_actions = data.release_actions === undefined ? {} : data.release_actions[frompage]
+					data.rotate_left_actions = data.rotate_left_actions === undefined ? {} : data.rotate_left_actions[frompage]
+					data.rotate_right_actions = data.rotate_right_actions === undefined ? {} : data.rotate_right_actions[frompage]
 					data.feedbacks = data.feedbacks === undefined ? {} : data.feedbacks[frompage]
 				}
 
@@ -471,6 +509,40 @@ function loadsave(_system) {
 						}
 					}
 
+					for (var bank in data.rotate_left_actions) {
+						if (!self.instance[instance_id]) {
+							// filter out actions from the missing instance
+							data.rotate_left_actions[bank] = data.rotate_left_actions[bank].filter((a) => a.instance != key)
+						} else {
+							for (var i = 0; i < data.rotate_left_actions[bank].length; ++i) {
+								var act = data.rotate_left_actions[bank][i]
+
+								if (act.instance == key) {
+									act.instance = instance_id
+									act.label = act.instance + ':' + act.action
+									instance_actions.push(act)
+								}
+							}
+						}
+					}
+
+					for (var bank in data.rotate_right_actions) {
+						if (!self.instance[instance_id]) {
+							// filter out actions from the missing instance
+							data.rotate_right_actions[bank] = data.rotate_right_actions[bank].filter((a) => a.instance != key)
+						} else {
+							for (var i = 0; i < data.rotate_right_actions[bank].length; ++i) {
+								var act = data.rotate_right_actions[bank][i]
+
+								if (act.instance == key) {
+									act.instance = instance_id
+									act.label = act.instance + ':' + act.action
+									instance_actions.push(act)
+								}
+							}
+						}
+					}
+
 					let instance_feedbacks = []
 					for (var bank in data.feedbacks) {
 						if (!self.instance[instance_id]) {
@@ -512,6 +584,8 @@ function loadsave(_system) {
 					obj.config = data.config !== undefined ? data.config[bank] : {}
 					obj.actions = data.actions !== undefined ? data.actions[bank] : []
 					obj.release_actions = data.release_actions !== undefined ? data.release_actions[bank] : []
+					obj.rotate_left_actions = data.rotate_left_actions !== undefined ? data.rotate_left_actions[bank] : []
+					obj.rotate_right_actions = data.rotate_right_actions !== undefined ? data.rotate_right_actions[bank] : []
 					obj.feedbacks = data.feedbacks !== undefined ? data.feedbacks[bank] : []
 
 					system.emit('import_bank', topage, bank, obj)
@@ -565,6 +639,38 @@ function loadsave(_system) {
 				var obj = imp.release_actions[i]
 				obj.id = shortid.generate()
 				release_actions.push(obj)
+			}
+		}
+
+		if (imp.rotate_left_actions !== undefined) {
+			if (self.bank_rotate_left_actions[page] === undefined) {
+				self.bank_rotate_left_actions[page] = {}
+			}
+			if (self.bank_rotate_left_actions[page][bank] === undefined) {
+				self.bank_rotate_left_actions[page][bank] = []
+			}
+			var rotate_left_actions = self.bank_rotate_left_actions[page][bank]
+
+			for (var i = 0; i < imp.rotate_left_actions.length; ++i) {
+				var obj = imp.rotate_left_actions[i]
+				obj.id = shortid.generate()
+				rotate_left_actions.push(obj)
+			}
+		}
+
+		if (imp.rotate_right_actions !== undefined) {
+			if (self.bank_rotate_right_actions[page] === undefined) {
+				self.bank_rotate_right_actions[page] = {}
+			}
+			if (self.bank_rotate_right_actions[page][bank] === undefined) {
+				self.bank_rotate_right_actions[page][bank] = []
+			}
+			var rotate_right_actions = self.bank_rotate_right_actions[page][bank]
+
+			for (var i = 0; i < imp.rotate_right_actions.length; ++i) {
+				var obj = imp.rotate_right_actions[i]
+				obj.id = shortid.generate()
+				rotate_right_actions.push(obj)
 			}
 		}
 
@@ -739,6 +845,8 @@ function loadsave(_system) {
 
 			exp.actions = self.bank_actions[page]
 			exp.release_actions = self.bank_release_actions[page]
+			exp.rotate_left_actions = self.bank_rotate_left_actions[page]
+			exp.rotate_right_actions = self.bank_rotate_right_actions[page]
 			exp.feedbacks = self.feedbacks[page]
 
 			system.emit('get_page', function (page_config) {
@@ -761,6 +869,21 @@ function loadsave(_system) {
 					}
 				}
 			}
+			for (var bank of Object.values(exp.rotate_left_actions)) {
+				if (bank) {
+					for (var action of bank) {
+						instance_ids.add(action.instance)
+					}
+				}
+			}
+			for (var bank of Object.values(exp.rotate_right_actions)) {
+				if (bank) {
+					for (var action of bank) {
+						instance_ids.add(action.instance)
+					}
+				}
+			}
+
 			for (var bank of Object.values(exp.feedbacks)) {
 				if (bank) {
 					for (var feedback of bank) {
@@ -798,6 +921,8 @@ function loadsave(_system) {
 
 			exp.actions = self.bank_actions
 			exp.release_actions = self.bank_release_actions
+			exp.rotate_left_actions = self.bank_rotate_left_actions
+			exp.rotate_right_actions = self.bank_rotate_right_actions
 
 			system.emit('get_page', function (page_config) {
 				exp.page = page_config

--- a/lib/satellite/satellite_device.js
+++ b/lib/satellite/satellite_device.js
@@ -51,6 +51,9 @@ function satellite_device(system, deviceInfo) {
 	system.on(deviceInfo.path + '_button', function (key, state) {
 		self.doButton(key, state)
 	})
+	system.on(deviceInfo.path + '_rotate', function (key, direction) {
+		self.doRotate(key, direction)
+	})
 
 	setImmediate(() => {
 		system.emit('elgato_ready', self.devicepath)
@@ -68,6 +71,7 @@ satellite_device.prototype.begin = function () {
 satellite_device.prototype.quit = function () {
 	var self = this
 	self.system.removeAllListeners(self.devicepath + '_button')
+	self.system.removeAllListeners(self.devicepath + '_rotate')
 }
 
 satellite_device.prototype.draw = function (key, buffer, style, isPressed) {
@@ -125,6 +129,14 @@ satellite_device.prototype.doButton = function (key, state) {
 	const keyIndex2 = this.toGlobalKey(key)
 
 	self.system.emit('elgato_click', self.devicepath, keyIndex2, state)
+}
+
+satellite_device.prototype.doRotate = function (key, direction) {
+	var self = this
+
+	const keyIndex2 = this.toGlobalKey(key)
+
+	self.system.emit('elgato_rotate', self.devicepath, keyIndex2, direction)
 }
 
 satellite_device.prototype.clearDeck = function () {

--- a/lib/satellite/satellite_server.js
+++ b/lib/satellite/satellite_server.js
@@ -22,8 +22,9 @@ const net = require('net')
  * 1.0.0 - Initial release
  * 1.1.0 - Add KEY-STATE TYPE and PRESSED properties
  * 1.2.0 - Add DEVICEID to any ERROR responses when known
+ * 1.3.0 - Add KEY-ROTATE message
  */
-const API_VERSION = '1.2.0'
+const API_VERSION = '1.3.0'
 
 function isFalsey(val) {
 	return (typeof val === 'string' && val.toLowerCase() == 'false') || val == '0'
@@ -150,6 +151,9 @@ class satelliteServer {
 				break
 			case 'KEY-PRESS':
 				this.keyPress(socket, params)
+				break
+			case 'KEY-ROTATE':
+				this.keyRotate(socket, params)
 				break
 			case 'PING':
 				socket.write(`PONG ${body}\n`)
@@ -281,6 +285,37 @@ class satelliteServer {
 			socket.write(`KEY-PRESS OK\n`)
 		} else {
 			socket.write(`KEY-PRESS ERROR DEVICEID="${params.DEVICEID}" MESSAGE="Device not found"\n`)
+		}
+	}
+	keyRotate(socket, params) {
+		if (!params.DEVICEID) {
+			socket.write(`KEY-ROTATE ERROR MESSAGE="Missing DEVICEID"\n`)
+			return
+		}
+		if (!params.KEY) {
+			socket.write(`KEY-ROTATE ERROR DEVICEID="${params.DEVICEID}" MESSAGE="Missing KEY"\n`)
+			return
+		}
+		if (!params.DIRECTION) {
+			socket.write(`KEY-ROTATE ERROR DEVICEID="${params.DEVICEID}" MESSAGE="Missing DIRECTION"\n`)
+			return
+		}
+
+		const key = parseInt(params.KEY)
+		if (isNaN(key) || key > global.MAX_BUTTONS || key < 0) {
+			socket.write(`KEY-ROTATE ERROR DEVICEID="${params.DEVICEID}" MESSAGE="Invalid KEY"\n`)
+			return
+		}
+
+		const direction = params.DIRECTION >= '1'
+
+		const id = `satellite-${params.DEVICEID}`
+		const device = this.devices[id]
+		if (device && device.socket === socket) {
+			this.system.emit(id + '_rotate', key, direction)
+			socket.write(`KEY-ROTATE OK\n`)
+		} else {
+			socket.write(`KEY-ROTATE ERROR DEVICEID="${params.DEVICEID}" MESSAGE="Device not found"\n`)
 		}
 	}
 }

--- a/lib/usb/loupedeck-live.js
+++ b/lib/usb/loupedeck-live.js
@@ -263,7 +263,7 @@ class LoupedeckLive {
 
 		if (key >= 24 && key < 32) {
 			const id = key - 24
-			if (id) {
+			if (id >= 0) {
 				const color = style ? colorToRgb(style.bgcolor) : { r: 0, g: 0, b: 0 }
 
 				self.loupedeck

--- a/lib/usb/loupedeck-live.js
+++ b/lib/usb/loupedeck-live.js
@@ -50,17 +50,17 @@ function rotaryToButtonIndex(info) {
 	if (info.type === 'rotary') {
 		switch (info.index) {
 			case 0:
-				return 1
+				return 0
 			case 1:
-				return 9
+				return 8
 			case 2:
-				return 17
+				return 16
 			case 3:
-				return 6
+				return 7
 			case 4:
-				return 14
+				return 15
 			case 5:
-				return 22
+				return 23
 			default:
 				return undefined
 		}
@@ -138,33 +138,12 @@ class LoupedeckLive {
 				self.loupedeck.on('rotate', function (info, delta) {
 					if (info.type !== 'rotary') return
 
-					let key = undefined
-					switch (info.index) {
-						case 0:
-							key = 0
-							break
-						case 1:
-							key = 8
-							break
-						case 2:
-							key = 16
-							break
-						case 3:
-							key = 7
-							break
-						case 4:
-							key = 15
-							break
-						case 5:
-							key = 23
-							break
-					}
-
+					const key = rotaryToButtonIndex(info)
 					if (key === undefined) {
 						return
 					}
 
-					self.system.emit('elgato_click', devicepath, key, delta == 1)
+					self.system.emit('elgato_rotate', devicepath, key, delta == 1)
 				})
 				self.loupedeck.on('touchstart', (data) => {
 					for (const touch of data.changedTouches) {

--- a/webui/src/Buttons/EditButton/ButtonStyleConfig.jsx
+++ b/webui/src/Buttons/EditButton/ButtonStyleConfig.jsx
@@ -11,7 +11,7 @@ import {
 } from '../../Components'
 import { FONT_SIZES } from '../../Constants'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faTrash } from '@fortawesome/free-solid-svg-icons'
+import { faQuestionCircle, faTrash } from '@fortawesome/free-solid-svg-icons'
 
 export function ButtonStyleConfig({ page, bank, config, configRef, valueChanged }) {
 	const context = useContext(StaticContext)
@@ -51,6 +51,7 @@ export function ButtonStyleConfig({ page, bank, config, configRef, valueChanged 
 
 	const setShowTopBar = useCallback((val) => setValueInner('show_topbar', val), [setValueInner])
 	const setLatchValue = useCallback((val) => setValueInner('latch', val), [setValueInner])
+	const setRotaryActions = useCallback((val) => setValueInner('rotary_actions', val), [setValueInner])
 	const setRelativeDelayValue = useCallback((val) => setValueInner('relative_delay', val), [setValueInner])
 
 	switch (config.style) {
@@ -127,6 +128,22 @@ export function ButtonStyleConfig({ page, bank, config, configRef, valueChanged 
 								definition={{ default: false }}
 								setValue={setRelativeDelayValue}
 								value={config.relative_delay}
+							/>
+						</p>
+					</CCol>
+					<CCol className="fieldtype-checkbox" sm={2} xs={3}>
+						<label>
+							Enable Rotary Actions
+							<FontAwesomeIcon
+								icon={faQuestionCircle}
+								title="Make this bank compatible with rotation events for the Loupedeck Live product range"
+							/>
+						</label>
+						<p>
+							<CheckboxInputField
+								definition={{ default: false, id: 'rotary_actions' }}
+								setValue={setRotaryActions}
+								value={config.rotary_actions}
 							/>
 						</p>
 					</CCol>

--- a/webui/src/Buttons/EditButton/index.jsx
+++ b/webui/src/Buttons/EditButton/index.jsx
@@ -142,7 +142,6 @@ export function EditButton({ page, bank, onKeyUp }) {
 							</CButtonGroup>
 							<CDropdownMenu>
 								<CDropdownItem onClick={() => setButtonType('png')}>Regular button</CDropdownItem>
-								<CDropdownItem onClick={() => setButtonType('rotary')}>Rotary Encoder</CDropdownItem>
 								<CDropdownItem onClick={() => setButtonType('pageup')}>Page up</CDropdownItem>
 								<CDropdownItem onClick={() => setButtonType('pagenum')}>Page number</CDropdownItem>
 								<CDropdownItem onClick={() => setButtonType('pagedown')}>Page down</CDropdownItem>
@@ -156,18 +155,18 @@ export function EditButton({ page, bank, onKeyUp }) {
 						<CButtonGroup>
 							<CButton
 								color="warning"
-								hidden={config.style !== 'png' && config.style !== 'rotary'}
+								hidden={config.style !== 'png'}
 								onMouseDown={() => context.socket.emit('hot_press', page, bank, true)}
 								onMouseUp={() => context.socket.emit('hot_press', page, bank, false)}
 							>
 								Test press
 							</CButton>
-							{config.style === 'rotary' && (
+							{config.rotary_actions && (
 								<CButton color="warning" onMouseDown={() => context.socket.emit('hot_rotate', page, bank, false)}>
 									Click Left
 								</CButton>
 							)}
-							{config.style === 'rotary' && (
+							{config.rotary_actions && (
 								<CButton color="warning" onMouseDown={() => context.socket.emit('hot_rotate', page, bank, true)}>
 									Click Right
 								</CButton>
@@ -177,7 +176,7 @@ export function EditButton({ page, bank, onKeyUp }) {
 
 					<ButtonStyleConfig config={config} configRef={configRef} page={page} bank={bank} valueChanged={loadConfig} />
 
-					{config.style === 'rotary' && (
+					{config.rotary_actions && (
 						<>
 							<h4 className="mt-3">Rotate left actions</h4>
 							<ActionsPanel
@@ -217,7 +216,7 @@ export function EditButton({ page, bank, onKeyUp }) {
 						</>
 					)}
 
-					{config.style === 'png' || config.style === 'rotary' ? (
+					{config.style === 'png' ? (
 						<>
 							<h4 className="mt-3">{config.latch ? 'Latch' : 'Press'} actions</h4>
 							<ActionsPanel

--- a/webui/src/Buttons/EditButton/index.jsx
+++ b/webui/src/Buttons/EditButton/index.jsx
@@ -142,6 +142,7 @@ export function EditButton({ page, bank, onKeyUp }) {
 							</CButtonGroup>
 							<CDropdownMenu>
 								<CDropdownItem onClick={() => setButtonType('png')}>Regular button</CDropdownItem>
+								<CDropdownItem onClick={() => setButtonType('rotary')}>Rotary Encoder</CDropdownItem>
 								<CDropdownItem onClick={() => setButtonType('pageup')}>Page up</CDropdownItem>
 								<CDropdownItem onClick={() => setButtonType('pagenum')}>Page number</CDropdownItem>
 								<CDropdownItem onClick={() => setButtonType('pagedown')}>Page down</CDropdownItem>
@@ -152,19 +153,71 @@ export function EditButton({ page, bank, onKeyUp }) {
 							Erase
 						</CButton>
 						&nbsp;
-						<CButton
-							color="warning"
-							hidden={config.style !== 'png'}
-							onMouseDown={() => context.socket.emit('hot_press', page, bank, true)}
-							onMouseUp={() => context.socket.emit('hot_press', page, bank, false)}
-						>
-							Test actions
-						</CButton>
+						<CButtonGroup>
+							<CButton
+								color="warning"
+								hidden={config.style !== 'png' && config.style !== 'rotary'}
+								onMouseDown={() => context.socket.emit('hot_press', page, bank, true)}
+								onMouseUp={() => context.socket.emit('hot_press', page, bank, false)}
+							>
+								Test press
+							</CButton>
+							{config.style === 'rotary' && (
+								<CButton color="warning" onMouseDown={() => context.socket.emit('hot_rotate', page, bank, false)}>
+									Click Left
+								</CButton>
+							)}
+							{config.style === 'rotary' && (
+								<CButton color="warning" onMouseDown={() => context.socket.emit('hot_rotate', page, bank, true)}>
+									Click Right
+								</CButton>
+							)}
+						</CButtonGroup>
 					</div>
 
 					<ButtonStyleConfig config={config} configRef={configRef} page={page} bank={bank} valueChanged={loadConfig} />
 
-					{config.style === 'png' ? (
+					{config.style === 'rotary' && (
+						<>
+							<h4 className="mt-3">Rotate left actions</h4>
+							<ActionsPanel
+								page={page}
+								bank={bank}
+								dragId={'rotateLeftAction'}
+								addCommand="bank_addRotateLeftAction"
+								getCommand="bank_rotate_left_actions_get"
+								updateOption="bank_rotate_left_action_update_option"
+								orderCommand="bank_rotate_left_action_update_option_order"
+								setDelay="bank_update_rotate_left_action_delay"
+								deleteCommand="bank_rotate_left_action_delete"
+								learnCommand="bank_rotate_left_action_learn"
+								addPlaceholder="+ Add rotate left action"
+								loadStatusKey={'rotateLeftActions'}
+								setLoadStatus={addLoadStatus}
+								reloadToken={reloadTablesToken}
+							/>
+
+							<h4 className="mt-3">Rotate right actions</h4>
+							<ActionsPanel
+								page={page}
+								bank={bank}
+								dragId={'rotateRightAction'}
+								addCommand="bank_addRotateRightAction"
+								getCommand="bank_rotate_right_actions_get"
+								updateOption="bank_rotate_right_action_update_option"
+								orderCommand="bank_rotate_right_action_update_option_order"
+								setDelay="bank_update_rotate_right_action_delay"
+								deleteCommand="bank_rotate_right_action_delete"
+								learnCommand="bank_rotate_right_action_learn"
+								addPlaceholder="+ Add rotate right action"
+								loadStatusKey={'rotateRightActions'}
+								setLoadStatus={addLoadStatus}
+								reloadToken={reloadTablesToken}
+							/>
+						</>
+					)}
+
+					{config.style === 'png' || config.style === 'rotary' ? (
 						<>
 							<h4 className="mt-3">{config.latch ? 'Latch' : 'Press'} actions</h4>
 							<ActionsPanel


### PR DESCRIPTION
Follow up to #2110.

Programming for the encoders on the loupedeck-live is confusing due to how they are split across two buttons. There is also a bug which is easy to hit, where turning left sometimes doesnt fire without turning right once first. I suspect something to do with wanting to reject up events if there wasnt a recent down event?

This adds a minimal/simple way for the user to mark a button as being an encoder, and presenting 4 groups of actions:
* press/latch
* release/unlatch
* rotate left
* rotate right

I am unsure if this should be done as its own mode like this, or if it should be done as a checkbox/button next to the latching option, to show the extra fields. 
A mode like this feels simpler/cleaner, but it could cause frustration, as switching a button to an encoder does reset it

![image (28)](https://user-images.githubusercontent.com/1327476/198882892-c3214d9a-a5ee-4a5e-afd6-575529379fbd.png)
![image (27)](https://user-images.githubusercontent.com/1327476/198882897-7727f850-6cbe-4f3f-a821-20ba7631b9c0.png)
![image (26)](https://user-images.githubusercontent.com/1327476/198882899-e6faa070-f7fc-434f-a3b8-9cdc49b0b3dd.png)

As part of this change, the loupedeck has been changed to utilise this instead of the split method, with the buttons it use to also use (in column 2 and 7), no longer used. In the future these could be used for the tall touch strip.

The satellite protocol has been extended to support this:
```
Rotating an encoder
KEY-ROTATE DEVICEID=00000 KEY=0 DIRECTION=1

DEVICEID the unique identifier used to add the device
KEY number of the key/encoder which is rotated
DIRECTION direction of the rotation. 1 for right, -1 for left
```

Import/export should be working, but needs some testing.
