### PR TITLE
feat: make surface ids unique

### DIFF
--- a/lib/Data/Metrics.js
+++ b/lib/Data/Metrics.js
@@ -37,7 +37,7 @@ class DataMetrics extends CoreBase {
 
 		try {
 			Object.values(devices).forEach((device) => {
-				if (device.id !== undefined && device.id !== 'emulator') {
+				if (device.id !== undefined && !device.id.startsWith('emulator:')) {
 					// remove leading "satellite-" from satellite device serial numbers.
 					const serialNumber = device.id.replace('satellite-', '')
 					// normalize serialnumber by md5 hashing it, we don't want/need the specific serialnumber anyways.

--- a/lib/Data/Metrics.js
+++ b/lib/Data/Metrics.js
@@ -38,8 +38,10 @@ class DataMetrics extends CoreBase {
 		try {
 			Object.values(devices).forEach((device) => {
 				if (device.id !== undefined && !device.id.startsWith('emulator:')) {
+					// remove leading "satellite-" from satellite device serial numbers.
+					const serialNumber = device.id.replace('satellite-', '')
 					// normalize serialnumber by md5 hashing it, we don't want/need the specific serialnumber anyways.
-					const deviceHash = crypto.createHash('md5').update(device.id).digest('hex')
+					const deviceHash = crypto.createHash('md5').update(serialNumber).digest('hex')
 					if (deviceHash && deviceHash.length === 32) relevantDevices.push(deviceHash)
 				}
 			})

--- a/lib/Data/Metrics.js
+++ b/lib/Data/Metrics.js
@@ -38,10 +38,8 @@ class DataMetrics extends CoreBase {
 		try {
 			Object.values(devices).forEach((device) => {
 				if (device.id !== undefined && !device.id.startsWith('emulator:')) {
-					// remove leading "satellite-" from satellite device serial numbers.
-					const serialNumber = device.id.replace('satellite-', '')
 					// normalize serialnumber by md5 hashing it, we don't want/need the specific serialnumber anyways.
-					const deviceHash = crypto.createHash('md5').update(serialNumber).digest('hex')
+					const deviceHash = crypto.createHash('md5').update(device.id).digest('hex')
 					if (deviceHash && deviceHash.length === 32) relevantDevices.push(deviceHash)
 				}
 			})

--- a/lib/Data/Upgrades/v2tov3.js
+++ b/lib/Data/Upgrades/v2tov3.js
@@ -319,6 +319,26 @@ function convertEmulatorToV3(db) {
 	}
 }
 
+function convertSurfacesToV3(db) {
+	const devices = db.getKey('deviceconfig')
+
+	// Ignore satellite for now, as that has not been updated, and no colon
+	const keys = Object.keys(devices).filter((d) => !d.startsWith('satellite-') && d.indexOf(':') === -1)
+
+	for (const key of keys) {
+		const key2 = key.trim()
+		if (key2.length === 12) {
+			// add prefix to known streamdeck
+			devices[`streamdeck:${key2}`] = devices[key]
+			delete devices[key]
+		} else if (key2.length === '27') {
+			// add prefix to known loupedeck
+			devices[`loupedeck:${key2}`] = devices[key]
+			delete devices[key]
+		}
+	}
+}
+
 /** do the database upgrades to convert from the v1 to the v2 format */
 function convertDatabaseToV3(db, logger) {
 	convertInstancesToV3(db)
@@ -328,6 +348,7 @@ function convertDatabaseToV3(db, logger) {
 	convertSchedulerToControls(db, logger)
 
 	convertEmulatorToV3(db)
+	convertSurfacesToV3(db)
 }
 
 function convertPageToV3(oldObj) {

--- a/lib/Internal/Surface.js
+++ b/lib/Internal/Surface.js
@@ -211,7 +211,7 @@ export default class Surface extends CoreBase {
 		if (action.action === 'set_brightness') {
 			const { theController } = fetchPageAndBankAndController(action.options, extras)
 
-			this.surfaces.setDeviceBrightness(theController, action.options.brightness)
+			this.surfaces.setDeviceBrightness(theController, action.options.brightness, true)
 			return true
 		} else if (action.action === 'set_page') {
 			const { theController, thePage } = fetchPageAndBankAndController(action.options, extras)
@@ -253,7 +253,7 @@ export default class Surface extends CoreBase {
 					if (this.userconfig.getKey('link_lockouts')) {
 						this.surfaces.setAllLocked(true)
 					} else {
-						this.surfaces.setDeviceLocked(theController, true)
+						this.surfaces.setDeviceLocked(theController, true, true)
 					}
 				})
 			}
@@ -266,7 +266,7 @@ export default class Surface extends CoreBase {
 					if (this.userconfig.getKey('link_lockouts')) {
 						this.surfaces.setAllLocked(false)
 					} else {
-						this.surfaces.setDeviceLocked(theController, false)
+						this.surfaces.setDeviceLocked(theController, false, true)
 					}
 				})
 			}
@@ -302,7 +302,7 @@ export default class Surface extends CoreBase {
 	}
 
 	#changeSurfacePage(surfaceId, toPage) {
-		const currentPage = this.surfaces.devicePageGet(surfaceId)
+		const currentPage = this.surfaces.devicePageGet(surfaceId, true)
 		if (currentPage === undefined) {
 			// Bad surfaceId
 		} else {
@@ -328,7 +328,7 @@ export default class Surface extends CoreBase {
 					pageHistory.index = pageIndex
 
 					setImmediate(() => {
-						this.surfaces.devicePageSet(surfaceId, pageTarget)
+						this.surfaces.devicePageSet(surfaceId, pageTarget, true)
 					})
 				}
 			} else {
@@ -346,7 +346,7 @@ export default class Surface extends CoreBase {
 
 				// Change page after this runloop
 				setImmediate(() => {
-					this.surfaces.devicePageSet(surfaceId, newPage)
+					this.surfaces.devicePageSet(surfaceId, newPage, true)
 				})
 
 				// Clear forward page history beyond current index, add new history entry, increment index;

--- a/lib/Service/Satellite.js
+++ b/lib/Service/Satellite.js
@@ -76,7 +76,7 @@ class ServiceSatellite extends ServiceBase {
 			return
 		}
 
-		const id = `satellite-${params.DEVICEID}`
+		const id = `${params.DEVICEID}`
 
 		const existing = Object.entries(this.devices).find(([internalId, dev]) => dev.id === id)
 		if (existing) {
@@ -270,7 +270,7 @@ class ServiceSatellite extends ServiceBase {
 
 		const pressed = !isFalsey(params.PRESSED)
 
-		const id = `satellite-${params.DEVICEID}`
+		const id = `${params.DEVICEID}`
 		const device = this.devices[id]
 
 		if (device && device.socket === socket) {
@@ -308,7 +308,7 @@ class ServiceSatellite extends ServiceBase {
 
 		const direction = params.DIRECTION >= '1'
 
-		const id = `satellite-${params.DEVICEID}`
+		const id = `${params.DEVICEID}`
 		const device = this.devices[id]
 		if (device && device.socket === socket) {
 			device.device.doRotate(key, direction)
@@ -329,7 +329,7 @@ class ServiceSatellite extends ServiceBase {
 			return
 		}
 
-		const id = `satellite-${params.DEVICEID}`
+		const id = `${params.DEVICEID}`
 		const device = this.devices[id]
 
 		if (device && device.socket === socket) {

--- a/lib/Surface/Controller.js
+++ b/lib/Surface/Controller.js
@@ -537,30 +537,26 @@ class SurfaceController extends CoreBase {
 		return undefined
 	}
 
-	devicePageUp(deviceId) {
-		deviceId = this.fixupDeviceId(deviceId)
-		const device = Object.values(this.instances).find((d) => d.deviceId === deviceId)
+	devicePageUp(deviceId, looseIdMatching) {
+		const device = this.#getDeviceForId(deviceId, looseIdMatching)
 		if (device) {
 			device.doPageUp()
 		}
 	}
-	devicePageDown(deviceId) {
-		deviceId = this.fixupDeviceId(deviceId)
-		const device = Object.values(this.instances).find((d) => d.deviceId === deviceId)
+	devicePageDown(deviceId, looseIdMatching) {
+		const device = this.#getDeviceForId(deviceId, looseIdMatching)
 		if (device) {
 			device.doPageDown()
 		}
 	}
-	devicePageSet(deviceId, page) {
-		deviceId = this.fixupDeviceId(deviceId)
-		const device = Object.values(this.instances).find((d) => d.deviceId === deviceId)
+	devicePageSet(deviceId, page, looseIdMatching) {
+		const device = this.#getDeviceForId(deviceId, looseIdMatching)
 		if (device) {
 			device.setCurrentPage(page)
 		}
 	}
-	devicePageGet(deviceId) {
-		deviceId = this.fixupDeviceId(deviceId)
-		const device = Object.values(this.instances).find((d) => d.deviceId === deviceId)
+	devicePageGet(deviceId, looseIdMatching) {
+		const device = this.#getDeviceForId(deviceId, looseIdMatching)
 		if (device) {
 			return device.getCurrentPage()
 		} else {
@@ -574,25 +570,45 @@ class SurfaceController extends CoreBase {
 		}
 	}
 
-	setDeviceLocked(deviceId, locked) {
-		deviceId = this.fixupDeviceId(deviceId)
-		const device = Object.values(this.instances).find((d) => d.deviceId === deviceId)
+	setDeviceLocked(deviceId, locked, looseIdMatching) {
+		const device = this.#getDeviceForId(deviceId, looseIdMatching)
 		if (device) {
 			device.setLocked(!!locked)
 		}
 	}
 
-	setDeviceBrightness(deviceId, brightness) {
-		deviceId = this.fixupDeviceId(deviceId)
-		const device = Object.values(this.instances).find((d) => d.deviceId === deviceId)
+	setDeviceBrightness(deviceId, brightness, looseIdMatching) {
+		const device = this.#getDeviceForId(deviceId, looseIdMatching)
 		if (device) {
 			device.setBrightness(brightness)
 		}
 	}
 
-	fixupDeviceId(deviceId) {
-		if (deviceId === 'emulator') return 'emulator:emulator'
-		return deviceId
+	#getDeviceForId(deviceId, looseIdMatching) {
+		if (deviceId === 'emulator') deviceId = 'emulator:emulator'
+
+		const instances = Object.values(this.instances)
+
+		// try and find exact match
+		let device = instances.find((d) => d.deviceId === deviceId)
+		if (device) return device
+
+		// only try more variations if the id isnt new format
+		if (!looseIdMatching || deviceId.includes(':')) return undefined
+
+		// try the most likely streamdeck prefix
+		let deviceId2 = `streamdeck:${deviceId}`
+		device = instances.find((d) => d.deviceId === deviceId2)
+		if (device) return device
+
+		// it is unlikely, but it could be a loupedeck
+		deviceId2 = `loupedeck:${deviceId}`
+		device = instances.find((d) => d.deviceId === deviceId2)
+		if (device) return device
+
+		// or maybe a satellite?
+		deviceId2 = `satellite-${deviceId}`
+		return instances.find((d) => d.deviceId === deviceId2)
 	}
 }
 

--- a/lib/Surface/Handler.js
+++ b/lib/Surface/Handler.js
@@ -57,7 +57,7 @@ class SurfaceHandler extends CoreBase {
 	#xkeysPageCount = 0
 
 	constructor(registry, integrationType, panel) {
-		super(registry, `device(${panel.info.serialnumber})`, `Surface/Handler/${panel.info.serialnumber}`)
+		super(registry, `device(${panel.info.deviceId})`, `Surface/Handler/${panel.info.deviceId}`)
 		this.logger.silly('loading for ' + panel.info.devicepath)
 
 		this.panel = panel
@@ -177,7 +177,7 @@ class SurfaceHandler extends CoreBase {
 	}
 
 	get deviceId() {
-		return this.panel.info.serialnumber
+		return this.panel.info.deviceId
 	}
 
 	#deviceIncreasePage() {

--- a/lib/Surface/IP/ElgatoEmulator.js
+++ b/lib/Surface/IP/ElgatoEmulator.js
@@ -66,7 +66,7 @@ class SurfaceIPElgatoEmulator extends EventEmitter {
 			configFields: ['emulator_control_enable', 'emulator_prompt_fullscreen'],
 			keysPerRow: 8,
 			keysTotal: 32,
-			serialnumber: `emulator:${emulatorId}`,
+			deviceId: `emulator:${emulatorId}`,
 		}
 
 		this.logger.debug('Adding Elgato Streamdeck Emulator')

--- a/lib/Surface/IP/ElgatoPlugin.js
+++ b/lib/Surface/IP/ElgatoPlugin.js
@@ -37,7 +37,7 @@ class SurfaceIPElgatoPlugin extends EventEmitter {
 			configFields: ['rotation'],
 			keysPerRow: 8,
 			keysTotal: 32,
-			serialnumber: 'plugin',
+			deviceId: 'plugin',
 		}
 
 		this._config = {

--- a/lib/Surface/IP/Satellite.js
+++ b/lib/Surface/IP/Satellite.js
@@ -34,7 +34,7 @@ class SurfaceIPSatellite extends EventEmitter {
 			configFields: ['brightness'],
 			keysPerRow: deviceInfo.keysPerRow,
 			keysTotal: deviceInfo.keysTotal,
-			serialnumber: deviceInfo.path,
+			deviceId: deviceInfo.path,
 			location: deviceInfo.socket.remoteAddress,
 		}
 

--- a/lib/Surface/USB/ElgatoStreamDeck.js
+++ b/lib/Surface/USB/ElgatoStreamDeck.js
@@ -49,7 +49,7 @@ class SurfaceUSBElgatoStreamDeck {
 				configFields: ['brightness', 'rotation'],
 				keysPerRow: this.streamDeck.KEY_COLUMNS,
 				keysTotal: this.streamDeck.NUM_KEYS,
-				serialnumber: undefined, // set in #init()
+				deviceId: undefined, // set in #init()
 			}
 
 			this.write_queue = new ImageWriteQueue(this.ipcWrapper, async (key, buffer) => {
@@ -171,7 +171,8 @@ class SurfaceUSBElgatoStreamDeck {
 	}
 
 	async #init() {
-		this.info.serialnumber = await this.streamDeck.getSerialNumber()
+		const serialnumber = await this.streamDeck.getSerialNumber()
+		this.info.deviceId = `streamdeck:${serialnumber}`
 
 		this.ipcWrapper.log('debug', `Elgato ${this.streamDeck.PRODUCT_NAME} detected`)
 

--- a/lib/Surface/USB/Infinitton.js
+++ b/lib/Surface/USB/Infinitton.js
@@ -31,13 +31,15 @@ class SurfaceUSBInfinitton {
 
 		this.Infinitton = new Infinitton(devicepath)
 
+		const serialnumber = this.Infinitton.device.getDeviceInfo().serialNumber
+
 		this.info = {
 			type: 'Infinitton iDisplay device',
 			devicepath: devicepath,
 			configFields: ['brightness', 'rotation'],
 			keysPerRow: 5,
 			keysTotal: 15,
-			serialnumber: this.Infinitton.device.getDeviceInfo().serialNumber,
+			deviceId: `infinitton:${serialnumber}`,
 		}
 
 		this.ipcWrapper.log('debug', 'Infinitton detected')

--- a/lib/Surface/USB/LoupedeckLive.js
+++ b/lib/Surface/USB/LoupedeckLive.js
@@ -93,7 +93,7 @@ class SurfaceUSBLoupedeckLive {
 			configFields: ['brightness'],
 			keysPerRow: this.modelInfo.totalCols,
 			keysTotal: this.modelInfo.totalCols * this.modelInfo.totalRows,
-			serialnumber: serialnumber,
+			deviceId: `loupedeck:${serialnumber}`,
 		}
 
 		this.loupedeck.on('error', (error) => {

--- a/lib/Surface/USB/XKeys.js
+++ b/lib/Surface/USB/XKeys.js
@@ -23,7 +23,7 @@ import { setupXkeysPanel } from 'xkeys'
  * @memberof xkeys
  */
 class SurfaceUSBXKeys {
-	constructor(ipcWrapper, devicepath, panel, serialnumber) {
+	constructor(ipcWrapper, devicepath, panel, deviceId) {
 		this.ipcWrapper = ipcWrapper
 		this.myXkeysPanel = panel
 
@@ -37,7 +37,7 @@ class SurfaceUSBXKeys {
 			type: `XKeys ${this.myXkeysPanel.info.name}`,
 			devicepath: devicepath,
 			configFields: ['brightness', 'illuminate_pressed'],
-			serialnumber: serialnumber,
+			deviceId: deviceId,
 
 			keysPerRow: global.MAX_BUTTONS_PER_ROW,
 			keysTotal: global.MAX_BUTTONS,
@@ -163,10 +163,10 @@ class SurfaceUSBXKeys {
 	static async create(ipcWrapper, devicepath) {
 		const panel = await setupXkeysPanel(devicepath)
 
-		const serialnumber = `xkeys:${panel.info.productId}-${panel.info.unitId}` // TODO - this needs some additional uniqueness to the sufix
+		const deviceId = `xkeys:${panel.info.productId}-${panel.info.unitId}` // TODO - this needs some additional uniqueness to the sufix
 		// (${devicepath.slice(0, -1).slice(-10)})` // This suffix produces `dev/hidraw` on linux, which is not useful.
 
-		const self = new SurfaceUSBXKeys(ipcWrapper, devicepath, panel, serialnumber)
+		const self = new SurfaceUSBXKeys(ipcWrapper, devicepath, panel, deviceId)
 
 		await self.#init()
 

--- a/webui/src/Surfaces.jsx
+++ b/webui/src/Surfaces.jsx
@@ -133,8 +133,8 @@ export const SurfacesPage = memo(function SurfacesPage() {
 	)
 
 	const updateName = useCallback(
-		(serialnumber, name) => {
-			socketEmitPromise(socket, 'surfaces:set-name', [serialnumber, name]).catch((err) => {
+		(deviceId, name) => {
+			socketEmitPromise(socket, 'surfaces:set-name', [deviceId, name]).catch((err) => {
 				console.error('Update name failed', err)
 			})
 		},


### PR DESCRIPTION
Connecting a streamdeck locally provides an id of `20DL0123456`, but if connected via satellite this becomes `satellite-20DL0123456`.

This results in some inconsistent behaviour, as plugging a streamdeck into different satellite machines will give it the same settings, but plugging it in directly will get different settings.

This changes the ids to always look like `streamdeck:20DL0123456` (or similar for other surface types).

This could break surface config for existing surfaces, but it is doing a crude attempt to fix up some ids. I expect there to be some friction for users here, partially as we need to either not change satellite or coordinate it.
It is attempting to gracefully handle old actions which use surface ids, trying to reliably fix them will prove complex