### PR TITLE
feat: better variable change tracking

### DIFF
--- a/lib/Controls/ControlTypes/Button/Base.js
+++ b/lib/Controls/ControlTypes/Button/Base.js
@@ -215,7 +215,7 @@ export default class ButtonControlBase extends ControlBase {
 		let style = this.feedbacks.getUnparsedStyle()
 
 		if (style.text) {
-			style.text = this.instance.variable.parseVariables(style.text)
+			style.text = this.instance.variable.parseVariables(style.text).text
 		}
 
 		style.pushed = !!this.pushed

--- a/lib/Controls/ControlTypes/Button/Base.js
+++ b/lib/Controls/ControlTypes/Button/Base.js
@@ -89,6 +89,13 @@ export default class ButtonControlBase extends ControlBase {
 	 */
 	pushed = false
 
+	/**
+	 * The variabls referenced in the last draw. Whenever one of these changes, a redraw should be performed
+	 * @access protected
+	 * @type {Set | null}
+	 */
+	last_draw_variables = null
+
 	constructor(registry, controlId, logSource, debugNamespace) {
 		super(registry, controlId, logSource, debugNamespace)
 
@@ -215,7 +222,9 @@ export default class ButtonControlBase extends ControlBase {
 		let style = this.feedbacks.getUnparsedStyle()
 
 		if (style.text) {
-			style.text = this.instance.variable.parseVariables(style.text).text
+			const parseResult = this.instance.variable.parseVariables(style.text)
+			style.text = parseResult.text
+			this.last_draw_variables = parseResult.variableIds.length > 0 ? new Set(parseResult.variableIds) : null
 		}
 
 		style.pushed = !!this.pushed
@@ -232,11 +241,9 @@ export default class ButtonControlBase extends ControlBase {
 	 * @access public
 	 */
 	onVariablesChanged(allChangedVariables) {
-		const style = this.feedbacks.getUnparsedStyle()
-
-		if (style && typeof style.text === 'string') {
+		if (this.last_draw_variables) {
 			for (const variable of allChangedVariables) {
-				if (style.text.includes(`$(${variable})`)) {
+				if (this.last_draw_variables.has(variable)) {
 					this.logger.silly('variable changed in bank ' + this.controlId)
 
 					this.triggerRedraw()

--- a/lib/Instance/Definitions.js
+++ b/lib/Instance/Definitions.js
@@ -111,7 +111,7 @@ class InstanceDefinitions extends CoreBase {
 					style: definition.type,
 				}
 
-				if (style.text) style.text = this.instance.variable.parseVariables(style.text)
+				if (style.text) style.text = this.instance.variable.parseVariables(style.text).text
 
 				const render = this.graphics.drawPreview(style)
 				if (render) {

--- a/lib/Instance/Host.js
+++ b/lib/Instance/Host.js
@@ -175,6 +175,22 @@ class ModuleHost {
 	}
 
 	/**
+	 * Send a list of changed variables to all active instances.
+	 * This will trigger feedbacks using variables to be rechecked
+	 */
+	onVariablesChanged(changed_variables, removed_variables) {
+		const changedVariableIds = [...Object.keys(changed_variables), ...removed_variables]
+
+		for (const child of this.children.values()) {
+			if (child.handler) {
+				child.handler.sendVariablesChanged(changedVariableIds).catch((e) => {
+					this.logger.warn(`sendVariablesChanged failed for "${child.connectionId}": ${e}`)
+				})
+			}
+		}
+	}
+
+	/**
 	 * Stop all running instances
 	 */
 	async queueStopAllConnections() {

--- a/lib/Instance/Variable.js
+++ b/lib/Instance/Variable.js
@@ -28,10 +28,15 @@ const VariableDefinitionsRoom = 'variable-definitions'
 // Export for unit tests
 export function parseVariablesInString(string, rawVariableValues, cachedVariableValues) {
 	if (string === undefined || string === null || string === '') {
-		return string
+		return {
+			text: string,
+			variableIds: [],
+		}
 	}
 	if (typeof string !== 'string') string = `${string}`
 	if (!cachedVariableValues) cachedVariableValues = {}
+
+	const referencedVariableIds = []
 
 	// Everybody stand back. I know regular expressions. - xckd #208 /ck/kc/
 	const reg = /\$\(([^:$)]+):([^)$]+)\)/
@@ -48,6 +53,7 @@ export function parseVariablesInString(string, rawVariableValues, cachedVariable
 		const fullId = matches[0]
 		const instanceId = matches[1]
 		const variableId = matches[2]
+		referencedVariableIds.push(`${instanceId}:${variableId}`)
 
 		let cachedValue = cachedVariableValues[fullId]
 		if (cachedVariableValues[fullId] === undefined) {
@@ -58,7 +64,9 @@ export function parseVariablesInString(string, rawVariableValues, cachedVariable
 			if (rawVariableValues[instanceId] && rawVariableValues[instanceId][variableId] !== undefined) {
 				const rawValue = rawVariableValues[instanceId][variableId]
 
-				cachedValue = parseVariablesInString(rawValue, rawVariableValues, cachedVariableValues)
+				const result = parseVariablesInString(rawValue, rawVariableValues, cachedVariableValues)
+				cachedValue = result.text
+				referencedVariableIds.push(...result.variableIds)
 				if (cachedValue === undefined) cachedValue = ''
 			} else {
 				// Variable has no value
@@ -71,7 +79,10 @@ export function parseVariablesInString(string, rawVariableValues, cachedVariable
 		string = string.replace(fullId, cachedValue)
 	}
 
-	return string
+	return {
+		text: string,
+		variableIds: referencedVariableIds,
+	}
 }
 
 class InstanceVariable extends CoreBase {
@@ -98,7 +109,9 @@ class InstanceVariable extends CoreBase {
 	 * @returns str with variables replaced with values
 	 */
 	parseVariables(str) {
-		return parseVariablesInString(str, this.variable_values)
+		const result = parseVariablesInString(str, this.variable_values)
+
+		return result.text
 	}
 
 	parseNumericExpression(str) {

--- a/lib/Instance/Variable.js
+++ b/lib/Instance/Variable.js
@@ -262,6 +262,7 @@ class InstanceVariable extends CoreBase {
 		if (Object.keys(changed_variables).length > 0 || removed_variables.length > 0) {
 			this.controls.onVariablesChanged(changed_variables, removed_variables)
 			this.internalModule.variablesChanged(changed_variables, removed_variables)
+			this.instance.moduleHost.onVariablesChanged(changed_variables, removed_variables)
 		}
 	}
 

--- a/lib/Instance/Variable.js
+++ b/lib/Instance/Variable.js
@@ -109,9 +109,7 @@ class InstanceVariable extends CoreBase {
 	 * @returns str with variables replaced with values
 	 */
 	parseVariables(str) {
-		const result = parseVariablesInString(str, this.variable_values)
-
-		return result.text
+		return parseVariablesInString(str, this.variable_values)
 	}
 
 	parseNumericExpression(str) {

--- a/lib/Instance/Wrapper.js
+++ b/lib/Instance/Wrapper.js
@@ -169,7 +169,7 @@ class SocketEventsHandler {
 	 * @access public - called whenever variables change
 	 */
 	async sendVariablesChanged(changedVariableIds) {
-		// Future: only inform module of variables it parsed in a feedback.
+		// Future: only inform module of variables it parsed and should react to.
 		// This will help avoid excess work when variables are not interesting to a module.
 
 		this.ipcWrapper.sendWithNoCb('variablesChanged', {

--- a/lib/Instance/Wrapper.js
+++ b/lib/Instance/Wrapper.js
@@ -165,6 +165,19 @@ class SocketEventsHandler {
 	}
 
 	/**
+	 * Send the list of changed variables to the child process
+	 * @access public - called whenever variables change
+	 */
+	async sendVariablesChanged(changedVariableIds) {
+		// Future: only inform module of variables it parsed in a feedback.
+		// This will help avoid excess work when variables are not interesting to a module.
+
+		this.ipcWrapper.sendWithNoCb('variablesChanged', {
+			variablesIds: changedVariableIds,
+		})
+	}
+
+	/**
 	 * Get all the action instances for this instance
 	 * @access private
 	 * @returns

--- a/lib/Instance/Wrapper.js
+++ b/lib/Instance/Wrapper.js
@@ -574,9 +574,9 @@ class SocketEventsHandler {
 	 */
 	async #handleParseVariablesInString(msg) {
 		try {
-			const newText = this.registry.instance.variable.parseVariables(msg.text)
+			const result = this.registry.instance.variable.parseVariables(msg.text)
 
-			return { text: newText }
+			return { text: result.text, vaiableIds: result.variablesIds }
 		} catch (e) {
 			this.logger.error(`Parse variables failed: ${e}`)
 

--- a/lib/Instance/Wrapper.js
+++ b/lib/Instance/Wrapper.js
@@ -576,7 +576,7 @@ class SocketEventsHandler {
 		try {
 			const result = this.registry.instance.variable.parseVariables(msg.text)
 
-			return { text: result.text, vaiableIds: result.variablesIds }
+			return { text: result.text, variableIds: result.variableIds }
 		} catch (e) {
 			this.logger.error(`Parse variables failed: ${e}`)
 

--- a/lib/Internal/ActionRecorder.js
+++ b/lib/Internal/ActionRecorder.js
@@ -184,10 +184,10 @@ export default class ActionRecorder extends CoreBase {
 
 			return true
 		} else if (action.action === 'action_recorder_save_to_button') {
-			let stepId = this.instance.variable.parseVariables(action.options.step)
-			let setId = this.instance.variable.parseVariables(action.options.set)
-			const pageRaw = this.instance.variable.parseVariables(action.options.page)
-			const bankRaw = this.instance.variable.parseVariables(action.options.bank)
+			let stepId = this.instance.variable.parseVariables(action.options.step).text
+			let setId = this.instance.variable.parseVariables(action.options.set).text
+			const pageRaw = this.instance.variable.parseVariables(action.options.page).text
+			const bankRaw = this.instance.variable.parseVariables(action.options.bank).text
 
 			if (setId === 'press') setId = 'down'
 			else if (setId === 'release') setId = 'up'

--- a/lib/Internal/Bank.js
+++ b/lib/Internal/Bank.js
@@ -442,7 +442,7 @@ export default class Bank extends CoreBase {
 			const [instanceLabel, variableName] = action.options.variable.split(':', 2)
 			const variable_value = this.instance.variable.getVariableValue(instanceLabel, variableName)
 
-			const condition = this.instance.variable.parseVariables(action.options.value)
+			const condition = this.instance.variable.parseVariables(action.options.value).text
 
 			let variable_value_number = Number(variable_value)
 			let condition_number = Number(condition)
@@ -473,7 +473,7 @@ export default class Bank extends CoreBase {
 			const [instanceLabel, variableName] = action.options.variable.split(':', 2)
 			const variable_value = this.instance.variable.getVariableValue(instanceLabel, variableName)
 
-			const condition = this.instance.variable.parseVariables(action.options.value)
+			const condition = this.instance.variable.parseVariables(action.options.value).text
 
 			let variable_value_number = Number(variable_value)
 			let condition_number = Number(condition)

--- a/lib/Internal/CustomVariables.js
+++ b/lib/Internal/CustomVariables.js
@@ -298,7 +298,7 @@ export default class CustomVariables extends CoreBase {
 			const variable_value = this.instance.variable.getVariableValue(instanceLabel, variableName)
 
 			const variable_value_number = Number(variable_value)
-			const operation_value = this.instance.variable.parseVariables(action.options.value)
+			const operation_value = this.instance.variable.parseVariables(action.options.value).text
 			const operation_value_number = Number(operation_value)
 			let value = variable_value_number
 			switch (action.options.operation) {
@@ -339,7 +339,7 @@ export default class CustomVariables extends CoreBase {
 			const [instanceLabel, variableName] = action.options.variable.split(':', 2)
 			const variable_value = this.instance.variable.getVariableValue(instanceLabel, variableName)
 
-			const operation_value = this.instance.variable.parseVariables(action.options.value)
+			const operation_value = this.instance.variable.parseVariables(action.options.value).text
 
 			let value = ''
 			if (action.options.order == 'variable_value') {
@@ -353,8 +353,8 @@ export default class CustomVariables extends CoreBase {
 			const [instanceLabel, variableName] = action.options.variable.split(':', 2)
 			const variable_value = this.instance.variable.getVariableValue(instanceLabel, variableName) + ''
 
-			const start = Number(this.instance.variable.parseVariables(action.options.start))
-			const end = Number(this.instance.variable.parseVariables(action.options.end))
+			const start = Number(this.instance.variable.parseVariables(action.options.start).text)
+			const end = Number(this.instance.variable.parseVariables(action.options.end).text)
 			const value = variable_value.substring(start, end)
 
 			this.instance.variable.custom.setValue(action.options.result, value)

--- a/lib/Internal/Surface.js
+++ b/lib/Internal/Surface.js
@@ -99,7 +99,7 @@ export default class Surface extends CoreBase {
 		let theController = options.controller
 
 		if (useVariableFields && options.controller_from_variable) {
-			theController = this.instance.variable.parseVariables(options.controller_variable)
+			theController = this.instance.variable.parseVariables(options.controller_variable).text
 		}
 
 		theController = theController.trim()

--- a/lib/Internal/System.js
+++ b/lib/Internal/System.js
@@ -146,7 +146,7 @@ export default class System extends CoreBase {
 	executeAction(action) {
 		if (action.action === 'exec') {
 			if (action.options.path) {
-				const path = this.instance.variable.parseVariables(action.options.path)
+				const path = this.instance.variable.parseVariables(action.options.path).text
 				this.logger.silly(`Running path: '${path}'`)
 
 				exec(


### PR DESCRIPTION
Partner to https://github.com/bitfocus/companion-module-base/pull/32/files, which combined will allow for feedback to use `parseVariablesInString` and be rechecked when the variables referenced change.

Additionally, the same tracking has been applied to button drawing, so that nesting of variables finally updates correctly, rather than just the top level variables