### PR TITLE
feat: Improve module list search filtering

### DIFF
--- a/webui/package.json
+++ b/webui/package.json
@@ -17,6 +17,7 @@
     "classnames": "^2.3.2",
     "dayjs": "^1.11.6",
     "fast-json-patch": "^3.1.1",
+    "fuse.js": "^6.6.2",
     "html-entities": "^2.3.3",
     "http-proxy-middleware": "^2.0.6",
     "intersection-observer": "^0.12.2",

--- a/webui/package.json
+++ b/webui/package.json
@@ -17,7 +17,7 @@
     "classnames": "^2.3.2",
     "dayjs": "^1.11.6",
     "fast-json-patch": "^3.1.1",
-    "fuse.js": "^6.6.2",
+    "fuzzysort": "^2.0.4",
     "html-entities": "^2.3.3",
     "http-proxy-middleware": "^2.0.6",
     "intersection-observer": "^0.12.2",

--- a/webui/src/Instances/AddInstance.jsx
+++ b/webui/src/Instances/AddInstance.jsx
@@ -68,7 +68,11 @@ const AddInstancesInner = memo(function AddInstancesInner({ showHelp, configureI
 				const name = `${module.manufacturer} ${subprod}`
 				const keywords = module.keywords || []
 
-				if (name.replace(';', ' ').match(regexp) || keywords.find((kw) => kw.match(regexp))) {
+				if (
+					name.replace(';', ' ').match(regexp) ||
+					name.replace(/[^\w]/g, '').toLowerCase().includes(filter.replace(/[^\w]/g, '').toLowerCase()) ||
+					keywords.find((kw) => kw.match(regexp))
+				) {
 					candidatesObj[name] = (
 						<div key={name + id}>
 							<CButton color="primary" onClick={() => addInstance(id, subprod, module)}>

--- a/webui/yarn.lock
+++ b/webui/yarn.lock
@@ -5025,6 +5025,11 @@ functions-have-names@^1.2.2:
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
 
+fuse.js@^6.6.2:
+  version "6.6.2"
+  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-6.6.2.tgz#fe463fed4b98c0226ac3da2856a415576dc9a111"
+  integrity sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==
+
 gauge@^4.0.3:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-4.0.4.tgz#52ff0652f2bbf607a989793d53b751bef2328dce"

--- a/webui/yarn.lock
+++ b/webui/yarn.lock
@@ -5025,10 +5025,10 @@ functions-have-names@^1.2.2:
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
 
-fuse.js@^6.6.2:
-  version "6.6.2"
-  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-6.6.2.tgz#fe463fed4b98c0226ac3da2856a415576dc9a111"
-  integrity sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==
+fuzzysort@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/fuzzysort/-/fuzzysort-2.0.4.tgz#a21d1ce8947eaf2797dc3b7c28c36db9d1165f84"
+  integrity sha512-Api1mJL+Ad7W7vnDZnWq5pGaXJjyencT+iKGia2PlHUcSsSzWwIQ3S1isiMpwpavjYtGd2FzhUIhnnhOULZgDw==
 
 gauge@^4.0.3:
   version "4.0.4"


### PR DESCRIPTION
A lot of people give up when they search for a product but can't find it in the list. Searching for things like `black magic`, or `artnet` currently returns no results, which is unexpected. 

This PR improves the search filtering so that it matches items, even if spaces or punctuation isn't quite right. 


Also, should this PR target the `beta`, `develop`, or `master` branch? I couldn't find any guidelines