### PR TITLE
fix: dockerfile install libasound2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ COPY . /app/
 RUN apt-get update && apt-get install -y \
     libusb-1.0-0-dev \
     libudev-dev \
+    libasound2 \
     unzip \
     cmake \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ COPY . /app/
 RUN apt-get update && apt-get install -y \
     libusb-1.0-0-dev \
     libudev-dev \
-    libasound2 \
     unzip \
     cmake \
     && rm -rf /var/lib/apt/lists/*
@@ -41,6 +40,7 @@ COPY --from=companion-builder /app/	/app/
 RUN apt update && apt install -y \
     curl \
     iputils-ping \
+    libasound2 \
     && rm -rf /var/lib/apt/lists/*
 
 # Create config directory and set correct permissions


### PR DESCRIPTION
Install libasound2 in the dockerfile which is required for some modules (ie Renewed Vision ProPresenter) 