### PR TITLE
feat: Expression timestamp types, and ms parsing

### DIFF
--- a/lib/Shared/Expression/ExpressionFunctions.js
+++ b/lib/Shared/Expression/ExpressionFunctions.js
@@ -38,14 +38,48 @@ export const ExpressionFunctions = {
 	substr: (str, start, end) => {
 		return (str + '').slice(start, end)
 	},
-	secondsToTimestamp: (v) => {
+	secondsToTimestamp: (v, type) => {
 		v = Math.max(0, v)
 
 		const seconds = pad(Math.floor(v) % 60, '0', 2)
 		const minutes = pad(Math.floor(v / 60) % 60, '0', 2)
 		const hours = pad(Math.floor(v / 3600), '0', 2)
 
-		return `${hours}:${minutes}:${seconds}`
+		if (!type) {
+			return `${hours}:${minutes}:${seconds}`
+		} else {
+			let timestamp = []
+			if (type.includes('HH') || type.includes('hh')) timestamp.push(hours)
+			if (type.includes('mm')) timestamp.push(minutes)
+			if (type.includes('ss')) timestamp.push(seconds)
+
+			timestamp = timestamp.join(':')
+			return timestamp
+		}
+	},
+	msToTimestamp: (v, type) => {
+		v = Math.max(0, v)
+
+		const ms = v % 1000
+		const seconds = pad(Math.floor(v / 1000) % 60, '0', 2)
+		const minutes = pad(Math.floor(v / 60000) % 60, '0', 2)
+		const hours = pad(Math.floor(v / 3600000), '0', 2)
+
+		let timestamp = []
+		if (type.includes('HH') || type.includes('hh')) timestamp.push(hours)
+		if (type.includes('mm')) timestamp.push(minutes)
+		if (type.includes('ss')) timestamp.push(seconds)
+
+		timestamp = timestamp.join(':')
+		if (type.endsWith('.ms') || type.endsWith('.S')) {
+			timestamp += `.${Math.floor(ms / 100)}`
+		} else if (type.endsWith('.SS')) {
+			timestamp += `.${pad(Math.floor(ms / 10), '0', 2)}`
+		} else if (type.endsWith('.SSS')) {
+			timestamp += `.${pad(ms, '0', 3)}`
+		}
+
+		return timestamp
 	},
 
 	// Bool operations

--- a/lib/Shared/Expression/ExpressionFunctions.js
+++ b/lib/Shared/Expression/ExpressionFunctions.js
@@ -45,17 +45,15 @@ export const ExpressionFunctions = {
 		const minutes = pad(Math.floor(v / 60) % 60, '0', 2)
 		const hours = pad(Math.floor(v / 3600), '0', 2)
 
-		if (!type) {
-			return `${hours}:${minutes}:${seconds}`
-		} else {
-			let timestamp = []
-			if (type.includes('HH') || type.includes('hh')) timestamp.push(hours)
-			if (type.includes('mm')) timestamp.push(minutes)
-			if (type.includes('ss')) timestamp.push(seconds)
+		if (!type) return `${hours}:${minutes}:${seconds}`
 
-			timestamp = timestamp.join(':')
-			return timestamp
-		}
+		let timestamp = []
+		if (type.includes('HH') || type.includes('hh')) timestamp.push(hours)
+		if (type.includes('mm')) timestamp.push(minutes)
+		if (type.includes('ss')) timestamp.push(seconds)
+
+		timestamp = timestamp.join(':')
+		return timestamp
 	},
 	msToTimestamp: (v, type) => {
 		v = Math.max(0, v)
@@ -64,6 +62,8 @@ export const ExpressionFunctions = {
 		const seconds = pad(Math.floor(v / 1000) % 60, '0', 2)
 		const minutes = pad(Math.floor(v / 60000) % 60, '0', 2)
 		const hours = pad(Math.floor(v / 3600000), '0', 2)
+
+		if (!type) return `${minutes}:${seconds}.${Math.floor(ms / 100)}`
 
 		let timestamp = []
 		if (type.includes('HH') || type.includes('hh')) timestamp.push(hours)


### PR DESCRIPTION
Added an additional Expression Function for parsing of milliseconds to a timestamp, and to allow the `secondsToTimestamp` function to default to the current `HH:mm:ss` format so it's non-breaking, but if specified it can also format the time in just hours, minutes, seconds, or a combination.

The parsing follows similarly to the Simple Date Format, but not exactly, as there is some adjustments for user experience. For example, `ms` is allowed in place of `.S` for tenth of a second, and `hh` and `HH` both format it in hours not bound by 12 or 24 respectively.

If we wanted a Expression Function for strictly formating date/time then that should be a separate function that more closely follows the Simple Date Format.

Usecase:
In preparation for making the vMix module, among others, v3 compatible the `:` symbol is no longer available in instance variables, so rather than trying to make it useable, or adjust the naming scheme in a way that becomes less user friendly, this change will allow me to switch to just providing instance variables in milliseconds or seconds, and let the user format them using Expression functions into the format they like. This will also reduce the number of instance variables needed and frequently updated.