### PR TITLE
feat: Add fontsize to Satellite API

### DIFF
--- a/lib/Service/Satellite.js
+++ b/lib/Service/Satellite.js
@@ -8,7 +8,7 @@ import net from 'net'
  * 1.1.0 - Add KEY-STATE TYPE and PRESSED properties
  * 1.2.0 - Add DEVICEID to any ERROR responses when known
  * 1.3.0 - Add KEY-ROTATE message
- * 1.4.0 - Add ADD-DEVICE FONTSIZE flag and KEY-STATE FONTSIZE property
+ * 1.4.0 - Add TEXT_STYLE as ADD-DEVICE flags with FONT_SIZE as KEY-STATE property
  */
 const API_VERSION = '1.4.0'
 
@@ -107,7 +107,7 @@ class ServiceSatellite extends ServiceBase {
 		const streamBitmaps = params.BITMAPS === undefined || !isFalsey(params.BITMAPS)
 		const streamColors = params.COLORS !== undefined && !isFalsey(params.COLORS)
 		const streamText = params.TEXT !== undefined && !isFalsey(params.TEXT)
-		const streamFontSize = params.FONTSIZE !== undefined && !isFalsey(params.FONTSIZE)
+		const streamTextStyle = params.TEXT_STYLE !== undefined && !isFalsey(params.TEXT_STYLE)
 
 		const device = this.surfaces.addSatelliteDevice({
 			path: id,
@@ -119,7 +119,7 @@ class ServiceSatellite extends ServiceBase {
 			streamBitmaps: streamBitmaps,
 			streamColors: streamColors,
 			streamText: streamText,
-			streamFontSize: streamFontSize,
+			streamTextStyle: streamTextStyle
 		})
 
 		this.devices[id] = {

--- a/lib/Service/Satellite.js
+++ b/lib/Service/Satellite.js
@@ -8,8 +8,9 @@ import net from 'net'
  * 1.1.0 - Add KEY-STATE TYPE and PRESSED properties
  * 1.2.0 - Add DEVICEID to any ERROR responses when known
  * 1.3.0 - Add KEY-ROTATE message
+ * 1.4.0 - Add ADD-DEVICE FONTSIZE flag and KEY-STATE FONTSIZE property
  */
-const API_VERSION = '1.3.0'
+const API_VERSION = '1.4.0'
 
 /**
  * Class providing the Satellite/Remote Surface api.
@@ -106,6 +107,7 @@ class ServiceSatellite extends ServiceBase {
 		const streamBitmaps = params.BITMAPS === undefined || !isFalsey(params.BITMAPS)
 		const streamColors = params.COLORS !== undefined && !isFalsey(params.COLORS)
 		const streamText = params.TEXT !== undefined && !isFalsey(params.TEXT)
+		const streamFontSize = params.FONTSIZE !== undefined && !isFalsey(params.FONTSIZE)
 
 		const device = this.surfaces.addSatelliteDevice({
 			path: id,
@@ -117,6 +119,7 @@ class ServiceSatellite extends ServiceBase {
 			streamBitmaps: streamBitmaps,
 			streamColors: streamColors,
 			streamText: streamText,
+			streamFontSize: streamFontSize,
 		})
 
 		this.devices[id] = {

--- a/lib/Surface/IP/Satellite.js
+++ b/lib/Surface/IP/Satellite.js
@@ -24,7 +24,7 @@ class SurfaceIPSatellite extends EventEmitter {
 	#streamBitmaps = false
 	#streamColors = false
 	#streamText = false
-	#streamFontSize = false
+	#streamTextStyle = false
 
 	constructor(deviceInfo) {
 		super()
@@ -46,7 +46,7 @@ class SurfaceIPSatellite extends EventEmitter {
 		this.#streamBitmaps = deviceInfo.streamBitmaps
 		this.#streamColors = deviceInfo.streamColors
 		this.#streamText = deviceInfo.streamText
-		this.#streamFontSize = deviceInfo.streamFontSize
+		this.#streamTextStyle = deviceInfo.streamTextStyle
 
 		this.logger.info(`Adding Satellite device "${this.deviceId}"`)
 
@@ -83,8 +83,8 @@ class SurfaceIPSatellite extends EventEmitter {
 				const text = style?.text || ''
 				params += ` TEXT=${Buffer.from(text).toString('base64')}`
 			}
-			if (this.#streamFontSize) {
-				params += ` FONTSIZE=${style ? style.size : 'auto'}`
+			if (this.#streamTextStyle) {
+				params += ` FONT_SIZE=${style ? style.size : 'auto'}`
 			}
 
 			let type = 'BUTTON'

--- a/lib/Surface/IP/Satellite.js
+++ b/lib/Surface/IP/Satellite.js
@@ -24,6 +24,7 @@ class SurfaceIPSatellite extends EventEmitter {
 	#streamBitmaps = false
 	#streamColors = false
 	#streamText = false
+	#streamFontSize = true
 
 	constructor(deviceInfo) {
 		super()
@@ -45,6 +46,7 @@ class SurfaceIPSatellite extends EventEmitter {
 		this.#streamBitmaps = deviceInfo.streamBitmaps
 		this.#streamColors = deviceInfo.streamColors
 		this.#streamText = deviceInfo.streamText
+		this.#streamFontSize = deviceInfo.streamFontSize
 
 		this.logger.info(`Adding Satellite device "${this.deviceId}"`)
 
@@ -80,6 +82,9 @@ class SurfaceIPSatellite extends EventEmitter {
 			if (this.#streamText) {
 				const text = style?.text || ''
 				params += ` TEXT=${Buffer.from(text).toString('base64')}`
+			}
+			if (this.#streamFontSize) {
+				params += ` FONTSIZE=${style ? style.size : 'auto'}`
 			}
 
 			let type = 'BUTTON'

--- a/lib/Surface/IP/Satellite.js
+++ b/lib/Surface/IP/Satellite.js
@@ -24,7 +24,7 @@ class SurfaceIPSatellite extends EventEmitter {
 	#streamBitmaps = false
 	#streamColors = false
 	#streamText = false
-	#streamFontSize = true
+	#streamFontSize = false
 
 	constructor(deviceInfo) {
 		super()


### PR DESCRIPTION
This PR adds Fontsize as optional streamed data to the Sattelite API.
I added a new Flag `FONTSIZE` for the `ADD-DEVICE` command, similar to the already existing `TEXT`, `COLOR`, ...
if this flag is set to true, the fontsize is passed on every `KEY-STATE` message.

If this gets merged, the wiki would need to be updated at two places:
- Messages to send -> Adding a satellite device -> Optional parameters:
`FONTSIZE` - true/false whether you want to be streamed button font size for display on the buttons (default false) 

- Messages to receive -> State change for key:
`FONTSIZE` Font size as an integer for the key. This is only sent for devices which were added where `FONTSIZE` was true