### PR TITLE
feat: import and export compressed configs

### DIFF
--- a/lib/Data/ImportExport.js
+++ b/lib/Data/ImportExport.js
@@ -44,7 +44,7 @@ function downloadBlob(res, next, data, filename, format) {
 	const dataStr = JSON.stringify(data, undefined, '\t')
 
 	if (!format || format === 'json-gz') {
-		zlib.gzip(Buffer.from(dataStr), (err, result) => {
+		zlib.gzip(dataStr, (err, result) => {
 			if (err) {
 				this.logger.warn(`Failed to gzip data, retrying uncompressed: ${err}`)
 				downloadBlob(res, next, data, filename, 'json')
@@ -391,10 +391,21 @@ class DataImportExport extends CoreBase {
 
 			return true
 		})
-		client.onPromise('loadsave:prepare-import', (dataStr) => {
+		client.onPromise('loadsave:prepare-import', async (dataStr) => {
+			try {
+				dataStr = await new Promise((resolve, reject) => {
+					zlib.gunzip(dataStr, (err, data) => {
+						if (err) reject(err)
+						else resolve(data || dataStr)
+					})
+				})
+			} catch (e) {
+				// Ignore, it is probably not compressed
+			}
+
 			let object
 			try {
-				object = JSON.parse(dataStr)
+				object = JSON.parse(dataStr.toString())
 			} catch (e) {
 				return ['File is corrupted or unknown format']
 			}

--- a/lib/Data/ImportExport.js
+++ b/lib/Data/ImportExport.js
@@ -29,6 +29,7 @@ import { nanoid } from 'nanoid'
 import { VisitorReferencesUpdater } from '../Util/Visitors/ReferencesUpdater.js'
 import path from 'path'
 import fs from 'fs'
+import zlib from 'node:zlib'
 
 /**
  * Default buttons on fresh pages
@@ -37,6 +38,33 @@ const default_nav_buttons = {
 	1: 'pageup',
 	9: 'pagenum',
 	17: 'pagedown',
+}
+
+function downloadBlob(res, next, data, filename, format) {
+	const dataStr = JSON.stringify(data, undefined, '\t')
+
+	if (!format || format === 'json-gz') {
+		zlib.gzip(Buffer.from(dataStr), (err, result) => {
+			if (err) {
+				this.logger.warn(`Failed to gzip data, retrying uncompressed: ${err}`)
+				downloadBlob(res, next, data, filename, 'json')
+			} else {
+				res.writeHeader(200, {
+					'Content-Type': 'application/gzip',
+					'Content-Disposition': `attachment; filename="${filename}"`,
+				})
+				res.end(result)
+			}
+		})
+	} else if (format === 'json') {
+		res.writeHeader(200, {
+			'Content-Type': 'application/json',
+			'Content-Disposition': `attachment; filename="${filename}"`,
+		})
+		res.end(dataStr)
+	} else {
+		next(new Error(`Unknown format: ${format}`))
+	}
 }
 
 class DataImportExport extends CoreBase {
@@ -96,17 +124,13 @@ class DataImportExport extends CoreBase {
 			}
 		}
 
-		this.registry.api_router.get('/export/triggers/all', (req, res) => {
+		this.registry.api_router.get('/export/triggers/all', (req, res, next) => {
 			const triggerControls = Object.values(this.controls.getAllControls()).filter((c) => c.type === 'trigger')
 			const exp = generate_export_for_triggers(triggerControls)
 
 			const filename = encodeURI(`${os.hostname()}_trigger_list_${getTimestamp()}.companionconfig`)
 
-			res.writeHeader(200, {
-				'Content-Type': 'application/json',
-				'Content-Disposition': `attachment; filename="${filename}"`,
-			})
-			res.end(JSON.stringify(exp))
+			downloadBlob(res, next, exp, filename, req.query.format)
 		})
 
 		this.registry.api_router.get('/export/triggers/single/:id', (req, res, next) => {
@@ -121,11 +145,7 @@ class DataImportExport extends CoreBase {
 						.replace(/\W/, '')}_${getTimestamp()}.companionconfig`
 				)
 
-				res.writeHeader(200, {
-					'Content-Type': 'application/json',
-					'Content-Disposition': `attachment; filename="${filename}"`,
-				})
-				res.end(JSON.stringify(exp))
+				downloadBlob(res, next, exp, filename, req.query.format)
 			} else {
 				next()
 			}
@@ -164,11 +184,7 @@ class DataImportExport extends CoreBase {
 
 				const filename = encodeURI(`${os.hostname()}_page${page}_${getTimestamp()}.companionconfig`)
 
-				res.writeHeader(200, {
-					'Content-Type': 'application/json',
-					'Content-Disposition': `attachment; filename="${filename}"`,
-				})
-				res.end(JSON.stringify(exp))
+				downloadBlob(res, next, exp, filename, req.query.format)
 			}
 		})
 
@@ -235,11 +251,7 @@ class DataImportExport extends CoreBase {
 
 			const filename = encodeURI(`${os.hostname()}_custom-config_${getTimestamp()}.companionconfig`)
 
-			res.writeHeader(200, {
-				'Content-Type': 'application/json',
-				'Content-Disposition': `attachment; filename="${filename}"`,
-			})
-			res.end(JSON.stringify(exp))
+			downloadBlob(res, next, exp, filename, req.query.format)
 		})
 
 		this.registry.api_router.get('/export/full', (req, res, next) => {
@@ -247,11 +259,7 @@ class DataImportExport extends CoreBase {
 
 			const filename = encodeURI(`${os.hostname()}full-config_${getTimestamp()}.companionconfig`)
 
-			res.writeHeader(200, {
-				'Content-Type': 'application/json',
-				'Content-Disposition': `attachment; filename="${filename}"`,
-			})
-			res.end(JSON.stringify(exp))
+			downloadBlob(res, next, exp, filename, req.query.format)
 		})
 
 		this.registry.api_router.get('/export/log', (req, res, next) => {

--- a/webui/src/Buttons/ButtonGrid.jsx
+++ b/webui/src/Buttons/ButtonGrid.jsx
@@ -30,6 +30,7 @@ import { GenericConfirmModal } from '../Components/GenericConfirmModal'
 import { nanoid } from 'nanoid'
 import { useSharedPageRenderCache } from '../ButtonRenderCache'
 import Select from 'react-select'
+import { ConfirmExportModal } from '../Components/ConfirmExportModal'
 
 export const ButtonsGridPanel = memo(function ButtonsPage({
 	pageNumber,
@@ -108,8 +109,15 @@ export const ButtonsGridPanel = memo(function ButtonsPage({
 
 	const pageName = pageInfo?.name ?? 'PAGE'
 
+	const exportModalRef = useRef(null)
+	const showExportModal = useCallback(() => {
+		exportModalRef.current.show(`/int/export/page/${pageNumber}`)
+	}, [pageNumber])
+
 	return (
 		<KeyReceiver onKeyDown={onKeyDown} tabIndex={0}>
+			<ConfirmExportModal ref={exportModalRef} title="Export Page" />
+
 			<h4>Buttons</h4>
 			<p>
 				The squares below represent each button on your Streamdeck. Click on them to set up how you want them to look,
@@ -124,8 +132,7 @@ export const ButtonsGridPanel = memo(function ButtonsPage({
 								float: 'right',
 								marginTop: 10,
 							}}
-							href={`/int/export/page/${pageNumber}`}
-							target="_new"
+							onClick={showExportModal}
 						>
 							<FontAwesomeIcon icon={faFileExport} /> Export page
 						</CButton>

--- a/webui/src/Components/ConfirmExportModal.jsx
+++ b/webui/src/Components/ConfirmExportModal.jsx
@@ -1,0 +1,76 @@
+import { CButton, CLabel, CModal, CModalBody, CModalFooter, CModalHeader } from '@coreui/react'
+import { forwardRef, useCallback, useImperativeHandle, useRef, useState } from 'react'
+import { ExportFormatDefault, SelectExportFormat } from '../ImportExport/ExportFormat'
+import { MenuPortalContext } from './DropdownInputField'
+import { windowLinkOpen } from '../Helpers/Window'
+
+export const ConfirmExportModal = forwardRef(function ConfirmExportModal(props, ref) {
+	const [data, setData] = useState(null)
+	const [show, setShow] = useState(false)
+	const [format, setFormat] = useState(ExportFormatDefault)
+
+	const buttonRef = useRef()
+
+	const buttonFocus = () => {
+		if (buttonRef.current) {
+			buttonRef.current.focus()
+		}
+	}
+
+	const doClose = useCallback(() => setShow(false), [])
+	const onClosed = useCallback(() => setData(null), [])
+	const doAction = useCallback(() => {
+		setData(null)
+		setShow(false)
+
+		const url = new URL(data, window.location.origin)
+		url.searchParams.set('format', format)
+
+		windowLinkOpen({ href: url.toString() })
+	}, [data, format])
+
+	useImperativeHandle(
+		ref,
+		() => ({
+			show(url) {
+				setData(url)
+				setShow(true)
+
+				// Focus the button asap. It also gets focused once the open is complete
+				setTimeout(buttonFocus, 50)
+			},
+		}),
+		[]
+	)
+
+	const [modalRef, setModalRef] = useState(null)
+
+	return (
+		<CModal innerRef={setModalRef} show={show} onClose={doClose} onClosed={onClosed} onOpened={buttonFocus}>
+			<MenuPortalContext.Provider value={modalRef}>
+				<CModalHeader closeButton>
+					<h5>{props.title}</h5>
+				</CModalHeader>
+				<CModalBody>
+					<div>
+						<div className="indent3">
+							<div className="form-check form-check-inline mr-1">
+								<CLabel htmlFor="file_format">File format</CLabel>
+								&nbsp;
+								<SelectExportFormat value={format} setValue={setFormat} />
+							</div>
+						</div>
+					</div>
+				</CModalBody>
+				<CModalFooter>
+					<CButton color="secondary" onClick={doClose}>
+						Cancel
+					</CButton>
+					<CButton innerRef={buttonRef} color="primary" onClick={doAction}>
+						Export
+					</CButton>
+				</CModalFooter>
+			</MenuPortalContext.Provider>
+		</CModal>
+	)
+})

--- a/webui/src/ImportExport/Export.jsx
+++ b/webui/src/ImportExport/Export.jsx
@@ -1,6 +1,8 @@
 import React, { forwardRef, useCallback, useImperativeHandle, useState } from 'react'
 import { CButton, CForm, CInputCheckbox, CLabel, CModal, CModalBody, CModalFooter, CModalHeader } from '@coreui/react'
 import { PreventDefaultHandler } from '../util'
+import { ExportFormatDefault, SelectExportFormat } from './ExportFormat'
+import { MenuPortalContext } from '../Components/DropdownInputField'
 
 export const ExportWizardModal = forwardRef(function WizardModal(_props, ref) {
 	const [show, setShow] = useState(false)
@@ -16,7 +18,11 @@ export const ExportWizardModal = forwardRef(function WizardModal(_props, ref) {
 
 			const params = new URLSearchParams()
 			for (const [key, value] of Object.entries(config)) {
-				params.set(key, value ? '1' : '0')
+				if (typeof value === 'boolean') {
+					params.set(key, value ? '1' : '0')
+				} else {
+					params.set(key, value + '')
+				}
 			}
 
 			const link = document.createElement('a')
@@ -49,6 +55,7 @@ export const ExportWizardModal = forwardRef(function WizardModal(_props, ref) {
 					triggers: true,
 					customVariables: true,
 					// userconfig: true,
+					format: ExportFormatDefault,
 				})
 
 				setShow(true)
@@ -59,27 +66,31 @@ export const ExportWizardModal = forwardRef(function WizardModal(_props, ref) {
 
 	const canExport = Object.values(config).find((v) => !!v)
 
+	const [modalRef, setModalRef] = useState(null)
+
 	return (
-		<CModal show={show} onClose={doClose} className={'wizard'} closeOnBackdrop={false}>
-			<CForm className={'flex-form'} onSubmit={PreventDefaultHandler}>
-				<CModalHeader>
-					<h2>
-						<img src="/img/icons/48x48.png" height="30" alt="logo" />
-						Export Configuration
-					</h2>
-				</CModalHeader>
-				<CModalBody>
-					<ExportOptionsStep config={config} setValue={setValue} />
-				</CModalBody>
-				<CModalFooter>
-					<CButton color="secondary" onClick={doClose}>
-						Close
-					</CButton>
-					<CButton color="primary" onClick={doSave} disabled={!canExport}>
-						Download
-					</CButton>
-				</CModalFooter>
-			</CForm>
+		<CModal innerRef={setModalRef} show={show} onClose={doClose} className={'wizard'} closeOnBackdrop={false}>
+			<MenuPortalContext.Provider value={modalRef}>
+				<CForm className={'flex-form'} onSubmit={PreventDefaultHandler}>
+					<CModalHeader>
+						<h2>
+							<img src="/img/icons/48x48.png" height="30" alt="logo" />
+							Export Configuration
+						</h2>
+					</CModalHeader>
+					<CModalBody>
+						<ExportOptionsStep config={config} setValue={setValue} />
+					</CModalBody>
+					<CModalFooter>
+						<CButton color="secondary" onClick={doClose}>
+							Close
+						</CButton>
+						<CButton color="primary" onClick={doSave} disabled={!canExport}>
+							Download
+						</CButton>
+					</CModalFooter>
+				</CForm>
+			</MenuPortalContext.Provider>
 		</CModal>
 	)
 })
@@ -155,6 +166,14 @@ function ExportOptionsStep({ config, setValue }) {
 					<CLabel htmlFor="wizard_userconfig">Settings</CLabel>
 				</div>
 			</div> */}
+
+			<div className="indent3">
+				<div className="form-check form-check-inline mr-1">
+					<CLabel htmlFor="file_format">File format</CLabel>
+					&nbsp;
+					<SelectExportFormat value={config.format} setValue={(val) => setValue('format', val)} />
+				</div>
+			</div>
 		</div>
 	)
 }

--- a/webui/src/ImportExport/ExportFormat.jsx
+++ b/webui/src/ImportExport/ExportFormat.jsx
@@ -1,0 +1,17 @@
+import { DropdownInputField } from '../Components/DropdownInputField'
+
+export const ExportFormatDefault = 'json-gz'
+const formatOptions = [
+	{
+		id: 'json-gz',
+		label: 'Compressed',
+	},
+	{
+		id: 'json',
+		label: 'Uncompressed',
+	},
+]
+
+export function SelectExportFormat({ value, setValue }) {
+	return <DropdownInputField choices={formatOptions} value={value} setValue={setValue} />
+}

--- a/webui/src/ImportExport/index.jsx
+++ b/webui/src/ImportExport/index.jsx
@@ -82,7 +82,7 @@ export function ImportExport() {
 						console.error('Failed to load config to import:', e)
 					})
 			}
-			fr.readAsText(newFile)
+			fr.readAsArrayBuffer(newFile)
 		},
 		[socket, instancesContext]
 	)

--- a/webui/src/Triggers/index.jsx
+++ b/webui/src/Triggers/index.jsx
@@ -30,6 +30,7 @@ import { nanoid } from 'nanoid'
 import { EditTriggerPanel } from './EditPanel'
 import { GenericConfirmModal } from '../Components/GenericConfirmModal'
 import { ParseControlId } from '@companion/shared/ControlId'
+import { ConfirmExportModal } from '../Components/ConfirmExportModal'
 
 export const Triggers = memo(function Triggers() {
 	const socket = useContext(SocketContext)
@@ -77,8 +78,15 @@ export const Triggers = memo(function Triggers() {
 			})
 	}, [socket, doEditItem])
 
+	const exportModalRef = useRef(null)
+	const showExportModal = useCallback(() => {
+		exportModalRef.current.show(`/int/export/triggers/all`)
+	}, [])
+
 	return (
 		<CRow className="triggers-page split-panels">
+			<ConfirmExportModal ref={exportModalRef} title="Export Triggers" />
+
 			<CCol xs={12} xl={6} className="primary-panel">
 				<h4>Triggers and schedules</h4>
 				<p>This allows you to run actions based on Companion, feedback or time events.</p>
@@ -96,8 +104,7 @@ export const Triggers = memo(function Triggers() {
 					style={{
 						marginTop: 10,
 					}}
-					href={`/int/export/triggers/all`}
-					target="_new"
+					onClick={showExportModal}
 				>
 					<FontAwesomeIcon icon={faFileExport} /> Export all
 				</CButton>


### PR DESCRIPTION
This makes the default export format be gzipped json.
In most places where an export is done, it is possible to export as uncompressed json.

![image](https://user-images.githubusercontent.com/1327476/234127266-6688d45d-2336-4220-b3dc-d56e4a5e07b7.png)
![image](https://user-images.githubusercontent.com/1327476/234127281-232701b3-246c-41b7-b5ff-ec8d1df0ff3b.png)
 
This uncompressed format is formatted json, so closes #2198. 
Compressed closes #231. gzip was chosen due to it being natively supported by nodejs, so it should be performent and will avoid any dependency issues.