### PR TITLE
Add sunrise/sunset trigger event

### DIFF
--- a/lib/Controls/ControlTypes/Triggers/Events/Timer.js
+++ b/lib/Controls/ControlTypes/Triggers/Events/Timer.js
@@ -201,13 +201,13 @@ export default class TriggersEventTimer {
 		let latitude = input.latitude
 		let longitude = input.longitude
 		let offset = input.offset
-		
+
 		// convert 0 or 1 to sunrise or sunset
 		let sunset = input.type == 'sunset'
 
 		// get sunrise/set time for today (nextDay is set to 0)
 		let time = getSunEvent(sunset, latitude, longitude, offset, 0)
-		
+
 		// if time is in the past, get the sun event for the next day
 		const now = new Date()
 		if (time < now) {
@@ -219,40 +219,40 @@ export default class TriggersEventTimer {
 
 		// Modified function to calculate the sunrise/set time by adam-carter-fms
 		// https://gist.github.com/adam-carter-fms/a44a14c0a8cdacbbc38276f6d553e024#file-sunriseset-js-L12
-		function getSunEvent(sunset ,latitude, longitude, offset, nextDay) {
+		function getSunEvent(sunset, latitude, longitude, offset, nextDay) {
 			const res = new Date()
 			res.setDate(res.getDate() + nextDay)
 			const now = res
-			
-			let start = new Date(now.getFullYear(), 0, 0);
-			let diff = (now - start) + ((start.getTimezoneOffset() - now.getTimezoneOffset()) * 60 * 1000)
-			let oneDay = 1000 * 60 * 60 * 24;
-			let day = Math.floor(diff / oneDay);
-			
+
+			let start = new Date(now.getFullYear(), 0, 0)
+			let diff = now - start + (start.getTimezoneOffset() - now.getTimezoneOffset()) * 60 * 1000
+			let oneDay = 1000 * 60 * 60 * 24
+			let day = Math.floor(diff / oneDay)
+
 			const zenith = 90.83333333333333
 			const D2R = Math.PI / 180
 			const R2D = 180 / Math.PI
-			
+
 			// convert the longitude to hour value and calculate an approximate time
 			let lnHour = longitude / 15
 			let t
 			if (!sunset) {
-				t = day + ((6 - lnHour) / 24)
+				t = day + (6 - lnHour) / 24
 			} else {
-				t = day + ((18 - lnHour) / 24)
+				t = day + (18 - lnHour) / 24
 			}
-			
+
 			// calculate the sun's mean anomaly
-			const M = (0.9856 * t) - 3.289
-			
+			const M = 0.9856 * t - 3.289
+
 			// calculate the sun's true longitude
-			let L = M + (1.916 * Math.sin(M * D2R)) + (0.020 * Math.sin(2 * M * D2R)) + 282.634
+			let L = M + 1.916 * Math.sin(M * D2R) + 0.02 * Math.sin(2 * M * D2R) + 282.634
 			if (L > 360) {
 				L = L - 360
 			} else if (L < 0) {
 				L = L + 360
 			}
-			
+
 			// calculate the sun's right ascension
 			let RA = R2D * Math.atan(0.91764 * Math.tan(L * D2R))
 			if (RA > 360) {
@@ -260,21 +260,20 @@ export default class TriggersEventTimer {
 			} else if (RA < 0) {
 				RA = RA + 360
 			}
-			
+
 			// right ascension value needs to be in the same quadrant
-			const Lquadrant = (Math.floor(L / (90))) * 90
-			const RAquadrant = (Math.floor(RA / (90))) * 90
-			RA = RA + (Lquadrant - RAquadrant);
-			
-			
+			const Lquadrant = Math.floor(L / 90) * 90
+			const RAquadrant = Math.floor(RA / 90) * 90
+			RA = RA + (Lquadrant - RAquadrant)
+
 			// right ascension value needs to be converted into hours
 			RA = RA / 15
-			
+
 			const sinDec = 0.39782 * Math.sin(L * D2R)
 			const cosDec = Math.cos(Math.asin(sinDec))
-			
+
 			// calculate the sun's local hour angle
-			const cosH = (Math.cos(zenith * D2R) - (sinDec * Math.sin(latitude * D2R))) / (cosDec * Math.cos(latitude * D2R))
+			const cosH = (Math.cos(zenith * D2R) - sinDec * Math.sin(latitude * D2R)) / (cosDec * Math.cos(latitude * D2R))
 			let H
 			if (!sunset) {
 				H = 360 - R2D * Math.acos(cosH)
@@ -282,10 +281,10 @@ export default class TriggersEventTimer {
 				H = R2D * Math.acos(cosH)
 			}
 			H = H / 15
-			
+
 			// calculate local mean time of rising/setting
-			const T = H + RA - (0.06571 * t) - 6.622
-			
+			const T = H + RA - 0.06571 * t - 6.622
+
 			// adjust back to UTC
 			let UT = T - lnHour
 			if (UT > 24) {
@@ -293,19 +292,19 @@ export default class TriggersEventTimer {
 			} else if (UT < 0) {
 				UT = UT + 24
 			}
-			
+
 			const ms = UT * 60 * 60 * 1000
-			
+
 			const sunEventTime = new Date(ms)
 			sunEventTime.setFullYear(now.getFullYear())
 			sunEventTime.setMonth(now.getMonth())
 			sunEventTime.setDate(now.getDate())
-			
+
 			const temp_minutes = sunEventTime.getMinutes()
-			
+
 			// add offset to time
 			sunEventTime.setMinutes(temp_minutes + 60 + offset)
-			return sunEventTime	
+			return sunEventTime
 		}
 	}
 

--- a/lib/Controls/ControlTypes/Triggers/Events/Timer.js
+++ b/lib/Controls/ControlTypes/Triggers/Events/Timer.js
@@ -203,12 +203,7 @@ export default class TriggersEventTimer {
 		let offset = input.offset
 		
 		// convert 0 or 1 to sunrise or sunset
-		let sunset
-		if (input.type == 0) {
-			sunset = false
-		} else if (input.type == 1) {
-			sunset = true
-		}
+		let sunset = input.type == 'sunset'
 
 		// get sunrise/set time for today (nextDay is set to 0)
 		let time = getSunEvent(sunset, latitude, longitude, offset, 0)

--- a/lib/Controls/ControlTypes/Triggers/Events/Timer.js
+++ b/lib/Controls/ControlTypes/Triggers/Events/Timer.js
@@ -70,6 +70,13 @@ export default class TriggersEventTimer {
 	 */
 	#timeOfDayEvents = []
 
+	/**
+	 * Enable sun based events
+	 * @type {Array}
+	 * @access private
+	 */
+	#sunEvents = []
+
 	constructor(registry, eventBus, controlId, executeActions) {
 		this.logger = registry.log.createLogger(`Controls/Triggers/Events/Timer/${controlId}`)
 
@@ -109,7 +116,7 @@ export default class TriggersEventTimer {
 	 * @param {Object} time - time details for timeofday event
 	 * @returns
 	 */
-	#getNextExecuteTime(time) {
+	#getNextTODExecuteTime(time) {
 		if (typeof time.time !== 'string' || !Array.isArray(time.days) || !time.days.length) return null
 
 		const timeMatch = time.time.match(/^(0[0-9]|1[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$/i)
@@ -181,6 +188,150 @@ export default class TriggersEventTimer {
 	}
 
 	/**
+	 * Calculate the next unix time that an sunrise or set event should execute at
+	 * @param {object} input
+	 * @param {number} input.type
+	 * @param {number} input.latitude
+	 * @param {number} input.longitude
+	 * @param {number} input.offset
+	 * @returns
+	 */
+
+	#getNextSunExecuteTime(input) {
+		let latitude = input.latitude
+		let longitude = input.longitude
+		let offset = input.offset
+		
+		// convert 0 or 1 to sunrise or sunset
+		let sunset
+		if (input.type == 0) {
+			sunset = false
+		} else if (input.type == 1) {
+			sunset = true
+		}
+
+		// get sunrise/set time for today (nextDay is set to 0)
+		let time = getSunEvent(sunset, latitude, longitude, offset, 0)
+		
+		// if time is in the past, get the sun event for the next day
+		const now = new Date()
+		if (time < now) {
+			// call the function for tomorrow (nextDay is set to 1)
+			time = getSunEvent(sunset, latitude, longitude, offset, 1)
+		}
+
+		return time.getTime()
+
+		// Modified function to calculate the sunrise/set time by adam-carter-fms
+		// https://gist.github.com/adam-carter-fms/a44a14c0a8cdacbbc38276f6d553e024#file-sunriseset-js-L12
+		function getSunEvent(sunset ,latitude, longitude, offset, nextDay) {
+			const res = new Date()
+			res.setDate(res.getDate() + nextDay)
+			const now = res
+			
+			let start = new Date(now.getFullYear(), 0, 0);
+			let diff = (now - start) + ((start.getTimezoneOffset() - now.getTimezoneOffset()) * 60 * 1000)
+			let oneDay = 1000 * 60 * 60 * 24;
+			let day = Math.floor(diff / oneDay);
+			
+			const zenith = 90.83333333333333
+			const D2R = Math.PI / 180
+			const R2D = 180 / Math.PI
+			
+			// convert the longitude to hour value and calculate an approximate time
+			let lnHour = longitude / 15
+			let t
+			if (!sunset) {
+				t = day + ((6 - lnHour) / 24)
+			} else {
+				t = day + ((18 - lnHour) / 24)
+			}
+			
+			// calculate the sun's mean anomaly
+			const M = (0.9856 * t) - 3.289
+			
+			// calculate the sun's true longitude
+			let L = M + (1.916 * Math.sin(M * D2R)) + (0.020 * Math.sin(2 * M * D2R)) + 282.634
+			if (L > 360) {
+				L = L - 360
+			} else if (L < 0) {
+				L = L + 360
+			}
+			
+			// calculate the sun's right ascension
+			let RA = R2D * Math.atan(0.91764 * Math.tan(L * D2R))
+			if (RA > 360) {
+				RA = RA - 360
+			} else if (RA < 0) {
+				RA = RA + 360
+			}
+			
+			// right ascension value needs to be in the same quadrant
+			const Lquadrant = (Math.floor(L / (90))) * 90
+			const RAquadrant = (Math.floor(RA / (90))) * 90
+			RA = RA + (Lquadrant - RAquadrant);
+			
+			
+			// right ascension value needs to be converted into hours
+			RA = RA / 15
+			
+			const sinDec = 0.39782 * Math.sin(L * D2R)
+			const cosDec = Math.cos(Math.asin(sinDec))
+			
+			// calculate the sun's local hour angle
+			const cosH = (Math.cos(zenith * D2R) - (sinDec * Math.sin(latitude * D2R))) / (cosDec * Math.cos(latitude * D2R))
+			let H
+			if (!sunset) {
+				H = 360 - R2D * Math.acos(cosH)
+			} else {
+				H = R2D * Math.acos(cosH)
+			}
+			H = H / 15
+			
+			// calculate local mean time of rising/setting
+			const T = H + RA - (0.06571 * t) - 6.622
+			
+			// adjust back to UTC
+			let UT = T - lnHour
+			if (UT > 24) {
+				UT = UT - 24
+			} else if (UT < 0) {
+				UT = UT + 24
+			}
+			
+			const ms = UT * 60 * 60 * 1000
+			
+			const sunEventTime = new Date(ms)
+			sunEventTime.setFullYear(now.getFullYear())
+			sunEventTime.setMonth(now.getMonth())
+			sunEventTime.setDate(now.getDate())
+			
+			const temp_minutes = sunEventTime.getMinutes()
+			
+			// add 1h plus offset to time, because of??
+			sunEventTime.setMinutes(temp_minutes + 60 + offset)
+			return sunEventTime
+		}
+	}
+
+	/**
+	 * Get a description for a sun event
+	 * @param {Object} event Event to describe
+	 * @returns
+	 */
+	getSunDescription(event) {
+		let type_str = 'Undefined'
+		if (event.options.type == 0) {
+			type_str = 'Sunrise'
+		} else if (event.options.type == 1) {
+			type_str = 'Sunset'
+		} else {
+			type_str = 'Error'
+		}
+		return `At <strong>${type_str}</strong>, ${event.options.offset} min offset`
+	}
+
+	/**
 	 * Handler for the timer tick event
 	 * @param {number} tickSeconds Number of ticks since application startup
 	 * @param {number} nowTime Current wall time of the event
@@ -202,7 +353,15 @@ export default class TriggersEventTimer {
 				// check if this timeofday should cause an execution
 				if (tod.nextExecute && tod.nextExecute <= nowTime) {
 					execute = true
-					tod.nextExecute = this.#getNextExecuteTime(tod.time)
+					tod.nextExecute = this.#getNextTODExecuteTime(tod.time)
+				}
+			}
+
+			for (const sun of this.#sunEvents) {
+				// check if this sun event should cause an execution
+				if (sun.nextExecute && sun.nextExecute <= nowTime) {
+					execute = true
+					sun.nextExecute = this.#getNextSunExecuteTime(sun.type)
 				}
 			}
 
@@ -270,7 +429,7 @@ export default class TriggersEventTimer {
 		this.#timeOfDayEvents.push({
 			id,
 			time,
-			nextExecute: this.#getNextExecuteTime(time),
+			nextExecute: this.#getNextTODExecuteTime(time),
 		})
 	}
 
@@ -280,5 +439,28 @@ export default class TriggersEventTimer {
 	 */
 	clearTimeOfDay(id) {
 		this.#timeOfDayEvents = this.#timeOfDayEvents.filter((tod) => tod.id !== id)
+	}
+
+	/**
+	 * Add a sun event listener
+	 * @param {string} id Id of the event
+	 * @param {boolean} params parameters: latitude, longitude and offset
+	 */
+	setSun(id, params) {
+		this.clearSun(id)
+
+		this.#sunEvents.push({
+			id,
+			params,
+			nextExecute: this.#getNextSunExecuteTime(params),
+		})
+	}
+
+	/**
+	 * Remove a timeofday event listener
+	 * @param {string} id Id of the event
+	 */
+	clearSun(id) {
+		this.#sunEvents = this.#sunEvents.filter((sun) => sun.id !== id)
 	}
 }

--- a/lib/Controls/ControlTypes/Triggers/Events/Timer.js
+++ b/lib/Controls/ControlTypes/Triggers/Events/Timer.js
@@ -308,9 +308,9 @@ export default class TriggersEventTimer {
 			
 			const temp_minutes = sunEventTime.getMinutes()
 			
-			// add 1h plus offset to time, because of??
+			// add offset to time
 			sunEventTime.setMinutes(temp_minutes + 60 + offset)
-			return sunEventTime
+			return sunEventTime	
 		}
 	}
 

--- a/lib/Controls/ControlTypes/Triggers/Trigger.js
+++ b/lib/Controls/ControlTypes/Triggers/Trigger.js
@@ -414,6 +414,9 @@ export default class ControlTrigger extends ControlBase {
 					case 'timeofday':
 						eventStrings.push(this.#timerEvents.getTimeOfDayDescription(event))
 						break
+					case 'sun_event':
+						eventStrings.push(this.#timerEvents.getSunDescription(event))
+						break
 					case 'startup':
 						eventStrings.push('Startup')
 						break
@@ -508,6 +511,9 @@ export default class ControlTrigger extends ControlBase {
 				case 'timeofday':
 					this.#timerEvents.setTimeOfDay(event.id, event.options)
 					break
+				case 'sun_event':
+					this.#timerEvents.setSun(event.id, event.options)
+					break
 				case 'startup':
 					this.#miscEvents.setStartup(event.id, event.options.delay)
 					break
@@ -542,6 +548,9 @@ export default class ControlTrigger extends ControlBase {
 				break
 			case 'timeofday':
 				this.#timerEvents.clearTimeOfDay(event.id)
+				break
+			case 'sun_event':
+				this.#timerEvents.clearSun(event.id)
 				break
 			case 'startup':
 				this.#miscEvents.clearStartup(event.id)

--- a/lib/Resources/EventDefinitions.js
+++ b/lib/Resources/EventDefinitions.js
@@ -69,7 +69,7 @@ export const EventDefinitions = {
 				label: 'Sunrise / Sunset',
 				type: 'dropdown',
 				default: 0,
-				choices: [{id: 0, label: 'Sunrise'}, {id:1, label: 'Sunset'}],
+				choices: [{id: 'sunrise', label: 'Sunrise'}, {id:'sunset', label: 'Sunset'}],
 			},
 			{
 				id: 'latitude',

--- a/lib/Resources/EventDefinitions.js
+++ b/lib/Resources/EventDefinitions.js
@@ -92,8 +92,8 @@ export const EventDefinitions = {
 				label: 'Offset (in min)',
 				type: 'number',
 				default: 0,
-				min: -180,
-				max: 180,
+				min: -720,
+				max: 720,
 			}
 		]
 	},

--- a/lib/Resources/EventDefinitions.js
+++ b/lib/Resources/EventDefinitions.js
@@ -62,7 +62,7 @@ export const EventDefinitions = {
 		],
 	},
 	sun_event: {
-		name: 'On sun event',
+		name: 'On Sunrise/Sunset',
 		options: [
 			{
 				id: 'type',
@@ -75,7 +75,7 @@ export const EventDefinitions = {
 				id: 'latitude',
 				label: 'Latitude',
 				type: 'number',
-				default: 59.91273,
+				default: 0,
 				min: -90,
 				max: 90,
 			},
@@ -83,7 +83,7 @@ export const EventDefinitions = {
 				id: 'longitude',
 				label: 'Longitude',
 				type: 'number',
-				default: 10.74609,
+				default: 0,
 				min: -180,
 				max: 180,
 			},

--- a/lib/Resources/EventDefinitions.js
+++ b/lib/Resources/EventDefinitions.js
@@ -69,7 +69,10 @@ export const EventDefinitions = {
 				label: 'Sunrise / Sunset',
 				type: 'dropdown',
 				default: 0,
-				choices: [{id: 'sunrise', label: 'Sunrise'}, {id:'sunset', label: 'Sunset'}],
+				choices: [
+					{ id: 'sunrise', label: 'Sunrise' },
+					{ id: 'sunset', label: 'Sunset' },
+				],
 			},
 			{
 				id: 'latitude',
@@ -94,8 +97,8 @@ export const EventDefinitions = {
 				default: 0,
 				min: -720,
 				max: 720,
-			}
-		]
+			},
+		],
 	},
 	startup: {
 		name: 'Startup',

--- a/lib/Resources/EventDefinitions.js
+++ b/lib/Resources/EventDefinitions.js
@@ -61,6 +61,42 @@ export const EventDefinitions = {
 			},
 		],
 	},
+	sun_event: {
+		name: 'On sun event',
+		options: [
+			{
+				id: 'type',
+				label: 'Sunrise / Sunset',
+				type: 'dropdown',
+				default: 0,
+				choices: [{id: 0, label: 'Sunrise'}, {id:1, label: 'Sunset'}],
+			},
+			{
+				id: 'latitude',
+				label: 'Latitude',
+				type: 'number',
+				default: 59.91273,
+				min: -90,
+				max: 90,
+			},
+			{
+				id: 'longitude',
+				label: 'Longitude',
+				type: 'number',
+				default: 10.74609,
+				min: -180,
+				max: 180,
+			},
+			{
+				id: 'offset',
+				label: 'Offset (in min)',
+				type: 'number',
+				default: 0,
+				min: -180,
+				max: 180,
+			}
+		]
+	},
 	startup: {
 		name: 'Startup',
 		options: [


### PR DESCRIPTION
Adding a sunrise and sunset trigger event with the option to set an offset of ±12h.

<img width="697" alt="image" src="https://user-images.githubusercontent.com/80170229/236215626-99d16a9d-808c-4c92-b314-08707e2ff468.png">

The event uses a modified version of [this function](https://gist.github.com/adam-carter-fms/a44a14c0a8cdacbbc38276f6d553e024#file-sunriseset-js-L12) to estimate the sunrise/sunset times for given coordinates, instead of an API in order to make it work offline.

Closes Issue #1993

