### PR TITLE
feat: settable properties #1187

### DIFF
--- a/lib/Controls/ActionRunner.js
+++ b/lib/Controls/ActionRunner.js
@@ -1,5 +1,6 @@
 import CoreBase from '../Core/Base.js'
 import { CreateBankControlId, ParseControlId } from '../Shared/ControlId.js'
+import PropertySetter from './PropertySetter.js'
 
 /**
  * Class to handle execution of actions.
@@ -30,10 +31,19 @@ export default class ActionRunner extends CoreBase {
 	#timers_running = new Map()
 
 	/**
+	 * Property setter helper
+	 * @access private
+	 * @type {PropertySetter}
+	 */
+	#propertySetter
+
+	/**
 	 * @param {Registry} registry - the application core
 	 */
 	constructor(registry) {
 		super(registry, 'action-runner', 'Control/ActionRunner')
+
+		this.#propertySetter = new PropertySetter(registry)
 	}
 
 	/**
@@ -116,64 +126,9 @@ export default class ActionRunner extends CoreBase {
 			const instance = this.instance.moduleHost.getChild(action.instance)
 			if (instance) {
 				if (action.propertyId) {
-					const propertyDefinition = this.instance.definitions.getPropertyDefinition(action.instance, action.propertyId)
-					if (propertyDefinition) {
-						if (action.action !== 'set-value') throw new Error('Not implemented!')
-
-						Promise.resolve()
-							.then(async () => {
-								let instanceId = null
-
-								// If the property has instanceIds, then determine what the user has chosen and validate it
-								if (propertyDefinition.instanceIds) {
-									if (action.options.instanceUseExpression) {
-										instanceId = this.instance.variable.parseExpression(action.options.instanceExpression).value
-									} else {
-										instanceId = action.options.instanceValue
-									}
-
-									// Try a strict then loose match
-									const match =
-										propertyDefinition.instanceIds.find((inst) => inst.id === instanceId) ||
-										propertyDefinition.instanceIds.find((inst) => inst.id == instanceId)
-									if (!match) {
-										throw new Error(`Invalid instanceId: ${instanceId}`)
-									}
-									instanceId = match.id
-								}
-
-								// Parse the value
-								let value = action.options.value
-								if (action.options.valueUseExpression) {
-									if (
-										propertyDefinition.type !== 'number' &&
-										propertyDefinition.type !== 'string' &&
-										propertyDefinition.type !== 'boolean' &&
-										propertyDefinition.type !== 'dropdown'
-									)
-										throw new Error(`Cannot parse an expression to type: "${propertyDefinition.type}"`)
-
-									value = this.instance.variable.parseExpression(
-										action.options.valueExpression,
-										propertyDefinition.type !== 'dropdown' ? propertyDefinition.type : undefined
-									).value
-
-									// TODO - check value looks valid?
-								} else if (propertyDefinition.type === 'string') {
-									// if a string, we need to parse variables in the normal value
-									value = this.instance.variable.parseVariables(action.options.value)
-								}
-
-								await instance.propertySet(action.propertyId, instanceId, value, extras)
-							})
-							.catch((e) => {
-								this.logger.warn(`Error setting property for ${instance.connectionId}: ${e.message ?? e}`)
-							})
-					} else {
-						this.logger.info(
-							`Skipping unknown property ${action.propertyId} for ${instance.connectionId}: ${e.message ?? e}`
-						)
-					}
+					this.#propertySetter.runAction(instance, action, extras).catch((e) => {
+						this.logger.warn(`Error setting property for ${instance.connectionId}: ${e.message ?? e}`)
+					})
 				} else {
 					instance.actionRun(action, extras).catch((e) => {
 						this.logger.silly(`Error executing action for ${instance.connectionId}: ${e.message ?? e}`)

--- a/lib/Controls/ActionRunner.js
+++ b/lib/Controls/ActionRunner.js
@@ -115,9 +115,24 @@ export default class ActionRunner extends CoreBase {
 		} else {
 			const instance = this.instance.moduleHost.getChild(action.instance)
 			if (instance) {
-				instance.actionRun(action, extras).catch((e) => {
-					this.logger.silly(`Error executing action for ${instance.connectionId}: ${e.message ?? e}`)
-				})
+				if (action.propertyId) {
+					instance
+						.propertySet(
+							{
+								propertyId: action.propertyId,
+								actionId: action.action,
+								...action.options,
+							},
+							extras
+						)
+						.catch((e) => {
+							this.logger.silly(`Error setting property for ${instance.connectionId}: ${e.message ?? e}`)
+						})
+				} else {
+					instance.actionRun(action, extras).catch((e) => {
+						this.logger.silly(`Error executing action for ${instance.connectionId}: ${e.message ?? e}`)
+					})
+				}
 			} else {
 				this.logger.silly('trying to run action on a missing instance.', action)
 			}

--- a/lib/Controls/ActionRunner.js
+++ b/lib/Controls/ActionRunner.js
@@ -116,18 +116,47 @@ export default class ActionRunner extends CoreBase {
 			const instance = this.instance.moduleHost.getChild(action.instance)
 			if (instance) {
 				if (action.propertyId) {
-					instance
-						.propertySet(
-							{
-								propertyId: action.propertyId,
-								actionId: action.action,
-								...action.options,
-							},
-							extras
+					const propertyDefinition = this.instance.definitions.getPropertyDefinition(action.instance, action.propertyId)
+					if (propertyDefinition) {
+						Promise.resolve()
+							.then(async () => {
+								let instanceId = null
+
+								if (propertyDefinition.instanceIds) {
+									if (action.options.instanceUseExpression) {
+										instanceId = this.instance.variable.parseExpression(action.options.instanceExpression).value
+									} else {
+										instanceId = action.options.instanceValue
+									}
+
+									// Try a strict then loose match
+									const match =
+										propertyDefinition.instanceIds.find((inst) => inst.id === instanceId) ||
+										propertyDefinition.instanceIds.find((inst) => inst.id == instanceId)
+									if (!match) {
+										throw new Error(`Invalid instanceId: ${instanceId}`)
+									}
+									instanceId = match.id
+								}
+
+								let value = action.options.value
+								if (action.options.valueUseExpression) {
+									value = this.instance.variable.parseExpression(
+										action.options.valueExpression,
+										'number' // TODO - correct type
+									).value
+								}
+
+								await instance.propertySet(action.propertyId, instanceId, value, extras)
+							})
+							.catch((e) => {
+								this.logger.warn(`Error setting property for ${instance.connectionId}: ${e.message ?? e}`)
+							})
+					} else {
+						this.logger.info(
+							`Skipping unknown property ${action.propertyId} for ${instance.connectionId}: ${e.message ?? e}`
 						)
-						.catch((e) => {
-							this.logger.silly(`Error setting property for ${instance.connectionId}: ${e.message ?? e}`)
-						})
+					}
 				} else {
 					instance.actionRun(action, extras).catch((e) => {
 						this.logger.silly(`Error executing action for ${instance.connectionId}: ${e.message ?? e}`)

--- a/lib/Controls/ActionRunner.js
+++ b/lib/Controls/ActionRunner.js
@@ -118,6 +118,8 @@ export default class ActionRunner extends CoreBase {
 				if (action.propertyId) {
 					const propertyDefinition = this.instance.definitions.getPropertyDefinition(action.instance, action.propertyId)
 					if (propertyDefinition) {
+						if (action.action !== 'set-value') throw new Error('Not implemented!')
+
 						Promise.resolve()
 							.then(async () => {
 								let instanceId = null
@@ -146,14 +148,17 @@ export default class ActionRunner extends CoreBase {
 									if (
 										propertyDefinition.type !== 'number' &&
 										propertyDefinition.type !== 'string' &&
-										propertyDefinition.type !== 'boolean'
+										propertyDefinition.type !== 'boolean' &&
+										propertyDefinition.type !== 'dropdown'
 									)
 										throw new Error(`Cannot parse an expression to type: "${propertyDefinition.type}"`)
 
 									value = this.instance.variable.parseExpression(
 										action.options.valueExpression,
-										propertyDefinition.type
+										propertyDefinition.type !== 'dropdown' ? propertyDefinition.type : undefined
 									).value
+
+									// TODO - check value looks valid?
 								} else if (propertyDefinition.type === 'string') {
 									// if a string, we need to parse variables in the normal value
 									value = this.instance.variable.parseVariables(action.options.value)

--- a/lib/Controls/ActionRunner.js
+++ b/lib/Controls/ActionRunner.js
@@ -122,6 +122,7 @@ export default class ActionRunner extends CoreBase {
 							.then(async () => {
 								let instanceId = null
 
+								// If the property has instanceIds, then determine what the user has chosen and validate it
 								if (propertyDefinition.instanceIds) {
 									if (action.options.instanceUseExpression) {
 										instanceId = this.instance.variable.parseExpression(action.options.instanceExpression).value
@@ -139,12 +140,23 @@ export default class ActionRunner extends CoreBase {
 									instanceId = match.id
 								}
 
+								// Parse the value
 								let value = action.options.value
 								if (action.options.valueUseExpression) {
+									if (
+										propertyDefinition.type !== 'number' &&
+										propertyDefinition.type !== 'string' &&
+										propertyDefinition.type !== 'boolean'
+									)
+										throw new Error(`Cannot parse an expression to type: "${propertyDefinition.type}"`)
+
 									value = this.instance.variable.parseExpression(
 										action.options.valueExpression,
-										'number' // TODO - correct type
+										propertyDefinition.type
 									).value
+								} else if (propertyDefinition.type === 'string') {
+									// if a string, we need to parse variables in the normal value
+									value = this.instance.variable.parseVariables(action.options.value)
 								}
 
 								await instance.propertySet(action.propertyId, instanceId, value, extras)

--- a/lib/Controls/ControlTypes/Button/Base.js
+++ b/lib/Controls/ControlTypes/Button/Base.js
@@ -124,16 +124,13 @@ export default class ButtonControlBase extends ControlBase {
 		for (const instance_id of instance_ids) {
 			const instance_status = this.instance.getInstanceStatus(instance_id)
 			if (instance_status) {
-				// TODO - can this be made simpler
-				switch (instance_status.category) {
-					case 'error':
-						status = 'error'
-						break
-					case 'warning':
-						if (status !== 'error') {
-							status = 'warning'
-						}
-						break
+				if (instance_status.category === 'error') {
+					// No need to keep searching
+					status = 'error'
+					break
+				} else if (instance_status.category === 'warning') {
+					// Keep lookig for an error
+					status = 'warning'
 				}
 			}
 		}

--- a/lib/Controls/Controller.js
+++ b/lib/Controls/Controller.js
@@ -360,12 +360,12 @@ class ControlsController extends CoreBase {
 			this.rotateControl(controlId, direction, deviceId ? `hot:${deviceId}` : undefined)
 		})
 
-		client.onPromise('controls:action:add', (controlId, stepId, setId, instanceId, actionId) => {
+		client.onPromise('controls:action:add', (controlId, stepId, setId, instanceId, actionId, propertyId) => {
 			const control = this.getControl(controlId)
 			if (!control) return false
 
 			if (typeof control.actionAdd === 'function') {
-				const actionItem = this.instance.definitions.createActionItem(instanceId, actionId)
+				const actionItem = this.instance.definitions.createActionItem(instanceId, actionId, propertyId)
 				if (actionItem) {
 					return control.actionAdd(stepId, setId, actionItem)
 				} else {

--- a/lib/Controls/PropertySetter.js
+++ b/lib/Controls/PropertySetter.js
@@ -1,0 +1,78 @@
+import CoreBase from '../Core/Base.js'
+
+export default class PropertySetter extends CoreBase {
+	/**
+	 * @param {Registry} registry - the application core
+	 */
+	constructor(registry) {
+		super(registry, 'property-setter', 'Control/PropertySetter')
+	}
+
+	async runAction(connection, action, extras) {
+		const propertyDefinition = this.instance.definitions.getPropertyDefinition(action.instance, action.propertyId)
+		if (propertyDefinition) {
+			const instanceId = this.#parseInstanceId(propertyDefinition, action)
+
+			switch (action.action) {
+				case 'set-value': {
+					await this.#runSetValue(propertyDefinition, action, connection, instanceId, extras)
+					break
+				}
+				default: {
+					throw new Error(`Action "${action.action}" not implemented!`)
+				}
+			}
+		} else {
+			this.logger.info(`Skipping unknown property ${action.propertyId} for ${connection.connectionId}`)
+		}
+	}
+
+	async #runSetValue(propertyDefinition, action, connection, instanceId, extras) {
+		// Parse the value
+		let value = action.options.value
+		if (action.options.valueUseExpression) {
+			if (
+				propertyDefinition.type !== 'number' &&
+				propertyDefinition.type !== 'string' &&
+				propertyDefinition.type !== 'boolean' &&
+				propertyDefinition.type !== 'dropdown'
+			)
+				throw new Error(`Cannot parse an expression to type: "${propertyDefinition.type}"`)
+
+			value = this.instance.variable.parseExpression(
+				action.options.valueExpression,
+				propertyDefinition.type !== 'dropdown' ? propertyDefinition.type : undefined
+			).value
+
+			// TODO - check value looks valid?
+		} else if (propertyDefinition.type === 'string') {
+			// if a string, we need to parse variables in the normal value
+			value = this.instance.variable.parseVariables(action.options.value)
+		}
+
+		await connection.propertySet(action.propertyId, instanceId, value, extras)
+	}
+
+	#parseInstanceId(propertyDefinition, action) {
+		// If the property has instanceIds, then determine what the user has chosen and validate it
+		if (propertyDefinition.instanceIds) {
+			let instanceId
+			if (action.options.instanceUseExpression) {
+				instanceId = this.instance.variable.parseExpression(action.options.instanceExpression).value
+			} else {
+				instanceId = action.options.instanceValue
+			}
+
+			// Try a strict then loose match
+			const match =
+				propertyDefinition.instanceIds.find((inst) => inst.id === instanceId) ||
+				propertyDefinition.instanceIds.find((inst) => inst.id == instanceId)
+			if (!match) {
+				throw new Error(`Invalid instanceId: ${instanceId}`)
+			}
+			return match.id
+		} else {
+			return null
+		}
+	}
+}

--- a/lib/Instance/Definitions.js
+++ b/lib/Instance/Definitions.js
@@ -153,9 +153,8 @@ class InstanceDefinitions extends CoreBase {
 	 */
 	createActionItem(instanceId, actionId, propertyId) {
 		if (propertyId) {
-			// TODO - what about different types of property actions
 			const definition = this.getPropertyDefinition(instanceId, propertyId)
-			if (definition) {
+			if (definition && definition.actions?.[actionId]) {
 				const action = {
 					id: nanoid(),
 					action: actionId,
@@ -163,7 +162,7 @@ class InstanceDefinitions extends CoreBase {
 					instance: instanceId,
 					options: {
 						valueInstance: definition.instanceIds?.[0]?.id ?? null,
-						value: definition.type === 'boolean' ? true : definition.type === 'number' ? 0 : '',
+						value: definition.type === 'boolean' ? true : definition.type === 'number' ? 0 : '', // TODO - better default value
 					},
 					delay: 0,
 				}

--- a/lib/Instance/Definitions.js
+++ b/lib/Instance/Definitions.js
@@ -147,29 +147,52 @@ class InstanceDefinitions extends CoreBase {
 	 * Create a action item without saving
 	 * @param {string} instanceId - the id of the instance
 	 * @param {string} actionId - the id of the action
+	 * @param {boolean} propertyId - if the action is a wrapper for a property
 	 * @access public
 	 */
-	createActionItem(instanceId, actionId) {
-		const definition = this.getActionDefinition(instanceId, actionId)
-		if (definition) {
-			const action = {
-				id: nanoid(),
-				action: actionId,
-				instance: instanceId,
-				options: {},
-				delay: 0,
-			}
-
-			if (definition.options !== undefined && definition.options.length > 0) {
-				for (const j in definition.options) {
-					const opt = definition.options[j]
-					action.options[opt.id] = cloneDeep(opt.default)
+	createActionItem(instanceId, actionId, propertyId) {
+		if (propertyId) {
+			// TODO - what about different types of property actions
+			const definition = this.getPropertyDefinition(instanceId, propertyId)
+			if (definition) {
+				const action = {
+					id: nanoid(),
+					action: actionId,
+					propertyId: propertyId,
+					instance: instanceId,
+					options: {
+						valueInstance: definition.instanceIds?.[0]?.id ?? null,
+						value: definition.type === 'boolean' ? true : definition.type === 'number' ? 0 : '',
+					},
+					delay: 0,
 				}
-			}
 
-			return action
+				return action
+			} else {
+				return null
+			}
 		} else {
-			return null
+			const definition = this.getActionDefinition(instanceId, actionId)
+			if (definition) {
+				const action = {
+					id: nanoid(),
+					action: actionId,
+					instance: instanceId,
+					options: {},
+					delay: 0,
+				}
+
+				if (definition.options !== undefined && definition.options.length > 0) {
+					for (const j in definition.options) {
+						const opt = definition.options[j]
+						action.options[opt.id] = cloneDeep(opt.default)
+					}
+				}
+
+				return action
+			} else {
+				return null
+			}
 		}
 	}
 

--- a/lib/Instance/Definitions.js
+++ b/lib/Instance/Definitions.js
@@ -161,7 +161,9 @@ class InstanceDefinitions extends CoreBase {
 					propertyId: propertyId,
 					instance: instanceId,
 					options: {
-						valueInstance: definition.instanceIds?.[0]?.id ?? null,
+						instanceUseExpression: false,
+						instanceValue: definition.instanceIds?.[0]?.id ?? null,
+
 						value: definition.type === 'boolean' ? true : definition.type === 'number' ? 0 : '', // TODO - better default value
 					},
 					delay: 0,

--- a/lib/Instance/Definitions.js
+++ b/lib/Instance/Definitions.js
@@ -5,6 +5,7 @@ import { CreateBankControlId } from '../Shared/ControlId.js'
 import { EventDefinitions } from '../Resources/EventDefinitions.js'
 import ControlButtonNormal from '../Controls/ControlTypes/Button/Normal.js'
 import jsonPatch from 'fast-json-patch'
+import PropertyActionsGenerator from './Properties/PropertyActions.js'
 
 const PresetsRoom = 'presets'
 const ActionsRoom = 'action-definitions'
@@ -473,14 +474,28 @@ class InstanceDefinitions extends CoreBase {
 	 * @access public
 	 */
 	setPropertyDefinitions(instanceId, properties) {
+		const propertiesWithActionsAndFeedbacks = {}
+
+		for (const [propertyId, property] of Object.entries(cloneDeep(properties))) {
+			propertiesWithActionsAndFeedbacks[propertyId] = {
+				...property,
+				actions: property.hasSetter ? PropertyActionsGenerator.AutoGenerate(property) : {},
+				feedbacks: property.hasGetter
+					? {
+							// TODO
+					  }
+					: {},
+			}
+		}
+
 		const lastPropertyDefinitions = this.#propertyDefinitions[instanceId]
-		this.#propertyDefinitions[instanceId] = cloneDeep(properties)
+		this.#propertyDefinitions[instanceId] = propertiesWithActionsAndFeedbacks
 
 		if (this.io.countRoomMembers(PropertiesRoom) > 0) {
 			if (!lastPropertyDefinitions) {
-				this.io.emitToRoom(PropertiesRoom, 'property-definitions:update', instanceId, properties)
+				this.io.emitToRoom(PropertiesRoom, 'property-definitions:update', instanceId, propertiesWithActionsAndFeedbacks)
 			} else {
-				const patch = jsonPatch.compare(lastPropertyDefinitions, properties || {})
+				const patch = jsonPatch.compare(lastPropertyDefinitions, propertiesWithActionsAndFeedbacks || {})
 				if (patch.length > 0) {
 					this.io.emitToRoom(PropertiesRoom, 'property-definitions:update', instanceId, patch)
 				}

--- a/lib/Instance/Definitions.js
+++ b/lib/Instance/Definitions.js
@@ -438,11 +438,29 @@ class InstanceDefinitions extends CoreBase {
 							const setActions = Array.isArray(set) ? set : set.actions
 							if (!isNaN(setId) && set.options?.runWhileHeld) options.runWhileHeld.push(Number(setId))
 
-							action_sets[setId] = setActions.map((act) => ({
-								action: act.actionId,
-								options: act.options,
-								delay: act.delay,
-							}))
+							action_sets[setId] = setActions.map((act) => {
+								if (act.propertyId) {
+									// Wrap a property up to be a proper action
+									return {
+										action: act.actionId,
+										propertyId: act.propertyId,
+										delay: act.delay,
+										options: {
+											instanceValue: act.instanceId,
+											instanceExpression: false,
+
+											value: act.value,
+											valueExpression: false, // TODO
+										},
+									}
+								} else {
+									return {
+										action: act.actionId,
+										options: act.options,
+										delay: act.delay,
+									}
+								}
+							})
 						}
 
 						return {

--- a/lib/Instance/Properties/PropertyActions.js
+++ b/lib/Instance/Properties/PropertyActions.js
@@ -109,6 +109,26 @@ class PropertyActionsGenerator {
 
 		return action
 	}
+	static SetDropdownValue(property) {
+		const action = {
+			label: `Set: ${property.name}`,
+			description: `Set ${property.description} to value`,
+			options: [
+				...this.#CreateSetValueExpressionFields({
+					type: 'dropdown',
+
+					choices: property.choices,
+					allowCustom: property.allowCustom,
+					regex: property.regex,
+				}),
+			],
+			hasLearn: false,
+		}
+
+		PropertyActionsGenerator.#InsertInstances(property, action)
+
+		return action
+	}
 
 	static AutoGenerate(property) {
 		const actions = {}
@@ -116,6 +136,15 @@ class PropertyActionsGenerator {
 		switch (property.type) {
 			case 'number':
 				actions['set-value'] = PropertyActionsGenerator.SetNumberValue(property)
+				break
+			case 'string':
+				actions['set-value'] = PropertyActionsGenerator.SetStringValue(property)
+				break
+			case 'boolean':
+				actions['set-value'] = PropertyActionsGenerator.SetBooleanValue(property)
+				break
+			case 'dropdown':
+				actions['set-value'] = PropertyActionsGenerator.SetDropdownValue(property)
 				break
 		}
 

--- a/lib/Instance/Properties/PropertyActions.js
+++ b/lib/Instance/Properties/PropertyActions.js
@@ -1,0 +1,45 @@
+class PropertyActionsGenerator {
+	static InsertInstances(property, action) {
+		if (property.instanceIds) {
+			action.options.unshift({
+				type: 'dropdown',
+				label: 'Instance',
+				id: 'valueInstance',
+				choices: property.instanceIds,
+			})
+		}
+	}
+	static SetNumberValue(property) {
+		// Basic setter property
+		const action = {
+			label: `Set: ${property.name}`,
+			description: `Set ${property.description} to value`,
+			options: [
+				{
+					type: 'number',
+					label: 'Value',
+					id: 'value',
+				},
+			],
+			hasLearn: false,
+		}
+
+		PropertyActionsGenerator.InsertInstances(property, action)
+
+		return action
+	}
+
+	static AutoGenerate(property) {
+		const actions = {}
+
+		switch (property.type) {
+			case 'number':
+				actions['set-value'] = PropertyActionsGenerator.SetNumberValue(property)
+				break
+		}
+
+		return actions
+	}
+}
+
+export default PropertyActionsGenerator

--- a/lib/Instance/Properties/PropertyActions.js
+++ b/lib/Instance/Properties/PropertyActions.js
@@ -53,13 +53,53 @@ class PropertyActionsGenerator {
 		])
 	}
 	static SetNumberValue(property) {
-		// Basic setter property
 		const action = {
 			label: `Set: ${property.name}`,
 			description: `Set ${property.description} to value`,
 			options: [
 				...this.#CreateSetValueExpressionFields({
 					type: 'number',
+
+					min: property.min,
+					max: property.max,
+					step: property.step,
+					range: property.range,
+				}),
+			],
+			hasLearn: false,
+		}
+
+		PropertyActionsGenerator.#InsertInstances(property, action)
+
+		return action
+	}
+	static SetBooleanValue(property) {
+		const action = {
+			label: `Set: ${property.name}`,
+			description: `Set ${property.description} to value`,
+			options: [
+				...this.#CreateSetValueExpressionFields({
+					type: 'checkbox',
+					default: false,
+				}),
+			],
+			hasLearn: false,
+		}
+
+		PropertyActionsGenerator.#InsertInstances(property, action)
+
+		return action
+	}
+	static SetStringValue(property) {
+		const action = {
+			label: `Set: ${property.name}`,
+			description: `Set ${property.description} to value`,
+			options: [
+				...this.#CreateSetValueExpressionFields({
+					type: 'textinput',
+
+					regex: property.regex,
+					useVariables: true,
 				}),
 			],
 			hasLearn: false,

--- a/lib/Instance/Properties/PropertyActions.js
+++ b/lib/Instance/Properties/PropertyActions.js
@@ -1,13 +1,56 @@
+import { serializeIsVisibleFn } from '@companion-module/base/dist/internal/base.js'
+
 class PropertyActionsGenerator {
 	static #InsertInstances(property, action) {
 		if (property.instanceIds) {
-			action.options.unshift({
-				type: 'dropdown',
-				label: 'Instance',
-				id: 'valueInstance',
-				choices: property.instanceIds,
-			})
+			action.options.unshift(
+				...serializeIsVisibleFn([
+					{
+						type: 'checkbox',
+						label: 'Instance from Expression',
+						id: 'instanceUseExpression',
+						default: false,
+					},
+					{
+						type: 'dropdown',
+						label: 'Instance',
+						id: 'instanceValue',
+						choices: property.instanceIds,
+						isVisible: (options) => !options.instanceUseExpression,
+					},
+					{
+						type: 'textinput',
+						label: 'Instance Expression',
+						id: 'instanceExpression',
+						isVisible: (options) => !!options.instanceUseExpression,
+						useVariables: true,
+					},
+				])
+			)
 		}
+	}
+	static #CreateSetValueExpressionFields(baseField) {
+		return serializeIsVisibleFn([
+			{
+				type: 'checkbox',
+				label: 'Value from Expression',
+				id: 'valueUseExpression',
+				default: false,
+			},
+			{
+				...baseField,
+				label: 'Value',
+				id: 'value',
+				isVisible: (options) => !options.valueUseExpression,
+			},
+			{
+				type: 'textinput',
+				label: 'Value Expression',
+				id: 'valueExpression',
+				isVisible: (options) => !!options.valueUseExpression,
+				useVariables: true,
+			},
+		])
 	}
 	static SetNumberValue(property) {
 		// Basic setter property
@@ -15,11 +58,9 @@ class PropertyActionsGenerator {
 			label: `Set: ${property.name}`,
 			description: `Set ${property.description} to value`,
 			options: [
-				{
+				...this.#CreateSetValueExpressionFields({
 					type: 'number',
-					label: 'Value',
-					id: 'value',
-				},
+				}),
 			],
 			hasLearn: false,
 		}

--- a/lib/Instance/Properties/PropertyActions.js
+++ b/lib/Instance/Properties/PropertyActions.js
@@ -1,5 +1,5 @@
 class PropertyActionsGenerator {
-	static InsertInstances(property, action) {
+	static #InsertInstances(property, action) {
 		if (property.instanceIds) {
 			action.options.unshift({
 				type: 'dropdown',
@@ -24,7 +24,7 @@ class PropertyActionsGenerator {
 			hasLearn: false,
 		}
 
-		PropertyActionsGenerator.InsertInstances(property, action)
+		PropertyActionsGenerator.#InsertInstances(property, action)
 
 		return action
 	}

--- a/lib/Instance/Wrapper.js
+++ b/lib/Instance/Wrapper.js
@@ -426,7 +426,6 @@ class SocketEventsHandler {
 	}
 
 	async propertySet(propertyId, instanceId, value, extras) {
-		console.log('property set', propertyId, instanceId, value, extras)
 		await this.ipcWrapper.sendWithCb('propertySet', {
 			property: {
 				propertyId: propertyId,

--- a/lib/Instance/Wrapper.js
+++ b/lib/Instance/Wrapper.js
@@ -422,6 +422,27 @@ class SocketEventsHandler {
 		}
 	}
 
+	async propertySet(property, extras) {
+		try {
+			console.log('property set', property, extras)
+			await this.ipcWrapper.sendWithCb('propertySet', {
+				property: {
+					actionId: property.actionId,
+					propertyId: property.propertyId,
+					instanceId: property.valueInstance,
+					value: property.value,
+				},
+
+				controlId: extras?.controlId,
+				surfaceId: extras?.deviceid,
+			})
+		} catch (e) {
+			this.logger.warn(`Error executing action: ${e.message ?? e}`)
+
+			throw e
+		}
+	}
+
 	/**
 	 * Tell the child instance class to 'destroy' itself
 	 */

--- a/lib/Instance/Wrapper.js
+++ b/lib/Instance/Wrapper.js
@@ -687,6 +687,15 @@ class SocketEventsHandler {
 
 				hasGetter: !!rawProperty.hasGetter,
 				hasSetter: !!rawProperty.hasSetter,
+
+				// type specific fields
+				choices: rawProperty.choices,
+				allowCustom: rawProperty.allowCustom,
+				regex: rawProperty.regex,
+				min: rawProperty.min,
+				max: rawProperty.max,
+				step: rawProperty.step,
+				range: rawProperty.range,
 			}
 		}
 

--- a/lib/Instance/Wrapper.js
+++ b/lib/Instance/Wrapper.js
@@ -425,25 +425,18 @@ class SocketEventsHandler {
 		}
 	}
 
-	async propertySet(property, extras) {
-		try {
-			console.log('property set', property, extras)
-			await this.ipcWrapper.sendWithCb('propertySet', {
-				property: {
-					actionId: property.actionId,
-					propertyId: property.propertyId,
-					instanceId: property.valueInstance,
-					value: property.value,
-				},
+	async propertySet(propertyId, instanceId, value, extras) {
+		console.log('property set', propertyId, instanceId, value, extras)
+		await this.ipcWrapper.sendWithCb('propertySet', {
+			property: {
+				propertyId: propertyId,
+				instanceId: instanceId,
+				value: value,
+			},
 
-				controlId: extras?.controlId,
-				surfaceId: extras?.deviceid,
-			})
-		} catch (e) {
-			this.logger.warn(`Error executing action: ${e.message ?? e}`)
-
-			throw e
-		}
+			controlId: extras?.controlId,
+			surfaceId: extras?.deviceid,
+		})
 	}
 
 	/**

--- a/lib/Instance/Wrapper.js
+++ b/lib/Instance/Wrapper.js
@@ -202,8 +202,8 @@ class SocketEventsHandler {
 				const actions = control.getAllActions()
 
 				for (const action of actions) {
-					const parsed = ParseControlId(controlId)
-					if (action.instance == this.connectionId) {
+					if (action.instance == this.connectionId && !action.propertyId) {
+						const parsed = ParseControlId(controlId)
 						allActions[action.id] = {
 							id: action.id,
 							controlId: controlId,
@@ -326,7 +326,7 @@ class SocketEventsHandler {
 	 */
 	async actionUpdate(action, controlId) {
 		if (action.instance !== this.connectionId) throw new Error(`Action is for a different instance`)
-		if (action.disabled) return
+		if (action.disabled || action.propertyId) return
 
 		const parsedId = ParseControlId(controlId)
 
@@ -353,6 +353,7 @@ class SocketEventsHandler {
 	 */
 	async actionDelete(oldAction) {
 		if (oldAction.instance !== this.connectionId) throw new Error(`Action is for a different instance`)
+		if (action.propertyId) return
 
 		await this.ipcWrapper.sendWithCb('updateActions', {
 			actions: {
@@ -364,6 +365,7 @@ class SocketEventsHandler {
 
 	async actionLearnValues(action, controlId) {
 		if (action.instance !== this.connectionId) throw new Error(`Action is for a different instance`)
+		if (action.propertyId) return
 
 		const parsedId = ParseControlId(controlId)
 
@@ -396,6 +398,7 @@ class SocketEventsHandler {
 	 */
 	async actionRun(action, extras) {
 		if (action.instance !== this.connectionId) throw new Error(`Action is for a different instance`)
+		if (action.propertyId) return
 
 		try {
 			await this.ipcWrapper.sendWithCb('executeAction', {

--- a/lib/Internal/Controller.js
+++ b/lib/Internal/Controller.js
@@ -72,7 +72,7 @@ export default class InternalController extends CoreBase {
 				const actions = control.getAllActions()
 
 				for (const action of actions) {
-					if (action.instance === 'internal') {
+					if (action.instance === 'internal' && !action.propertyId) {
 						// Try and run an upgrade
 						const newAction = this.actionUpgrade(action)
 						if (newAction) {


### PR DESCRIPTION
This is 'Stage 2' of properties, continuing #2431 

This extends 'Stage 1', by any property which has a setter now gets some actions to be auto-generated.
Currently, this is only allows for setting the value for every type. 

For example, a 'dropdown' property looks like:
![image](https://github.com/bitfocus/companion/assets/1327476/228c05e2-f78f-4614-a691-30862b26513a)

Note that both the `Instance` and `Value` fields can be switched to the expression mode. These values are resolved and validated with only the parsed values being fed to the module.

Presets are able to setup these properties as actions https://github.com/bitfocus/companion-module-bmd-atem/blob/f666e6d20758793d272f940a681b871e3acd5a1d/src/presets.ts#L96-L104, but not using expressions yet

An example implementation using this can be found at https://github.com/bitfocus/companion-module-bmd-atem/tree/wip/properties/src/properties

### TODO:
- [ ] support converting actions to properties in upgrade scripts
- [ ] subscriptions
- [ ] learn button
- [ ] expressions from presets?