### PR TITLE
feat: videohub panel server

### DIFF
--- a/lib/Data/UserConfig.js
+++ b/lib/Data/UserConfig.js
@@ -61,6 +61,8 @@ class DataUserConfig extends CoreBase {
 
 		emberplus_enabled: false,
 
+		videohub_panel_enabled: false,
+
 		artnet_enabled: false,
 		artnet_universe: 1,
 		artnet_channel: 1,

--- a/lib/Service/Controller.js
+++ b/lib/Service/Controller.js
@@ -9,6 +9,7 @@ import ServiceRosstalk from './Rosstalk.js'
 import ServiceSatellite from './Satellite.js'
 import ServiceTcp from './Tcp.js'
 import ServiceUdp from './Udp.js'
+import ServiceVideohubPanel from './VideohubPanel.js'
 
 /**
  * Class that manages all of the services.
@@ -46,6 +47,7 @@ class ServiceController {
 		this.rosstalk = new ServiceRosstalk(registry)
 		this.satellite = new ServiceSatellite(registry)
 		this.elgatoPlugin = new ServiceElgatoPlugin(registry)
+		this.videohubPanel = new ServiceVideohubPanel(registry)
 	}
 
 	/**
@@ -65,6 +67,7 @@ class ServiceController {
 		this.satellite.updateUserConfig(key, value)
 		this.tcp.updateUserConfig(key, value)
 		this.udp.updateUserConfig(key, value)
+		this.videohubPanel.updateUserConfig(key, value)
 	}
 }
 

--- a/lib/Service/VideohubPanel.js
+++ b/lib/Service/VideohubPanel.js
@@ -1,0 +1,108 @@
+import ServiceBase from './Base.js'
+import VideohubServer from 'videohub-server'
+
+/**
+ * Class providing the Videohub Server api.
+ *
+ * @extends ServiceBase
+ * @author Håkon Nessjøen <haakon@bitfocus.io>
+ * @author Keith Rocheck <keith.rocheck@gmail.com>
+ * @author William Viker <william@bitfocus.io>
+ * @author Julian Waller <me@julusian.co.uk>
+ * @since 2.2.0
+ * @copyright 2022 Bitfocus AS
+ * @license
+ * This program is free software.
+ * You should have received a copy of the MIT licence as well as the Bitfocus
+ * Individual Contributor License Agreement for Companion along with
+ * this program.
+ *
+ * You can be released from the requirements of the license by purchasing
+ * a commercial license. Buying such a license is mandatory as soon as you
+ * develop commercial activities involving the Companion software without
+ * disclosing the source code of your own applications.
+ */
+class ServiceVideohubPanel extends ServiceBase {
+	/**
+	 * @type {VideohubServer | undefined}
+	 */
+	server
+
+	/**
+	 * The remote devices
+	 * @type {Object}
+	 * @access protected
+	 */
+	devices = {}
+
+	/**
+	 * @param {Registry} registry - the application core
+	 */
+	constructor(registry) {
+		super(registry, 'videohub-panel', 'Service/VideohubPanel')
+
+		this.init()
+	}
+
+	listen() {
+		this.server = new VideohubServer()
+
+		this.server.on('error', (e) => {
+			this.logger.debug(`listen-socket error: ${e}`)
+		})
+		this.server.on('connect', this.#connectPanel.bind(this))
+
+		this.server.on('disconnect', this.#disconnectPanel.bind(this))
+		this.server.on('press', this.#pressPanel.bind(this))
+
+		try {
+			this.server.start()
+		} catch (e) {
+			this.logger.debug(`ERROR opening videohub server port`)
+		}
+	}
+
+	#connectPanel(id, info, remoteAddress) {
+		const fullId = `videohub:${id}`
+		this.logger.info(`Panel "${fullId}" connected from ${remoteAddress}`)
+
+		const device = this.surfaces.addVideohubPanelDevice({
+			path: fullId,
+			keysTotal: info.buttonsTotal,
+			keysPerRow: info.buttonsColumns,
+			remoteAddress: remoteAddress,
+			productName: `Videohub ${info.model}`,
+		})
+
+		this.devices[fullId] = {
+			id: fullId,
+			device: device,
+		}
+	}
+
+	#disconnectPanel(id) {
+		const fullId = `videohub:${id}`
+		this.logger.info(`Panel "${fullId}" disconnected from`)
+
+		this.surfaces.removeDevice(fullId)
+	}
+
+	#pressPanel(id, button) {
+		const fullId = `videohub:${id}`
+		this.logger.debug(`Panel "${fullId}" pressed ${button}`)
+
+		const device = this.devices[fullId]
+		if (device) {
+			const keyIndex = button
+			// TODO - button index translation
+			device.device.doButton(keyIndex, true)
+
+			setTimeout(() => {
+				// Release after a short delay
+				device.device.doButton(keyIndex, false)
+			}, 20)
+		}
+	}
+}
+
+export default ServiceVideohubPanel

--- a/lib/Service/VideohubPanel.js
+++ b/lib/Service/VideohubPanel.js
@@ -39,7 +39,7 @@ class ServiceVideohubPanel extends ServiceBase {
 	 * @param {Registry} registry - the application core
 	 */
 	constructor(registry) {
-		super(registry, 'videohub-panel', 'Service/VideohubPanel')
+		super(registry, 'videohub-panel', 'Service/VideohubPanel', 'videohub_panel_enabled')
 
 		this.init()
 	}
@@ -57,9 +57,15 @@ class ServiceVideohubPanel extends ServiceBase {
 
 		try {
 			this.server.start()
+			this.currentState = true
 		} catch (e) {
 			this.logger.debug(`ERROR opening videohub server port`)
 		}
+	}
+
+	close() {
+		console.log('trying destroy')
+		this.server.destroy()
 	}
 
 	#connectPanel(id, info, remoteAddress) {

--- a/lib/Service/VideohubPanel.js
+++ b/lib/Service/VideohubPanel.js
@@ -64,7 +64,6 @@ class ServiceVideohubPanel extends ServiceBase {
 	}
 
 	close() {
-		console.log('trying destroy')
 		this.server.destroy()
 	}
 
@@ -90,6 +89,7 @@ class ServiceVideohubPanel extends ServiceBase {
 		const fullId = `videohub:${id}`
 		this.logger.info(`Panel "${fullId}" disconnected from`)
 
+		delete this.devices[fullId]
 		this.surfaces.removeDevice(fullId)
 	}
 

--- a/lib/Service/VideohubPanel.js
+++ b/lib/Service/VideohubPanel.js
@@ -45,7 +45,9 @@ class ServiceVideohubPanel extends ServiceBase {
 	}
 
 	listen() {
-		this.server = new VideohubServer()
+		this.server = new VideohubServer({
+			manualConfigure: true,
+		})
 
 		this.server.on('error', (e) => {
 			this.logger.debug(`listen-socket error: ${e}`)
@@ -102,14 +104,7 @@ class ServiceVideohubPanel extends ServiceBase {
 
 		const device = this.devices[fullId]
 		if (device) {
-			const keyIndex = button
-			// TODO - button index translation
-			device.device.doButton(keyIndex, true)
-
-			setTimeout(() => {
-				// Release after a short delay
-				device.device.doButton(keyIndex, false)
-			}, 20)
+			device.device.doButton(destination, button)
 		}
 	}
 }

--- a/lib/Service/VideohubPanel.js
+++ b/lib/Service/VideohubPanel.js
@@ -96,9 +96,9 @@ class ServiceVideohubPanel extends ServiceBase {
 		this.surfaces.removeDevice(fullId)
 	}
 
-	#pressPanel(id, button) {
+	#pressPanel(id, destination, button) {
 		const fullId = `videohub:${id}`
-		this.logger.debug(`Panel "${fullId}" pressed ${button}`)
+		this.logger.debug(`Panel "${fullId}" pressed ${destination}-${button}`)
 
 		const device = this.devices[fullId]
 		if (device) {

--- a/lib/Service/VideohubPanel.js
+++ b/lib/Service/VideohubPanel.js
@@ -73,10 +73,10 @@ class ServiceVideohubPanel extends ServiceBase {
 
 		const device = this.surfaces.addVideohubPanelDevice({
 			path: fullId,
-			keysTotal: info.buttonsTotal,
-			keysPerRow: info.buttonsColumns,
 			remoteAddress: remoteAddress,
 			productName: `Videohub ${info.model}`,
+
+			panelInfo: info,
 
 			server: this.server,
 			serverId: remoteAddress, // TODO

--- a/lib/Service/VideohubPanel.js
+++ b/lib/Service/VideohubPanel.js
@@ -77,6 +77,9 @@ class ServiceVideohubPanel extends ServiceBase {
 			keysPerRow: info.buttonsColumns,
 			remoteAddress: remoteAddress,
 			productName: `Videohub ${info.model}`,
+
+			server: this.server,
+			serverId: remoteAddress, // TODO
 		})
 
 		this.devices[fullId] = {

--- a/lib/Surface/Controller.js
+++ b/lib/Surface/Controller.js
@@ -37,6 +37,7 @@ import LoupedeckLiveDriver from './USB/LoupedeckLive.js'
 import SurfaceUSBLoupedeckCt from './USB/LoupedeckCt.js'
 
 import CoreBase from '../Core/Base.js'
+import SurfaceIPVideohubPanel from './IP/VideohubPanel.js'
 
 // Force it to load the hidraw driver just in case
 HID.setDriverType('hidraw')
@@ -580,6 +581,20 @@ class SurfaceController extends CoreBase {
 		const device = new SurfaceIPSatellite(deviceInfo)
 
 		this.#createSurfaceHandler(deviceInfo.path, 'satellite', device)
+
+		setImmediate(() => {
+			this.updateDevicesList()
+		})
+
+		return device
+	}
+
+	addVideohubPanelDevice(deviceInfo) {
+		this.removeDevice(deviceInfo.path)
+
+		const device = new SurfaceIPVideohubPanel(deviceInfo)
+
+		this.#createSurfaceHandler(deviceInfo.path, 'videohub-panel', device)
 
 		setImmediate(() => {
 			this.updateDevicesList()

--- a/lib/Surface/IP/VideohubPanel.js
+++ b/lib/Surface/IP/VideohubPanel.js
@@ -20,13 +20,16 @@ import { EventEmitter } from 'events'
 class SurfaceIPVideohubPanel extends EventEmitter {
 	logger = LogController.createLogger('Surface/IP/VideohubPanel')
 
+	runningBrightness = false
+	pendingBrightness = false
+
 	constructor(deviceInfo) {
 		super()
 
 		this.info = {
 			type: deviceInfo.productName,
 			devicepath: deviceInfo.path,
-			configFields: [],
+			configFields: ['brightness'],
 			// HACK sizes until the grid can be bigger
 			keysPerRow: global.MAX_BUTTONS_PER_ROW, // deviceInfo.keysPerRow,
 			keysTotal: global.MAX_BUTTONS, //deviceInfo.keysTotal,
@@ -34,7 +37,10 @@ class SurfaceIPVideohubPanel extends EventEmitter {
 			location: deviceInfo.remoteAddress,
 		}
 
-		this.deviceId = deviceInfo.deviceId
+		this.server = deviceInfo.server
+		this.serverId = deviceInfo.serverId
+
+		this.deviceId = deviceInfo.path
 
 		this.logger.info(`Adding Videohub Panel device "${this.deviceId}"`)
 
@@ -69,19 +75,38 @@ class SurfaceIPVideohubPanel extends EventEmitter {
 	/* elgato-streamdeck functions */
 
 	setConfig(config, force) {
-		// if ((force || this._config.brightness != config.brightness) && config.brightness !== undefined) {
-		// 	this.setBrightness(config.brightness)
-		// }
-
-		this._config = config
+		const newBrightness = Math.floor(config.brightness / 10)
+		if ((force || this._config.brightness != newBrightness) && config.brightness !== undefined) {
+			this._config.brightness = newBrightness
+			this.#setBrightness(newBrightness)
+		}
 	}
 
-	// setBrightness(value) {
-	// 	this.logger.silly('brightness: ' + value)
-	// 	if (this.socket !== undefined) {
-	// 		this.socket.write(`BRIGHTNESS DEVICEID=${this.deviceId} VALUE=${value}\n`)
-	// 	}
-	// }
+	#setBrightness(value) {
+		if (this.runningBrightness) {
+			this.pendingBrightness = true
+			return
+		}
+
+		this.runningBrightness = true
+		this.pendingBrightness = false
+
+		// TODO - this is broken now...
+		// It was fighting itself being run in parallel
+
+		this.logger.silly('brightness: ' + value)
+		this.server
+			.setBacklight(this.serverId, value)
+			.catch((e) => {
+				this.logger.error('Failed to set videohub panel brightness: ' + e?.toString())
+			})
+			.then(() => {
+				this.runningBrightness = false
+				if (this.pendingBrightness) {
+					this.#setBrightness(this._config.brightness)
+				}
+			})
+	}
 }
 
 export default SurfaceIPVideohubPanel

--- a/lib/Surface/IP/VideohubPanel.js
+++ b/lib/Surface/IP/VideohubPanel.js
@@ -27,7 +27,7 @@ class SurfaceIPVideohubPanel extends EventEmitter {
 		this.info = {
 			type: deviceInfo.productName,
 			devicepath: deviceInfo.path,
-			configFields: ['brightness'],
+			configFields: ['brightness', 'videohub_page_count'],
 			deviceId: deviceInfo.path,
 			location: deviceInfo.remoteAddress,
 		}
@@ -46,6 +46,7 @@ class SurfaceIPVideohubPanel extends EventEmitter {
 
 		this._config = {
 			brightness: 100,
+			videohub_page_count: 0,
 		}
 	}
 
@@ -57,9 +58,16 @@ class SurfaceIPVideohubPanel extends EventEmitter {
 		return true
 	}
 
-	doButton(key, state) {
-		const xy = convertPanelIndexToXY(key, this.gridSize)
-		if (xy) this.emit('click', ...xy, state)
+	doButton(destination, button) {
+		const xy = convertPanelIndexToXY(button, this.gridSize)
+		if (xy) {
+			this.emit('click', ...xy, true, destination)
+
+			setTimeout(() => {
+				// Release after a short delay
+				this.emit('click', ...xy, false, destination)
+			}, 20)
+		}
 	}
 
 	clearDeck() {
@@ -69,10 +77,17 @@ class SurfaceIPVideohubPanel extends EventEmitter {
 	/* elgato-streamdeck functions */
 
 	setConfig(config, force) {
+		console.log('setup', config, force)
 		const newBrightness = Math.floor(config.brightness / 10)
 		if ((force || this._config.brightness != newBrightness) && config.brightness !== undefined) {
 			this._config.brightness = newBrightness
 			this.#setBrightness(newBrightness)
+		}
+
+		const page_count = Math.floor(config.videohub_page_count / 2) * 2
+		if (force || this._config.videohub_page_count != page_count) {
+			this._config.videohub_page_count = page_count
+			this.#setPageCount(page_count)
 		}
 	}
 
@@ -83,6 +98,16 @@ class SurfaceIPVideohubPanel extends EventEmitter {
 			this.server.setBacklight(this.serverId, value)
 		} catch (e) {
 			this.logger.error('Failed to set videohub panel brightness: ' + e?.toString())
+		}
+	}
+
+	#setPageCount(value) {
+		this.logger.silly('page count: ' + value)
+
+		try {
+			this.server.configureDevice(this.serverId, { destinationCount: value })
+		} catch (e) {
+			this.logger.error('Failed to set videohub panel destination count: ' + e?.toString())
 		}
 	}
 }

--- a/lib/Surface/IP/VideohubPanel.js
+++ b/lib/Surface/IP/VideohubPanel.js
@@ -1,0 +1,87 @@
+/*
+ * This file is part of the Companion project
+ * Copyright (c) 2019 Bitfocus AS
+ * Authors: Håkon Nessjøen <haakon@bitfocus.io>, William Viker <william@bitfocus.io>
+ *
+ * This program is free software.
+ * You should have received a copy of the MIT licence as well as the Bitfocus
+ * Individual Contributor License Agreement for companion along with
+ * this program.
+ *
+ * You can be released from the requirements of the license by purchasing
+ * a commercial license. Buying such a license is mandatory as soon as you
+ * develop commercial activities involving the Companion software without
+ * disclosing the source code of your own applications.
+ *
+ */
+import LogController from '../../Log/Controller.js'
+import { EventEmitter } from 'events'
+
+class SurfaceIPVideohubPanel extends EventEmitter {
+	logger = LogController.createLogger('Surface/IP/VideohubPanel')
+
+	constructor(deviceInfo) {
+		super()
+
+		this.info = {
+			type: deviceInfo.productName,
+			devicepath: deviceInfo.path,
+			configFields: [],
+			// HACK sizes until the grid can be bigger
+			keysPerRow: global.MAX_BUTTONS_PER_ROW, // deviceInfo.keysPerRow,
+			keysTotal: global.MAX_BUTTONS, //deviceInfo.keysTotal,
+			deviceId: deviceInfo.path,
+			location: deviceInfo.remoteAddress,
+		}
+
+		this.deviceId = deviceInfo.deviceId
+
+		this.logger.info(`Adding Videohub Panel device "${this.deviceId}"`)
+
+		this._config = {
+			brightness: 100,
+		}
+	}
+
+	quit() {}
+
+	draw(key, buffer, style) {
+		// Not supported
+
+		return true
+	}
+
+	doButton(key, state) {
+		let offset = 0
+		if (key >= global.MAX_BUTTONS) {
+			// HACK sizes until the grid can be bigger
+			offset = Math.floor(key / global.MAX_BUTTONS)
+			key = key % global.MAX_BUTTONS
+		}
+
+		this.emit('click', key, state, offset)
+	}
+
+	clearDeck() {
+		// Not supported
+	}
+
+	/* elgato-streamdeck functions */
+
+	setConfig(config, force) {
+		// if ((force || this._config.brightness != config.brightness) && config.brightness !== undefined) {
+		// 	this.setBrightness(config.brightness)
+		// }
+
+		this._config = config
+	}
+
+	// setBrightness(value) {
+	// 	this.logger.silly('brightness: ' + value)
+	// 	if (this.socket !== undefined) {
+	// 		this.socket.write(`BRIGHTNESS DEVICEID=${this.deviceId} VALUE=${value}\n`)
+	// 	}
+	// }
+}
+
+export default SurfaceIPVideohubPanel

--- a/lib/Surface/IP/VideohubPanel.js
+++ b/lib/Surface/IP/VideohubPanel.js
@@ -16,6 +16,7 @@
  */
 import LogController from '../../Log/Controller.js'
 import { EventEmitter } from 'events'
+import { convertPanelIndexToXY } from '../Util.js'
 
 class SurfaceIPVideohubPanel extends EventEmitter {
 	logger = LogController.createLogger('Surface/IP/VideohubPanel')
@@ -30,11 +31,13 @@ class SurfaceIPVideohubPanel extends EventEmitter {
 			type: deviceInfo.productName,
 			devicepath: deviceInfo.path,
 			configFields: ['brightness'],
-			// HACK sizes until the grid can be bigger
-			keysPerRow: global.MAX_BUTTONS_PER_ROW, // deviceInfo.keysPerRow,
-			keysTotal: global.MAX_BUTTONS, //deviceInfo.keysTotal,
 			deviceId: deviceInfo.path,
 			location: deviceInfo.remoteAddress,
+		}
+
+		this.gridSize = {
+			columns: deviceInfo.panelInfo.buttonsColumns,
+			rows: deviceInfo.panelInfo.buttonsRows,
 		}
 
 		this.server = deviceInfo.server
@@ -58,14 +61,8 @@ class SurfaceIPVideohubPanel extends EventEmitter {
 	}
 
 	doButton(key, state) {
-		let offset = 0
-		if (key >= global.MAX_BUTTONS) {
-			// HACK sizes until the grid can be bigger
-			offset = Math.floor(key / global.MAX_BUTTONS)
-			key = key % global.MAX_BUTTONS
-		}
-
-		this.emit('click', key, state, offset)
+		const xy = convertPanelIndexToXY(key, this.gridSize)
+		if (xy) this.emit('click', ...xy, state)
 	}
 
 	clearDeck() {

--- a/lib/Surface/IP/VideohubPanel.js
+++ b/lib/Surface/IP/VideohubPanel.js
@@ -21,9 +21,6 @@ import { convertPanelIndexToXY } from '../Util.js'
 class SurfaceIPVideohubPanel extends EventEmitter {
 	logger = LogController.createLogger('Surface/IP/VideohubPanel')
 
-	runningBrightness = false
-	pendingBrightness = false
-
 	constructor(deviceInfo) {
 		super()
 
@@ -80,29 +77,13 @@ class SurfaceIPVideohubPanel extends EventEmitter {
 	}
 
 	#setBrightness(value) {
-		if (this.runningBrightness) {
-			this.pendingBrightness = true
-			return
-		}
-
-		this.runningBrightness = true
-		this.pendingBrightness = false
-
-		// TODO - this is broken now...
-		// It was fighting itself being run in parallel
-
 		this.logger.silly('brightness: ' + value)
-		this.server
-			.setBacklight(this.serverId, value)
-			.catch((e) => {
-				this.logger.error('Failed to set videohub panel brightness: ' + e?.toString())
-			})
-			.then(() => {
-				this.runningBrightness = false
-				if (this.pendingBrightness) {
-					this.#setBrightness(this._config.brightness)
-				}
-			})
+
+		try {
+			this.server.setBacklight(this.serverId, value)
+		} catch (e) {
+			this.logger.error('Failed to set videohub panel brightness: ' + e?.toString())
+		}
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
 		"usb": "^2.9.0",
 		"utf-8-validate": "^6.0.3",
 		"winston": "^3.10.0",
-		"videohub-server": "^0.2.0",
+		"videohub-server": "^0.3.0",
 		"ws": "^8.13.0",
 		"xkeys": "npm:@julusian/xkeys@2.5.0-1"
 	},

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
 		"usb": "^2.9.0",
 		"utf-8-validate": "^6.0.3",
 		"winston": "^3.10.0",
-		"videohub-server": "^0.1.0",
+		"videohub-server": "^0.2.0",
 		"ws": "^8.13.0",
 		"xkeys": "npm:@julusian/xkeys@2.5.0-1"
 	},

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
 		"usb": "^2.9.0",
 		"utf-8-validate": "^6.0.3",
 		"winston": "^3.10.0",
+		"videohub-server": "^0.1.0",
 		"ws": "^8.13.0",
 		"xkeys": "npm:@julusian/xkeys@2.5.0-1"
 	},

--- a/webui/src/Surfaces/EditModal.jsx
+++ b/webui/src/Surfaces/EditModal.jsx
@@ -250,6 +250,20 @@ export const SurfaceEditModal = forwardRef(function SurfaceEditModal(_props, ref
 								/>
 							</CFormGroup>
 						)}
+						{deviceInfo.configFields?.includes('videohub_page_count') && (
+							<CFormGroup>
+								<CLabel htmlFor="videohub_page_count">Page Count</CLabel>
+								<CInput
+									name="videohub_page_count"
+									type="range"
+									min={0}
+									max={8}
+									step={2}
+									value={deviceConfig.videohub_page_count}
+									onChange={(e) => updateConfig('videohub_page_count', parseInt(e.currentTarget.value))}
+								/>
+							</CFormGroup>
+						)}
 						<CFormGroup>
 							<CLabel htmlFor="never_lock">Never Pin code lock</CLabel>
 							<CInputCheckbox

--- a/webui/src/UserConfig/VideohubServerConfig.jsx
+++ b/webui/src/UserConfig/VideohubServerConfig.jsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { CButton, CInput } from '@coreui/react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faUndo } from '@fortawesome/free-solid-svg-icons'
+import CSwitch from '../CSwitch'
+
+export function VideohubServerConfig({ config, setValue, resetValue }) {
+	return (
+		<>
+			<tr>
+				<th colSpan="3" className="settings-category">
+					Videohub Panel
+				</th>
+			</tr>
+			<tr>
+				<td>Videohub Panel Listener</td>
+				<td>
+					<div className="form-check form-check-inline mr-1 float-right">
+						<CSwitch
+							color="success"
+							checked={config.videohub_panel_enabled}
+							size={'lg'}
+							onChange={(e) => setValue('videohub_panel_enabled', e.currentTarget.checked)}
+						/>
+					</div>
+				</td>
+				<td>
+					<CButton onClick={() => resetValue('videohub_panel_enabled')} title="Reset to default">
+						<FontAwesomeIcon icon={faUndo} />
+					</CButton>
+				</td>
+			</tr>
+		</>
+	)
+}

--- a/webui/src/UserConfig/index.jsx
+++ b/webui/src/UserConfig/index.jsx
@@ -20,6 +20,7 @@ import { OscConfig } from './OscConfig'
 import { RosstalkConfig } from './RosstalkConfig'
 import { ArtnetConfig } from './ArtnetConfig'
 import { GridConfig } from './GridConfig'
+import { VideohubServerConfig } from './VideohubServerConfig'
 
 export const UserConfig = memo(function UserConfig() {
 	return (
@@ -77,6 +78,7 @@ function UserConfigTable() {
 				<OscConfig config={config} setValue={setValue} resetValue={resetValue} />
 				<RosstalkConfig config={config} setValue={setValue} resetValue={resetValue} />
 				<EmberPlusConfig config={config} setValue={setValue} resetValue={resetValue} />
+				<VideohubServerConfig config={config} setValue={setValue} resetValue={resetValue} />
 				<ArtnetConfig config={config} setValue={setValue} resetValue={resetValue} />
 
 				<AdminPasswordConfig config={config} setValue={setValue} resetValue={resetValue} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -5668,10 +5668,10 @@ vary@^1, vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
-videohub-server@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/videohub-server/-/videohub-server-0.1.0.tgz#0c263888393e16978991cdf70941103c1b0fa6b3"
-  integrity sha512-eZf+o0wTQBQDbbG2dNg5CvLxPqME8K2ro1t5VXzev8b4p+Vl1B71417ADFmP86CpNPAlJMc1RHbh9r4I41K2Qg==
+videohub-server@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/videohub-server/-/videohub-server-0.2.0.tgz#869f861e72c7acde27aa3194f4b18ef3d90ec535"
+  integrity sha512-mZfbV00u3FPMG09xzta5fQ9EyvRnuQly5T0i78PvjRPUIaPbxPDa7KTaVYB2xyLX0EM+Gg8GLT0bfE6EgKhmqQ==
 
 vinyl-buffer@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5668,6 +5668,11 @@ vary@^1, vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
+videohub-server@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/videohub-server/-/videohub-server-0.1.0.tgz#0c263888393e16978991cdf70941103c1b0fa6b3"
+  integrity sha512-eZf+o0wTQBQDbbG2dNg5CvLxPqME8K2ro1t5VXzev8b4p+Vl1B71417ADFmP86CpNPAlJMc1RHbh9r4I41K2Qg==
+
 vinyl-buffer@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/vinyl-buffer/-/vinyl-buffer-1.0.1.tgz#96c1a3479b8c5392542c612029013b5b27f88bbf"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5668,10 +5668,10 @@ vary@^1, vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
-videohub-server@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/videohub-server/-/videohub-server-0.2.0.tgz#869f861e72c7acde27aa3194f4b18ef3d90ec535"
-  integrity sha512-mZfbV00u3FPMG09xzta5fQ9EyvRnuQly5T0i78PvjRPUIaPbxPDa7KTaVYB2xyLX0EM+Gg8GLT0bfE6EgKhmqQ==
+videohub-server@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/videohub-server/-/videohub-server-0.3.0.tgz#124963caa3ead89e3a9604504e0ebfaae66b820b"
+  integrity sha512-r9CYkiuChpkBvSa0sdLSuwgzrfXqf7sYNI3XBltBkv9ubfFqG4HCzrwYyqYZ13SwH7HuubWOQWZ/d/Px8fgM3g==
 
 vinyl-buffer@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Replaces https://github.com/bitfocus/companion-module-bmd-videohub-controlpanel

This provides a minimal videohub 'server' implementation, to allow control panels to be connectde and be used as a surface.

Because of the number of buttons on the panels, the last 8 buttons take up a second row on the following page. Once we can make the grid larger, this can be fixed up.
Should this instead split it so each row is on a separate page? Perhaps only occupying a space of 5x4 on each of those pages?

This has been tested with a single panel, there is no reason it shouldn't work just fine with more.

When a panel connects, its settings are modified (requiring the ability for companion to connect back to the panels on port 9991) to be a 40 source, 1 output setup with sequential button order that we need.

The leds on the buttons do not light up currently, this will be hard to do well, so has been omitted for now.