### PR TITLE
buttons page edit

### DIFF
--- a/.github/workflows/sync-modules.yml
+++ b/.github/workflows/sync-modules.yml
@@ -8,16 +8,17 @@ on:
 
 env:
   MODULES_BRANCH: main
+  COMPANION_BRANCH: beta
 
 jobs:
-  sync-beta:
+  sync-modules:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: true
-          ref: beta
+          ref: ${{ env.COMPANION_BRANCH }}
           token: ${{ secrets.SYNC_MODULES_PAT }}
 
       - name: update submodule
@@ -43,3 +44,4 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "chore: update bundled-modules\n\n${{ env.CHANGES_MESSAGE }}"
+          commit_author: 'Companion Module Sync <companion-module-bot@users.noreply.github.com>'


### PR DESCRIPTION
It's possible to add one more page preview on the buttons page?
This will help a lot when you rearrange your buttons/Macro , easy to copy or move. or can copy multiple buttons once

![Screenshot_15](https://github.com/bitfocus/companion/assets/134008595/1cdf6a5d-4658-4a0c-8283-17287094b8cb)
