### PR TITLE
fix: broken description of sun event

### DIFF
--- a/lib/Controls/ControlTypes/Triggers/Events/Timer.js
+++ b/lib/Controls/ControlTypes/Triggers/Events/Timer.js
@@ -315,9 +315,9 @@ export default class TriggersEventTimer {
 	 */
 	getSunDescription(event) {
 		let type_str = 'Undefined'
-		if (event.options.type == 0) {
+		if (event.options.type == 'sunrise') {
 			type_str = 'Sunrise'
-		} else if (event.options.type == 1) {
+		} else if (event.options.type == 'sunset') {
 			type_str = 'Sunset'
 		} else {
 			type_str = 'Error'

--- a/lib/Resources/EventDefinitions.js
+++ b/lib/Resources/EventDefinitions.js
@@ -68,7 +68,7 @@ export const EventDefinitions = {
 				id: 'type',
 				label: 'Sunrise / Sunset',
 				type: 'dropdown',
-				default: 0,
+				default: 'sunrise',
 				choices: [
 					{ id: 'sunrise', label: 'Sunrise' },
 					{ id: 'sunset', label: 'Sunset' },


### PR DESCRIPTION
the Sunrise/Sunset in the description of the event did not work properly because the ids didn't matched