### PR TITLE
feat: tidy config dirs, and show message box when switching between versions

### DIFF
--- a/launcher/main.js
+++ b/launcher/main.js
@@ -12,6 +12,7 @@ const stripAnsi = require('strip-ansi')
 const chokidar = require('chokidar')
 const debounceFn = require('debounce-fn')
 const fileStreamRotator = require('file-stream-rotator')
+const { ConfigReleaseDirs } = require('../lib/Data/Paths.cjs')
 
 // Ensure there isn't another instance of companion running already
 var lock = app.requestSingleInstanceLock()
@@ -100,6 +101,9 @@ if (!lock) {
 	} catch (e) {
 		// Ignore the failure, its not worth trying to handle
 	}
+
+	const thisDbFolderName = ConfigReleaseDirs[ConfigReleaseDirs.length - 1]
+	const thisDbPath = path.join(configDir, thisDbFolderName, 'db')
 
 	const uiConfig = new Store({
 		cwd: configDir,
@@ -553,6 +557,75 @@ if (!lock) {
 	}
 
 	app.whenReady().then(async () => {
+		// Check for a more recently modified db
+		const dirs = fs.readdirSync(configDir)
+		let mostRecentDir = null
+		for (const dirname of dirs) {
+			try {
+				const dbStat = fs.statSync(path.join(configDir, dirname, 'db'))
+				if (dirname.match('^v(.*)') && dbStat && dbStat.isFile()) {
+					if (!mostRecentDir || mostRecentDir[0] < dbStat.mtimeMs) {
+						mostRecentDir = [dbStat.mtimeMs, dirname]
+					}
+				}
+			} catch (e) {
+				// Not worth considering
+			}
+		}
+
+		if (mostRecentDir && mostRecentDir[1] !== thisDbFolderName) {
+			let selected
+			// Check for a new db file
+			if (fs.existsSync(thisDbPath)) {
+				selected = electron.dialog.showMessageBoxSync({
+					title: 'Config version mismatch',
+					message:
+						`Another version of Companion (${mostRecentDir[1]}) has been run more recently.\n` +
+						`Any config changes you have made to that version will not be loaded, but will return when you next open the other version.\n\n` +
+						`Do you wish to continue?`,
+					type: 'question',
+					buttons: ['Continue', 'Exit'],
+					defaultId: 0,
+				})
+			} else {
+				if (!ConfigReleaseDirs.includes(mostRecentDir[1])) {
+					// Figure out what version the upgrade will be from
+					let importFrom = null
+					for (let i = ConfigReleaseDirs.length - 2; i--; i > 0) {
+						const dirname = ConfigReleaseDirs[i]
+						if (fs.existsSync(path.join(configDir, dirname, 'db'))) {
+							importFrom = dirname
+						}
+					}
+					if (!importFrom && fs.existsSync(path.join(configDir, 'db'))) {
+						importFrom = 'v2.4'
+					}
+					const importNote = importFrom
+						? `This will import the configuration from ${importFrom}`
+						: `This will create an empty configuration`
+
+					// It looks like a newer version has been opened
+					selected = electron.dialog.showMessageBoxSync({
+						title: 'Config version mismatch',
+						message:
+							`Another version of Companion (${mostRecentDir[1]}) has been run more recently.\n` +
+							`Any config changes you have made to that version will not be loaded, but will return when you next open the other version.\n\n` +
+							`Do you wish to continue? ${importNote}`,
+						type: 'question',
+						buttons: ['Continue', 'Exit'],
+						defaultId: 0,
+					})
+				}
+			}
+
+			if (selected == 1) {
+				app.exit(1)
+			} else {
+				// Mark the current config as most recently modified
+				fs.utimesSync(path.join(configDir, dirname, 'db'), Date.now(), Date.now())
+			}
+		}
+
 		createTray()
 		createWindow()
 

--- a/lib/Data/Paths.cjs
+++ b/lib/Data/Paths.cjs
@@ -1,0 +1,10 @@
+const ConfigReleaseDirs = [
+	null, // Root
+	// The config subfolders that exist.
+	// For each major/minor release, a new entry should be added here,
+	'v3.0',
+]
+
+module.exports = {
+	ConfigReleaseDirs,
+}

--- a/main.js
+++ b/main.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 // Setup logging before anything else runs
-import Logging from './lib/Log/Controller.js'
+import './lib/Log/Controller.js'
 
 // Now we can think about startup
 import { Command } from 'commander'
@@ -12,6 +12,7 @@ import fs from 'fs-extra'
 import envPaths from 'env-paths'
 import { nanoid } from 'nanoid'
 import logger from './lib/Log/Controller.js'
+import { ConfigReleaseDirs } from './lib/Data/Paths.cjs'
 
 const program = new Command()
 
@@ -104,15 +105,30 @@ program.command('start', { isDefault: true, hidden: true }).action(() => {
 	// machid is always in the configDir
 	const machineIdPath = path.join(configDir, 'machid')
 
+	// Make sure README file exists in the config dir
+	const readmePath = path.join(configDir, 'README.txt')
+	if (!fs.existsSync(readmePath)) {
+		fs.writeFileSync(
+			readmePath,
+			'Since Companion 3.0, each release your config gets put into a new folder.\n' +
+				'This makes it much easier and safer to downgrade to older releases, as their configuration will be left untouched.\n' +
+				"When launching a version whose folder doesn't yet exist, the config will be copied from one of the previous releases, looking in release order.\n" +
+				'\n' +
+				'The db file in this folder is used for 2.4 or older, use the appropriate folders for newer configs\n'
+		)
+	}
+
+	// Handle the rename from `develop` to `v3.0`, setting up a link for backwards compatibility
+	const developDir = path.join(configDir, 'develop')
+	const v30Dir = path.join(configDir, 'v3.0')
+	if (fs.existsSync(developDir) && !fs.existsSync(v30Dir)) {
+		fs.moveSync(developDir, v30Dir)
+		fs.symlinkSync(v30Dir, developDir, process.platform === 'win32' ? 'junction' : undefined)
+	}
+
 	// develop should use subfolder. This should be disabled when ready for mass testing
 	const rootConfigDir = configDir
-	configDir = path.join(configDir, 'develop')
-
-	// Hack: move config from older 3.0 config. This should be removed before 3.0 switches to the main config path
-	const oldConfigPath = path.join(configDir, '../../companion3-test')
-	if (!fs.existsSync(configDir) && fs.existsSync(oldConfigPath)) fs.moveSync(oldConfigPath, configDir)
-	const oldConfigPath2 = envPaths('companion3-test').config
-	if (!fs.existsSync(configDir) && fs.existsSync(oldConfigPath2)) fs.moveSync(oldConfigPath2, configDir)
+	configDir = path.join(configDir, ConfigReleaseDirs[ConfigReleaseDirs.length - 1])
 
 	try {
 		fs.ensureDirSync(configDir)
@@ -121,13 +137,18 @@ program.command('start', { isDefault: true, hidden: true }).action(() => {
 		process.exit(1)
 	}
 
-	// try and import the non-develop copy. we only need to take `db` for this
-	if (
-		configDir !== rootConfigDir &&
-		!fs.existsSync(path.join(configDir, 'db')) &&
-		fs.existsSync(path.join(rootConfigDir, 'db'))
-	)
-		fs.copyFileSync(path.join(rootConfigDir, 'db'), path.join(configDir, 'db'))
+	// copy an older db if needed
+	if (configDir !== rootConfigDir && !fs.existsSync(path.join(configDir, 'db'))) {
+		// try and import the non-develop copy. we only need to take `db` for this
+		for (let i = ConfigReleaseDirs.length - 1; i--; i >= 0) {
+			const previousDbPath =
+				i > 0 ? path.join(rootConfigDir, ConfigReleaseDirs[i], 'db') : path.join(rootConfigDir, 'db')
+			if (fs.existsSync(previousDbPath)) {
+				// Found the one to copy
+				fs.copyFileSync(previousDbPath, path.join(configDir, 'db'))
+			}
+		}
+	}
 
 	if (options.logLevel) {
 		logger.setLogLevel(options.logLevel)


### PR DESCRIPTION
3.0.0-rc1 is still using the `develop` subdirectory, as there was no convenient time to change it back to the root level without losing the config for some users.
This resolves that by renaming the folder to v3.0, and creating a symlink called develop, so that it is properly named, but older builds will still be able to load the same db through the symlink (verified on linux, macos and windows).

With this it is expected that each major/minor release, we will update it to use a new folder matching the release name, so that users can more easily jump between versions without risking db 'corruption', or having to manage the db file themselves.

Additionally, this embraces this new layout and performs a few checks at startup, to warn the user if a different version of companion has been run more recently. To remind them that anything they programmed in the other version will not be present in this version