### PR TITLE
feat: use crisper image rendering when buttons are upscaled

### DIFF
--- a/webui/src/scss/_bank.scss
+++ b/webui/src/scss/_bank.scss
@@ -8,6 +8,7 @@
 	height: fit-content;
 	display: inline-block;
 	border: 1px solid transparent;
+	container-type: inline-size;
 
 	&.clickable {
 		cursor: pointer;
@@ -50,6 +51,10 @@
 		margin: 0 auto;
 
 		-webkit-user-drag: none;
+
+		@container (min-width: 72px) {
+			image-rendering: pixelated;
+		}
 	}
 }
 


### PR DESCRIPTION
When viewing the button grid on a larger screen, by default browsers try to smoothen out the images which makes them look blurry. This PR adds a query that forces browsers to use nearest-neighbour upscaling when buttons exceed the 72px width that images are rendered at.

IMO, this makes the text easier to read because it has more contrast against its background. What do you think?

Before:
![CleanShot 2023-06-14 at 11 49 49@2x](https://github.com/bitfocus/companion/assets/541628/da2a15b1-2178-4714-8582-11139fc379bd)

After:
![CleanShot 2023-06-14 at 11 49 38@2x](https://github.com/bitfocus/companion/assets/541628/51e08c1b-74ef-48da-b4b0-522e39fff66f)
