### PR TITLE
feat: resizable emulator

### DIFF
--- a/lib/Controls/Controller.js
+++ b/lib/Controls/Controller.js
@@ -127,7 +127,7 @@ class ControlsController extends CoreBase {
 				if (location) {
 					const img = this.graphics.getBank(location)
 					// TODO - rework this to use the shared render cache concept
-					client.emit(`controls:preview-${controlId}`, img?.buffer)
+					client.emit(`controls:preview-${controlId}`, img?.asDataUrl)
 				}
 			})
 

--- a/lib/Data/ImportExport.js
+++ b/lib/Data/ImportExport.js
@@ -529,10 +529,10 @@ class DataImportExport extends CoreBase {
 					...controlObj.style,
 					style: controlObj.type,
 				})
-				return res?.buffer ?? null
+				return res?.asDataUrl ?? null
 			} else {
 				const res = this.graphics.drawPreview({})
-				return res?.buffer ?? null
+				return res?.asDataUrl ?? null
 			}
 		})
 

--- a/lib/Graphics/Controller.js
+++ b/lib/Graphics/Controller.js
@@ -19,6 +19,7 @@ import { FontLibrary } from 'skia-canvas'
 import GraphicsRenderer from './Renderer.js'
 import CoreBase from '../Core/Base.js'
 import { formatLocation, xyToOldBankIndex } from '../Shared/ControlId.js'
+import { ImageResult } from './ImageWrapper.js'
 
 class GraphicsController extends CoreBase {
 	constructor(registry) {
@@ -192,10 +193,7 @@ class GraphicsController extends CoreBase {
 		this.logger.silly('!!!! ERROR: UNEXPECTED ERROR while fetching image for unbuffered bank: ' + renderId)
 
 		// continue gracefully, even though something is terribly wrong
-		return {
-			buffer: Buffer.alloc(72 * 72 * 3),
-			updated: Date.now(),
-		}
+		return new ImageResult(Buffer.alloc(72 * 72 * 3))
 	}
 }
 

--- a/lib/Graphics/Image.js
+++ b/lib/Graphics/Image.js
@@ -978,14 +978,6 @@ class Image {
 	}
 
 	/**
-	 * returns the pixel buffer of the image in base64 encoding
-	 * @returns {string} base64 representation of the pixel buffer
-	 */
-	toBase64() {
-		return this.buffer().toString('base64')
-	}
-
-	/**
 	 * returns the pixels of the image in a buffer
 	 * color order is RGBA
 	 * @returns {Buffer} RGBA buffer of the pixels
@@ -994,22 +986,6 @@ class Image {
 		const buffer = Buffer.from(this.context2d.getImageData(0, 0, this.realwidth, this.realheight).data)
 		//const buffer = this.canvas.toBuffer('png')
 		return buffer
-	}
-
-	/**
-	 * returns an object with the image buffer and the last time of update
-	 * @returns {{updated: number, buffer: Buffer}}
-	 */
-	bufferAndTime() {
-		return { updated: this.lastUpdate, buffer: this.buffer() }
-	}
-
-	/**
-	 * returns an fully empty and transparent image in an object together with update time
-	 * @returns {{updated: number, buffer: Buffer}}
-	 */
-	static emptyAndTime() {
-		return { updated: Date.now(), buffer: Buffer.alloc(this.width * this.height * 4) }
 	}
 }
 

--- a/lib/Graphics/ImageWrapper.js
+++ b/lib/Graphics/ImageWrapper.js
@@ -1,0 +1,58 @@
+export class ImageResult {
+	#dataUrl = null
+
+	constructor(buffer, style) {
+		this.buffer = buffer
+		this.style = style
+
+		this.updated = Date.now()
+	}
+
+	get asDataUrl() {
+		if (!this.#dataUrl && this.buffer) {
+			const imageSize = Math.sqrt(this.buffer.length / 4)
+			const bmpHeader = this.#createBmpHeader(imageSize, imageSize)
+
+			this.#dataUrl = 'data:image/bmp;base64,' + Buffer.concat([bmpHeader, this.buffer]).toString('base64')
+		}
+
+		return this.#dataUrl
+	}
+
+	/**
+	 * Creates a BMP image header for the given size
+	 * assuming RGBA channel order, 32Bit/Pixel, starting with top left pixel
+	 * @param {number} imageWidth
+	 * @param {number} imageHeight
+	 * @returns {Buffer} buffer containing the header
+	 */
+	#createBmpHeader(imageWidth = 72, imageHeight = 72) {
+		const dataLength = imageWidth * imageHeight * 4
+		const bmpHeaderSize = 138
+		const bmpHeader = Buffer.alloc(bmpHeaderSize, 0)
+		// file header
+		bmpHeader.write('BM', 0, 2) // flag
+		bmpHeader.writeUInt32LE(dataLength + bmpHeaderSize, 2) // filesize
+		bmpHeader.writeUInt32LE(0, 6) // reserved
+		bmpHeader.writeUInt32LE(bmpHeaderSize, 10) // data start
+		// image header
+		bmpHeader.writeUInt32LE(bmpHeaderSize - 14, 14) // header info size
+		bmpHeader.writeUInt32LE(imageWidth, 18) // width
+		bmpHeader.writeInt32LE(imageHeight * -1, 22) // height
+		bmpHeader.writeUInt16LE(1, 26) // planes
+		bmpHeader.writeUInt16LE(32, 28) // bits per pixel
+		bmpHeader.writeUInt32LE(3, 30) // compress
+		bmpHeader.writeUInt32LE(dataLength, 34) // data size
+		bmpHeader.writeUInt32LE(Math.round(39.375 * imageWidth), 38) // hr
+		bmpHeader.writeUInt32LE(Math.round(39.375 * imageHeight), 42) // vr
+		bmpHeader.writeUInt32LE(0, 46) // colors
+		bmpHeader.writeUInt32LE(0, 50) // importantColors
+		bmpHeader.writeUInt32LE(0x000000ff, 54) // Red Bitmask
+		bmpHeader.writeUInt32LE(0x0000ff00, 58) // Green Bitmask
+		bmpHeader.writeUInt32LE(0x00ff0000, 62) // Blue Bitmask
+		bmpHeader.writeUInt32LE(0xff000000, 66) // Alpha Bitmask
+		bmpHeader.write('BGRs', 70, 4) // colorspace
+
+		return bmpHeader
+	}
+}

--- a/lib/Graphics/Preview.js
+++ b/lib/Graphics/Preview.js
@@ -52,17 +52,12 @@ class GraphicsPreview extends CoreBase {
 		client.onPromise('preview:page:subscribe', (page) => {
 			client.join(PreviewPageRoom(page))
 
+			const populatedLocations = this.page.getAllPopulatedLocationsOnPage(page)
+
 			const renders = {}
-			for (let y = 0; y < global.MAX_BUTTONS_PER_COL; ++y) {
-				const rowRenders = (renders[y] = {})
-				for (let x = 0; x < global.MAX_BUTTONS_PER_ROW; ++x) {
-					rowRenders[x]
-					rowRenders[x] = this.graphics.getBank({
-						pageNumber: page,
-						column: x,
-						row: y,
-					}).buffer
-				}
+			for (const location of populatedLocations) {
+				if (!renders[location.row]) renders[location.row] = {}
+				renders[location.row][location.column] = this.graphics.getBank(location).asDataUrl
 			}
 
 			return renders
@@ -89,7 +84,7 @@ class GraphicsPreview extends CoreBase {
 				client,
 			})
 
-			return result.location ? this.graphics.getBank(result.location).buffer : null
+			return result.location ? this.graphics.getBank(result.location).asDataUrl : null
 		})
 		client.onPromise('preview:button-reference:unsubscribe', (id) => {
 			const fullId = `${client.id}::${id}`
@@ -110,13 +105,13 @@ class GraphicsPreview extends CoreBase {
 		if (controlId) {
 			const controlRoom = ControlConfigRoom(controlId)
 			if (this.io.countRoomMembers(controlRoom) > 0) {
-				this.io.emitToRoom(controlRoom, `controls:preview-${controlId}`, render.buffer)
+				this.io.emitToRoom(controlRoom, `controls:preview-${controlId}`, render.asDataUrl)
 			}
 		}
 
 		const previewRoom = PreviewPageRoom(location.pageNumber)
 		if (this.io.countRoomMembers(previewRoom) > 0) {
-			this.io.emitToRoom(previewRoom, `preview:page-bank`, location, render.buffer)
+			this.io.emitToRoom(previewRoom, `preview:page-bank`, location, render.asDataUrl)
 		}
 
 		// Lookup any sessions
@@ -126,7 +121,7 @@ class GraphicsPreview extends CoreBase {
 			if (previewSession.resolvedLocation.row != location.row) continue
 			if (previewSession.resolvedLocation.column != location.column) continue
 
-			previewSession.client.emit(`preview:button-reference:update:${previewSession.id}`, render.buffer)
+			previewSession.client.emit(`preview:button-reference:update:${previewSession.id}`, render.asDataUrl)
 		}
 	}
 
@@ -165,7 +160,7 @@ class GraphicsPreview extends CoreBase {
 
 			previewSession.client.emit(
 				`preview:button-reference:update:${previewSession.id}`,
-				this.graphics.getBank(result.location).buffer
+				this.graphics.getBank(result.location).asDataUrl
 			)
 		}
 	}

--- a/lib/Graphics/Renderer.js
+++ b/lib/Graphics/Renderer.js
@@ -18,6 +18,7 @@
 import Image from './Image.js'
 import { ParseAlignment, parseColor } from '../Resources/Util.js'
 import { formatLocation } from '../Shared/ControlId.js'
+import { ImageResult } from './ImageWrapper.js'
 //import {performance} from 'perf_hooks'
 
 const colorButtonYellow = 'rgb(255, 198, 0)'
@@ -60,7 +61,7 @@ export default class GraphicsRenderer {
 			img.horizontalLine(13.5, 'rgb(30, 30, 30)')
 		}
 		// console.timeEnd('drawBlankImage')
-		return img.bufferAndTime()
+		return new ImageResult(img.buffer())
 	}
 
 	/**
@@ -173,11 +174,7 @@ export default class GraphicsRenderer {
 						: img.drawAlignedText(2, 18, 68, 52, 'PNG ERROR', 'red', 10, 'center', 'center')
 
 					GraphicsRenderer.#drawTopbar(img, show_topbar, bankStyle, location)
-					return {
-						buffer: img.buffer(),
-						updated: Date.now(),
-						style: draw_style,
-					}
+					return new ImageResult(img.buffer(), draw_style)
 				}
 			}
 
@@ -202,11 +199,7 @@ export default class GraphicsRenderer {
 					: img.drawAlignedText(2, 18, 68, 52, 'IMAGE\\nDRAW\\nERROR', 'red', 10, 'center', 'center')
 
 				GraphicsRenderer.#drawTopbar(img, show_topbar, bankStyle, location)
-				return {
-					buffer: img.buffer(),
-					updated: Date.now(),
-					style: draw_style,
-				}
+				return new ImageResult(img.buffer(), draw_style)
 			}
 
 			// Draw button text
@@ -225,11 +218,7 @@ export default class GraphicsRenderer {
 		}
 
 		// console.timeEnd('drawBankImage')
-		return {
-			buffer: img.buffer(),
-			updated: Date.now(),
-			style: draw_style,
-		}
+		return new ImageResult(img.buffer(), draw_style)
 	}
 
 	/**
@@ -322,7 +311,7 @@ export default class GraphicsRenderer {
 		const img = new Image(72, 72, 3)
 		img.fillColor(colorDarkGrey)
 		img.drawTextLineAligned(36, 36, `${num}`, colorWhite, 44, 'center', 'center')
-		return img.bufferAndTime()
+		return new ImageResult(img.buffer())
 	}
 
 	static drawPincodeEntry(code) {
@@ -333,6 +322,6 @@ export default class GraphicsRenderer {
 			img.drawAlignedText(0, 15, 72, 72, code.replace(/[a-z0-9]/gi, '*'), colorWhite, 18, 'center', 'center')
 		}
 
-		return img.bufferAndTime()
+		return new ImageResult(img.buffer())
 	}
 }

--- a/lib/Instance/Definitions.js
+++ b/lib/Instance/Definitions.js
@@ -116,7 +116,7 @@ class InstanceDefinitions extends CoreBase {
 
 				const render = this.graphics.drawPreview(style)
 				if (render) {
-					return render.buffer
+					return render.asDataUrl
 				} else {
 					return null
 				}

--- a/lib/Service/Satellite.js
+++ b/lib/Service/Satellite.js
@@ -120,8 +120,10 @@ class ServiceSatellite extends ServiceBase {
 
 		const device = this.surfaces.addSatelliteDevice({
 			path: id,
-			keysTotal: keysTotal,
-			keysPerRow: keysPerRow,
+			gridSize: {
+				columns: keysPerRow,
+				rows: keysTotal / keysPerRow,
+			},
 			socket: socket,
 			deviceId: params.DEVICEID,
 			productName: params.PRODUCT_NAME,

--- a/lib/Surface/Handler.js
+++ b/lib/Surface/Handler.js
@@ -121,13 +121,7 @@ class SurfaceHandler extends CoreBase {
 		this.currentPage = 1 // The current page of the device
 
 		// Fill in max offsets
-		const keysPerRow = this.panel.info.keysPerRow || 0
-		const keysTotal = this.panel.info.keysTotal || 0
-		if (keysPerRow && keysTotal) {
-			const maxRows = Math.ceil(global.MAX_BUTTONS / global.MAX_BUTTONS_PER_ROW)
-			this.panelInfo.xOffsetMax = Math.max(Math.floor(global.MAX_BUTTONS_PER_ROW - keysPerRow), 0)
-			this.panelInfo.yOffsetMax = Math.max(Math.floor(maxRows - Math.ceil(keysTotal / keysPerRow)), 0)
-		}
+		this.updateMaxOffset()
 
 		{
 			const rawConfig = this.db.getKey('deviceconfig', {})
@@ -149,6 +143,9 @@ class SurfaceHandler extends CoreBase {
 
 		if (!this.panelconfig.config) {
 			this.panelconfig.config = cloneDeep(SurfaceHandler.PanelDefaults)
+			if (typeof this.panel.getDefaultConfig === 'function') {
+				Object.assign(this.panelconfig.config, this.panel.getDefaultConfig())
+			}
 		}
 
 		if (this.panelconfig.config.xOffset === undefined || this.panelconfig.config.yOffset === undefined) {
@@ -187,6 +184,7 @@ class SurfaceHandler extends CoreBase {
 		this.panel.on('click', this.#onDeviceClick.bind(this))
 		this.panel.on('rotate', this.#onDeviceRotate.bind(this))
 		this.panel.on('remove', this.#onDeviceRemove.bind(this))
+		this.panel.on('resized', this.#onDeviceResized.bind(this))
 
 		// subscribe to some xkeys specific events
 		this.panel.on('xkeys-subscribePage', this.#onXkeysSubscribePages.bind(this))
@@ -204,6 +202,16 @@ class SurfaceHandler extends CoreBase {
 
 			this.drawPage()
 		})
+	}
+
+	updateMaxOffset() {
+		const keysPerRow = this.panel.info.keysPerRow || 0
+		const keysTotal = this.panel.info.keysTotal || 0
+		if (keysPerRow && keysTotal) {
+			const maxRows = Math.ceil(global.MAX_BUTTONS / global.MAX_BUTTONS_PER_ROW)
+			this.panelInfo.xOffsetMax = Math.max(Math.floor(global.MAX_BUTTONS_PER_ROW - keysPerRow), 0)
+			this.panelInfo.yOffsetMax = Math.max(Math.floor(maxRows - Math.ceil(keysTotal / keysPerRow)), 0)
+		}
 	}
 
 	get deviceId() {
@@ -346,9 +354,16 @@ class SurfaceHandler extends CoreBase {
 	}
 
 	#onDeviceRemove() {
-		if (this.panel) {
-			this.surfaces.removeDevice(this.panel.info.devicepath)
-		}
+		if (!this.panel) return
+		this.surfaces.removeDevice(this.panel.info.devicepath)
+	}
+
+	#onDeviceResized() {
+		if (!this.panel) return
+
+		this.drawPage()
+
+		this.updateMaxOffset()
 	}
 
 	#onDeviceClick(x, y, pressed, pageOffset) {

--- a/lib/Surface/Handler.js
+++ b/lib/Surface/Handler.js
@@ -240,11 +240,11 @@ class SurfaceHandler extends CoreBase {
 				const buffers = this.graphics.getImagesForPincode(this.currentPincodeEntry)
 				this.panel.clearDeck()
 
-				this.panel.draw(this.pincodeCodePosition[0], this.pincodeCodePosition[1], buffers.code.buffer)
+				this.panel.draw(this.pincodeCodePosition[0], this.pincodeCodePosition[1], buffers.code)
 
 				this.pincodeNumberPositions.forEach(([x, y], i) => {
 					if (buffers[i]) {
-						this.panel.draw(x, y, buffers[i].buffer)
+						this.panel.draw(x, y, buffers[i])
 					}
 				})
 			} else if (this.#xkeysPageCount > 0) {
@@ -261,7 +261,7 @@ class SurfaceHandler extends CoreBase {
 							row: y % 4,
 						})
 
-						this.panel.draw(x, y, image.buffer, image.style)
+						this.panel.draw(x, y, image)
 					}
 				}
 			} else {
@@ -277,7 +277,7 @@ class SurfaceHandler extends CoreBase {
 							row: y + yOffset,
 						})
 
-						this.panel.draw(x, y, image.buffer, image.style)
+						this.panel.draw(x, y, image)
 					}
 				}
 			}
@@ -320,13 +320,13 @@ class SurfaceHandler extends CoreBase {
 			location.row < 3 // lower half of CT has only 3 rows, zero based
 		) {
 			// Loupdeck CT lower half, draw button with row offset by 4
-			this.panel.draw(location.column, location.row + 4, render.buffer, render.style)
+			this.panel.draw(location.column, location.row + 4, render)
 		} else if (location.pageNumber == this.currentPage) {
 			// normal mode
 			const xOffset = Math.min(Math.max(this.panelconfig.config.xOffset || 0, 0), this.panelInfo.xOffsetMax)
 			const yOffset = Math.min(Math.max(this.panelconfig.config.yOffset || 0, 0), this.panelInfo.yOffsetMax)
 
-			this.panel.draw(location.column - xOffset, location.row - yOffset, render.buffer, render.style)
+			this.panel.draw(location.column - xOffset, location.row - yOffset, render)
 		}
 	}
 
@@ -408,7 +408,7 @@ class SurfaceHandler extends CoreBase {
 				if (this.isSurfaceLocked) {
 					// Update lockout button
 					const datap = this.graphics.getImagesForPincode(this.currentPincodeEntry)
-					this.panel.draw(this.pincodeCodePosition[0], this.pincodeCodePosition[1], datap.code.buffer)
+					this.panel.draw(this.pincodeCodePosition[0], this.pincodeCodePosition[1], datap.code)
 				}
 			}
 		}

--- a/lib/Surface/Handler.js
+++ b/lib/Surface/Handler.js
@@ -205,12 +205,11 @@ class SurfaceHandler extends CoreBase {
 	}
 
 	updateMaxOffset() {
-		const keysPerRow = this.panel.info.keysPerRow || 0
-		const keysTotal = this.panel.info.keysTotal || 0
-		if (keysPerRow && keysTotal) {
+		const gridSize = this.panel.gridSize
+		if (gridSize.columns && gridSize.rows) {
 			const maxRows = Math.ceil(global.MAX_BUTTONS / global.MAX_BUTTONS_PER_ROW)
-			this.panelInfo.xOffsetMax = Math.max(Math.floor(global.MAX_BUTTONS_PER_ROW - keysPerRow), 0)
-			this.panelInfo.yOffsetMax = Math.max(Math.floor(maxRows - Math.ceil(keysTotal / keysPerRow)), 0)
+			this.panelInfo.xOffsetMax = Math.max(Math.floor(global.MAX_BUTTONS_PER_ROW - gridSize.columns), 0)
+			this.panelInfo.yOffsetMax = Math.max(Math.floor(maxRows - gridSize.rows), 0)
 		}
 	}
 
@@ -258,11 +257,14 @@ class SurfaceHandler extends CoreBase {
 			} else if (this.#xkeysPageCount > 0) {
 				this.#xkeysDrawPages()
 			} else if (this.panel.info.type === 'Loupedeck CT') {
-				for (let y = 0; y < 7; y += 1) {
+				const gridSize = this.panel.gridSize
+
+				for (let y = 0; y < gridSize.rows; y += 1) {
 					let pageNumber = this.currentPage
-					if (y > 3) pageNumber += 1
+					if (y >= gridSize.rows) pageNumber += 1
 					if (pageNumber > 99) pageNumber = 1
-					for (let x = 0; x < this.panel.info.keysPerRow; x += 1) {
+
+					for (let x = 0; x < gridSize.columns; x += 1) {
 						const image = this.graphics.getBank({
 							pageNumber,
 							column: x,
@@ -276,9 +278,10 @@ class SurfaceHandler extends CoreBase {
 				const xOffset = Math.min(Math.max(this.panelconfig.config.xOffset || 0, 0), this.panelInfo.xOffsetMax)
 				const yOffset = Math.min(Math.max(this.panelconfig.config.yOffset || 0, 0), this.panelInfo.yOffsetMax)
 
-				const rows = this.panel.info.keysTotal / this.panel.info.keysPerRow
-				for (let y = 0; y < rows; y++) {
-					for (let x = 0; x < this.panel.info.keysPerRow; x++) {
+				const gridSize = this.panel.gridSize
+
+				for (let y = 0; y < gridSize.rows; y++) {
+					for (let x = 0; x < gridSize.columns; x++) {
 						const image = this.graphics.getBank({
 							pageNumber: this.currentPage,
 							column: x + xOffset,

--- a/lib/Surface/IP/ElgatoEmulator.js
+++ b/lib/Surface/IP/ElgatoEmulator.js
@@ -105,10 +105,10 @@ class SurfaceIPElgatoEmulator extends EventEmitter {
 
 	quit() {}
 
-	draw(x, y, buffer, style) {
-		//if (buffer === undefined || buffer.length != 15552) {
-		if (buffer === undefined || buffer.length === 0) {
-			this.logger.verbose('buffer was not 15552, but ', buffer.length)
+	draw(x, y, render) {
+		const dataUrl = render.asDataUrl
+		if (!dataUrl) {
+			this.logger.verbose('draw call had no data-url')
 			return false
 		}
 
@@ -116,7 +116,7 @@ class SurfaceIPElgatoEmulator extends EventEmitter {
 		const key = xyToOldBankIndex(x, y)
 		if (key !== null) {
 			if (!this.imageCache[y]) this.imageCache[y] = {}
-			this.imageCache[y][x] = buffer || null
+			this.imageCache[y][x] = dataUrl || null
 
 			this.#pendingBufferUpdates.set(`${x}/${y}`, [x, y])
 			this.#emitChanged()

--- a/lib/Surface/IP/ElgatoEmulator.js
+++ b/lib/Surface/IP/ElgatoEmulator.js
@@ -20,7 +20,6 @@ import { cloneDeep } from 'lodash-es'
 import LogController from '../../Log/Controller.js'
 import jsonPatch from 'fast-json-patch'
 import debounceFn from 'debounce-fn'
-import { xyToOldBankIndex } from '../../Shared/ControlId.js'
 
 export function EmulatorRoom(id) {
 	return `emulator:${id}`
@@ -68,21 +67,15 @@ class SurfaceIPElgatoEmulator extends EventEmitter {
 		this.info = {
 			type: 'Emulator',
 			devicepath: `emulator:${emulatorId}`,
-			configFields: ['emulator_control_enable', 'emulator_prompt_fullscreen'],
-			keysPerRow: 8,
-			keysTotal: 32,
+			configFields: ['emulator_control_enable', 'emulator_prompt_fullscreen', 'emulator_size'],
+			keysPerRow: 8, // Overridden later
+			keysTotal: 32, // Overridden later
 			deviceId: `emulator:${emulatorId}`,
 		}
 
 		this.logger.debug('Adding Elgato Streamdeck Emulator')
 
 		this.imageCache = {}
-		for (let y = 0; y < global.MAX_BUTTONS_PER_COL; ++y) {
-			this.imageCache[y] = {}
-			for (let x = 0; x < global.MAX_BUTTONS_PER_ROW; ++x) {
-				this.imageCache[y][x] = null
-			}
-		}
 	}
 
 	setupClient(client) {
@@ -91,7 +84,26 @@ class SurfaceIPElgatoEmulator extends EventEmitter {
 		return this.#lastSentConfigJson
 	}
 
+	getDefaultConfig() {
+		return {
+			emulator_control_enable: false,
+			emulator_prompt_fullscreen: false,
+
+			emulator_columns: 8,
+			emulator_rows: 4,
+		}
+	}
+
 	setConfig(config) {
+		// Populate some defaults
+		if (!config.emulator_columns) config.emulator_columns = this.getDefaultConfig().emulator_columns
+		if (!config.emulator_rows) config.emulator_rows = this.getDefaultConfig().emulator_rows
+
+		// Ensure info is accurate
+		this.info.keysPerRow = config.emulator_columns
+		this.info.keysTotal = config.emulator_columns * config.emulator_rows
+
+		// Send config to clients
 		const roomName = EmulatorRoom(this.id)
 		if (this.io.countRoomMembers(roomName) > 0) {
 			const patch = jsonPatch.compare(this.#lastSentConfigJson || {}, config || {})
@@ -100,12 +112,35 @@ class SurfaceIPElgatoEmulator extends EventEmitter {
 			}
 		}
 
+		// Handle resize
+		if (
+			config.emulator_columns !== this.#lastSentConfigJson.emulator_columns ||
+			config.emulator_rows !== this.#lastSentConfigJson.emulator_rows
+		) {
+			// Clear the cache to ensure no bleed
+			this.imageCache = {}
+
+			for (let y = 0; y < this.#lastSentConfigJson.emulator_rows; y++) {
+				for (let x = 0; x < this.#lastSentConfigJson.emulator_columns; x++) {
+					this.#trackChanged(x, y)
+				}
+			}
+
+			setImmediate(() => {
+				// Trigger the redraw after this call has completed
+				this.emit('resized')
+			})
+		}
+
 		this.#lastSentConfigJson = cloneDeep(config)
 	}
 
 	quit() {}
 
 	draw(x, y, render) {
+		if (x < 0 || y < 0 || x >= this.#lastSentConfigJson.emulator_columns || y >= this.#lastSentConfigJson.emulator_rows)
+			return true
+
 		const dataUrl = render.asDataUrl
 		if (!dataUrl) {
 			this.logger.verbose('draw call had no data-url')
@@ -113,16 +148,17 @@ class SurfaceIPElgatoEmulator extends EventEmitter {
 		}
 
 		// Temporarily use this to validate that the key is usable by the emulator
-		const key = xyToOldBankIndex(x, y)
-		if (key !== null) {
-			if (!this.imageCache[y]) this.imageCache[y] = {}
-			this.imageCache[y][x] = dataUrl || null
+		if (!this.imageCache[y]) this.imageCache[y] = {}
+		this.imageCache[y][x] = dataUrl || null
 
-			this.#pendingBufferUpdates.set(`${x}/${y}`, [x, y])
-			this.#emitChanged()
-		}
+		this.#trackChanged(x, y)
+		this.#emitChanged()
 
 		return true
+	}
+
+	#trackChanged(x, y) {
+		this.#pendingBufferUpdates.set(`${x}/${y}`, [x, y])
 	}
 
 	clearDeck() {
@@ -130,13 +166,6 @@ class SurfaceIPElgatoEmulator extends EventEmitter {
 
 		// clear all images
 		this.imageCache = {}
-		for (let y = 0; y < global.MAX_BUTTONS_PER_COL; ++y) {
-			if (!this.imageCache[y]) this.imageCache[y] = {}
-			for (let x = 0; x < global.MAX_BUTTONS_PER_ROW; ++x) {
-				this.imageCache[y][x] = null
-			}
-		}
-
 		this.io.emitToRoom(EmulatorRoom(this.id), 'emulator:images', {})
 	}
 }

--- a/lib/Surface/IP/ElgatoEmulator.js
+++ b/lib/Surface/IP/ElgatoEmulator.js
@@ -68,14 +68,19 @@ class SurfaceIPElgatoEmulator extends EventEmitter {
 			type: 'Emulator',
 			devicepath: `emulator:${emulatorId}`,
 			configFields: ['emulator_control_enable', 'emulator_prompt_fullscreen', 'emulator_size'],
-			keysPerRow: 8, // Overridden later
-			keysTotal: 32, // Overridden later
 			deviceId: `emulator:${emulatorId}`,
 		}
 
 		this.logger.debug('Adding Elgato Streamdeck Emulator')
 
 		this.imageCache = {}
+	}
+
+	get gridSize() {
+		return {
+			columns: this.#lastSentConfigJson?.emulator_columns || 8,
+			rows: this.#lastSentConfigJson?.emulator_rows || 4,
+		}
 	}
 
 	setupClient(client) {
@@ -99,10 +104,6 @@ class SurfaceIPElgatoEmulator extends EventEmitter {
 		if (!config.emulator_columns) config.emulator_columns = this.getDefaultConfig().emulator_columns
 		if (!config.emulator_rows) config.emulator_rows = this.getDefaultConfig().emulator_rows
 
-		// Ensure info is accurate
-		this.info.keysPerRow = config.emulator_columns
-		this.info.keysTotal = config.emulator_columns * config.emulator_rows
-
 		// Send config to clients
 		const roomName = EmulatorRoom(this.id)
 		if (this.io.countRoomMembers(roomName) > 0) {
@@ -113,15 +114,13 @@ class SurfaceIPElgatoEmulator extends EventEmitter {
 		}
 
 		// Handle resize
-		if (
-			config.emulator_columns !== this.#lastSentConfigJson.emulator_columns ||
-			config.emulator_rows !== this.#lastSentConfigJson.emulator_rows
-		) {
+		const oldSize = this.gridSize
+		if (config.emulator_columns !== oldSize.columns || config.emulator_rows !== oldSize.rows) {
 			// Clear the cache to ensure no bleed
 			this.imageCache = {}
 
-			for (let y = 0; y < this.#lastSentConfigJson.emulator_rows; y++) {
-				for (let x = 0; x < this.#lastSentConfigJson.emulator_columns; x++) {
+			for (let y = 0; y < oldSize.rows; y++) {
+				for (let x = 0; x < oldSize.columns; x++) {
 					this.#trackChanged(x, y)
 				}
 			}
@@ -138,8 +137,8 @@ class SurfaceIPElgatoEmulator extends EventEmitter {
 	quit() {}
 
 	draw(x, y, render) {
-		if (x < 0 || y < 0 || x >= this.#lastSentConfigJson.emulator_columns || y >= this.#lastSentConfigJson.emulator_rows)
-			return true
+		const size = this.gridSize
+		if (x < 0 || y < 0 || x >= size.columns || y >= size.rows) return true
 
 		const dataUrl = render.asDataUrl
 		if (!dataUrl) {

--- a/lib/Surface/IP/ElgatoPlugin.js
+++ b/lib/Surface/IP/ElgatoPlugin.js
@@ -40,9 +40,12 @@ class SurfaceIPElgatoPlugin extends EventEmitter {
 			type: 'Elgato Streamdeck Plugin',
 			devicepath: devicepath,
 			configFields: ['rotation'],
-			keysPerRow: 8,
-			keysTotal: 32,
 			deviceId: 'plugin',
+		}
+
+		this.gridSize = {
+			columns: 8,
+			rows: 4,
 		}
 
 		this._config = {
@@ -101,7 +104,7 @@ class SurfaceIPElgatoPlugin extends EventEmitter {
 			let right = data.ticks > 0
 
 			if (key !== undefined) {
-				const xy = convertPanelIndexToXY(key, this.info)
+				const xy = convertPanelIndexToXY(key, this.gridSize)
 				if (xy) {
 					this.emit('rotate', ...xy, right)
 				}
@@ -144,7 +147,7 @@ class SurfaceIPElgatoPlugin extends EventEmitter {
 	}
 
 	#emitClick(key, state) {
-		const xy = convertPanelIndexToXY(key, this.info)
+		const xy = convertPanelIndexToXY(key, this.gridSize)
 		if (xy) {
 			this.emit('click', ...xy, state)
 		}

--- a/lib/Surface/IP/ElgatoPlugin.js
+++ b/lib/Surface/IP/ElgatoPlugin.js
@@ -156,17 +156,17 @@ class SurfaceIPElgatoPlugin extends EventEmitter {
 		this.socket.removeAllListeners('rotate')
 	}
 
-	draw(x, y, buffer, style) {
+	draw(x, y, render) {
 		// if (buffer === undefined || buffer.length != 15552) {
-		if (buffer === undefined || buffer.length === 0) {
-			this.logger.silly('buffer was not 15552, but ', buffer.length)
+		if (render.buffer === undefined || render.buffer.length === 0) {
+			this.logger.silly('buffer was not 15552, but ', render.buffer?.length)
 			return false
 		}
 
 		const key = xyToOldBankIndex(x, y)
 		if (key) {
 			if (this.supportsRgba) {
-				const imagesize = Math.sqrt(buffer.length / 4) // TODO: assuming here that the image is square
+				const imagesize = Math.sqrt(render.buffer.length / 4) // TODO: assuming here that the image is square
 
 				const png = new PNG({
 					width: imagesize,
@@ -177,7 +177,7 @@ class SurfaceIPElgatoPlugin extends EventEmitter {
 						blue: 0,
 					},
 				})
-				png.data = buffer
+				png.data = render.buffer
 
 				const pngBuffer = PNG.sync.write(png)
 
@@ -187,7 +187,7 @@ class SurfaceIPElgatoPlugin extends EventEmitter {
 					data: 'data:image/png;base64,' + pngBuffer.toString('base64'),
 				})
 			} else {
-				this.write_queue.queue(key, buffer)
+				this.write_queue.queue(key, render.buffer)
 			}
 		}
 

--- a/lib/Surface/IP/Satellite.js
+++ b/lib/Surface/IP/Satellite.js
@@ -127,15 +127,15 @@ class SurfaceIPSatellite extends EventEmitter {
 		}
 	}
 
-	draw(x, y, buffer, style) {
+	draw(x, y, render) {
 		const key = convertXYToIndexForPanel(x, y, this.info)
 		if (key === null) return true
 
 		if (this.#streamBitmapSize) {
 			// Images need scaling
-			this.write_queue.queue(key, buffer, style)
+			this.write_queue.queue(key, render.buffer, render.style)
 		} else {
-			this.#sendDraw(key, undefined, style)
+			this.#sendDraw(key, undefined, render.style)
 		}
 
 		return true

--- a/lib/Surface/IP/Satellite.js
+++ b/lib/Surface/IP/Satellite.js
@@ -36,11 +36,11 @@ class SurfaceIPSatellite extends EventEmitter {
 			type: deviceInfo.productName,
 			devicepath: deviceInfo.path,
 			configFields: ['brightness'],
-			keysPerRow: deviceInfo.keysPerRow,
-			keysTotal: deviceInfo.keysTotal,
 			deviceId: deviceInfo.path,
 			location: deviceInfo.socket.remoteAddress,
 		}
+
+		this.gridSize = deviceInfo.gridSize
 
 		this.deviceId = deviceInfo.deviceId
 
@@ -128,7 +128,7 @@ class SurfaceIPSatellite extends EventEmitter {
 	}
 
 	draw(x, y, render) {
-		const key = convertXYToIndexForPanel(x, y, this.info)
+		const key = convertXYToIndexForPanel(x, y, this.gridSize)
 		if (key === null) return true
 
 		if (this.#streamBitmapSize) {
@@ -142,14 +142,14 @@ class SurfaceIPSatellite extends EventEmitter {
 	}
 
 	doButton(key, state) {
-		const xy = convertPanelIndexToXY(key, this.info)
+		const xy = convertPanelIndexToXY(key, this.gridSize)
 		if (xy) {
 			this.emit('click', ...xy, state)
 		}
 	}
 
 	doRotate(key, direction) {
-		const xy = convertPanelIndexToXY(key, this.info)
+		const xy = convertPanelIndexToXY(key, this.gridSize)
 		if (xy) {
 			this.emit('rotate', ...xy, direction)
 		}

--- a/lib/Surface/USB/ElgatoStreamDeck.js
+++ b/lib/Surface/USB/ElgatoStreamDeck.js
@@ -44,9 +44,15 @@ class SurfaceUSBElgatoStreamDeck extends EventEmitter {
 			type: `Elgato ${this.streamDeck.PRODUCT_NAME}`,
 			devicepath: devicepath,
 			configFields: ['brightness', 'rotation'],
-			keysPerRow: this.streamDeck.KEY_COLUMNS,
-			keysTotal: this.streamDeck.NUM_KEYS,
 			deviceId: undefined, // set in #init()
+		}
+
+		this.gridSize = {
+			columns: this.streamDeck.KEY_COLUMNS,
+			rows: this.streamDeck.KEY_ROWS,
+		}
+		if (this.streamDeck.MODEL === DeviceModelId.PLUS) {
+			this.gridSize.rows += 2
 		}
 
 		this.write_queue = new ImageWriteQueue(this.logger, async (key, buffer) => {
@@ -103,8 +109,6 @@ class SurfaceUSBElgatoStreamDeck extends EventEmitter {
 		})
 
 		if (this.streamDeck.MODEL === DeviceModelId.PLUS) {
-			this.info.keysTotal += 8
-
 			const encoderOffset = 12
 			this.streamDeck.on('rotateLeft', (encoderIndex) => {
 				this.#emitRotate(encoderOffset + encoderIndex, false)
@@ -175,14 +179,14 @@ class SurfaceUSBElgatoStreamDeck extends EventEmitter {
 	}
 
 	#emitClick(key, state) {
-		const xy = convertPanelIndexToXY(key, this.info)
+		const xy = convertPanelIndexToXY(key, this.gridSize)
 		if (xy) {
 			this.emit('click', ...xy, state)
 		}
 	}
 
 	#emitRotate(key, direction) {
-		const xy = convertPanelIndexToXY(key, this.info)
+		const xy = convertPanelIndexToXY(key, this.gridSize)
 		if (xy) {
 			this.emit('rotate', ...xy, direction)
 		}
@@ -251,7 +255,7 @@ class SurfaceUSBElgatoStreamDeck extends EventEmitter {
 	}
 
 	draw(x, y, render) {
-		const key = convertXYToIndexForPanel(x, y, this.info)
+		const key = convertXYToIndexForPanel(x, y, this.gridSize)
 		if (key === null) return true
 
 		if (key >= 0 && key < this.streamDeck.NUM_KEYS) {

--- a/lib/Surface/USB/ElgatoStreamDeck.js
+++ b/lib/Surface/USB/ElgatoStreamDeck.js
@@ -250,17 +250,17 @@ class SurfaceUSBElgatoStreamDeck extends EventEmitter {
 		})
 	}
 
-	draw(x, y, buffer, style) {
+	draw(x, y, render) {
 		const key = convertXYToIndexForPanel(x, y, this.info)
 		if (key === null) return true
 
 		if (key >= 0 && key < this.streamDeck.NUM_KEYS) {
-			this.write_queue.queue(key, buffer)
+			this.write_queue.queue(key, render.buffer)
 		}
 
 		const segmentIndex = key - this.streamDeck.NUM_KEYS
 		if (this.lcdWriteQueue && segmentIndex >= 0 && segmentIndex < this.streamDeck.KEY_COLUMNS) {
-			this.lcdWriteQueue.queue(segmentIndex, buffer)
+			this.lcdWriteQueue.queue(segmentIndex, render.buffer)
 		}
 
 		return true

--- a/lib/Surface/USB/Infinitton.js
+++ b/lib/Surface/USB/Infinitton.js
@@ -101,23 +101,24 @@ class SurfaceUSBInfinitton {
 		}
 	}
 
-	draw(key, buffer, style) {
+	draw(key, render) {
 		key = this.mapButton(key)
 
 		if (key >= 0 && !isNaN(key)) {
-			let imagesize = Math.sqrt(buffer.length / 4) // TODO: assuming here that the image is square
+			const imagesize = Math.sqrt(render.buffer.length / 4) // TODO: assuming here that the image is square
 			const rotation = translateRotation(this.config.rotation)
 
 			try {
-				let newbuffer = buffer
-				let image = imageRs.ImageTransformer.fromBuffer(buffer, imagesize, imagesize, imageRs.PixelFormat.Rgba).scale(
-					targetSize,
-					targetSize
-				)
+				let image = imageRs.ImageTransformer.fromBuffer(
+					render.buffer,
+					imagesize,
+					imagesize,
+					imageRs.PixelFormat.Rgba
+				).scale(targetSize, targetSize)
 
 				if (rotation !== null) image = image.rotate(rotation)
 
-				newbuffer = Buffer.from(image.toBufferSync(imageRs.PixelFormat.Rgb))
+				const newbuffer = Buffer.from(image.toBufferSync(imageRs.PixelFormat.Rgb))
 				this.Infinitton.fillImage(key, newbuffer)
 			} catch (e) {
 				this.logger.debug(`scale image failed: ${e}\n${e.stack}`)

--- a/lib/Surface/USB/Infinitton.js
+++ b/lib/Surface/USB/Infinitton.js
@@ -38,9 +38,12 @@ class SurfaceUSBInfinitton {
 			type: 'Infinitton iDisplay device',
 			devicepath: devicepath,
 			configFields: ['brightness', 'rotation'],
-			keysPerRow: 5,
-			keysTotal: 15,
 			deviceId: `infinitton:${serialnumber}`,
+		}
+
+		this.gridSize = {
+			columns: 5,
+			rows: 3,
 		}
 
 		this.ipcWrapper.log('debug', 'Infinitton detected')
@@ -150,7 +153,8 @@ class SurfaceUSBInfinitton {
 	clearDeck() {
 		this.ipcWrapper.log('debug', 'infinitton.prototype.clearDeck()')
 
-		for (let x = 0; x < this.info.keysTotal; x++) {
+		const keysTotal = this.gridSize.columns * this.gridSize.rows
+		for (let x = 0; x < keysTotal; x++) {
 			this.Infinitton.clearKey(x)
 		}
 	}

--- a/lib/Surface/USB/LoupedeckCt.js
+++ b/lib/Surface/USB/LoupedeckCt.js
@@ -349,20 +349,20 @@ class SurfaceUSBLoupedeckCt extends EventEmitter {
 		this.loupedeck.close()
 	}
 
-	draw(x, y, buffer, style) {
+	draw(x, y, render) {
 		let screen = this.modelInfo.displays.center
 		const lcdX = x - screen.lcdXOffset
 
 		if (x === 3 && y === 4) {
-			this.key_write_queue.queue(35, buffer)
+			this.key_write_queue.queue(35, render.buffer)
 		} else if (lcdX >= 0 && lcdX < screen.lcdCols && y >= 0 && y < screen.lcdRows) {
 			const button = lcdX + y * screen.lcdCols
-			this.key_write_queue.queue(button, buffer)
+			this.key_write_queue.queue(button, render.buffer)
 		}
 
 		const buttonIndex = this.modelInfo.buttons.findIndex((btn) => btn[0] == x && btn[1] == y)
 		if (buttonIndex >= 0) {
-			const color = style ? colorToRgb(style.bgcolor) : { r: 0, g: 0, b: 0 }
+			const color = render.style ? colorToRgb(render.style.bgcolor) : { r: 0, g: 0, b: 0 }
 
 			this.loupedeck
 				.setButtonColor({

--- a/lib/Surface/USB/LoupedeckCt.js
+++ b/lib/Surface/USB/LoupedeckCt.js
@@ -72,9 +72,12 @@ class SurfaceUSBLoupedeckCt extends EventEmitter {
 			type: `Loupedeck CT`,
 			devicepath: devicepath,
 			configFields: ['brightness'],
-			keysPerRow: 8,
-			keysTotal: 56,
 			deviceId: `loupedeck:${serialnumber}`,
+		}
+
+		this.gridSize = {
+			columns: 8,
+			rows: 7,
 		}
 
 		this.loupedeck.on('error', (error) => {
@@ -105,7 +108,7 @@ class SurfaceUSBLoupedeckCt extends EventEmitter {
 			for (const touch of data.changedTouches) {
 				if (touch.target.key !== undefined) {
 					const keyIndex = translateTouchKeyIndex(this.modelInfo.displays[touch.target.screen], touch.target.key)
-					const xy = convertPanelIndexToXY(keyIndex, this.info)
+					const xy = convertPanelIndexToXY(keyIndex, this.gridSize)
 					this.#emitClick(xy, true)
 				} else if (touch.target.screen == LoupedeckDisplayId.Wheel) {
 					this.#emitClick([2, 4], true)
@@ -117,7 +120,7 @@ class SurfaceUSBLoupedeckCt extends EventEmitter {
 			for (const touch of data.changedTouches) {
 				if (touch.target.key !== undefined) {
 					const keyIndex = translateTouchKeyIndex(this.modelInfo.displays[touch.target.screen], touch.target.key)
-					const xy = convertPanelIndexToXY(keyIndex, this.info)
+					const xy = convertPanelIndexToXY(keyIndex, this.gridSize)
 					this.#emitClick(xy, false)
 				} else if (touch.target.screen == LoupedeckDisplayId.Wheel) {
 					this.#emitClick([2, 4], false)

--- a/lib/Surface/USB/LoupedeckLive.js
+++ b/lib/Surface/USB/LoupedeckLive.js
@@ -294,17 +294,17 @@ class SurfaceUSBLoupedeckLive extends EventEmitter {
 		this.loupedeck.close()
 	}
 
-	draw(x, y, buffer, style) {
+	draw(x, y, render) {
 		const lcdX = x - this.modelInfo.lcdXOffset
 		if (lcdX >= 0 && lcdX < this.modelInfo.lcdCols && y >= 0 && y < this.modelInfo.lcdRows) {
 			const button = lcdX + y * this.modelInfo.lcdCols
 
-			this.write_queue.queue(button, buffer)
+			this.write_queue.queue(button, render.buffer)
 		}
 
 		const buttonIndex = this.modelInfo.buttons.findIndex((btn) => btn[0] == x && btn[1] == y)
 		if (buttonIndex >= 0) {
-			const color = style ? colorToRgb(style.bgcolor) : { r: 0, g: 0, b: 0 }
+			const color = render.style ? colorToRgb(render.style.bgcolor) : { r: 0, g: 0, b: 0 }
 
 			this.loupedeck
 				.setButtonColor({

--- a/lib/Surface/USB/LoupedeckLive.js
+++ b/lib/Surface/USB/LoupedeckLive.js
@@ -131,9 +131,12 @@ class SurfaceUSBLoupedeckLive extends EventEmitter {
 			type: `Loupedeck ${this.loupedeck.modelName}`,
 			devicepath: devicepath,
 			configFields: ['brightness'],
-			keysPerRow: this.modelInfo.totalCols,
-			keysTotal: this.modelInfo.totalCols * this.modelInfo.totalRows,
 			deviceId: `loupedeck:${serialnumber}`,
+		}
+
+		this.gridSize = {
+			columns: this.modelInfo.totalCols,
+			rows: this.modelInfo.totalRows,
 		}
 
 		this.loupedeck.on('error', (error) => {
@@ -230,7 +233,7 @@ class SurfaceUSBLoupedeckLive extends EventEmitter {
 	}
 
 	#emitClick(key, state) {
-		const xy = convertPanelIndexToXY(key, this.info)
+		const xy = convertPanelIndexToXY(key, this.gridSize)
 		if (xy) {
 			this.emit('click', ...xy, state)
 		}

--- a/lib/Surface/USB/XKeys.js
+++ b/lib/Surface/USB/XKeys.js
@@ -43,9 +43,11 @@ class SurfaceUSBXKeys extends EventEmitter {
 			devicepath: devicepath,
 			configFields: ['brightness', 'illuminate_pressed'],
 			deviceId: deviceId,
+		}
 
-			keysPerRow: global.MAX_BUTTONS_PER_ROW,
-			keysTotal: global.MAX_BUTTONS,
+		this.gridSize = {
+			columns: global.MAX_BUTTONS_PER_ROW,
+			rows: global.MAX_BUTTONS / global.MAX_BUTTONS_PER_ROW,
 		}
 
 		this.config = {
@@ -164,7 +166,7 @@ class SurfaceUSBXKeys extends EventEmitter {
 	}
 
 	#emitClick(key, state, pageOffset) {
-		const xy = convertPanelIndexToXY(key, this.info)
+		const xy = convertPanelIndexToXY(key, this.gridSize)
 		if (xy) {
 			this.emit('click', ...xy, state, pageOffset)
 		}
@@ -247,7 +249,7 @@ class SurfaceUSBXKeys extends EventEmitter {
 			b: color & 0xff,
 		}
 
-		const key = convertXYToIndexForPanel(x, y, this.info)
+		const key = convertXYToIndexForPanel(x, y, this.gridSize)
 		if (!key) return
 
 		const buttonNumber = page * global.MAX_BUTTONS + key

--- a/lib/Surface/Util.js
+++ b/lib/Surface/Util.js
@@ -1,17 +1,14 @@
-export function convertXYToIndexForPanel(x, y, panelInfo) {
-	if (x < 0 || y < 0 || x >= panelInfo.keysPerRow) return null
+export function convertXYToIndexForPanel(x, y, gridSize) {
+	if (x < 0 || y < 0 || x >= gridSize.columns || y >= gridSize.rows) return null
 
-	const key = y * panelInfo.keysPerRow + x
-	if (key >= panelInfo.keysTotal) return null
-
-	return key
+	return y * gridSize.columns + x
 }
 
-export function convertPanelIndexToXY(index, panelInfo) {
+export function convertPanelIndexToXY(index, gridSize) {
 	index = Number(index)
-	if (isNaN(index) || index < 0 || index >= panelInfo.keysTotal) return null
+	if (isNaN(index) || index < 0 || index >= gridSize.columns * gridSize.rows) return null
 
-	const x = index % panelInfo.keysPerRow
-	const y = Math.floor(index / panelInfo.keysPerRow)
+	const x = index % gridSize.columns
+	const y = Math.floor(index / gridSize.columns)
 	return [x, y]
 }

--- a/webui/src/Buttons/EditButton.jsx
+++ b/webui/src/Buttons/EditButton.jsx
@@ -41,7 +41,7 @@ import React, {
 	useMemo,
 } from 'react'
 import { nanoid } from 'nanoid'
-import { ButtonPreview, dataToButtonImage } from '../Components/ButtonPreview'
+import { ButtonPreview } from '../Components/ButtonPreview'
 import { GenericConfirmModal } from '../Components/GenericConfirmModal'
 import {
 	KeyReceiver,
@@ -123,7 +123,7 @@ export function EditButton({ location, onKeyUp, contentHeight }) {
 		socket.on(`controls:runtime-${controlId}`, patchRuntimeProps)
 
 		const updateImage = (img) => {
-			setPreviewImage(dataToButtonImage(img))
+			setPreviewImage(img)
 		}
 		socket.on(`controls:preview-${controlId}`, updateImage)
 

--- a/webui/src/Buttons/Presets.jsx
+++ b/webui/src/Buttons/Presets.jsx
@@ -9,7 +9,7 @@ import {
 	ModulesContext,
 } from '../util'
 import { useDrag } from 'react-dnd'
-import { ButtonPreview, dataToButtonImage, RedImage } from '../Components/ButtonPreview'
+import { ButtonPreview, RedImage } from '../Components/ButtonPreview'
 import { nanoid } from 'nanoid'
 
 export const InstancePresets = function InstancePresets({ resetToken }) {
@@ -230,7 +230,7 @@ function PresetIconPreview({ preset, instanceId, ...childProps }) {
 
 		socketEmitPromise(socket, 'presets:preview_render', [instanceId, preset.id])
 			.then((img) => {
-				setPreviewImage(img ? dataToButtonImage(img) : null)
+				setPreviewImage(img)
 			})
 			.catch((e) => {
 				console.error('Failed to preview bank')

--- a/webui/src/Components/ButtonPreview.jsx
+++ b/webui/src/Components/ButtonPreview.jsx
@@ -56,7 +56,7 @@ export const ButtonPreview = React.memo(function (props) {
 					backgroundRepeat: 'no-repeat',
 				}}
 			>
-				<img width={72} height={72} src={props.preview ?? BlackImage} alt={props.alt} title={props.title} />
+				<img width={72} height={72} src={props.preview || BlackImage} alt={props.alt} title={props.title} />
 			</div>
 		</div>
 	)

--- a/webui/src/Components/ButtonPreview.jsx
+++ b/webui/src/Components/ButtonPreview.jsx
@@ -1,54 +1,12 @@
 import React from 'react'
 import classnames from 'classnames'
-import { Buffer } from 'buffer'
 
-/**
- * Creates a BMP image header for the given size
- * assuming RGBA channel order, 32Bit/Pixel, starting with top left pixel
- * @param {number} imageWidth
- * @param {number} imageHeight
- * @returns {Buffer} buffer containing the header
- */
-export function createBmpHeader(imageWidth = 72, imageHeight = 72) {
-	const dataLength = imageWidth * imageHeight * 4
-	const bmpHeaderSize = 138
-	const bmpHeader = Buffer.alloc(bmpHeaderSize, 0)
-	// file header
-	bmpHeader.write('BM', 0, 2) // flag
-	bmpHeader.writeUInt32LE(dataLength + bmpHeaderSize, 2) // filesize
-	bmpHeader.writeUInt32LE(0, 6) // reserved
-	bmpHeader.writeUInt32LE(bmpHeaderSize, 10) // data start
-	// image header
-	bmpHeader.writeUInt32LE(bmpHeaderSize - 14, 14) // header info size
-	bmpHeader.writeUInt32LE(imageWidth, 18) // width
-	bmpHeader.writeInt32LE(imageHeight * -1, 22) // height
-	bmpHeader.writeUInt16LE(1, 26) // planes
-	bmpHeader.writeUInt16LE(32, 28) // bits per pixel
-	bmpHeader.writeUInt32LE(3, 30) // compress
-	bmpHeader.writeUInt32LE(dataLength, 34) // data size
-	bmpHeader.writeUInt32LE(Math.round(39.375 * imageWidth), 38) // hr
-	bmpHeader.writeUInt32LE(Math.round(39.375 * imageHeight), 42) // vr
-	bmpHeader.writeUInt32LE(0, 46) // colors
-	bmpHeader.writeUInt32LE(0, 50) // importantColors
-	bmpHeader.writeUInt32LE(0x000000ff, 54) // Red Bitmask
-	bmpHeader.writeUInt32LE(0x0000ff00, 58) // Green Bitmask
-	bmpHeader.writeUInt32LE(0x00ff0000, 62) // Blue Bitmask
-	bmpHeader.writeUInt32LE(0xff000000, 66) // Alpha Bitmask
-	bmpHeader.write('BGRs', 70, 4) // colorspace
-
-	return bmpHeader
-}
-
-export function dataToButtonImage(data) {
-	const sourceData = Buffer.from(data)
-	const imageSize = Math.sqrt(sourceData.length / 4)
-	const bmpHeader = createBmpHeader(imageSize, imageSize)
-
-	return 'data:image/bmp;base64,' + Buffer.concat([bmpHeader, sourceData]).toString('base64')
-}
-
-export const BlackImage = dataToButtonImage(Buffer.alloc(24 * 24 * 4))
-export const RedImage = dataToButtonImage(Buffer.alloc(24 * 24 * 4, Buffer.from([255, 0, 0, 0])))
+// Single pixel of black
+export const BlackImage =
+	'data:image/bmp;base64,Qk2OAAAAAAAAAIoAAAB8AAAAAQAAAP////8BACAAAwAAAAQAAAAnAAAAJwAAAAAAAAAAAAAA/wAAAAD/AAAAAP8AAAAA/0JHUnMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=='
+// Single pixel of red
+export const RedImage =
+	'data:image/bmp;base64,Qk2OAAAAAAAAAIoAAAB8AAAAAQAAAP////8BACAAAwAAAAQAAAAnAAAAJwAAAAAAAAAAAAAA/wAAAAD/AAAAAP8AAAAA/0JHUnMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/wAAAA=='
 
 export const ButtonPreview = React.memo(function (props) {
 	const classes = {

--- a/webui/src/Constants.js
+++ b/webui/src/Constants.js
@@ -1,5 +1,3 @@
-import { Buffer } from 'buffer'
-
 export const MAX_BUTTONS = 32
 export const MAX_COLS = 8
 export const MAX_ROWS = MAX_BUTTONS / MAX_COLS

--- a/webui/src/Controls/OptionButtonPreview.jsx
+++ b/webui/src/Controls/OptionButtonPreview.jsx
@@ -1,6 +1,6 @@
 import React, { useContext, useState } from 'react'
 import { nanoid } from 'nanoid'
-import { ButtonPreview, dataToButtonImage } from '../Components/ButtonPreview'
+import { ButtonPreview } from '../Components/ButtonPreview'
 import { SocketContext, socketEmitPromise } from '../util'
 import { useDeepCompareEffect } from 'use-deep-compare'
 
@@ -18,7 +18,7 @@ export function OptionButtonPreview({ location, options }) {
 		socketEmitPromise(socket, 'preview:button-reference:subscribe', [id, location, options])
 			.then((newImage) => {
 				console.log('got image', newImage)
-				setImage(newImage ? dataToButtonImage(newImage) : newImage)
+				setImage(newImage)
 			})
 			.catch((err) => {
 				console.error('Subscribe failure', err)
@@ -26,7 +26,7 @@ export function OptionButtonPreview({ location, options }) {
 			})
 
 		const updateImage = (newImage) => {
-			setImage(newImage ? dataToButtonImage(newImage) : newImage)
+			setImage(newImage)
 		}
 
 		socket.on(`preview:button-reference:update:${id}`, updateImage)

--- a/webui/src/Emulator/Emulator.jsx
+++ b/webui/src/Emulator/Emulator.jsx
@@ -13,7 +13,6 @@ import { nanoid } from 'nanoid'
 import { useParams } from 'react-router-dom'
 import { dsanMastercueKeymap, keyboardKeymap, logitecKeymap } from './Keymaps'
 import { ButtonPreview } from '../Components/ButtonPreview'
-import { MAX_COLS, MAX_ROWS } from '../Constants'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCancel, faExpand } from '@fortawesome/free-solid-svg-icons'
 import { formatLocation } from '@companion/shared/ControlId'
@@ -68,6 +67,7 @@ export function Emulator() {
 
 	useEffect(() => {
 		const updateImages = (newImages) => {
+			console.log('new images', newImages)
 			setImageCache((old) => {
 				if (Array.isArray(newImages)) {
 					const res = { ...old }
@@ -172,7 +172,12 @@ export function Emulator() {
 					<>
 						<ConfigurePanel config={config} />
 
-						<CyclePages imageCache={imageCache} setKeyDown={setKeyDown} />
+						<CyclePages
+							imageCache={imageCache}
+							setKeyDown={setKeyDown}
+							columns={config.emulator_columns}
+							rows={config.emulator_rows}
+						/>
 					</>
 				) : (
 					<CRow>
@@ -233,29 +238,7 @@ function ConfigurePanel({ config }) {
 // 	return Math.min(Math.max(0, val), max)
 // }
 
-function CyclePages({ imageCache, setKeyDown }) {
-	// const goPrevPage = useCallback(() => {
-	// 	// if (currentIndex <= 0) {
-	// 	// 	if (loop) {
-	// 	// 		setCurrentIndex(orderedPages.length - 1)
-	// 	// 	}
-	// 	// } else {
-	// 	// 	setCurrentIndex(currentIndex - 1)
-	// 	// }
-	// }, [])
-	// const goNextPage = useCallback(() => {
-	// 	// if (currentIndex >= orderedPages.length - 1) {
-	// 	// 	if (loop) {
-	// 	// 		setCurrentIndex(0)
-	// 	// 	}
-	// 	// } else {
-	// 	// 	setCurrentIndex(currentIndex + 1)
-	// 	// }
-	// }, [])
-	// const goFirstPage = useCallback(() => {
-	// 	// setCurrentIndex(0)
-	// }, [])
-
+function CyclePages({ imageCache, setKeyDown, columns, rows }) {
 	const bankClick = useCallback(
 		(location, pressed) => {
 			if (pressed) {
@@ -266,9 +249,6 @@ function CyclePages({ imageCache, setKeyDown }) {
 		},
 		[setKeyDown]
 	)
-
-	const cols = 8
-	const rows = 4
 
 	return (
 		<CRow className="flex-grow-1">
@@ -293,12 +273,12 @@ function CyclePages({ imageCache, setKeyDown }) {
 					</div>
 					<div className="bankgrid">
 						{' '}
-						{Array(Math.min(MAX_ROWS, rows))
+						{Array(rows)
 							.fill(0)
 							.map((_, y) => {
 								return (
 									<CCol key={y} sm={12} className="pagebank-row">
-										{Array(Math.min(MAX_COLS, cols))
+										{Array(columns)
 											.fill(0)
 											.map((_2, x) => {
 												return (

--- a/webui/src/Emulator/Emulator.jsx
+++ b/webui/src/Emulator/Emulator.jsx
@@ -12,7 +12,7 @@ import { CButton, CCol, CContainer, CForm, CRow } from '@coreui/react'
 import { nanoid } from 'nanoid'
 import { useParams } from 'react-router-dom'
 import { dsanMastercueKeymap, keyboardKeymap, logitecKeymap } from './Keymaps'
-import { ButtonPreview, dataToButtonImage } from '../Components/ButtonPreview'
+import { ButtonPreview } from '../Components/ButtonPreview'
 import { MAX_COLS, MAX_ROWS } from '../Constants'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCancel, faExpand } from '@fortawesome/free-solid-svg-icons'
@@ -74,21 +74,12 @@ export function Emulator() {
 
 					for (const change of newImages) {
 						res[change.y] = { ...res[change.y] }
-						res[change.y][change.x] = change.buffer ? dataToButtonImage(change.buffer) : undefined
+						res[change.y][change.x] = change.buffer
 					}
 
 					return res
 				} else {
-					const res = {}
-
-					for (const [y, yObj] of Object.entries(newImages)) {
-						res[y] = {}
-						for (const [x, data] of Object.entries(yObj)) {
-							res[y][x] = data ? dataToButtonImage(data) : undefined
-						}
-					}
-
-					return res
+					return newImages
 				}
 			})
 		}

--- a/webui/src/ImportExport/Import/Page.jsx
+++ b/webui/src/ImportExport/Import/Page.jsx
@@ -8,7 +8,7 @@ import {
 	SocketContext,
 	socketEmitPromise,
 } from '../../util'
-import { ButtonPreview, dataToButtonImage } from '../../Components/ButtonPreview'
+import { ButtonPreview } from '../../Components/ButtonPreview'
 import { formatLocation } from '@companion/shared/ControlId'
 import { MAX_COLS, MAX_ROWS } from '../../Constants'
 import { ButtonGrid, ButtonGridHeader, usePagePicker } from '../../Buttons/ButtonGrid'
@@ -216,7 +216,7 @@ function ButtonImportPreview({ pageNumber, column, row, instanceId, ...childProp
 			},
 		])
 			.then((img) => {
-				setPreviewImage(img ? dataToButtonImage(img) : null)
+				setPreviewImage(img)
 			})
 			.catch((e) => {
 				console.error(`Failed to preview bank: ${e}`)

--- a/webui/src/Surfaces.jsx
+++ b/webui/src/Surfaces.jsx
@@ -30,6 +30,7 @@ import { nanoid } from 'nanoid'
 import { TextInputField } from './Components/TextInputField'
 import { useMemo } from 'react'
 import { GenericConfirmModal } from './Components/GenericConfirmModal'
+import { MAX_COLS, MAX_ROWS } from './Constants'
 
 export const SurfacesPage = memo(function SurfacesPage() {
 	const socket = useContext(SocketContext)
@@ -357,6 +358,15 @@ const SurfaceEditModal = forwardRef(function SurfaceEditModal(_props, ref) {
 		[socket, deviceInfo?.id]
 	)
 
+	const maxHorizontalOffset =
+		deviceInfo?.configFields?.includes('emulator_size') && deviceConfig
+			? MAX_COLS - deviceConfig.emulator_columns
+			: deviceConfigInfo?.xOffsetMax
+	const maxVerticalOffset =
+		deviceInfo?.configFields?.includes('emulator_size') && deviceConfig
+			? MAX_ROWS - deviceConfig.emulator_rows
+			: deviceConfigInfo?.yOffsetMax
+
 	return (
 		<CModal show={show} onClose={doClose} onClosed={onClosed}>
 			<CModalHeader closeButton>
@@ -394,14 +404,45 @@ const SurfaceEditModal = forwardRef(function SurfaceEditModal(_props, ref) {
 							/>
 							<span>{deviceConfig.page}</span>
 						</CFormGroup>
-						{deviceConfigInfo.xOffsetMax > 0 && (
+						{deviceInfo.configFields?.includes('emulator_size') && (
+							<>
+								<CFormGroup>
+									<CLabel htmlFor="page">Row count</CLabel>
+									<CInput
+										name="emulator_rows"
+										type="range"
+										min={1}
+										max={MAX_ROWS}
+										step={1}
+										value={deviceConfig.emulator_rows}
+										onChange={(e) => updateConfig('emulator_rows', parseInt(e.currentTarget.value))}
+									/>
+									<span>{deviceConfig.emulator_rows}</span>
+								</CFormGroup>
+								<CFormGroup>
+									<CLabel htmlFor="page">Column count</CLabel>
+									<CInput
+										name="emulator_columns"
+										type="range"
+										min={1}
+										max={MAX_COLS}
+										step={1}
+										value={deviceConfig.emulator_columns}
+										onChange={(e) => updateConfig('emulator_columns', parseInt(e.currentTarget.value))}
+									/>
+									<span>{deviceConfig.emulator_columns}</span>
+								</CFormGroup>
+							</>
+						)}
+
+						{maxHorizontalOffset > 0 && (
 							<CFormGroup>
-								<CLabel htmlFor="page">X Offset in grid</CLabel>
+								<CLabel htmlFor="page">Horizontal Offset in grid</CLabel>
 								<CInput
 									name="page"
 									type="range"
 									min={0}
-									max={deviceConfigInfo.xOffsetMax}
+									max={maxHorizontalOffset}
 									step={1}
 									value={deviceConfig.xOffset}
 									onChange={(e) => updateConfig('xOffset', parseInt(e.currentTarget.value))}
@@ -409,14 +450,14 @@ const SurfaceEditModal = forwardRef(function SurfaceEditModal(_props, ref) {
 								<span>{deviceConfig.xOffset}</span>
 							</CFormGroup>
 						)}
-						{deviceConfigInfo.yOffsetMax > 0 && (
+						{maxVerticalOffset > 0 && (
 							<CFormGroup>
-								<CLabel htmlFor="page">Y Offset in grid</CLabel>
+								<CLabel htmlFor="page">Vertical Offset in grid</CLabel>
 								<CInput
 									name="page"
 									type="range"
 									min={0}
-									max={deviceConfigInfo.yOffsetMax}
+									max={maxVerticalOffset}
 									step={1}
 									value={deviceConfig.yOffset}
 									onChange={(e) => updateConfig('yOffset', parseInt(e.currentTarget.value))}


### PR DESCRIPTION
Groundwork for supporting a larger grid size in the emulator

![image](https://github.com/bitfocus/companion/assets/1327476/b642cbb9-843c-4be6-8e1b-bc49f3d1ceee)
![image](https://github.com/bitfocus/companion/assets/1327476/ee750be9-7a07-4816-ba8d-43cbc97fa05f)


Also reworks the button render streaming to do the base64 conversion on the backend.  