### PR TITLE
feat: improved surface rotation

### DIFF
--- a/lib/Data/Upgrades/v3tov4.js
+++ b/lib/Data/Upgrades/v3tov4.js
@@ -32,6 +32,12 @@ function addControlIdsToPages(db) {
 /** do the database upgrades to convert from the v3 to the v4 format */
 function convertDatabaseToV4(db, logger) {
 	addControlIdsToPages(db)
+
+	// If xkeys was previously enabled, then preserve the old layout
+	const userconfig = db.getKey('userconfig', {})
+	if (userconfig.xkeys_enable && userconfig.xkeys_legacy_layout === undefined) {
+		userconfig.xkeys_legacy_layout = true
+	}
 }
 
 function ParseBankControlId(controlId) {

--- a/lib/Data/UserConfig.js
+++ b/lib/Data/UserConfig.js
@@ -39,6 +39,7 @@ class DataUserConfig extends CoreBase {
 		remove_topbar: false,
 
 		xkeys_enable: true,
+		xkeys_legacy_layout: false,
 		elgato_plugin_enable: false, // Also disables local streamdeck
 		usb_hotplug: true,
 		loupedeck_enable: false,
@@ -342,6 +343,10 @@ class DataUserConfig extends CoreBase {
 		}
 
 		this.data[key] = value
+		if (save) {
+			this.db.setKey('userconfig', this.data)
+		}
+
 		this.logger.info(`set '${key}' to: ${JSON.stringify(value)}`)
 		this.io.emit('set_userconfig_key', key, value)
 		setImmediate(() => {
@@ -359,10 +364,6 @@ class DataUserConfig extends CoreBase {
 			}
 
 			this.graphics.discardAllOutOfBoundsControls()
-		}
-
-		if (save) {
-			this.db.setKey('userconfig', this.data)
 		}
 	}
 

--- a/lib/Resources/Util.js
+++ b/lib/Resources/Util.js
@@ -154,9 +154,9 @@ export function clamp(val, min, max) {
 }
 
 export function translateRotation(rotation) {
-	if (rotation === 90) return imageRs.RotationMode.CW270
-	if (rotation === -90) return imageRs.RotationMode.CW90
-	if (rotation === 180) return imageRs.RotationMode.CW180
+	if (rotation === 90 || rotation === 'surface90') return imageRs.RotationMode.CW270
+	if (rotation === -90 || rotation === 'surface-90') return imageRs.RotationMode.CW90
+	if (rotation === 180 || rotation === 'surface180') return imageRs.RotationMode.CW180
 	return null
 }
 

--- a/lib/Surface/Controller.js
+++ b/lib/Surface/Controller.js
@@ -527,6 +527,9 @@ class SurfaceController extends CoreBase {
 									// } else
 									if (deviceInfo.vendorId === 1523 && deviceInfo.interface === 0) {
 										if (this.userconfig.getKey('xkeys_enable')) {
+											deviceInfo.options = {
+												useLegacyLayout: !!this.userconfig.getKey('xkeys_legacy_layout'),
+											}
 											await this.#addDevice(deviceInfo, 'xkeys', XKeysDriver)
 										}
 									}
@@ -621,7 +624,7 @@ class SurfaceController extends CoreBase {
 		}
 
 		try {
-			const dev = await factory.create(deviceInfo.path)
+			const dev = await factory.create(deviceInfo.path, deviceInfo.options)
 			this.#createSurfaceHandler(deviceInfo.path, type, dev)
 
 			setImmediate(() => {

--- a/lib/Surface/Handler.js
+++ b/lib/Surface/Handler.js
@@ -19,6 +19,7 @@ import CoreBase from '../Core/Base.js'
 import { oldBankIndexToXY } from '../Shared/ControlId.js'
 import { cloneDeep } from 'lodash-es'
 import { LEGACY_BUTTONS_PER_COLUMN, LEGACY_BUTTONS_PER_ROW, LEGACY_MAX_BUTTONS } from '../Util/Constants.js'
+import { invertRotation, rotateXYForPanel } from './Util.js'
 
 const PINCODE_NUMBER_POSITIONS = [
 	// 0
@@ -91,6 +92,21 @@ class SurfaceHandler extends CoreBase {
 	 * Xkeys: How many pages of colours it has asked for
 	 */
 	#xkeysPageCount = 0
+
+	get panelGridSize() {
+		const rotation = this.panelconfig.config.rotation
+		// TODO-rotation, backwards compatible
+		if (rotation === 90 || rotation === -90) {
+			const rawGridSize = this.panel.gridSize
+
+			return {
+				rows: rawGridSize.columns,
+				columns: rawGridSize.rows,
+			}
+		} else {
+			return this.panel.gridSize
+		}
+	}
 
 	constructor(registry, integrationType, panel, isLocked) {
 		super(registry, `device(${panel.info.deviceId})`, `Surface/Handler/${panel.info.deviceId}`)
@@ -250,7 +266,7 @@ class SurfaceHandler extends CoreBase {
 			} else if (this.#xkeysPageCount > 0) {
 				this.#xkeysDrawPages()
 			} else if (this.panel.info.type === 'Loupedeck CT') {
-				const gridSize = this.panel.gridSize
+				const gridSize = this.panelGridSize
 
 				for (let y = 0; y < gridSize.rows; y += 1) {
 					let pageNumber = this.currentPage
@@ -264,13 +280,13 @@ class SurfaceHandler extends CoreBase {
 							row: y % 4,
 						})
 
-						this.panel.draw(x, y, image)
+						this.#drawButtonTransformed(x, y, image)
 					}
 				}
 			} else {
 				const { xOffset, yOffset } = this.#getCurrentOffset()
 
-				const gridSize = this.panel.gridSize
+				const gridSize = this.panelGridSize
 
 				for (let y = 0; y < gridSize.rows; y++) {
 					for (let x = 0; x < gridSize.columns; x++) {
@@ -280,11 +296,19 @@ class SurfaceHandler extends CoreBase {
 							row: y + yOffset,
 						})
 
-						this.panel.draw(x, y, image)
+						this.#drawButtonTransformed(x, y, image)
 					}
 				}
 			}
 		}
+	}
+
+	#drawButtonTransformed(x, y, image) {
+		const [transformedX, transformedY] = rotateXYForPanel(x, y, this.panelGridSize, this.panelconfig.config.rotation)
+
+		// TODO-rotation
+
+		this.panel.draw(transformedX, transformedY, image)
 	}
 
 	getPanelConfig() {
@@ -328,7 +352,7 @@ class SurfaceHandler extends CoreBase {
 			// normal mode
 			const { xOffset, yOffset } = this.#getCurrentOffset()
 
-			this.panel.draw(location.column - xOffset, location.row - yOffset, render)
+			this.#drawButtonTransformed(location.column - xOffset, location.row - yOffset, render)
 		}
 	}
 
@@ -363,10 +387,12 @@ class SurfaceHandler extends CoreBase {
 			if (!this.isSurfaceLocked) {
 				this.emit('interaction')
 
+				const [x2, y2] = rotateXYForPanel(x, y, this.panelGridSize, invertRotation(this.panelconfig.config.rotation))
+
 				// Translate key for offset
 				const { xOffset, yOffset } = this.#getCurrentOffset()
 
-				const coordinate = `${x + xOffset}/${y + yOffset}`
+				const coordinate = `${x2 + xOffset}/${y2 + yOffset}`
 
 				let thisPage = this.currentPage
 
@@ -386,12 +412,12 @@ class SurfaceHandler extends CoreBase {
 
 				const controlId = this.page.getControlIdAt({
 					pageNumber: thisPage,
-					column: x + xOffset,
-					row: y + yOffset,
+					column: x2 + xOffset,
+					row: y2 + yOffset,
 				})
 
 				this.controls.pressControl(controlId, pressed, this.deviceId)
-				this.logger.debug(`Button ${thisPage}/${x + xOffset}/${y + yOffset} ${pressed ? 'pressed' : 'released'}`)
+				this.logger.debug(`Button ${thisPage}/${coordinate} ${pressed ? 'pressed' : 'released'}`)
 			} else {
 				if (pressed) {
 					const pressCode = this.pincodeNumberPositions.findIndex((pos) => pos[0] == x && pos[1] == y)
@@ -425,6 +451,8 @@ class SurfaceHandler extends CoreBase {
 			if (!this.isSurfaceLocked) {
 				this.emit('interaction')
 
+				const [x2, y2] = rotateXYForPanel(x, y, this.panelGridSize, invertRotation(this.panelconfig.config.rotation))
+
 				// Translate key for offset
 				const { xOffset, yOffset } = this.#getCurrentOffset()
 
@@ -437,12 +465,12 @@ class SurfaceHandler extends CoreBase {
 
 				const controlId = this.page.getControlIdAt({
 					pageNumber: thisPage,
-					column: x + xOffset,
-					row: y + yOffset,
+					column: x2 + xOffset,
+					row: y2 + yOffset,
 				})
 
 				this.controls.rotateControl(controlId, direction, this.deviceId)
-				this.logger.debug(`Rotary ${thisPage}/${x + xOffset}/${y + yOffset} rotated ${direction ? 'right' : 'left'}`)
+				this.logger.debug(`Rotary ${thisPage}/${x2 + xOffset}/${y2 + yOffset} rotated ${direction ? 'right' : 'left'}`)
 			} else {
 				// Ignore when locked out
 			}

--- a/lib/Surface/Handler.js
+++ b/lib/Surface/Handler.js
@@ -336,7 +336,14 @@ class SurfaceHandler extends CoreBase {
 			// xkeys mode
 			const pageOffset = location.pageNumber - this.currentPage
 			if (pageOffset >= 0 && pageOffset < this.#xkeysPageCount) {
-				this.panel.drawColor(pageOffset, location.column, location.row, render.style?.bgcolor || 0)
+				const [transformedX, transformedY] = rotateXYForPanel(
+					location.column,
+					location.row,
+					this.panelGridSize,
+					this.panelconfig.config.rotation
+				)
+
+				this.panel.drawColor(pageOffset, transformedX, transformedY, render.style?.bgcolor || 0)
 			}
 		} else if (
 			this.panel.info.type === 'Loupedeck CT' &&
@@ -390,7 +397,7 @@ class SurfaceHandler extends CoreBase {
 				// Translate key for offset
 				const { xOffset, yOffset } = this.#getCurrentOffset()
 
-				const coordinate = `${x2 + xOffset}/${y2 + yOffset}`
+				const coordinate = `${y2 + yOffset}/${x2 + xOffset}`
 
 				let thisPage = this.currentPage
 
@@ -492,7 +499,13 @@ class SurfaceHandler extends CoreBase {
 						row: xy[1],
 					})
 
-					this.panel.drawColor(page, ...xy, render.style?.bgcolor || 0)
+					const [transformedX, transformedY] = rotateXYForPanel(
+						...xy,
+						this.panelGridSize,
+						this.panelconfig.config.rotation
+					)
+
+					this.panel.drawColor(page, transformedX, transformedY, render.style?.bgcolor || 0)
 				}
 			}
 		}

--- a/lib/Surface/Handler.js
+++ b/lib/Surface/Handler.js
@@ -367,7 +367,6 @@ class SurfaceHandler extends CoreBase {
 				this.emit('interaction')
 
 				const [x2, y2] = unrotateXYForPanel(x, y, this.panelGridSize, this.panelconfig.config.rotation)
-				console.log(x, y, x2, y2, this.panelGridSize, this.panel.gridSize)
 
 				// Translate key for offset
 				const { xOffset, yOffset } = this.#getCurrentOffset()

--- a/lib/Surface/Handler.js
+++ b/lib/Surface/Handler.js
@@ -18,8 +18,8 @@
 import CoreBase from '../Core/Base.js'
 import { oldBankIndexToXY } from '../Shared/ControlId.js'
 import { cloneDeep } from 'lodash-es'
-import { LEGACY_BUTTONS_PER_COLUMN, LEGACY_BUTTONS_PER_ROW, LEGACY_MAX_BUTTONS } from '../Util/Constants.js'
-import { invertRotation, rotateXYForPanel } from './Util.js'
+import { LEGACY_MAX_BUTTONS } from '../Util/Constants.js'
+import { rotateXYForPanel, unrotateXYForPanel } from './Util.js'
 
 const PINCODE_NUMBER_POSITIONS = [
 	// 0
@@ -95,8 +95,7 @@ class SurfaceHandler extends CoreBase {
 
 	get panelGridSize() {
 		const rotation = this.panelconfig.config.rotation
-		// TODO-rotation, backwards compatible
-		if (rotation === 90 || rotation === -90) {
+		if (rotation === 'surface90' || rotation === 'surface-90') {
 			const rawGridSize = this.panel.gridSize
 
 			return {
@@ -306,8 +305,6 @@ class SurfaceHandler extends CoreBase {
 	#drawButtonTransformed(x, y, image) {
 		const [transformedX, transformedY] = rotateXYForPanel(x, y, this.panelGridSize, this.panelconfig.config.rotation)
 
-		// TODO-rotation
-
 		this.panel.draw(transformedX, transformedY, image)
 	}
 
@@ -387,7 +384,8 @@ class SurfaceHandler extends CoreBase {
 			if (!this.isSurfaceLocked) {
 				this.emit('interaction')
 
-				const [x2, y2] = rotateXYForPanel(x, y, this.panelGridSize, invertRotation(this.panelconfig.config.rotation))
+				const [x2, y2] = unrotateXYForPanel(x, y, this.panelGridSize, this.panelconfig.config.rotation)
+				console.log(x, y, x2, y2, this.panelGridSize, this.panel.gridSize)
 
 				// Translate key for offset
 				const { xOffset, yOffset } = this.#getCurrentOffset()
@@ -451,7 +449,7 @@ class SurfaceHandler extends CoreBase {
 			if (!this.isSurfaceLocked) {
 				this.emit('interaction')
 
-				const [x2, y2] = rotateXYForPanel(x, y, this.panelGridSize, invertRotation(this.panelconfig.config.rotation))
+				const [x2, y2] = unrotateXYForPanel(x, y, this.panelGridSize, this.panelconfig.config.rotation)
 
 				// Translate key for offset
 				const { xOffset, yOffset } = this.#getCurrentOffset()

--- a/lib/Surface/Handler.js
+++ b/lib/Surface/Handler.js
@@ -264,24 +264,6 @@ class SurfaceHandler extends CoreBase {
 				})
 			} else if (this.#xkeysPageCount > 0) {
 				this.#xkeysDrawPages()
-			} else if (this.panel.info.type === 'Loupedeck CT') {
-				const gridSize = this.panelGridSize
-
-				for (let y = 0; y < gridSize.rows; y += 1) {
-					let pageNumber = this.currentPage
-					if (y >= gridSize.rows) pageNumber += 1
-					if (pageNumber > 99) pageNumber = 1
-
-					for (let x = 0; x < gridSize.columns; x += 1) {
-						const image = this.graphics.getBank({
-							pageNumber,
-							column: x,
-							row: y % 4,
-						})
-
-						this.#drawButtonTransformed(x, y, image)
-					}
-				}
 			} else {
 				const { xOffset, yOffset } = this.#getCurrentOffset()
 
@@ -345,13 +327,6 @@ class SurfaceHandler extends CoreBase {
 
 				this.panel.drawColor(pageOffset, transformedX, transformedY, render.style?.bgcolor || 0)
 			}
-		} else if (
-			this.panel.info.type === 'Loupedeck CT' &&
-			(location.pageNumber - this.currentPage == 1 || (location.pageNumber == 1 && this.currentPage == 99)) &&
-			location.row < 3 // lower half of CT has only 3 rows, zero based
-		) {
-			// Loupdeck CT lower half, draw button with row offset by 4
-			this.panel.draw(location.column, location.row + 4, render)
 		} else if (location.pageNumber == this.currentPage) {
 			// normal mode
 			const { xOffset, yOffset } = this.#getCurrentOffset()
@@ -410,7 +385,7 @@ class SurfaceHandler extends CoreBase {
 					delete this.#currentButtonPresses[coordinate]
 				}
 
-				// allow the xkeys and loupedeck CT to span pages
+				// allow the xkeys (legacy mode) to span pages
 				thisPage += pageOffset ?? 0
 				// loop at page 99
 				if (thisPage > 99) thisPage = 1
@@ -463,7 +438,7 @@ class SurfaceHandler extends CoreBase {
 
 				let thisPage = this.currentPage
 
-				// allow the xkeys and loupedeck CT to span pages
+				// allow the xkeys (legacy mode) to span pages
 				thisPage += pageOffset ?? 0
 				// loop at page 99
 				if (thisPage > 99) thisPage = 1

--- a/lib/Surface/Handler.js
+++ b/lib/Surface/Handler.js
@@ -41,19 +41,19 @@ const PINCODE_CODE_POSITION = [0, 1]
 
 const PINCODE_NUMBER_POSITIONS_SKIP_FIRST_COL = [
 	// 0
-	[4, 1],
+	[5, 1],
 	// 1 2 3
-	[1, 2],
 	[2, 2],
 	[3, 2],
+	[4, 2],
 	// 4 5 6
-	[1, 1],
 	[2, 1],
 	[3, 1],
+	[4, 1],
 	// 7 8 9
-	[1, 0],
 	[2, 0],
 	[3, 0],
+	[4, 0],
 ]
 
 class SurfaceHandler extends CoreBase {
@@ -128,7 +128,7 @@ class SurfaceHandler extends CoreBase {
 		}
 		if (this.panel.info.type === 'Loupedeck CT') {
 			this.pincodeNumberPositions = PINCODE_NUMBER_POSITIONS_SKIP_FIRST_COL
-			this.pincodeCodePosition = [2, 4]
+			this.pincodeCodePosition = [3, 4]
 		}
 
 		this.currentPage = 1 // The current page of the device

--- a/lib/Surface/IP/ElgatoPlugin.js
+++ b/lib/Surface/IP/ElgatoPlugin.js
@@ -40,7 +40,7 @@ class SurfaceIPElgatoPlugin extends EventEmitter {
 		this.info = {
 			type: 'Elgato Streamdeck Plugin',
 			devicepath: devicepath,
-			configFields: ['rotation'],
+			configFields: ['legacy_rotation'],
 			deviceId: 'plugin',
 		}
 

--- a/lib/Surface/IP/Satellite.js
+++ b/lib/Surface/IP/Satellite.js
@@ -54,7 +54,7 @@ class SurfaceIPSatellite extends EventEmitter {
 		this.logger.info(`Adding Satellite device "${this.deviceId}"`)
 
 		if (this.#streamBitmapSize) {
-			this.info.configFields.push('rotation')
+			this.info.configFields.push('legacy_rotation')
 		}
 
 		this._config = {

--- a/lib/Surface/USB/ElgatoStreamDeck.js
+++ b/lib/Surface/USB/ElgatoStreamDeck.js
@@ -22,7 +22,7 @@ import imageRs from '@julusian/image-rs'
 import LogController from '../../Log/Controller.js'
 import ImageWriteQueue from '../../Resources/ImageWriteQueue.js'
 import { translateRotation } from '../../Resources/Util.js'
-import { convertXYToIndexForPanel, convertPanelIndexToXY } from '../Util.js'
+import { convertXYToIndexForPanel, convertPanelIndexToXY, rotateXYForPanel } from '../Util.js'
 const setTimeoutPromise = util.promisify(setTimeout)
 
 class SurfaceUSBElgatoStreamDeck extends EventEmitter {
@@ -255,6 +255,7 @@ class SurfaceUSBElgatoStreamDeck extends EventEmitter {
 	}
 
 	draw(x, y, render) {
+		// const [x2, y2] = rotateXYForPanel(x, y, this.gridSize, this.config.rotation)
 		const key = convertXYToIndexForPanel(x, y, this.gridSize)
 		if (key === null) return true
 

--- a/lib/Surface/USB/ElgatoStreamDeck.js
+++ b/lib/Surface/USB/ElgatoStreamDeck.js
@@ -255,7 +255,6 @@ class SurfaceUSBElgatoStreamDeck extends EventEmitter {
 	}
 
 	draw(x, y, render) {
-		// const [x2, y2] = rotateXYForPanel(x, y, this.gridSize, this.config.rotation)
 		const key = convertXYToIndexForPanel(x, y, this.gridSize)
 		if (key === null) return true
 

--- a/lib/Surface/USB/ElgatoStreamDeck.js
+++ b/lib/Surface/USB/ElgatoStreamDeck.js
@@ -43,7 +43,7 @@ class SurfaceUSBElgatoStreamDeck extends EventEmitter {
 		this.info = {
 			type: `Elgato ${this.streamDeck.PRODUCT_NAME}`,
 			devicepath: devicepath,
-			configFields: ['brightness', 'rotation'],
+			configFields: ['brightness', 'legacy_rotation'],
 			deviceId: undefined, // set in #init()
 		}
 

--- a/lib/Surface/USB/Infinitton.js
+++ b/lib/Surface/USB/Infinitton.js
@@ -37,7 +37,7 @@ class SurfaceUSBInfinitton {
 		this.info = {
 			type: 'Infinitton iDisplay device',
 			devicepath: devicepath,
-			configFields: ['brightness', 'rotation'],
+			configFields: ['brightness', 'legacy_rotation'],
 			deviceId: `infinitton:${serialnumber}`,
 		}
 

--- a/lib/Surface/USB/LoupedeckCt.js
+++ b/lib/Surface/USB/LoupedeckCt.js
@@ -18,6 +18,7 @@
 import { EventEmitter } from 'events'
 import { LoupedeckBufferFormat, LoupedeckDisplayId, openLoupedeck } from '@loupedeck/node'
 import { convertPanelIndexToXY } from '../Util.js'
+import { translateRotation } from '../../Resources/Util.js'
 import ImageWriteQueue from '../../Resources/ImageWriteQueue.js'
 import imageRs from '@julusian/image-rs'
 import LogController from '../../Log/Controller.js'
@@ -100,8 +101,7 @@ class SurfaceUSBLoupedeckCt extends EventEmitter {
 			const xy = rotaryToXY(this.modelInfo, info)
 			if (!xy) return
 
-			const pageOffset = Math.floor(xy[1] / 4)
-			this.emit('rotate', xy[0], xy[1] % 4, delta == 1, pageOffset)
+			this.emit('rotate', xy[0], xy[1], delta == 1)
 		})
 
 		this.loupedeck.on('touchstart', (data) => {
@@ -211,8 +211,8 @@ class SurfaceUSBLoupedeckCt extends EventEmitter {
 					height
 				)
 
-				// const rotation = translateRotation(this.config.rotation)
-				// if (rotation !== null) image = image.rotate(rotation)
+				const rotation = translateRotation(this.config.rotation)
+				if (rotation !== null) image = image.rotate(rotation)
 
 				newbuffer = Buffer.from(await image.toBuffer(imageRs.PixelFormat.Rgb))
 			} catch (e) {
@@ -246,10 +246,9 @@ class SurfaceUSBLoupedeckCt extends EventEmitter {
 		if (!xy) return
 
 		const x = xy[0]
-		const y = xy[1] % 4
-		const pageOffset = Math.floor(xy[1] / 4)
+		const y = xy[1]
 
-		this.emit('click', x, y, state, pageOffset)
+		this.emit('click', x, y, state)
 	}
 
 	async #init() {
@@ -365,7 +364,10 @@ class SurfaceUSBLoupedeckCt extends EventEmitter {
 
 		const buttonIndex = this.modelInfo.buttons.findIndex((btn) => btn[0] == x && btn[1] == y)
 		if (buttonIndex >= 0) {
-			const color = render.style ? colorToRgb(render.style.bgcolor) : { r: 0, g: 0, b: 0 }
+			let color = { r: 0, g: 0, b: 0 }
+			if (render.style === 'pageup') color = { r: 255, g: 255, b: 255 }
+			else if (render.style === 'pagedown') color = { r: 0, g: 0, b: 255 }
+			else if (render.style) color = colorToRgb(render.style.bgcolor)
 
 			this.loupedeck
 				.setButtonColor({

--- a/lib/Surface/USB/LoupedeckLive.js
+++ b/lib/Surface/USB/LoupedeckLive.js
@@ -21,6 +21,7 @@ import ImageWriteQueue from '../../Resources/ImageWriteQueue.js'
 import imageRs from '@julusian/image-rs'
 import LogController from '../../Log/Controller.js'
 import { convertPanelIndexToXY } from '../Util.js'
+import { translateRotation } from '../../Resources/Util.js'
 
 const loupedeckLiveInfo = {
 	totalCols: 8,
@@ -203,8 +204,6 @@ class SurfaceUSBLoupedeckLive extends EventEmitter {
 			const width = this.loupedeck.lcdKeySize
 			const height = this.loupedeck.lcdKeySize
 
-			// const rotation = translateRotation(this.config.rotation)
-
 			let newbuffer
 			try {
 				let imagesize = Math.sqrt(buffer.length / 4) // TODO: assuming here that the image is square
@@ -213,8 +212,8 @@ class SurfaceUSBLoupedeckLive extends EventEmitter {
 					height
 				)
 
-				// const rotation = translateRotation(this.config.rotation)
-				// if (rotation !== null) image = image.rotate(rotation)
+				const rotation = translateRotation(this.config.rotation)
+				if (rotation !== null) image = image.rotate(rotation)
 
 				newbuffer = Buffer.from(await image.toBuffer(imageRs.PixelFormat.Rgb))
 			} catch (e) {

--- a/lib/Surface/USB/XKeys.js
+++ b/lib/Surface/USB/XKeys.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /*
  * This file is part of the Companion project
  * Copyright (c) 2022 VICREO BV
@@ -27,12 +29,13 @@ import { LEGACY_BUTTONS_PER_COLUMN, LEGACY_BUTTONS_PER_ROW, LEGACY_MAX_BUTTONS }
  * @memberof xkeys
  */
 class SurfaceUSBXKeys extends EventEmitter {
-	constructor(devicepath, panel, deviceId) {
+	constructor(devicepath, panel, deviceId, options) {
 		super()
 
 		this.logger = LogController.createLogger(`Surface/USB/XKeys/${devicepath}`)
 
 		this.myXkeysPanel = panel
+		this.useLegacyLayout = !!options.useLegacyLayout
 		this.mapDeviceToCompanion = []
 		this.mapCompanionToDevice = []
 
@@ -46,11 +49,6 @@ class SurfaceUSBXKeys extends EventEmitter {
 			deviceId: deviceId,
 		}
 
-		this.gridSize = {
-			columns: LEGACY_BUTTONS_PER_ROW,
-			rows: LEGACY_BUTTONS_PER_COLUMN,
-		}
-
 		this.config = {
 			brightness: 60,
 			illuminate_pressed: true,
@@ -58,16 +56,28 @@ class SurfaceUSBXKeys extends EventEmitter {
 
 		const { colCount, rowCount } = this.myXkeysPanel.info
 
-		// Mapping buttons
-		for (var leftRight = 0; leftRight < colCount; leftRight++) {
-			for (var topBottom = 0; topBottom < rowCount; topBottom++) {
-				this.mapDeviceToCompanion.push(leftRight + topBottom * colCount)
+		if (this.useLegacyLayout) {
+			this.gridSize = {
+				columns: LEGACY_BUTTONS_PER_ROW,
+				rows: LEGACY_BUTTONS_PER_COLUMN,
 			}
-		}
-		// Mapping for feedback
-		for (let topBottom = 1; topBottom <= rowCount; topBottom++) {
-			for (let leftRight = 0; leftRight < colCount; leftRight++) {
-				this.mapCompanionToDevice.push(topBottom + leftRight * rowCount)
+
+			// Mapping buttons
+			for (var leftRight = 0; leftRight < colCount; leftRight++) {
+				for (var topBottom = 0; topBottom < rowCount; topBottom++) {
+					this.mapDeviceToCompanion.push(leftRight + topBottom * colCount)
+				}
+			}
+			// Mapping for feedback
+			for (let topBottom = 1; topBottom <= rowCount; topBottom++) {
+				for (let leftRight = 0; leftRight < colCount; leftRight++) {
+					this.mapCompanionToDevice.push(topBottom + leftRight * rowCount)
+				}
+			}
+		} else {
+			this.gridSize = {
+				columns: colCount,
+				rows: rowCount,
 			}
 		}
 
@@ -90,18 +100,15 @@ class SurfaceUSBXKeys extends EventEmitter {
 
 		// Listen to pressed buttons:
 		this.myXkeysPanel.on('down', (keyIndex, metadata) => {
-			const key = this.mapDeviceToCompanion[keyIndex - 1]
-			if (key === undefined) {
-				return
-			}
+			const location = this.#translateIndexToXY(keyIndex)
+			if (!location) return
 
-			this.logger.debug(`keyIndex: ${keyIndex}, companion button: ${key}`)
+			const [x, y, pageOffset] = location
+
+			this.logger.debug(`keyIndex: ${keyIndex}, companion button: ${y}/${x}`)
 			this.pressed.add(keyIndex)
 
-			const pageOffset = Math.floor(key / LEGACY_MAX_BUTTONS)
-			const localKey = key % LEGACY_MAX_BUTTONS
-
-			this.#emitClick(localKey, true, pageOffset)
+			this.emit('click', x, y, true, pageOffset)
 
 			// Light up a button when pressed:
 			try {
@@ -116,18 +123,15 @@ class SurfaceUSBXKeys extends EventEmitter {
 
 		// Listen to released buttons:
 		this.myXkeysPanel.on('up', (keyIndex, metadata) => {
-			const key = this.mapDeviceToCompanion[keyIndex - 1]
-			if (key === undefined) {
-				return
-			}
+			const location = this.#translateIndexToXY(keyIndex)
+			if (!location) return
 
-			this.logger.debug(`keyIndex: ${keyIndex}, companion button: ${key}`)
+			const [x, y, pageOffset] = location
+
+			this.logger.debug(`keyIndex: ${keyIndex}, companion button: ${y}/${x}`)
 			this.pressed.delete(keyIndex)
 
-			const pageOffset = Math.floor(key / LEGACY_MAX_BUTTONS)
-			const localKey = key % LEGACY_MAX_BUTTONS
-
-			this.#emitClick(localKey, false, pageOffset)
+			this.emit('click', x, y, false, pageOffset)
 
 			// Turn off button light when released:
 			try {
@@ -166,31 +170,50 @@ class SurfaceUSBXKeys extends EventEmitter {
 		})
 	}
 
-	#emitClick(key, state, pageOffset) {
-		const xy = convertPanelIndexToXY(key, this.gridSize)
-		if (xy) {
-			this.emit('click', ...xy, state, pageOffset)
+	#translateIndexToXY(keyIndex) {
+		if (this.useLegacyLayout) {
+			const key = this.mapDeviceToCompanion[keyIndex - 1]
+			if (key === undefined) {
+				return
+			}
+
+			const pageOffset = Math.floor(key / LEGACY_MAX_BUTTONS)
+			const localKey = key % LEGACY_MAX_BUTTONS
+
+			const xy = convertPanelIndexToXY(localKey, this.gridSize)
+			if (xy) {
+				return [...xy, pageOffset]
+			}
+		} else {
+			const gridSize = this.gridSize
+			keyIndex -= 1
+			if (isNaN(keyIndex) || keyIndex < 0 || keyIndex >= gridSize.columns * gridSize.rows) return undefined
+			const x = Math.floor(keyIndex / gridSize.rows)
+			const y = keyIndex % gridSize.rows
+			return [x, y, undefined]
 		}
 	}
 
 	async #init() {
 		this.logger.debug(`Xkeys ${this.myXkeysPanel.info.name} detected`)
 
-		setTimeout(() => {
-			const { colCount, rowCount } = this.myXkeysPanel.info
-			// Ask companion to provide colours for enough pages of buttons
-			this.emit('xkeys-subscribePage', Math.ceil((colCount * rowCount) / LEGACY_MAX_BUTTONS))
-		}, 1000)
+		if (this.useLegacyLayout) {
+			setTimeout(() => {
+				const { colCount, rowCount } = this.myXkeysPanel.info
+				// Ask companion to provide colours for enough pages of buttons
+				this.emit('xkeys-subscribePage', Math.ceil((colCount * rowCount) / LEGACY_MAX_BUTTONS))
+			}, 1000)
+		}
 	}
 
-	static async create(devicepath) {
+	static async create(devicepath, options) {
 		const panel = await setupXkeysPanel(devicepath)
 
 		try {
 			const deviceId = `xkeys:${panel.info.productId}-${panel.info.unitId}` // TODO - this needs some additional uniqueness to the sufix
 			// (${devicepath.slice(0, -1).slice(-10)})` // This suffix produces `dev/hidraw` on linux, which is not useful.
 
-			const self = new SurfaceUSBXKeys(devicepath, panel, deviceId)
+			const self = new SurfaceUSBXKeys(devicepath, panel, deviceId, options || {})
 
 			await self.#init()
 
@@ -204,7 +227,7 @@ class SurfaceUSBXKeys extends EventEmitter {
 
 	/**
 	 * Process the information from the GUI and what is saved in database
-	 * @param {companion config} config
+	 * @param {object} config
 	 * @returns false when nothing happens
 	 */
 	setConfig(config) {
@@ -238,11 +261,35 @@ class SurfaceUSBXKeys extends EventEmitter {
 		}
 	}
 
-	draw() {
-		// Should never be fired
+	draw(x, y, render) {
+		// Should never be used for legacy layout
+		if (this.useLegacyLayout) return
+
+		const gridSize = this.gridSize
+		if (x < 0 || y < 0 || x >= gridSize.columns || y >= gridSize.rows) return
+
+		const buttonIndex = x * gridSize.rows + y + 1
+		const color = render?.style?.bgcolor ?? 0
+		this.#drawColorAtIndex(buttonIndex, color)
 	}
 
 	drawColor(page, x, y, color) {
+		if (!this.useLegacyLayout) return
+
+		const key = convertXYToIndexForPanel(x, y, this.gridSize)
+		if (key === undefined) return
+
+		const buttonNumber = page * LEGACY_MAX_BUTTONS + key + 1
+		if (buttonNumber <= this.mapCompanionToDevice.length) {
+			const buttonIndex = this.mapCompanionToDevice[buttonNumber - 1]
+
+			this.#drawColorAtIndex(buttonIndex, color)
+		}
+	}
+
+	#drawColorAtIndex(buttonIndex, color) {
+		if (buttonIndex === undefined) return
+
 		// Feedback
 		const color2 = {
 			r: (color >> 16) & 0xff,
@@ -250,25 +297,16 @@ class SurfaceUSBXKeys extends EventEmitter {
 			b: color & 0xff,
 		}
 
-		const key = convertXYToIndexForPanel(x, y, this.gridSize)
-		if (!key) return
+		const tmpColor = { ...color2 }
+		if (this.pressed.has(buttonIndex) && this.config.illuminate_pressed) tmpColor.r = 255
 
-		const buttonNumber = page * LEGACY_MAX_BUTTONS + key
-		if (buttonNumber <= this.mapCompanionToDevice.length) {
-			const buttonIndex = this.mapCompanionToDevice[buttonNumber - 1]
-			if (buttonIndex !== undefined) {
-				const tmpColor = { ...color2 }
-				if (this.pressed.has(buttonIndex) && this.config.illuminate_pressed) tmpColor.r = 255
-
-				try {
-					this.myXkeysPanel.setBacklight(buttonIndex, tmpColor)
-				} catch (e) {
-					this.logger.debug(`Failed to set backlight: ${e}`)
-				}
-
-				this.lastColors[buttonIndex] = color2
-			}
+		try {
+			this.myXkeysPanel.setBacklight(buttonIndex, tmpColor)
+		} catch (e) {
+			this.logger.debug(`Failed to set backlight: ${e}`)
 		}
+
+		this.lastColors[buttonIndex] = color2
 	}
 }
 

--- a/lib/Surface/Util.js
+++ b/lib/Surface/Util.js
@@ -15,24 +15,26 @@ export function convertPanelIndexToXY(index, gridSize) {
 
 export function rotateXYForPanel(x, y, gridSize, rotation) {
 	switch (rotation) {
-		case 90:
+		case 'surface90':
 			return [y, gridSize.columns - x - 1]
-		case -90:
+		case 'surface-90':
 			return [gridSize.rows - y - 1, x]
-		case 180:
+		case 'surface180':
 			return [gridSize.columns - x - 1, gridSize.rows - y - 1]
 		default:
 			return [x, y]
 	}
 }
 
-export function invertRotation(rotation) {
+export function unrotateXYForPanel(x, y, gridSize, rotation) {
 	switch (rotation) {
-		case 90:
-			return -90
-		case -90:
-			return 90
+		case 'surface90':
+			return [gridSize.columns - y - 1, x]
+		case 'surface-90':
+			return [y, gridSize.rows - x - 1]
+		case 'surface180':
+			return [gridSize.columns - x - 1, gridSize.rows - y - 1]
 		default:
-			return rotation
+			return [x, y]
 	}
 }

--- a/lib/Surface/Util.js
+++ b/lib/Surface/Util.js
@@ -12,3 +12,27 @@ export function convertPanelIndexToXY(index, gridSize) {
 	const y = Math.floor(index / gridSize.columns)
 	return [x, y]
 }
+
+export function rotateXYForPanel(x, y, gridSize, rotation) {
+	switch (rotation) {
+		case 90:
+			return [y, gridSize.columns - x - 1]
+		case -90:
+			return [gridSize.rows - y - 1, x]
+		case 180:
+			return [gridSize.columns - x - 1, gridSize.rows - y - 1]
+		default:
+			return [x, y]
+	}
+}
+
+export function invertRotation(rotation) {
+	switch (rotation) {
+		case 90:
+			return -90
+		case -90:
+			return 90
+		default:
+			return rotation
+	}
+}

--- a/webui/src/Surfaces/EditModal.jsx
+++ b/webui/src/Surfaces/EditModal.jsx
@@ -211,21 +211,31 @@ export const SurfaceEditModal = forwardRef(function SurfaceEditModal(_props, ref
 								/>
 							</CFormGroup>
 						)}
-						{deviceInfo.configFields?.includes('rotation') && (
-							<CFormGroup>
-								<CLabel htmlFor="rotation">Button rotation</CLabel>
-								<CSelect
-									name="rotation"
-									value={deviceConfig.rotation}
-									onChange={(e) => updateConfig('rotation', parseInt(e.currentTarget.value))}
-								>
-									<option value="0">Normal</option>
-									<option value="-90">90 CCW</option>
-									<option value="90">90 CW</option>
-									<option value="180">180</option>
-								</CSelect>
-							</CFormGroup>
-						)}
+
+						<CFormGroup>
+							<CLabel htmlFor="rotation">Button rotation</CLabel>
+							<CSelect
+								name="rotation"
+								value={deviceConfig.rotation}
+								onChange={(e) => {
+									const valueNumber = parseInt(e.currentTarget.value)
+									updateConfig('rotation', isNaN(valueNumber) ? e.currentTarget.value : valueNumber)
+								}}
+							>
+								<option value="0">Normal</option>
+								<option value="surface-90">90 CCW</option>
+								<option value="surface90">90 CW</option>
+								<option value="surface180">180</option>
+
+								{deviceInfo.configFields?.includes('legacy_rotation') && (
+									<>
+										<option value="-90">90 CCW (Legacy)</option>
+										<option value="90">90 CW (Legacy)</option>
+										<option value="180">180 (Legacy)</option>
+									</>
+								)}
+							</CSelect>
+						</CFormGroup>
 						{deviceInfo.configFields?.includes('emulator_control_enable') && (
 							<CFormGroup>
 								<CLabel htmlFor="emulator_control_enable">Enable support for Logitech R400/Mastercue/DSan</CLabel>

--- a/webui/src/UserConfig/SurfacesConfig.jsx
+++ b/webui/src/UserConfig/SurfacesConfig.jsx
@@ -78,6 +78,28 @@ export function SurfacesConfig({ config, setValue, resetValue }) {
 			</tr>
 			<tr>
 				<td>
+					Use old layout for X-keys
+					<br />
+					<em>(Requires Companion restart)</em>
+				</td>
+				<td>
+					<div className="form-check form-check-inline mr-1 float-right">
+						<CSwitch
+							color="success"
+							checked={config.xkeys_legacy_layout}
+							size={'lg'}
+							onChange={(e) => setValue('xkeys_legacy_layout', e.currentTarget.checked)}
+						/>
+					</div>
+				</td>
+				<td>
+					<CButton onClick={() => resetValue('xkeys_legacy_layout')} title="Reset to default">
+						<FontAwesomeIcon icon={faUndo} />
+					</CButton>
+				</td>
+			</tr>
+			<tr>
+				<td>
 					Enable connected Loupedeck and Razer Stream Controller devices
 					<br />
 					<em>(Requires Companion restart)</em>


### PR DESCRIPTION
Related: #409

Instead of rotating purely the bitmaps inside of each key, this makes it possible to rotate everything about the panel.
For example, a 15 key streamdeck normally occupied a 5x3 area in the grid and once rotated will now occupy a 3x5 area instead.
![PXL_20230807_201806284](https://github.com/bitfocus/companion/assets/1327476/43784e65-83ae-4d38-b349-f8c05fdb90c8)


For backwards compatibility, the old rotation modes have not been removed, that can be done in a later release.

Additionally, xkeys has been reworked, so that it no longer needs to span multiple pages or do other mangling to fit the panels into the grid.
![PXL_20230807_194059424](https://github.com/bitfocus/companion/assets/1327476/ec5a8007-2977-4b8e-b353-20154b009908)
This is controlled by a setting, so that existing xkeys users can choose when to switch their configurations to the new layout.
I have only tested this with a XK-24 and a XK-12 (Jog&Shuttle)
With this new layout, rotation works as you would expect. It is also offered when using the old layout, but makes configuring even more confusing.

loupedeck ct now also uses a single page, with a suitable grid size

