### PR TITLE
fix: Don't crash if feedbacks options are missing from presets bitfocus/companion-module-base#53

### DIFF
--- a/lib/Instance/Definitions.js
+++ b/lib/Instance/Definitions.js
@@ -368,7 +368,7 @@ class InstanceDefinitions extends CoreBase {
 					style: rawPreset.style,
 					previewStyle: rawPreset.previewStyle,
 					options: rawPreset.options,
-					feedbacks: rawPreset.feedbacks.map((fb) => ({
+					feedbacks: (rawPreset.feedbacks ?? []).map((fb) => ({
 						type: fb.feedbackId,
 						options: fb.options,
 						style: fb.style,


### PR DESCRIPTION
Closes https://github.com/bitfocus/companion-module-base/issues/53