### PR TITLE
feat: indiciate variables support on input field

### DIFF
--- a/webui/src/Controls/OptionsInputField.jsx
+++ b/webui/src/Controls/OptionsInputField.jsx
@@ -132,13 +132,15 @@ export function OptionsInputField({
 		control = <CInputGroupText>Unknown type "{option.type}"</CInputGroupText>
 	}
 
+	const featureIcons = []
+	if (features.variables)
+		featureIcons.push(<FontAwesomeIcon key="variables" icon={faDollarSign} title={'Supports variables'} />)
+
 	return (
 		<CFormGroup style={{ display: visibility === false ? 'none' : null }}>
 			<CLabel>
 				{option.label}
-				{features.variables && (
-					<FontAwesomeIcon className="feature-icon" icon={faDollarSign} title={'Supports variables'} />
-				)}
+				{featureIcons.length && <span className="feature-icons">{featureIcons}</span>}
 				{option.tooltip && <FontAwesomeIcon icon={faQuestionCircle} title={option.tooltip} />}
 			</CLabel>
 			{control}

--- a/webui/src/Controls/OptionsInputField.jsx
+++ b/webui/src/Controls/OptionsInputField.jsx
@@ -9,7 +9,7 @@ import {
 } from '../Components'
 import { InternalCustomVariableDropdown, InternalInstanceField } from './InternalInstanceFields'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons'
+import { faDollarSign, faQuestionCircle } from '@fortawesome/free-solid-svg-icons'
 
 export function OptionsInputField({
 	instanceId,
@@ -29,6 +29,7 @@ export function OptionsInputField({
 	}
 
 	let control = undefined
+	let features = {}
 	switch (option.type) {
 		case 'textinput': {
 			control = (
@@ -42,6 +43,7 @@ export function OptionsInputField({
 					setValue={setValue2}
 				/>
 			)
+			features.variables = !!option.useVariables
 			break
 		}
 		case 'dropdown': {
@@ -134,9 +136,10 @@ export function OptionsInputField({
 		<CFormGroup style={{ display: visibility === false ? 'none' : null }}>
 			<CLabel>
 				{option.label}
-				{option.tooltip && (
-					<FontAwesomeIcon style={{ marginLeft: '5px' }} icon={faQuestionCircle} title={option.tooltip} />
+				{features.variables && (
+					<FontAwesomeIcon className="feature-icon" icon={faDollarSign} title={'Supports variables'} />
 				)}
+				{option.tooltip && <FontAwesomeIcon icon={faQuestionCircle} title={option.tooltip} />}
 			</CLabel>
 			{control}
 		</CFormGroup>

--- a/webui/src/scss/_button-edit.scss
+++ b/webui/src/scss/_button-edit.scss
@@ -23,9 +23,20 @@
 
 		svg {
 			margin-left: 5px;
+		}
 
-			&.feature-icon {
-				margin-left: 3px;
+		.feature-icons {
+			background-color: #ddd;
+			border-radius: 50%;
+
+			margin-left: 3px;
+
+			padding-left: 3px;
+			padding-right: 3px;
+
+			svg {
+				margin-left: 2px;
+				margin-right: 2px;
 
 				font-size: 0.8rem;
 			}

--- a/webui/src/scss/_button-edit.scss
+++ b/webui/src/scss/_button-edit.scss
@@ -18,8 +18,18 @@
 	label {
 		justify-content: left;
 		font-weight: bold;
-		font-size: 0.85em;
+		font-size: 0.95em;
 		margin-bottom: 0.15rem;
+
+		svg {
+			margin-left: 5px;
+
+			&.feature-icon {
+				margin-left: 3px;
+
+				font-size: 0.8rem;
+			}
+		}
 	}
 
 	.png-browse {


### PR DESCRIPTION
This is a pretty small change, that I think will help users. I am not 100% sold on the look, if anyone has ideas on how to improve it please do say

A simple indicator to show that the input field supports variables. On hover it shows `Supports variables`. It is using the `useVariables` property to decide to show this, which matches how we decide whether to suggest variables while typing.

I am hoping that we can add more icons to both this field type and others over time to indicate support for other features that modules need to implement support for

![image](https://github.com/bitfocus/companion/assets/1327476/c2c6ead7-2000-4a72-ad42-4f6e4937e145)

