### PR TITLE
Add default for lastUpgradeIndex

### DIFF
--- a/lib/Data/ImportExport.js
+++ b/lib/Data/ImportExport.js
@@ -409,6 +409,11 @@ class DataImportExport extends CoreBase {
 
 			object = upgradeImport(object)
 
+			// fix any db instances missing the upgradeIndex property
+			for (const inst of Object.keys(object.instances)) {
+				object.instances[inst].lastUpgradeIndex = object.instances[inst].lastUpgradeIndex ?? -1
+			}
+
 			// TODO - this should be an upgrade, but isnt enough to justify a version bump
 			if (object.triggers && Array.isArray(object.triggers)) {
 				const triggersObj = {}

--- a/lib/Data/ImportExport.js
+++ b/lib/Data/ImportExport.js
@@ -410,8 +410,8 @@ class DataImportExport extends CoreBase {
 			object = upgradeImport(object)
 
 			// fix any db instances missing the upgradeIndex property
-			for (const inst of Object.keys(object.instances)) {
-				object.instances[inst].lastUpgradeIndex = object.instances[inst].lastUpgradeIndex ?? -1
+			for (const inst of Object.values(object.instances)) {
+				inst.lastUpgradeIndex = inst.lastUpgradeIndex ?? -1
 			}
 
 			// TODO - this should be an upgrade, but isnt enough to justify a version bump


### PR DESCRIPTION
Modules that did not have an `upgradeScripts` prior to v3.0 do not have a `lastUpgradeIndex` in the instance database. This resulted in the upgrade script starting point being `undefined` when importing or upgrading.
As a result, no actions or feedbacks were passed to the upgrade scripts but the index was updated afterwards as if they had run.
