### PR TITLE
bug: (2645) fix LoupedeckLive constructor #loupedeck initialization (2645)

### DIFF
--- a/lib/Surface/USB/LoupedeckLive.js
+++ b/lib/Surface/USB/LoupedeckLive.js
@@ -193,7 +193,7 @@ class SurfaceUSBLoupedeckLive extends EventEmitter {
 
 		this.logger = LogController.createLogger(`Surface/USB/Loupedeck/${devicePath}`)
 
-		this.loupedeck = loupedeck
+		this.#loupedeck = loupedeck
 		this.#modelInfo = modelInfo
 
 		this.config = {


### PR DESCRIPTION
Fixes https://github.com/bitfocus/companion/issues/2645

fixed `#loupedeck` initialization in `SurfaceUSBLoupedeckLive` constructor  (`LoupedeckLive.js`)
