### PR TITLE
feat: configurable learn timeout

### DIFF
--- a/lib/Controls/Controller.js
+++ b/lib/Controls/Controller.js
@@ -13,6 +13,7 @@ import TriggerEvents from './TriggerEvents.js'
 import debounceFn from 'debounce-fn'
 
 export const TriggersListRoom = 'triggers:list'
+const ActiveLearnRoom = 'learn:active'
 
 /**
  * @typedef {import('../Shared/Model/ButtonModel.js').SomeButtonModel | import('../Shared/Model/TriggerModel.js').TriggerModel} SomeControlModel
@@ -71,6 +72,13 @@ class ControlsController extends CoreBase {
 	 * @access public
 	 */
 	triggers
+
+	/**
+	 * Active learn requests. Ids of actions & feedbacks
+	 * @type {Set<string>}
+	 * @access private
+	 */
+	#activeLearnRequests = new Set()
 
 	/**
 	 * @param {import('../Registry.js').default} registry - the application core
@@ -408,7 +416,24 @@ class ControlsController extends CoreBase {
 				if (!control) return false
 
 				if (control.supportsFeedbacks) {
-					return control.feedbacks.feedbackLearn(id)
+					if (this.#activeLearnRequests.has(id)) throw new Error('Learn is already running')
+					try {
+						this.#setIsLearning(id, true)
+
+						control.feedbacks
+							.feedbackLearn(id)
+							.catch((e) => {
+								this.logger.error(`Learn failed: ${e}`)
+							})
+							.then(() => {
+								this.#setIsLearning(id, false)
+							})
+
+						return true
+					} catch (e) {
+						this.#setIsLearning(id, false)
+						throw e
+					}
 				} else {
 					throw new Error(`Control "${controlId}" does not support feedbacks`)
 				}
@@ -651,7 +676,24 @@ class ControlsController extends CoreBase {
 				if (!control) return false
 
 				if (control.supportsActions) {
-					return control.actionLearn(stepId, setId, id)
+					if (this.#activeLearnRequests.has(id)) throw new Error('Learn is already running')
+					try {
+						this.#setIsLearning(id, true)
+
+						control
+							.actionLearn(stepId, setId, id)
+							.catch((e) => {
+								this.logger.error(`Learn failed: ${e}`)
+							})
+							.then(() => {
+								this.#setIsLearning(id, false)
+							})
+
+						return true
+					} catch (e) {
+						this.#setIsLearning(id, false)
+						throw e
+					}
 				} else {
 					throw new Error(`Control "${controlId}" does not support actions`)
 				}
@@ -1216,6 +1258,15 @@ class ControlsController extends CoreBase {
 				}
 			}
 		)
+
+		client.onPromise('controls:subscribe:learn', async () => {
+			client.join(ActiveLearnRoom)
+
+			return Array.from(this.#activeLearnRequests)
+		})
+		client.onPromise('controls:unsubscribe:learn', async () => {
+			client.leave(ActiveLearnRoom)
+		})
 	}
 
 	/**
@@ -1502,6 +1553,22 @@ class ControlsController extends CoreBase {
 		this.graphics.invalidateButton(location)
 
 		return controlId
+	}
+
+	/**
+	 * Set an item as learning, or not
+	 * @param {string} id
+	 * @param {boolean} isActive
+	 * @returns {void}
+	 */
+	#setIsLearning(id, isActive) {
+		if (isActive) {
+			this.#activeLearnRequests.add(id)
+			this.io.emitToRoom(ActiveLearnRoom, 'learn:add', id)
+		} else {
+			this.#activeLearnRequests.delete(id)
+			this.io.emitToRoom(ActiveLearnRoom, 'learn:remove', id)
+		}
 	}
 
 	/**

--- a/lib/Instance/Wrapper.js
+++ b/lib/Instance/Wrapper.js
@@ -341,27 +341,35 @@ class SocketEventsHandler {
 
 		const control = this.registry.controls.getControl(controlId)
 
+		const feedbackSpec = this.registry.instance.definitions.getFeedbackDefinition(this.connectionId, feedback.type)
+		const learnTimeout = feedbackSpec?.learnTimeout
+
 		try {
-			const msg = await this.ipcWrapper.sendWithCb('learnFeedback', {
-				feedback: {
-					id: feedback.id,
-					controlId: controlId,
-					feedbackId: feedback.type,
-					options: feedback.options,
+			const msg = await this.ipcWrapper.sendWithCb(
+				'learnFeedback',
+				{
+					feedback: {
+						id: feedback.id,
+						controlId: controlId,
+						feedbackId: feedback.type,
+						options: feedback.options,
 
-					isInverted: !!feedback.isInverted,
+						isInverted: !!feedback.isInverted,
 
-					image: control?.getBitmapSize() ?? undefined,
-					page: 0,
-					bank: 0,
+						image: control?.getBitmapSize() ?? undefined,
+						page: 0,
+						bank: 0,
 
-					upgradeIndex: null,
-					disabled: !!feedback.disabled,
+						upgradeIndex: null,
+						disabled: !!feedback.disabled,
 
-					// Pass the current default style for compatibility reasons
-					rawBank: {},
+						// Pass the current default style for compatibility reasons
+						rawBank: {},
+					},
 				},
-			})
+				undefined,
+				learnTimeout
+			)
 
 			return msg.options
 		} catch (/** @type {any} */ e) {
@@ -437,21 +445,29 @@ class SocketEventsHandler {
 	async actionLearnValues(action, controlId) {
 		if (action.instance !== this.connectionId) throw new Error(`Action is for a different instance`)
 
+		const actionSpec = this.registry.instance.definitions.getActionDefinition(this.connectionId, action.action)
+		const learnTimeout = actionSpec?.learnTimeout
+
 		try {
-			const msg = await this.ipcWrapper.sendWithCb('learnAction', {
-				action: {
-					id: action.id,
-					controlId: controlId,
-					actionId: action.action,
-					options: action.options,
+			const msg = await this.ipcWrapper.sendWithCb(
+				'learnAction',
+				{
+					action: {
+						id: action.id,
+						controlId: controlId,
+						actionId: action.action,
+						options: action.options,
 
-					upgradeIndex: null,
-					disabled: !!action.disabled,
+						upgradeIndex: null,
+						disabled: !!action.disabled,
 
-					page: null,
-					bank: null,
+						page: null,
+						bank: null,
+					},
 				},
-			})
+				undefined,
+				learnTimeout
+			)
 
 			return msg.options
 		} catch (/** @type {any} */ e) {
@@ -611,6 +627,8 @@ class SocketEventsHandler {
 				// @ts-expect-error @companion-module-base exposes these through a mapping that loses the differentiation between types
 				options: rawAction.options || [],
 				hasLearn: !!rawAction.hasLearn,
+				// @ts-expect-error needs @companion-module/base update
+				learnTimeout: rawAction.learnTimeout,
 			}
 		}
 
@@ -635,6 +653,8 @@ class SocketEventsHandler {
 				type: rawFeedback.type,
 				style: rawFeedback.defaultStyle,
 				hasLearn: !!rawFeedback.hasLearn,
+				// @ts-expect-error needs @companion-module/base update
+				learnTimeout: rawFeedback.learnTimeout,
 				showInvert: rawFeedback.showInvert ?? shouldShowInvertForFeedback(rawFeedback.options || []),
 			}
 		}

--- a/lib/Shared/Model/Options.ts
+++ b/lib/Shared/Model/Options.ts
@@ -10,6 +10,7 @@ import type {
 	CompanionInputFieldStaticText,
 	CompanionInputFieldTextInput,
 } from '@companion-module/base'
+import type { SetOptional } from 'type-fest'
 
 // TODO: move to '@companion-module/base'
 export type IsVisibleFunction = Required<CompanionInputFieldBase>['isVisible']
@@ -101,7 +102,8 @@ export interface ActionDefinition {
 	label: string
 	description: string | undefined
 	options: InternalActionInputField[]
-	hasLearn?: boolean
+	hasLearn: boolean
+	learnTimeout: number | undefined
 }
 
 export interface FeedbackDefinition {
@@ -111,14 +113,16 @@ export interface FeedbackDefinition {
 	type: 'advanced' | 'boolean'
 	style: Partial<CompanionButtonStyleProps> | undefined
 	hasLearn: boolean
+	learnTimeout: number | undefined
 	showInvert: boolean
 }
 
-export interface InternalFeedbackDefinition extends FeedbackDefinition {
+export interface InternalFeedbackDefinition extends SetOptional<FeedbackDefinition, 'hasLearn' | 'learnTimeout'> {
 	showButtonPreview?: boolean
 }
 
-export interface InternalActionDefinition extends Omit<ActionDefinition, 'options'> {
+export interface InternalActionDefinition
+	extends SetOptional<Omit<ActionDefinition, 'options'>, 'hasLearn' | 'learnTimeout'> {
 	showButtonPreview?: boolean
 	options: InternalActionInputField[]
 }

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
 		"socket.io": "^4.7.2",
 		"socketcluster-client": "^16.1.1",
 		"supports-color": "^9.4.0",
+		"type-fest": "^4.8.2",
 		"usb": "^2.11.0",
 		"utf-8-validate": "^6.0.3",
 		"uuid": "^9.0.1",

--- a/webui/package.json
+++ b/webui/package.json
@@ -31,6 +31,8 @@
     "lodash-es": "^4.17.21",
     "marked": "^9.1.6",
     "marked-base-url": "^1.1.1",
+    "mobx": "^6.12.0",
+    "mobx-react-lite": "^4.0.5",
     "nanoid": "^5.0.3",
     "p-timeout": "^6.1.2",
     "parse-numeric-range": "^1.3.0",

--- a/webui/src/Buttons/EditButton.tsx
+++ b/webui/src/Buttons/EditButton.tsx
@@ -236,8 +236,6 @@ export const EditButton = memo(function EditButton({ location, onKeyUp }: EditBu
 	// const isTwoColumn = window.matchMedia('(min-width: 1200px)').matches
 	// const [, { height: hintHeight }] = useElementSize()
 
-	console.log('ty', dataReady, hasConfig, hasRuntimeProps, loadError)
-
 	return (
 		<KeyReceiver onKeyUp={onKeyUp} tabIndex={0} className="edit-button-panel flex-form">
 			<GenericConfirmModal ref={resetModalRef} />

--- a/webui/src/Components/LearnButton.tsx
+++ b/webui/src/Components/LearnButton.tsx
@@ -1,0 +1,30 @@
+import React, { useContext } from 'react'
+import { CButton } from '@coreui/react'
+import { ActiveLearnContext } from '../util'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faSync } from '@fortawesome/free-solid-svg-icons'
+import { observer } from 'mobx-react-lite'
+
+interface LearnButtonProps {
+	id: string
+	disabled?: boolean
+	doLearn: () => void
+}
+
+export const LearnButton = observer(function LearnButton({ id, disabled, doLearn }: LearnButtonProps) {
+	const activeLearnRequets = useContext(ActiveLearnContext)
+
+	const isActive = activeLearnRequets.has(id)
+
+	return (
+		<CButton
+			disabled={isActive || disabled}
+			color="info"
+			size="sm"
+			onClick={doLearn}
+			title="Capture the current values from the device"
+		>
+			Learn {isActive && <FontAwesomeIcon icon={faSync} spin />}
+		</CButton>
+	)
+})

--- a/webui/src/ContextData.tsx
+++ b/webui/src/ContextData.tsx
@@ -18,6 +18,7 @@ import {
 	ModulesContext,
 	RecentActionsContext,
 	RecentFeedbacksContext,
+	ActiveLearnContext,
 } from './util'
 import { NotificationsManager, NotificationsManagerRef } from './Components/Notifications'
 import { cloneDeep } from 'lodash-es'
@@ -30,6 +31,7 @@ import type { AllVariableDefinitions, ModuleVariableDefinitions } from '@compani
 import type { CustomVariablesModel } from '@companion/shared/Model/CustomVariableModel'
 import type { ClientDevicesListItem } from '@companion/shared/Model/Surfaces'
 import type { ClientTriggerData } from '@companion/shared/Model/TriggerModel'
+import { useActiveLearnRequests } from './_Model/ActiveLearn'
 
 interface ContextDataProps {
 	children: (progressPercent: number, loadingComplete: boolean) => React.JSX.Element | React.JSX.Element[]
@@ -301,6 +303,8 @@ export function ContextData({ children }: ContextDataProps) {
 		}
 	}, [socket])
 
+	const [activeLearnRequests, activeLearnRequestsReady] = useActiveLearnRequests(socket)
+
 	const notifierRef = useRef<NotificationsManagerRef>(null)
 
 	const steps = [
@@ -316,6 +320,7 @@ export function ContextData({ children }: ContextDataProps) {
 		surfaces,
 		pages,
 		triggers,
+		activeLearnRequestsReady,
 	]
 	const completedSteps = steps.filter((s) => s !== null && s !== undefined)
 
@@ -336,9 +341,11 @@ export function ContextData({ children }: ContextDataProps) {
 													<TriggersContext.Provider value={triggers!}>
 														<RecentActionsContext.Provider value={recentActionsContext}>
 															<RecentFeedbacksContext.Provider value={recentFeedbacksContext}>
-																<NotificationsManager ref={notifierRef} />
+																<ActiveLearnContext.Provider value={activeLearnRequests}>
+																	<NotificationsManager ref={notifierRef} />
 
-																{children(progressPercent, completedSteps.length === steps.length)}
+																	{children(progressPercent, completedSteps.length === steps.length)}
+																</ActiveLearnContext.Provider>
 															</RecentFeedbacksContext.Provider>
 														</RecentActionsContext.Provider>
 													</TriggersContext.Provider>

--- a/webui/src/Controls/ActionSetEditor.tsx
+++ b/webui/src/Controls/ActionSetEditor.tsx
@@ -32,6 +32,7 @@ import type { FilterOptionOption } from 'react-select/dist/declarations/src/filt
 import { ActionInstance } from '@companion/shared/Model/ActionModel'
 import { ControlLocation } from '@companion/shared/Model/Common'
 import { useOptionsAndIsVisible } from '../Hooks/useOptionsAndIsVisible'
+import { LearnButton } from '../Components/LearnButton'
 
 interface ControlActionSetEditorProps {
 	controlId: string
@@ -548,17 +549,7 @@ function ActionTableRow({
 						</div>
 
 						<div className="cell-actions">
-							{actionSpec?.hasLearn && (
-								<CButton
-									disabled={readonly}
-									color="info"
-									size="sm"
-									onClick={innerLearn}
-									title="Capture the current values from the device"
-								>
-									Learn
-								</CButton>
-							)}
+							{actionSpec?.hasLearn && <LearnButton id={action.id} disabled={readonly} doLearn={innerLearn} />}
 						</div>
 
 						<div className="cell-option">

--- a/webui/src/Controls/FeedbackEditor.tsx
+++ b/webui/src/Controls/FeedbackEditor.tsx
@@ -32,10 +32,11 @@ import { MenuPortalContext } from '../Components/DropdownInputField'
 import { ButtonStyleProperties } from '@companion/shared/Style'
 import { FilterOptionOption } from 'react-select/dist/declarations/src/filters'
 import { FeedbackInstance } from '@companion/shared/Model/FeedbackModel'
-import { FeedbackDefinition } from '@companion/shared/Model/Options'
+import { InternalFeedbackDefinition } from '@companion/shared/Model/Options'
 import { DropdownChoiceId } from '@companion-module/base'
 import { ControlLocation } from '@companion/shared/Model/Common'
 import { useOptionsAndIsVisible } from '../Hooks/useOptionsAndIsVisible'
+import { LearnButton } from '../Components/LearnButton'
 
 interface ControlFeedbacksEditorProps {
 	controlId: string
@@ -476,11 +477,7 @@ function FeedbackEditor({
 					)}
 
 					<div className="cell-actions">
-						{feedbackSpec?.hasLearn && (
-							<CButton color="info" size="sm" onClick={innerLearn} title="Capture the current values from the device">
-								Learn
-							</CButton>
-						)}
+						{feedbackSpec?.hasLearn && <LearnButton id={feedback.id} doLearn={innerLearn} />}
 					</div>
 
 					<div className="cell-option">
@@ -543,7 +540,7 @@ function FeedbackEditor({
 }
 
 interface FeedbackManageStylesProps {
-	feedbackSpec: FeedbackDefinition | undefined
+	feedbackSpec: InternalFeedbackDefinition | undefined
 	feedback: FeedbackInstance
 	setSelectedStyleProps: (keys: string[]) => void
 }
@@ -576,7 +573,7 @@ function FeedbackManageStyles({ feedbackSpec, feedback, setSelectedStyleProps }:
 }
 
 interface FeedbackStylesProps {
-	feedbackSpec: FeedbackDefinition | undefined
+	feedbackSpec: InternalFeedbackDefinition | undefined
 	feedback: FeedbackInstance
 	setStylePropsValue: (key: string, value: any) => void
 }

--- a/webui/src/_Model/ActiveLearn.ts
+++ b/webui/src/_Model/ActiveLearn.ts
@@ -1,0 +1,47 @@
+import { observable, ObservableSet } from 'mobx'
+import { useEffect, useMemo, useState } from 'react'
+import type { Socket } from 'socket.io-client'
+import { socketEmitPromise } from '../util'
+
+export function useActiveLearnRequests(socket: Socket): [ObservableSet<string>, boolean] {
+	const [isReady, setIsReady] = useState<boolean>(false)
+	const activeIds = useMemo(() => observable.set<string>(), [])
+
+	useEffect(() => {
+		let aborted = false
+		socketEmitPromise(socket, 'controls:subscribe:learn', [])
+			.then((active: string[]) => {
+				if (aborted) return
+				activeIds.clear()
+				for (const id of active) {
+					activeIds.add(id)
+				}
+
+				setIsReady(true)
+			})
+			.catch((e) => {
+				console.error('subscribe to learn failed', e)
+			})
+
+		const onAdd = (id: string) => activeIds.add(id)
+		const onRemove = (id: string) => activeIds.delete(id)
+
+		socket.on('learn:add', onAdd)
+		socket.on('learn:remove', onRemove)
+
+		return () => {
+			setIsReady(false)
+			activeIds.clear()
+
+			aborted = true
+			socketEmitPromise(socket, 'controls:unsubscribe:learn', []).catch((e) => {
+				console.error('unsubscribe to learn failed', e)
+			})
+
+			socket.off('learn:add', onAdd)
+			socket.off('learn:remove', onRemove)
+		}
+	}, [activeIds, socket])
+
+	return [activeIds, isReady]
+}

--- a/webui/src/util.tsx
+++ b/webui/src/util.tsx
@@ -22,7 +22,6 @@ import type { UserConfigModel } from '@companion/shared/Model/UserConfigModel.js
 import type { ClientDevicesListItem } from '@companion/shared/Model/Surfaces.js'
 import type { PageModel } from '@companion/shared/Model/PageModel.js'
 import type { CustomVariablesModel } from '@companion/shared/Model/CustomVariableModel.js'
-import { ActiveLearnRequests } from './_Model/ActiveLearn.js'
 import { observable, ObservableSet } from 'mobx'
 
 export const SocketContext = React.createContext<Socket>(null as any) // TODO - fix this

--- a/webui/src/util.tsx
+++ b/webui/src/util.tsx
@@ -22,6 +22,8 @@ import type { UserConfigModel } from '@companion/shared/Model/UserConfigModel.js
 import type { ClientDevicesListItem } from '@companion/shared/Model/Surfaces.js'
 import type { PageModel } from '@companion/shared/Model/PageModel.js'
 import type { CustomVariablesModel } from '@companion/shared/Model/CustomVariableModel.js'
+import { ActiveLearnRequests } from './_Model/ActiveLearn.js'
+import { observable, ObservableSet } from 'mobx'
 
 export const SocketContext = React.createContext<Socket>(null as any) // TODO - fix this
 export const EventDefinitionsContext = React.createContext<Record<string, ClientEventDefinition | undefined>>({})
@@ -53,6 +55,7 @@ export const RecentFeedbacksContext = React.createContext<{
 	recentFeedbacks: string[]
 	trackRecentFeedback: (feedbackType: string) => void
 } | null>(null)
+export const ActiveLearnContext = React.createContext<ObservableSet<string>>(observable.set())
 
 export function socketEmitPromise(
 	socket: Socket,

--- a/webui/yarn.lock
+++ b/webui/yarn.lock
@@ -1859,6 +1859,18 @@ micromark@^3.0.0:
     micromark-util-types "^1.0.1"
     uvu "^0.5.0"
 
+mobx-react-lite@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/mobx-react-lite/-/mobx-react-lite-4.0.5.tgz#e2cb98f813e118917bcc463638f5bf6ea053a67b"
+  integrity sha512-StfB2wxE8imKj1f6T8WWPf4lVMx3cYH9Iy60bbKXEs21+HQ4tvvfIBZfSmMXgQAefi8xYEwQIz4GN9s0d2h7dg==
+  dependencies:
+    use-sync-external-store "^1.2.0"
+
+mobx@^6.12.0:
+  version "6.12.0"
+  resolved "https://registry.yarnpkg.com/mobx/-/mobx-6.12.0.tgz#72b2685ca5af031aaa49e77a4d76ed67fcbf9135"
+  integrity sha512-Mn6CN6meXEnMa0a5u6a5+RKrqRedHBhZGd15AWLk9O6uFY4KYHzImdt8JI8WODo1bjTSRnwXhJox+FCUZhCKCQ==
+
 mri@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"
@@ -2626,6 +2638,11 @@ use-isomorphic-layout-effect@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz#497cefb13d863d687b08477d9e5a164ad8c1a6fb"
   integrity sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==
+
+use-sync-external-store@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
 usehooks-ts@^2.9.1:
   version "2.9.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4771,7 +4771,6 @@ node-forge@^1:
 
 node-gyp-build@^4.3.0, node-gyp-build@^4.5.0, "node-gyp-build@github:julusian/node-gyp-build#cross-install-support":
   version "4.5.0"
-  uid "33c9759a3215892a520d50ad20c947795b813904"
   resolved "https://codeload.github.com/julusian/node-gyp-build/tar.gz/33c9759a3215892a520d50ad20c947795b813904"
 
 node-hid@^2.1.1, node-hid@^2.1.2, "node-hid@npm:@julusian/hid@3.0.0-2", "node-hid@npm:@julusian/hid@^3.0.0-0":
@@ -5973,6 +5972,11 @@ type-fest@^0.21.3:
   version "0.21.3"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
+
+type-fest@^4.8.2:
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.8.2.tgz#20d4cc287745723dbabf925de644eeb7de0349c1"
+  integrity sha512-mcvrCjixA5166hSrUoJgGb9gBQN4loMYyj9zxuMs/66ibHNEFd5JXMw37YVDx58L4/QID9jIzdTBB4mDwDJ6KQ==
 
 type-is@~1.6.18:
   version "1.6.18"


### PR DESCRIPTION
Closes #2619

To achieve this, the backend is now keeping track of the ids of the actions/feedbacks which are currently executing a 'learn', and it will reject an attempt to run two for the same id in parallel.
The client subscribes to the list of currently running learn requests, and any currently running learn buttons are now disabled, and show a spinning icon to indicate them running.

I have written this using mobx, as I want to try and use this more for the ui as a better way to do focused reactivity. The current context approach is not granular enough, causing large re-renders for small unrelated changes, which using mobx should resolve. I intend to explore that rework in develop, but don't see the harm in adding it for new stuff to beta