### PR TITLE
feat: more than 99 pages #2003

### DIFF
--- a/docs/3_config/buttons.md
+++ b/docs/3_config/buttons.md
@@ -2,7 +2,7 @@ In the Buttons tab, you can configure the buttons for your Stream Deck.
 
 ![Buttons Page](images/buttons.png?raw=true 'Buttons Page')
 
-The Buttons layout has 99 pages that can be navigated using the grey left/right arrows, or the dropdown box. You can give your pages a unique name by replacing the word _PAGE_ right next to the page number.
+The Buttons layout has numerous pages that can be navigated using the grey left/right arrows, or the dropdown box. You can give your pages a unique name by replacing the word _PAGE_ right next to the page number.
 
 If you hold down the SHIFT key on your keyboard, you can trigger a button directly by clicking on it.
 

--- a/lib/Controls/Controller.js
+++ b/lib/Controls/Controller.js
@@ -1593,6 +1593,7 @@ class ControlsController extends CoreBase {
 
 	/**
 	 * Create a control
+	 * Danger: This will not delete an existing control from the specified location
 	 * @param {import('../Resources/Util.js').ControlLocation} location Location to place in the grid
 	 * @param {string} newType The type of the new control to create (if any)
 	 * @returns {string | null} controlId

--- a/lib/Data/ImportExport.js
+++ b/lib/Data/ImportExport.js
@@ -243,7 +243,7 @@ class DataImportExport extends CoreBase {
 			if (isNaN(page)) {
 				next()
 			} else {
-				const pageInfo = this.page.getPage(page, true)
+				const pageInfo = this.page.getPageInfo(page, true)
 				if (!pageInfo) throw new Error(`Page "${page}" not found!`)
 
 				const referencedConnectionIds = new Set()
@@ -845,7 +845,7 @@ class DataImportExport extends CoreBase {
 				}
 
 				// Import the new page
-				this.page.importPage(topage, pageInfo)
+				this.page.setPageName(topage, pageInfo.name)
 
 				// Import the controls
 				for (const [row, rowObj] of Object.entries(pageInfo.controls)) {

--- a/lib/Data/ImportExport.js
+++ b/lib/Data/ImportExport.js
@@ -754,10 +754,12 @@ class DataImportExport extends CoreBase {
 			'loadsave:delete-page',
 			/**
 			 * @param {number} pageNumber
-			 * @returns {'ok'}
+			 * @returns {'ok' | 'fail'}
 			 */
 			(pageNumber) => {
 				this.logger.silly(`Delete page ${pageNumber}`)
+
+				if (this.page.getPageCount() === 1) return 'fail'
 
 				// Delete the controls, and allow them to redraw
 				const controlIds = this.page.getAllControlIdsOnPage(pageNumber)
@@ -1026,7 +1028,7 @@ class DataImportExport extends CoreBase {
 
 			// Delete other pages
 			const pageCount = this.page.getPageCount()
-			for (let pageNumber = 2; pageNumber <= pageCount; ++pageNumber) {
+			for (let pageNumber = pageCount; pageNumber >= 2; pageNumber--) {
 				this.page.deletePage(pageNumber) // Note: controls were already deleted above
 			}
 

--- a/lib/Data/ImportExport.js
+++ b/lib/Data/ImportExport.js
@@ -813,8 +813,8 @@ class DataImportExport extends CoreBase {
 
 					if (data.pages && (!config || config.buttons)) {
 						// Import pages
-						for (let page = 1; page <= 99; page++) {
-							doPageImport(data.pages[page], page, instanceIdMap)
+						for (const [pageNumber, pageInfo] of Object.entries(data.pages)) {
+							doPageImport(pageInfo, Number(pageNumber), instanceIdMap)
 						}
 					}
 
@@ -1010,21 +1010,24 @@ class DataImportExport extends CoreBase {
 				}
 			}
 
-			const pageCount = this.page.getPageCount()
-			for (let pageNumber = 1; pageNumber <= pageCount; ++pageNumber) {
-				this.page.resetPage(pageNumber) // Note: controls were already deleted above
-
-				if (!skipNavButtons) {
-					for (const { type, location } of default_nav_buttons_definitions) {
-						this.controls.createButtonControl(
-							{
-								pageNumber,
-								...location,
-							},
-							type
-						)
-					}
+			// Reset page 1
+			this.page.resetPage(1) // Note: controls were already deleted above
+			if (!skipNavButtons) {
+				for (const { type, location } of default_nav_buttons_definitions) {
+					this.controls.createButtonControl(
+						{
+							pageNumber: 1,
+							...location,
+						},
+						type
+					)
 				}
+			}
+
+			// Delete other pages
+			const pageCount = this.page.getPageCount()
+			for (let pageNumber = 2; pageNumber <= pageCount; ++pageNumber) {
+				this.page.deletePage(pageNumber) // Note: controls were already deleted above
 			}
 
 			// reset the size

--- a/lib/Data/ImportExport.js
+++ b/lib/Data/ImportExport.js
@@ -703,13 +703,17 @@ class DataImportExport extends CoreBase {
 			 */
 			(pageNumber) => {
 				this.logger.silly(`Reset page ${pageNumber}`)
+
+				// Delete the controls, and allow them to redraw
 				const controlIds = this.page.getAllControlIdsOnPage(pageNumber)
 				for (const controlId of controlIds) {
 					this.controls.deleteControl(controlId)
 				}
 
+				// Clear the references on the page
 				this.page.resetPage(pageNumber)
 
+				// Re-add the nav buttons
 				for (const { type, location } of default_nav_buttons_definitions) {
 					this.controls.createButtonControl(
 						{
@@ -741,6 +745,28 @@ class DataImportExport extends CoreBase {
 						type
 					)
 				}
+
+				return 'ok'
+			}
+		)
+
+		client.onPromise(
+			'loadsave:delete-page',
+			/**
+			 * @param {number} pageNumber
+			 * @returns {'ok'}
+			 */
+			(pageNumber) => {
+				this.logger.silly(`Delete page ${pageNumber}`)
+
+				// Delete the controls, and allow them to redraw
+				const controlIds = this.page.getAllControlIdsOnPage(pageNumber)
+				for (const controlId of controlIds) {
+					this.controls.deleteControl(controlId)
+				}
+
+				// Delete the page
+				this.page.deletePage(pageNumber)
 
 				return 'ok'
 			}
@@ -984,7 +1010,7 @@ class DataImportExport extends CoreBase {
 			}
 
 			for (let pageNumber = 1; pageNumber <= 99; ++pageNumber) {
-				this.page.resetPage(pageNumber)
+				this.page.resetPage(pageNumber) // Note: controls were already deleted above
 
 				if (!skipNavButtons) {
 					for (const { type, location } of default_nav_buttons_definitions) {

--- a/lib/Data/ImportExport.js
+++ b/lib/Data/ImportExport.js
@@ -775,6 +775,34 @@ class DataImportExport extends CoreBase {
 		)
 
 		client.onPromise(
+			'loadsave:insert-page',
+			/**
+			 * @param {number} asPageNumber
+			 * @returns {'ok' | 'fail'}
+			 */
+			(asPageNumber) => {
+				this.logger.silly(`Insert new page ${asPageNumber}`)
+
+				// Delete the page
+				const pageId = this.page.insertPage(asPageNumber)
+				if (!pageId) throw new Error(`Failed to insert page`)
+
+				// Add nav buttons
+				for (const { type, location } of default_nav_buttons_definitions) {
+					this.controls.createButtonControl(
+						{
+							pageNumber: asPageNumber,
+							...location,
+						},
+						type
+					)
+				}
+
+				return 'ok'
+			}
+		)
+
+		client.onPromise(
 			'loadsave:reset',
 			/**
 			 * @param {ClientResetSelection} config

--- a/lib/Data/ImportExport.js
+++ b/lib/Data/ImportExport.js
@@ -906,7 +906,8 @@ class DataImportExport extends CoreBase {
 					const data = clientPendingImport?.object
 					if (!data) throw new Error('No in-progress import object')
 
-					if (topage <= 0 || topage > 99) throw new Error('Invalid target page')
+					const oldPageInfo = this.page.getPageInfo(topage, false)
+					if (!oldPageInfo) throw new Error('Invalid target page')
 
 					let pageInfo
 
@@ -1009,7 +1010,8 @@ class DataImportExport extends CoreBase {
 				}
 			}
 
-			for (let pageNumber = 1; pageNumber <= 99; ++pageNumber) {
+			const pageCount = this.page.getPageCount()
+			for (let pageNumber = 1; pageNumber <= pageCount; ++pageNumber) {
 				this.page.resetPage(pageNumber) // Note: controls were already deleted above
 
 				if (!skipNavButtons) {

--- a/lib/Data/ImportExport.js
+++ b/lib/Data/ImportExport.js
@@ -33,33 +33,6 @@ import { visitEventOptions } from '../Resources/EventDefinitions.js'
 import { compareExportedInstances } from '../Shared/Import.js'
 
 /**
- * Default buttons on fresh pages
- */
-const default_nav_buttons_definitions = [
-	{
-		type: 'pageup',
-		location: {
-			column: 0,
-			row: 0,
-		},
-	},
-	{
-		type: 'pagenum',
-		location: {
-			column: 0,
-			row: 1,
-		},
-	},
-	{
-		type: 'pagedown',
-		location: {
-			column: 0,
-			row: 2,
-		},
-	},
-]
-
-/**
  * @param {import('winston').Logger} logger
  * @param {import("express").Response} res
  * @param {import("express").NextFunction} next
@@ -504,26 +477,6 @@ class DataImportExport extends CoreBase {
 	}
 
 	/**
-	 *
-	 * @param {number} pageCount
-	 * @returns {void}
-	 */
-	createInitialPageButtons(pageCount) {
-		for (let page = 1; page <= pageCount; page++) {
-			for (const definition of default_nav_buttons_definitions) {
-				const location = {
-					...definition.location,
-					pageNumber: page,
-				}
-				const oldControlId = this.page.getControlIdAt(location)
-				if (oldControlId) this.controls.deleteControl(oldControlId)
-
-				this.controls.createButtonControl(location, definition.type)
-			}
-		}
-	}
-
-	/**
 	 * Setup a new socket client's events
 	 * @param {import('../UI/Handler.js').ClientSocket} client - the client socket
 	 * @access public
@@ -692,113 +645,6 @@ class DataImportExport extends CoreBase {
 					style: controlObj.type,
 				})
 				return !!res?.style ? res?.asDataUrl ?? null : null
-			}
-		)
-
-		client.onPromise(
-			'loadsave:reset-page-clear',
-			/**
-			 * @param {number} pageNumber
-			 * @returns {'ok'}
-			 */
-			(pageNumber) => {
-				this.logger.silly(`Reset page ${pageNumber}`)
-
-				// Delete the controls, and allow them to redraw
-				const controlIds = this.page.getAllControlIdsOnPage(pageNumber)
-				for (const controlId of controlIds) {
-					this.controls.deleteControl(controlId)
-				}
-
-				// Clear the references on the page
-				this.page.resetPage(pageNumber)
-
-				// Re-add the nav buttons
-				for (const { type, location } of default_nav_buttons_definitions) {
-					this.controls.createButtonControl(
-						{
-							pageNumber,
-							...location,
-						},
-						type
-					)
-				}
-
-				return 'ok'
-			}
-		)
-
-		client.onPromise(
-			'loadsave:reset-page-nav',
-			/**
-			 * @param {number} pageNumber
-			 * @returns {'ok'}
-			 */
-			(pageNumber) => {
-				// make magical page buttons!
-				for (const { type, location } of default_nav_buttons_definitions) {
-					this.controls.createButtonControl(
-						{
-							pageNumber,
-							...location,
-						},
-						type
-					)
-				}
-
-				return 'ok'
-			}
-		)
-
-		client.onPromise(
-			'loadsave:delete-page',
-			/**
-			 * @param {number} pageNumber
-			 * @returns {'ok' | 'fail'}
-			 */
-			(pageNumber) => {
-				this.logger.silly(`Delete page ${pageNumber}`)
-
-				if (this.page.getPageCount() === 1) return 'fail'
-
-				// Delete the controls, and allow them to redraw
-				const controlIds = this.page.getAllControlIdsOnPage(pageNumber)
-				for (const controlId of controlIds) {
-					this.controls.deleteControl(controlId)
-				}
-
-				// Delete the page
-				this.page.deletePage(pageNumber)
-
-				return 'ok'
-			}
-		)
-
-		client.onPromise(
-			'loadsave:insert-page',
-			/**
-			 * @param {number} asPageNumber
-			 * @returns {'ok' | 'fail'}
-			 */
-			(asPageNumber) => {
-				this.logger.silly(`Insert new page ${asPageNumber}`)
-
-				// Delete the page
-				const pageId = this.page.insertPage(asPageNumber)
-				if (!pageId) throw new Error(`Failed to insert page`)
-
-				// Add nav buttons
-				for (const { type, location } of default_nav_buttons_definitions) {
-					this.controls.createButtonControl(
-						{
-							pageNumber: asPageNumber,
-							...location,
-						},
-						type
-					)
-				}
-
-				return 'ok'
 			}
 		)
 
@@ -1043,15 +889,7 @@ class DataImportExport extends CoreBase {
 			// Reset page 1
 			this.page.resetPage(1) // Note: controls were already deleted above
 			if (!skipNavButtons) {
-				for (const { type, location } of default_nav_buttons_definitions) {
-					this.controls.createButtonControl(
-						{
-							pageNumber: 1,
-							...location,
-						},
-						type
-					)
-				}
+				this.page.createPageDefaultNavButtons(1)
 			}
 
 			// Delete other pages

--- a/lib/Data/ImportExport.js
+++ b/lib/Data/ImportExport.js
@@ -782,8 +782,15 @@ class DataImportExport extends CoreBase {
 					const data = clientPendingImport?.object
 					if (!data) throw new Error('No in-progress import object')
 
-					const oldPageInfo = this.page.getPageInfo(topage, false)
-					if (!oldPageInfo) throw new Error('Invalid target page')
+					if (topage === -1) {
+						// Add a new page at the end
+						const currentPageCount = this.page.getPageCount()
+						topage = currentPageCount + 1
+						this.page.insertPages(topage, ['Importing Page'])
+					} else {
+						const oldPageInfo = this.page.getPageInfo(topage, false)
+						if (!oldPageInfo) throw new Error('Invalid target page')
+					}
 
 					let pageInfo
 

--- a/lib/Data/Upgrades/v1tov2.js
+++ b/lib/Data/Upgrades/v1tov2.js
@@ -1,4 +1,4 @@
-import { LEGACY_MAX_BUTTONS } from '../../Util/Constants.js'
+import { LEGACY_MAX_BUTTONS, LEGACY_PAGE_COUNT } from '../../Util/Constants.js'
 
 /**
  * do the database upgrades to convert from the v1 to the v2 format
@@ -12,7 +12,7 @@ function convertDatabase15To32(db, _logger) {
 	const oldReleaseActions = db.getKey('bank_release_actions', {})
 	const oldFeedbacks = db.getKey('feedbacks', {})
 
-	for (let page = 1; page <= 99; page++) {
+	for (let page = 1; page <= LEGACY_PAGE_COUNT; page++) {
 		const obj = {
 			config: oldBankConfig[page],
 			actions: oldActions[page],

--- a/lib/Graphics/Controller.js
+++ b/lib/Graphics/Controller.js
@@ -177,19 +177,7 @@ class GraphicsController extends CoreBase {
 
 					// Only cache the render, if it is within the valid bounds
 					if (locationIsInBounds && location) {
-						let pageCache = this.#renderCache.get(location.pageNumber)
-						if (!pageCache) {
-							pageCache = new Map()
-							this.#renderCache.set(location.pageNumber, pageCache)
-						}
-
-						let rowCache = pageCache.get(location.row)
-						if (!rowCache) {
-							rowCache = new Map()
-							pageCache.set(location.row, rowCache)
-						}
-
-						rowCache.set(location.column, render)
+						this.#updateCacheWithRender(location, render)
 					}
 
 					if (!skipInvalidation) {
@@ -218,6 +206,53 @@ class GraphicsController extends CoreBase {
 		})
 		this.fonts = FontLibrary.families
 		this.logger.info('Fonts loaded')
+	}
+
+	/**
+	 * Clear all renders for the specified page, replacing with 'blank' renders
+	 * @param {number} pageNumber
+	 * @returns
+	 */
+	clearAllForPage(pageNumber) {
+		const pageCache = this.#renderCache.get(pageNumber)
+		if (!pageCache) return
+
+		for (const [row, rowCache] of pageCache.entries()) {
+			for (const column of rowCache.keys()) {
+				/** @type {import('../Resources/Util.js').ControlLocation} */
+				const location = {
+					pageNumber,
+					row,
+					column,
+				}
+
+				const blankRender = GraphicsRenderer.drawBlank(this.#drawOptions, location)
+
+				this.#updateCacheWithRender(location, blankRender)
+				this.emit('button_drawn', location, blankRender)
+			}
+		}
+	}
+
+	/**
+	 * Store a new render
+	 * @param {import('../Resources/Util.js').ControlLocation} location
+	 * @param {ImageResult} render
+	 */
+	#updateCacheWithRender(location, render) {
+		let pageCache = this.#renderCache.get(location.pageNumber)
+		if (!pageCache) {
+			pageCache = new Map()
+			this.#renderCache.set(location.pageNumber, pageCache)
+		}
+
+		let rowCache = pageCache.get(location.row)
+		if (!rowCache) {
+			rowCache = new Map()
+			pageCache.set(location.row, rowCache)
+		}
+
+		rowCache.set(location.column, render)
 	}
 
 	/**

--- a/lib/Graphics/Controller.js
+++ b/lib/Graphics/Controller.js
@@ -353,7 +353,8 @@ class GraphicsController extends CoreBase {
 	 * @access private
 	 */
 	regenerateAll(skipInvalidation = false) {
-		for (let pageNumber = 1; pageNumber <= 99; pageNumber++) {
+		const pageCount = this.page.getPageCount()
+		for (let pageNumber = 1; pageNumber <= pageCount; pageNumber++) {
 			const populatedLocations = this.page.getAllPopulatedLocationsOnPage(pageNumber)
 			for (const location of populatedLocations) {
 				this.#drawAndCacheButton(location, skipInvalidation)

--- a/lib/Internal/Controller.js
+++ b/lib/Internal/Controller.js
@@ -48,7 +48,7 @@ export default class InternalController extends CoreBase {
 			new Controls(this, registry.graphics, registry.controls, registry.page, registry.instance.variable),
 			new CustomVariables(this, registry.instance.variable),
 			new Page(this, registry.page),
-			new Surface(this, registry.surfaces, registry.controls, registry.instance.variable),
+			new Surface(this, registry.surfaces, registry.controls, registry.instance.variable, registry.page),
 			new System(this, registry),
 			new Triggers(this, registry.controls),
 			new Variables(this, registry.instance.variable),

--- a/lib/Internal/Page.js
+++ b/lib/Internal/Page.js
@@ -51,7 +51,7 @@ export default class Page {
 	 */
 	#nameChange(page, name) {
 		this.#internalModule.setVariables({
-			[`page_number_${page}_name`]: name ?? '',
+			[`page_number_${page}_name`]: name,
 		})
 	}
 
@@ -74,7 +74,7 @@ export default class Page {
 		/** @type {Record<string, import('@companion-module/base').CompanionVariableValue | undefined>} */
 		const variables = {}
 		for (let i = 1; i < 100; i++) {
-			variables[`page_number_${i}_name`] = this.#pageController.getPageName(i) || ''
+			variables[`page_number_${i}_name`] = this.#pageController.getPageName(i)
 		}
 		this.#internalModule.setVariables(variables)
 	}

--- a/lib/Internal/Page.js
+++ b/lib/Internal/Page.js
@@ -42,6 +42,7 @@ export default class Page {
 		this.#pageController = pageController
 
 		this.#pageController.on('name', this.#nameChange.bind(this))
+		this.#pageController.on('pagecount', () => this.#internalModule.regenerateVariables())
 	}
 
 	/**

--- a/lib/Internal/Page.js
+++ b/lib/Internal/Page.js
@@ -62,7 +62,7 @@ export default class Page {
 	getVariableDefinitions() {
 		/** @type {import('../Instance/Wrapper.js').VariableDefinitionTmp[]} */
 		const variables = []
-		for (let i = 1; i < 100; i++) {
+		for (let i = 1; i <= this.#pageController.getPageCount(); i++) {
 			variables.push({
 				name: `page_number_${i}_name`,
 				label: `Page ${i} name`,
@@ -74,7 +74,7 @@ export default class Page {
 	updateVariables() {
 		/** @type {Record<string, import('@companion-module/base').CompanionVariableValue | undefined>} */
 		const variables = {}
-		for (let i = 1; i < 100; i++) {
+		for (let i = 1; i <= this.#pageController.getPageCount(); i++) {
 			variables[`page_number_${i}_name`] = this.#pageController.getPageName(i)
 		}
 		this.#internalModule.setVariables(variables)

--- a/lib/Internal/Surface.js
+++ b/lib/Internal/Surface.js
@@ -126,6 +126,12 @@ export default class Surface {
 	 */
 	#variableController
 
+	/**
+	 * @type {import('../Page/Controller.js').default}
+	 * @readonly
+	 */
+	#pageController
+
 	/** Page history for surfaces */
 	#pageHistory = new Map()
 
@@ -134,12 +140,14 @@ export default class Surface {
 	 * @param {import('../Surface/Controller.js').default} surfaceController
 	 * @param {import('../Controls/Controller.js').default} controlsController
 	 * @param {import('../Instance/Variable.js').default} variableController
+	 * @param {import('../Page/Controller.js').default} pageController
 	 */
-	constructor(internalModule, surfaceController, controlsController, variableController) {
+	constructor(internalModule, surfaceController, controlsController, variableController, pageController) {
 		this.#internalModule = internalModule
 		this.#surfaceController = surfaceController
 		this.#controlsController = controlsController
 		this.#variableController = variableController
+		this.#pageController = pageController
 
 		setImmediate(() => {
 			this.#internalModule.setVariables({
@@ -565,13 +573,15 @@ export default class Surface {
 					this.#surfaceController.devicePageSet(surfaceId, pageTarget, true)
 				}
 			} else {
+				const pageCount = this.#pageController.getPageCount()
+
 				let newPage = toPage
 				if (newPage === '+1') {
 					newPage = currentPage + 1
-					if (newPage > 99) newPage = 1
+					if (newPage > pageCount) newPage = 1
 				} else if (newPage === '-1') {
 					newPage = currentPage - 1
-					if (newPage < 1) newPage = 99
+					if (newPage < 1) newPage = pageCount
 				} else {
 					newPage = Number(newPage)
 				}

--- a/lib/Page/Controller.js
+++ b/lib/Page/Controller.js
@@ -110,6 +110,8 @@ class PageController extends CoreBase {
 	deletePage(pageNumber) {
 		this.logger.silly('Delete page ' + pageNumber)
 
+		console.log('delete page', pageNumber)
+
 		if (pageNumber === 1 && this.getPageCount() == 1) throw new Error(`Can't delete last page`)
 
 		const removedControls = this.getAllControlIdsOnPage(pageNumber)
@@ -451,6 +453,7 @@ class PageController extends CoreBase {
 				this.io.emitToRoom(PagesRoom, 'pages:patch', patch)
 			}
 		}
+		this.#lastClientJson = newJson
 
 		this.db.setKey('page', this.getAll(false))
 

--- a/lib/Page/Controller.js
+++ b/lib/Page/Controller.js
@@ -2,6 +2,7 @@ import { cloneDeep } from 'lodash-es'
 import CoreBase from '../Core/Base.js'
 import { oldBankIndexToXY } from '../Shared/ControlId.js'
 import { nanoid } from 'nanoid'
+import jsonPatch from 'fast-json-patch'
 
 const PagesRoom = 'pages'
 
@@ -50,6 +51,13 @@ class PageController extends CoreBase {
 	#pageIds = []
 
 	/**
+	 * Last sent data to clients
+	 * @type {Record<number, import('../Shared/Model/PageModel.js').PageModel> | null}
+	 * @access private
+	 */
+	#lastClientJson = null
+
+	/**
 	 * @param {import('../Registry.js').default} registry - the application core
 	 */
 	constructor(registry) {
@@ -75,7 +83,7 @@ class PageController extends CoreBase {
 			this.logger.silly('Set page name ' + pageNumber + ' to ', name)
 			existingData.name = name
 
-			this.#commitChanges(pageNumber, existingData, true)
+			this.#commitChanges([pageNumber], true)
 		})
 
 		client.onPromise('pages:subscribe', () => {
@@ -83,7 +91,9 @@ class PageController extends CoreBase {
 
 			client.join(PagesRoom)
 
-			return this.getAll(false)
+			if (!this.#lastClientJson) this.#lastClientJson = this.getAll(true)
+
+			return this.#lastClientJson
 		})
 		client.onPromise('pages:unsubscribe', () => {
 			client.leave(PagesRoom)
@@ -114,12 +124,15 @@ class PageController extends CoreBase {
 		this.#rebuildLocationCache()
 
 		// Update cache for controls on later pages
-		this.#updateAndRedrawAllPagesAfter(pageNumber)
+		const changedPageNumbers = this.#updateAndRedrawAllPagesAfter(pageNumber)
 
 		// the list is a page shorter, ensure the 'old last' page is reported as undefined
 		const missingPageNumber = this.#pageIds.length + 1
-		this.#commitChanges(missingPageNumber, undefined, false)
+		changedPageNumbers.push(missingPageNumber)
 		this.graphics.clearAllForPage(missingPageNumber)
+		this.#commitChanges(changedPageNumbers, false)
+
+		// TODO - update variable definitions
 
 		return removedControls
 	}
@@ -127,27 +140,31 @@ class PageController extends CoreBase {
 	/**
 	 * Update page info and all renders for pages following
 	 * @param {number} firstPageNumber
+	 * @return {number[]} pageNumbers
 	 */
 	#updateAndRedrawAllPagesAfter(firstPageNumber) {
+		const pageNumbers = []
+
 		for (let pageNumber = firstPageNumber; pageNumber <= this.#pageIds.length; pageNumber++) {
 			const pageInfo = this.getPageInfo(pageNumber)
 			if (!pageInfo) continue
 
 			this.#invalidateAllControls(pageNumber, pageInfo)
 
-			// save and broadcast changes
-			this.#commitChanges(pageNumber, pageInfo, false)
+			pageNumbers.push(pageNumber)
 		}
+
+		return pageNumbers
 	}
 
 	/**
 	 * Get the entire page table
 	 * @param {boolean} [clone = false] - <code>true</code> if a copy should be returned
-	 * @returns {Record<string, import('../Shared/Model/PageModel.js').PageModel>} the pages
+	 * @returns {Record<number, import('../Shared/Model/PageModel.js').PageModel>} the pages
 	 * @access public
 	 */
 	getAll(clone = false) {
-		/** @type {Record<string, import('../Shared/Model/PageModel.js').PageModel>} **/
+		/** @type {Record<number, import('../Shared/Model/PageModel.js').PageModel>} **/
 		const savePages = {}
 		this.#pageIds.map((id, index) => {
 			const pageInfo = this.#pagesById[id]
@@ -254,7 +271,7 @@ class PageController extends CoreBase {
 				delete page.controls[location.row][location.column]
 			}
 
-			this.#commitChanges(location.pageNumber, page, false)
+			this.#commitChanges([location.pageNumber], false)
 
 			return true
 		} else {
@@ -317,12 +334,13 @@ class PageController extends CoreBase {
 	/**
 	 * Get the name for a page
 	 * @param {number} pageNumber - the page id
-	 * @returns {string} the page's name
+	 * @returns {string | undefined} the page's name
 	 * @access public
 	 */
 	getPageName(pageNumber) {
 		const pageInfo = this.getPageInfo(pageNumber)
-		return pageInfo?.name ?? ''
+		if (!pageInfo) return undefined
+		return pageInfo.name ?? ''
 	}
 
 	/**
@@ -351,7 +369,7 @@ class PageController extends CoreBase {
 		pageInfo.name = 'PAGE'
 		pageInfo.controls = {}
 
-		this.#commitChanges(pageNumber, pageInfo, redraw)
+		this.#commitChanges([pageNumber], redraw)
 
 		return removedControls
 	}
@@ -406,38 +424,45 @@ class PageController extends CoreBase {
 
 		this.logger.silly('Set page ' + pageNumber + ' to ', name)
 
-		this.#commitChanges(pageNumber, pageInfo, redraw)
+		this.#commitChanges([pageNumber], redraw)
 	}
 
 	/**
 	 * Commit changes to a page entry
-	 * @param {number} pageNumber
-	 * @param {import('../Shared/Model/PageModel.js').PageModel | undefined} newValue
+	 * @param {number[]} pageNumbers
 	 * @param {boolean} redraw
 	 */
-	#commitChanges(pageNumber, newValue, redraw = true) {
+	#commitChanges(pageNumbers, redraw = true) {
+		const newJson = this.getAll(true)
 		if (this.io.countRoomMembers(PagesRoom) > 0) {
-			this.io.emitToRoom(PagesRoom, 'pages:update', pageNumber, newValue)
+			const patch = jsonPatch.compare(this.#lastClientJson || {}, newJson || {})
+			if (patch.length > 0) {
+				this.io.emitToRoom(PagesRoom, 'pages:patch', patch)
+			}
 		}
 
 		this.db.setKey('page', this.getAll(false))
 
-		this.emit('name', pageNumber, newValue?.name)
+		for (const pageNumber of pageNumbers) {
+			const pageInfo = this.getPageInfo(pageNumber)
 
-		if (redraw && newValue) {
-			this.logger.silly('page controls invalidated for page', pageNumber)
-			this.#invalidatePageNumberControls(pageNumber, newValue)
+			this.emit('name', pageNumber, pageInfo ? pageInfo.name ?? '' : undefined)
+
+			if (redraw && pageInfo) {
+				this.logger.silly('page controls invalidated for page', pageNumber)
+				this.#invalidatePageNumberControls(pageNumber, pageInfo)
+			}
 		}
 	}
 
 	/**
 	 * Redraw the page number control on the specified page
 	 * @param {number} pageNumber
-	 * @param {import('../Shared/Model/PageModel.js').PageModel} newValue
+	 * @param {import('../Shared/Model/PageModel.js').PageModel} pageInfo
 	 */
-	#invalidatePageNumberControls(pageNumber, newValue) {
-		if (newValue?.controls) {
-			for (const [row, rowObj] of Object.entries(newValue.controls)) {
+	#invalidatePageNumberControls(pageNumber, pageInfo) {
+		if (pageInfo?.controls) {
+			for (const [row, rowObj] of Object.entries(pageInfo.controls)) {
 				for (const [column, controlId] of Object.entries(rowObj)) {
 					const control = this.controls.getControl(controlId)
 					if (control && control.type === 'pagenum') {

--- a/lib/Page/Controller.js
+++ b/lib/Page/Controller.js
@@ -1,6 +1,7 @@
 import { cloneDeep } from 'lodash-es'
 import CoreBase from '../Core/Base.js'
 import { oldBankIndexToXY } from '../Shared/ControlId.js'
+import { nanoid } from 'nanoid'
 
 const PagesRoom = 'pages'
 
@@ -34,12 +35,19 @@ class PageController extends CoreBase {
 	#locationCache = new Map()
 
 	/**
-	 * Persisted pages data
-	 * @type {Record<number, import('../Shared/Model/PageModel.js').PageModel>}
+	 * Pages data
+	 * @type {Record<string, import('../Shared/Model/PageModel.js').PageModel>}
 	 * @access private
 	 * @readonly
 	 */
-	#pages
+	#pagesById = {}
+
+	/**
+	 * Page ids by index
+	 * @type {string[]}
+	 * @access private
+	 */
+	#pageIds = []
 
 	/**
 	 * @param {import('../Registry.js').default} registry - the application core
@@ -47,9 +55,9 @@ class PageController extends CoreBase {
 	constructor(registry) {
 		super(registry, 'page', 'Page/Controller')
 
-		this.#pages = this.db.getKey('page', {}) ?? {}
+		const rawPageData = this.db.getKey('page', {}) ?? {}
 
-		this.#setupPages()
+		this.#setupPages(rawPageData)
 	}
 
 	/**
@@ -61,13 +69,13 @@ class PageController extends CoreBase {
 		client.onPromise('pages:set-name', (/** @type {number} */ pageNumber, /** @type {string} */ name) => {
 			this.logger.silly(`socket: pages:set-name ${pageNumber}: ${name}`)
 
-			const existingData = this.#pages[pageNumber]
+			const existingData = this.getPageInfo(pageNumber)
 			if (!existingData) throw new Error(`Page "${pageNumber}" does not exist`)
 
 			this.logger.silly('Set page name ' + pageNumber + ' to ', name)
-			this.#pages[pageNumber].name = name
+			existingData.name = name
 
-			this.#commitChanges(pageNumber, this.#pages[pageNumber], true)
+			this.#commitChanges(pageNumber, existingData, true)
 		})
 
 		client.onPromise('pages:subscribe', () => {
@@ -75,7 +83,7 @@ class PageController extends CoreBase {
 
 			client.join(PagesRoom)
 
-			return this.#pages
+			return this.getAll(false)
 		})
 		client.onPromise('pages:unsubscribe', () => {
 			client.leave(PagesRoom)
@@ -89,10 +97,21 @@ class PageController extends CoreBase {
 	 * @access public
 	 */
 	getAll(clone = false) {
+		/** @type {Record<string, import('../Shared/Model/PageModel.js').PageModel>} **/
+		const savePages = {}
+		this.#pageIds.map((id, index) => {
+			const pageInfo = this.#pagesById[id]
+			savePages[index + 1] = pageInfo || {
+				id: nanoid(),
+				name: 'PAGE',
+				controls: {},
+			}
+		})
+
 		if (clone) {
-			return cloneDeep(this.#pages)
+			return cloneDeep(savePages)
 		} else {
-			return this.#pages
+			return savePages
 		}
 	}
 
@@ -102,7 +121,7 @@ class PageController extends CoreBase {
 	 * @returns {string[]}
 	 */
 	getAllControlIdsOnPage(pageNumber) {
-		const page = this.#pages[pageNumber]
+		const page = this.getPageInfo(pageNumber)
 		if (page) {
 			return Object.values(page.controls)
 				.flatMap((row) => Object.values(row))
@@ -118,7 +137,7 @@ class PageController extends CoreBase {
 	 * @returns {import('../Resources/Util.js').ControlLocation[]}
 	 */
 	getAllPopulatedLocationsOnPage(pageNumber) {
-		const page = this.#pages[pageNumber]
+		const page = this.getPageInfo(pageNumber)
 		if (page) {
 			/** @type {import('../Resources/Util.js').ControlLocation[]} */
 			const locations = []
@@ -150,7 +169,7 @@ class PageController extends CoreBase {
 	 * @returns {boolean}
 	 */
 	isPageValid(pageNumber) {
-		return !!this.#pages[pageNumber]
+		return !!this.getPageInfo(pageNumber)
 	}
 
 	/**
@@ -164,12 +183,12 @@ class PageController extends CoreBase {
 
 	/**
 	 * Set the controlId at a specific location
-	 * @param {*} location
+	 * @param {import('../Resources/Util.js').ControlLocation} location
 	 * @param {string | null} controlId
 	 * @returns {boolean}
 	 */
 	setControlIdAt(location, controlId) {
-		const page = this.#pages[location.pageNumber]
+		const page = this.getPageInfo(location.pageNumber)
 		if (page) {
 			if (!page.controls[location.row]) page.controls[location.row] = {}
 			// Update the cache
@@ -199,7 +218,7 @@ class PageController extends CoreBase {
 	 * @returns {string | null}
 	 */
 	getControlIdAt(location) {
-		const page = this.#pages[location.pageNumber]
+		const page = this.getPageInfo(location.pageNumber)
 		if (page) {
 			return page.controls[location.row]?.[location.column]
 		} else {
@@ -228,63 +247,61 @@ class PageController extends CoreBase {
 
 	/**
 	 * Get a specific page object
-	 * @param {number} page - the page id
+	 * @param {number} pageNumber - the page id
 	 * @param {boolean} [clone = false] - <code>true</code> if a copy should be returned
 	 * @returns {import('../Shared/Model/PageModel.js').PageModel | undefined} the requested page
 	 * @access public
 	 */
-	getPage(page, clone = false) {
-		let out
+	getPageInfo(pageNumber, clone = false) {
+		const pageId = this.#pageIds[pageNumber - 1]
+		if (!pageId) return undefined
 
-		if (this.#pages[page] !== undefined) {
-			if (clone === true) {
-				out = cloneDeep(this.#pages[page])
-			} else {
-				out = this.#pages[page]
-			}
+		const pageInfo = this.#pagesById[pageId]
+		if (clone) {
+			return cloneDeep(pageInfo)
+		} else {
+			return pageInfo
 		}
-
-		return out
 	}
 
 	/**
 	 * Get the name for a page
-	 * @param {number} page - the page id
+	 * @param {number} pageNumber - the page id
 	 * @returns {string} the page's name
 	 * @access public
 	 */
-	getPageName(page) {
-		let out = ''
-
-		if (this.#pages[page] !== undefined && this.#pages[page].name !== undefined) {
-			out = this.#pages[page].name
-		}
-
-		return out
+	getPageName(pageNumber) {
+		const pageInfo = this.getPageInfo(pageNumber)
+		return pageInfo?.name ?? ''
 	}
 
 	/**
 	 * Reset a page to defaults and empty
-	 * Note: Controls will be orphaned if not explicitly deleted
+	 * Note: Controls will be orphaned if not explicitly deleted by the caller
 	 * @param {number} pageNumber - the page id
 	 * @param {boolean} [redraw = false] - <code>true</code> if the graphics should invalidate
 	 * @returns ControlIds referenced on the page
 	 * @access public
 	 */
 	resetPage(pageNumber, redraw = true) {
+		this.logger.silly('Reset page ' + pageNumber)
+
 		const removedControls = this.getAllControlIdsOnPage(pageNumber)
 
+		// Fetch the page and ensure it exists
+		const pageInfo = this.getPageInfo(pageNumber)
+		if (!pageInfo) return removedControls
+
 		// Clear cache for old controls
-		if (this.#pages[pageNumber]) {
-			for (const controlId of Object.values(this.#pages[pageNumber])) {
-				this.#locationCache.delete(controlId)
-			}
+		for (const controlId of Object.values(pageInfo.controls)) {
+			this.#locationCache.delete(controlId)
 		}
 
-		this.logger.silly('Reset page ' + pageNumber)
-		this.#pages[pageNumber] = { name: 'PAGE', controls: {} }
+		// Reset relevant properties, but not the id
+		pageInfo.name = 'PAGE'
+		pageInfo.controls = {}
 
-		this.#commitChanges(pageNumber, this.#pages[pageNumber], redraw)
+		this.#commitChanges(pageNumber, pageInfo, redraw)
 
 		return removedControls
 	}
@@ -300,7 +317,7 @@ class PageController extends CoreBase {
 
 		const { minColumn, maxColumn, minRow, maxRow } = this.userconfig.getKey('gridSize')
 
-		for (const page of Object.values(this.#pages)) {
+		for (const page of Object.values(this.#pagesById)) {
 			for (const row of Object.keys(page.controls)) {
 				const rowObj = page.controls[Number(row)]
 				if (!rowObj) continue
@@ -325,25 +342,21 @@ class PageController extends CoreBase {
 	/**
 	 * Set/update a page
 	 * @param {number} pageNumber - the page id
-	 * @param {Omit<import('../Shared/Model/PageModel.js').PageModel, 'controls'>} value - the page object containing the name
-	 * @param {boolean} [redraw = false] - <code>true</code> if the graphics should invalidate
+	 * @param {string} name - the page object containing the name
+	 * @param {boolean} [redraw = true] - <code>true</code> if the graphics should invalidate
 	 * @access public
 	 */
-	importPage(pageNumber, value, redraw = true) {
-		this.resetPage(pageNumber, false)
-
-		if (value) {
-			const fullValue = cloneDeep({
-				...value,
-				// Control's must be setup explicitly
-				controls: {},
-			})
-
-			this.logger.silly('Set page ' + pageNumber + ' to ', value)
-			this.#pages[pageNumber] = fullValue
-
-			this.#commitChanges(pageNumber, fullValue, redraw)
+	setPageName(pageNumber, name, redraw = true) {
+		const pageInfo = this.getPageInfo(pageNumber)
+		if (!pageInfo) {
+			throw new Error('Page must be created before it can be imported to')
 		}
+
+		pageInfo.name = name
+
+		this.logger.silly('Set page ' + pageNumber + ' to ', name)
+
+		this.#commitChanges(pageNumber, pageInfo, redraw)
 	}
 
 	/**
@@ -357,7 +370,7 @@ class PageController extends CoreBase {
 			this.io.emitToRoom(PagesRoom, 'pages:update', pageNumber, newValue)
 		}
 
-		this.db.setKey('page', this.#pages)
+		this.db.setKey('page', this.getAll(false))
 
 		this.emit('name', pageNumber, newValue?.name)
 
@@ -391,30 +404,49 @@ class PageController extends CoreBase {
 
 	/**
 	 * Load the page table with defaults
+	 * @param {Record<string, import('../Shared/Model/PageModel.js').PageModel>} rawPageData
 	 * @access protected
 	 */
-	#setupPages() {
+	#setupPages(rawPageData) {
+		// Load existing data
+		for (let i = 1; true; i++) {
+			const pageInfo = rawPageData[i]
+			if (!pageInfo) break
+
+			// Ensure each page has an id defined
+			if (!pageInfo.id) pageInfo.id = nanoid()
+
+			this.#pagesById[pageInfo.id] = pageInfo
+			this.#pageIds.push(pageInfo.id)
+		}
+
 		// Default values
-		if (Object.keys(this.#pages).length === 0) {
-			for (let n = 1; n <= 99; n++) {
-				if (!this.#pages[n]) {
-					this.#pages[n] = {
-						name: 'PAGE',
-						controls: {},
-					}
-				}
+		if (this.#pageIds.length === 0) {
+			/** @type {import('../Shared/Model/PageModel.js').PageModel} */
+			const newPageInfo = {
+				id: nanoid(),
+				name: 'PAGE',
+				controls: {},
 			}
 
-			this.db.setKey('page', this.#pages)
+			// Create a single page
+			this.#pagesById[newPageInfo.id] = newPageInfo
+			this.#pageIds = [newPageInfo.id]
+
+			this.db.setKey('page', { 1: newPageInfo })
 
 			setImmediate(() => {
 				// @ts-ignore
-				this.registry.data.importExport.createInitialPageButtons(99)
+				this.registry.data.importExport.createInitialPageButtons(1)
 			})
 		}
 
 		// Setup #locationCache
-		for (const [pageNumber, pageInfo] of Object.entries(this.#pages)) {
+		this.#pageIds.forEach((pageId, pageIndex) => {
+			const pageNumber = pageIndex + 1
+			const pageInfo = this.#pagesById[pageId]
+			if (!pageInfo) return
+
 			for (const [row, rowObj] of Object.entries(pageInfo.controls)) {
 				for (const [column, controlId] of Object.entries(rowObj)) {
 					this.#locationCache.set(controlId, {
@@ -424,7 +456,7 @@ class PageController extends CoreBase {
 					})
 				}
 			}
-		}
+		})
 	}
 }
 

--- a/lib/Page/Controller.js
+++ b/lib/Page/Controller.js
@@ -124,9 +124,6 @@ class PageController extends CoreBase {
 		delete this.#pagesById[pageInfo.id]
 		this.#pageIds.splice(pageNumber - 1, 1)
 
-		// Rebuild location cache
-		this.#rebuildLocationCache()
-
 		// Update cache for controls on later pages
 		const changedPageNumbers = this.#updateAndRedrawAllPagesAfter(pageNumber)
 
@@ -143,11 +140,44 @@ class PageController extends CoreBase {
 	}
 
 	/**
+	 * Insert a new page, with the given page number
+	 * @param {number} asPageNumber
+	 */
+	insertPage(asPageNumber) {
+		/** @type {import('../Shared/Model/PageModel.js').PageModel} */
+		const newPageInfo = {
+			id: nanoid(),
+			name: 'PAGE',
+			controls: {},
+		}
+
+		if (asPageNumber > this.getPageCount() + 1 || asPageNumber <= 0) throw new Error('New page number is out of range')
+
+		// store the new page
+		this.#pagesById[newPageInfo.id] = newPageInfo
+		this.#pageIds.splice(asPageNumber - 1, 0, newPageInfo.id)
+
+		// Update cache for controls on later pages
+		const changedPageNumbers = this.#updateAndRedrawAllPagesAfter(asPageNumber)
+
+		// the list is a page shorter, ensure the 'old last' page is reported as undefined
+		this.#commitChanges(changedPageNumbers, false)
+
+		// inform other interested controllers
+		this.emit('pagecount', this.getPageCount())
+
+		return newPageInfo.id
+	}
+
+	/**
 	 * Update page info and all renders for pages following
 	 * @param {number} firstPageNumber
 	 * @return {number[]} pageNumbers
 	 */
 	#updateAndRedrawAllPagesAfter(firstPageNumber) {
+		// Rebuild location cache
+		this.#rebuildLocationCache()
+
 		const pageNumbers = []
 
 		for (let pageNumber = firstPageNumber; pageNumber <= this.#pageIds.length; pageNumber++) {

--- a/lib/Page/Controller.js
+++ b/lib/Page/Controller.js
@@ -110,6 +110,8 @@ class PageController extends CoreBase {
 	deletePage(pageNumber) {
 		this.logger.silly('Delete page ' + pageNumber)
 
+		if (pageNumber === 1 && this.getPageCount() == 1) throw new Error(`Can't delete last page`)
+
 		const removedControls = this.getAllControlIdsOnPage(pageNumber)
 
 		// Fetch the page and ensure it exists

--- a/lib/Page/Controller.js
+++ b/lib/Page/Controller.js
@@ -91,6 +91,56 @@ class PageController extends CoreBase {
 	}
 
 	/**
+	 * Deletes a page
+	 * Note: Controls will be orphaned if not explicitly deleted by the caller
+	 * @param {number} pageNumber - the page id
+	 * @returns ControlIds referenced on the page
+	 * @access public
+	 */
+	deletePage(pageNumber) {
+		this.logger.silly('Delete page ' + pageNumber)
+
+		const removedControls = this.getAllControlIdsOnPage(pageNumber)
+
+		// Fetch the page and ensure it exists
+		const pageInfo = this.getPageInfo(pageNumber)
+		if (!pageInfo) return removedControls
+
+		// Delete the info for the page
+		delete this.#pagesById[pageInfo.id]
+		this.#pageIds.splice(pageNumber - 1, 1)
+
+		// Rebuild location cache
+		this.#rebuildLocationCache()
+
+		// Update cache for controls on later pages
+		this.#updateAndRedrawAllPagesAfter(pageNumber)
+
+		// the list is a page shorter, ensure the 'old last' page is reported as undefined
+		const missingPageNumber = this.#pageIds.length + 1
+		this.#commitChanges(missingPageNumber, undefined, false)
+		this.graphics.clearAllForPage(missingPageNumber)
+
+		return removedControls
+	}
+
+	/**
+	 * Update page info and all renders for pages following
+	 * @param {number} firstPageNumber
+	 */
+	#updateAndRedrawAllPagesAfter(firstPageNumber) {
+		for (let pageNumber = firstPageNumber; pageNumber <= this.#pageIds.length; pageNumber++) {
+			const pageInfo = this.getPageInfo(pageNumber)
+			if (!pageInfo) continue
+
+			this.#invalidateAllControls(pageNumber, pageInfo)
+
+			// save and broadcast changes
+			this.#commitChanges(pageNumber, pageInfo, false)
+		}
+	}
+
+	/**
 	 * Get the entire page table
 	 * @param {boolean} [clone = false] - <code>true</code> if a copy should be returned
 	 * @returns {Record<string, import('../Shared/Model/PageModel.js').PageModel>} the pages
@@ -362,7 +412,7 @@ class PageController extends CoreBase {
 	/**
 	 * Commit changes to a page entry
 	 * @param {number} pageNumber
-	 * @param {import('../Shared/Model/PageModel.js').PageModel} newValue
+	 * @param {import('../Shared/Model/PageModel.js').PageModel | undefined} newValue
 	 * @param {boolean} redraw
 	 */
 	#commitChanges(pageNumber, newValue, redraw = true) {
@@ -374,7 +424,7 @@ class PageController extends CoreBase {
 
 		this.emit('name', pageNumber, newValue?.name)
 
-		if (redraw) {
+		if (redraw && newValue) {
 			this.logger.silly('page controls invalidated for page', pageNumber)
 			this.#invalidatePageNumberControls(pageNumber, newValue)
 		}
@@ -400,6 +450,50 @@ class PageController extends CoreBase {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Redraw allcontrols on the specified page
+	 * @param {number} pageNumber
+	 * @param {import('../Shared/Model/PageModel.js').PageModel} pageInfo
+	 */
+	#invalidateAllControls(pageNumber, pageInfo) {
+		if (pageInfo?.controls) {
+			this.graphics.clearAllForPage(pageNumber)
+
+			for (const [row, rowObj] of Object.entries(pageInfo.controls)) {
+				for (const [column, controlId] of Object.entries(rowObj)) {
+					const control = this.controls.getControl(controlId)
+					if (control) {
+						this.graphics.invalidateButton({
+							pageNumber: pageNumber,
+							column: Number(column),
+							row: Number(row),
+						})
+					}
+				}
+			}
+		}
+	}
+
+	#rebuildLocationCache() {
+		this.#locationCache.clear()
+
+		this.#pageIds.forEach((pageId, pageIndex) => {
+			const pageNumber = pageIndex + 1
+			const pageInfo = this.#pagesById[pageId]
+			if (!pageInfo) return
+
+			for (const [row, rowObj] of Object.entries(pageInfo.controls)) {
+				for (const [column, controlId] of Object.entries(rowObj)) {
+					this.#locationCache.set(controlId, {
+						pageNumber: Number(pageNumber),
+						column: Number(column),
+						row: Number(row),
+					})
+				}
+			}
+		})
 	}
 
 	/**
@@ -442,21 +536,7 @@ class PageController extends CoreBase {
 		}
 
 		// Setup #locationCache
-		this.#pageIds.forEach((pageId, pageIndex) => {
-			const pageNumber = pageIndex + 1
-			const pageInfo = this.#pagesById[pageId]
-			if (!pageInfo) return
-
-			for (const [row, rowObj] of Object.entries(pageInfo.controls)) {
-				for (const [column, controlId] of Object.entries(rowObj)) {
-					this.#locationCache.set(controlId, {
-						pageNumber: Number(pageNumber),
-						column: Number(column),
-						row: Number(row),
-					})
-				}
-			}
-		})
+		this.#rebuildLocationCache()
 	}
 }
 

--- a/lib/Page/Controller.js
+++ b/lib/Page/Controller.js
@@ -132,7 +132,8 @@ class PageController extends CoreBase {
 		this.graphics.clearAllForPage(missingPageNumber)
 		this.#commitChanges(changedPageNumbers, false)
 
-		// TODO - update variable definitions
+		// inform other interested controllers
+		this.emit('pagecount', this.getPageCount())
 
 		return removedControls
 	}
@@ -310,6 +311,14 @@ class PageController extends CoreBase {
 		} else {
 			return null
 		}
+	}
+
+	/**
+	 * Get the total number of pages
+	 * @returns number
+	 */
+	getPageCount() {
+		return this.#pageIds.length
 	}
 
 	/**

--- a/lib/Page/Controller.js
+++ b/lib/Page/Controller.js
@@ -3,6 +3,7 @@ import CoreBase from '../Core/Base.js'
 import { oldBankIndexToXY } from '../Shared/ControlId.js'
 import { nanoid } from 'nanoid'
 import jsonPatch from 'fast-json-patch'
+import { default_nav_buttons_definitions } from './Defaults.js'
 
 const PagesRoom = 'pages'
 
@@ -98,6 +99,89 @@ class PageController extends CoreBase {
 		client.onPromise('pages:unsubscribe', () => {
 			client.leave(PagesRoom)
 		})
+
+		client.onPromise(
+			'pages:delete-page',
+			/**
+			 * @param {number} pageNumber
+			 * @returns {'ok' | 'fail'}
+			 */
+			(pageNumber) => {
+				this.logger.silly(`Delete page ${pageNumber}`)
+
+				if (this.getPageCount() === 1) return 'fail'
+
+				// Delete the controls, and allow them to redraw
+				const controlIds = this.getAllControlIdsOnPage(pageNumber)
+				for (const controlId of controlIds) {
+					this.controls.deleteControl(controlId)
+				}
+
+				// Delete the page
+				this.deletePage(pageNumber)
+
+				return 'ok'
+			}
+		)
+
+		client.onPromise(
+			'pages:insert-page',
+			/**
+			 * @param {number} asPageNumber
+			 * @returns {'ok' | 'fail'}
+			 */
+			(asPageNumber) => {
+				this.logger.silly(`Insert new page ${asPageNumber}`)
+
+				// Delete the page
+				const pageId = this.insertPage(asPageNumber)
+				if (!pageId) throw new Error(`Failed to insert page`)
+
+				// Add nav buttons
+				this.createPageDefaultNavButtons(asPageNumber)
+
+				return 'ok'
+			}
+		)
+
+		client.onPromise(
+			'pages:reset-page-clear',
+			/**
+			 * @param {number} pageNumber
+			 * @returns {'ok'}
+			 */
+			(pageNumber) => {
+				this.logger.silly(`Reset page ${pageNumber}`)
+
+				// Delete the controls, and allow them to redraw
+				const controlIds = this.getAllControlIdsOnPage(pageNumber)
+				for (const controlId of controlIds) {
+					this.controls.deleteControl(controlId)
+				}
+
+				// Clear the references on the page
+				this.resetPage(pageNumber)
+
+				// Re-add the nav buttons
+				this.createPageDefaultNavButtons(pageNumber)
+
+				return 'ok'
+			}
+		)
+
+		client.onPromise(
+			'pages:reset-page-nav',
+			/**
+			 * @param {number} pageNumber
+			 * @returns {'ok'}
+			 */
+			(pageNumber) => {
+				// make magical page buttons!
+				this.createPageDefaultNavButtons(pageNumber)
+
+				return 'ok'
+			}
+		)
 	}
 
 	/**
@@ -388,7 +472,7 @@ class PageController extends CoreBase {
 	 * Reset a page to defaults and empty
 	 * Note: Controls will be orphaned if not explicitly deleted by the caller
 	 * @param {number} pageNumber - the page id
-	 * @param {boolean} [redraw = false] - <code>true</code> if the graphics should invalidate
+	 * @param {boolean} [redraw = true] - <code>true</code> if the graphics should invalidate
 	 * @returns ControlIds referenced on the page
 	 * @access public
 	 */
@@ -413,6 +497,24 @@ class PageController extends CoreBase {
 		this.#commitChanges([pageNumber], redraw)
 
 		return removedControls
+	}
+
+	/**
+	 * Recreate the default nav buttons on a page
+	 * @param {number} pageNumber - the page id
+	 * @access public
+	 */
+	createPageDefaultNavButtons(pageNumber) {
+		for (const { type, location } of default_nav_buttons_definitions) {
+			const fullLocation = {
+				...location,
+				pageNumber,
+			}
+			const oldControlId = this.page.getControlIdAt(fullLocation)
+			if (oldControlId) this.controls.deleteControl(oldControlId)
+
+			this.controls.createButtonControl(fullLocation, type)
+		}
 	}
 
 	/**
@@ -598,7 +700,7 @@ class PageController extends CoreBase {
 
 			setImmediate(() => {
 				// @ts-ignore
-				this.registry.data.importExport.createInitialPageButtons(1)
+				this.createPageDefaultNavButtons(1)
 			})
 		}
 

--- a/lib/Page/Controller.js
+++ b/lib/Page/Controller.js
@@ -699,7 +699,6 @@ class PageController extends CoreBase {
 			this.db.setKey('page', { 1: newPageInfo })
 
 			setImmediate(() => {
-				// @ts-ignore
 				this.createPageDefaultNavButtons(1)
 			})
 		}

--- a/lib/Page/Controller.js
+++ b/lib/Page/Controller.js
@@ -110,8 +110,6 @@ class PageController extends CoreBase {
 	deletePage(pageNumber) {
 		this.logger.silly('Delete page ' + pageNumber)
 
-		console.log('delete page', pageNumber)
-
 		if (pageNumber === 1 && this.getPageCount() == 1) throw new Error(`Can't delete last page`)
 
 		const removedControls = this.getAllControlIdsOnPage(pageNumber)

--- a/lib/Page/Controller.js
+++ b/lib/Page/Controller.js
@@ -125,20 +125,23 @@ class PageController extends CoreBase {
 		)
 
 		client.onPromise(
-			'pages:insert-page',
+			'pages:insert-pages',
 			/**
 			 * @param {number} asPageNumber
+			 * @param {string[]} pageNames
 			 * @returns {'ok' | 'fail'}
 			 */
-			(asPageNumber) => {
+			(asPageNumber, pageNames) => {
 				this.logger.silly(`Insert new page ${asPageNumber}`)
 
 				// Delete the page
-				const pageId = this.insertPage(asPageNumber)
-				if (!pageId) throw new Error(`Failed to insert page`)
+				const pageIds = this.insertPages(asPageNumber, pageNames)
+				if (pageIds.length === 0) throw new Error(`Failed to insert pages`)
 
 				// Add nav buttons
-				this.createPageDefaultNavButtons(asPageNumber)
+				for (let i = 0; i < pageIds.length; i++) {
+					this.createPageDefaultNavButtons(asPageNumber + i)
+				}
 
 				return 'ok'
 			}
@@ -224,20 +227,33 @@ class PageController extends CoreBase {
 	/**
 	 * Insert a new page, with the given page number
 	 * @param {number} asPageNumber
+	 * @param {string[]} pageNames
 	 */
-	insertPage(asPageNumber) {
-		/** @type {import('../Shared/Model/PageModel.js').PageModel} */
-		const newPageInfo = {
-			id: nanoid(),
-			name: 'PAGE',
-			controls: {},
-		}
-
+	insertPages(asPageNumber, pageNames) {
 		if (asPageNumber > this.getPageCount() + 1 || asPageNumber <= 0) throw new Error('New page number is out of range')
 
-		// store the new page
-		this.#pagesById[newPageInfo.id] = newPageInfo
-		this.#pageIds.splice(asPageNumber - 1, 0, newPageInfo.id)
+		/** @type {string[]} */
+		const insertedPageIds = []
+
+		for (const pageName of pageNames) {
+			/** @type {import('../Shared/Model/PageModel.js').PageModel} */
+			const newPageInfo = {
+				id: nanoid(),
+				name: pageName ?? 'PAGE',
+				controls: {},
+			}
+
+			// store the new page
+			this.#pagesById[newPageInfo.id] = newPageInfo
+			insertedPageIds.push(newPageInfo.id)
+		}
+
+		// Early exit if not inserting anything
+		if (insertedPageIds.length === 0) {
+			return []
+		}
+
+		this.#pageIds.splice(asPageNumber - 1, 0, ...insertedPageIds)
 
 		// Update cache for controls on later pages
 		const changedPageNumbers = this.#updateAndRedrawAllPagesAfter(asPageNumber)
@@ -248,7 +264,7 @@ class PageController extends CoreBase {
 		// inform other interested controllers
 		this.emit('pagecount', this.getPageCount())
 
-		return newPageInfo.id
+		return insertedPageIds
 	}
 
 	/**

--- a/lib/Page/Defaults.js
+++ b/lib/Page/Defaults.js
@@ -1,0 +1,26 @@
+/**
+ * Default buttons on fresh pages
+ */
+export const default_nav_buttons_definitions = [
+	{
+		type: 'pageup',
+		location: {
+			column: 0,
+			row: 0,
+		},
+	},
+	{
+		type: 'pagenum',
+		location: {
+			column: 0,
+			row: 1,
+		},
+	},
+	{
+		type: 'pagedown',
+		location: {
+			column: 0,
+			row: 2,
+		},
+	},
+]

--- a/lib/Service/EmberPlus.js
+++ b/lib/Service/EmberPlus.js
@@ -3,6 +3,7 @@ import { getPath } from 'emberplus-connection/dist/Ember/Lib/util.js'
 import ServiceBase from './Base.js'
 import { formatLocation, xyToOldBankIndex } from '../Shared/ControlId.js'
 import { pad, parseColorToNumber } from '../Resources/Util.js'
+import { LEGACY_MAX_BUTTONS } from '../Util/Constants.js'
 
 // const LOCATION_NODE_CONTROLID = 0
 const LOCATION_NODE_PRESSED = 1
@@ -107,6 +108,7 @@ class ServiceEmberPlus extends ServiceBase {
 		super(registry, 'ember+', 'Service/EmberPlus', 'emberplus_enabled', null)
 
 		this.graphics.on('button_drawn', this.#updateBankFromRender.bind(this))
+		this.page.on('pagecount', this.#pageCountChange.bind(this))
 
 		this.init()
 	}
@@ -130,10 +132,12 @@ class ServiceEmberPlus extends ServiceBase {
 		/** @type {Record<number, EmberModel.NumberedTreeNodeImpl<any>>} */
 		let output = {}
 
-		for (let pageNumber = 1; pageNumber <= 99; pageNumber++) {
+		const pageCount = this.page.getPageCount() // TODO - handle resize
+
+		for (let pageNumber = 1; pageNumber <= pageCount; pageNumber++) {
 			/** @type {Record<number, EmberModel.NumberedTreeNodeImpl<any>>} */
 			const children = {}
-			for (let bank = 1; bank <= 32; bank++) {
+			for (let bank = 1; bank <= LEGACY_MAX_BUTTONS; bank++) {
 				const controlId = this.page.getControlIdAtOldBankIndex(pageNumber, bank)
 				const control = controlId ? this.controls.getControl(controlId) : undefined
 
@@ -224,7 +228,9 @@ class ServiceEmberPlus extends ServiceBase {
 		/** @type {Record<number, EmberModel.NumberedTreeNodeImpl<any>>} */
 		const output = {}
 
-		for (let pageNumber = 1; pageNumber <= 99; pageNumber++) {
+		const pageCount = this.page.getPageCount() // TODO - handle resize
+
+		for (let pageNumber = 1; pageNumber <= pageCount; pageNumber++) {
 			// TODO - the numbers won't be stable  when resizing the `min` grid values
 
 			/** @type {Record<number, EmberModel.NumberedTreeNodeImpl<any>>} */
@@ -530,6 +536,15 @@ class ServiceEmberPlus extends ServiceBase {
 		}
 
 		return false
+	}
+
+	/**
+	 * Update the tree from the pageCount changing
+	 * @param {number} _pageCount
+	 */
+	#pageCountChange(_pageCount) {
+		// TODO: This is excessive, but further research is needed to figure out how to edit the ember tree structure
+		this.restartModule()
 	}
 
 	/**

--- a/lib/Shared/Model/PageModel.ts
+++ b/lib/Shared/Model/PageModel.ts
@@ -1,4 +1,5 @@
 export interface PageModel {
+	id: string
 	name: string
 	controls: Record<number, Record<number, string>>
 }

--- a/lib/Surface/Group.js
+++ b/lib/Surface/Group.js
@@ -206,11 +206,12 @@ export class SurfaceGroup extends CoreBase {
 	 * @returns {void}
 	 */
 	setCurrentPage(newPage, defer = false) {
-		if (newPage == 100) {
+		const pageCount = this.page.getPageCount()
+		if (newPage > pageCount) {
 			newPage = 1
 		}
-		if (newPage == 0) {
-			newPage = 99
+		if (newPage <= 0) {
+			newPage = pageCount
 		}
 		this.#storeNewPage(newPage, defer)
 	}
@@ -236,27 +237,11 @@ export class SurfaceGroup extends CoreBase {
 	}
 
 	#increasePage() {
-		let newPage = this.#currentPage + 1
-		if (newPage >= 100) {
-			newPage = 1
-		}
-		if (newPage <= 0) {
-			newPage = 99
-		}
-
-		this.#storeNewPage(newPage)
+		this.setCurrentPage(this.#currentPage + 1)
 	}
 
 	#decreasePage() {
-		let newPage = this.#currentPage - 1
-		if (newPage >= 100) {
-			newPage = 1
-		}
-		if (newPage <= 0) {
-			newPage = 99
-		}
-
-		this.#storeNewPage(newPage)
+		this.setCurrentPage(this.#currentPage - 1)
 	}
 
 	/**

--- a/lib/Surface/Group.js
+++ b/lib/Surface/Group.js
@@ -125,13 +125,14 @@ export class SurfaceGroup extends CoreBase {
 		if (soleHandler) this.attachSurface(soleHandler)
 
 		this.#saveConfig()
+		this.page.on('pagecount', this.#pageCountChange)
 	}
 
 	/**
 	 * Stop anything processing this group, it is being marked as inactive
 	 */
 	dispose() {
-		// Nothing to do (yet)
+		this.page.off('pagecount', this.#pageCountChange)
 	}
 
 	/**
@@ -242,6 +243,16 @@ export class SurfaceGroup extends CoreBase {
 
 	#decreasePage() {
 		this.setCurrentPage(this.#currentPage - 1)
+	}
+
+	/**
+	 * Update the current page if the total number of pages change
+	 * @param {number} pageCount
+	 */
+	#pageCountChange = (pageCount) => {
+		if (this.#currentPage > pageCount) {
+			this.#storeNewPage(pageCount, true)
+		}
 	}
 
 	/**

--- a/lib/Surface/Handler.js
+++ b/lib/Surface/Handler.js
@@ -489,8 +489,10 @@ class SurfaceHandler extends CoreBase {
 
 				// allow the xkeys (legacy mode) to span pages
 				thisPage += pageOffset ?? 0
-				// loop at page 99
-				if (thisPage > 99) thisPage = 1
+
+				// loop after last page
+				const pageCount = this.page.getPageCount()
+				if (thisPage > pageCount) thisPage = 1
 
 				const controlId = this.page.getControlIdAt({
 					pageNumber: thisPage,
@@ -551,8 +553,9 @@ class SurfaceHandler extends CoreBase {
 
 				// allow the xkeys (legacy mode) to span pages
 				thisPage += pageOffset ?? 0
-				// loop at page 99
-				if (thisPage > 99) thisPage = 1
+				// loop after last page
+				const pageCount = this.page.getPageCount()
+				if (thisPage > pageCount) thisPage = 1
 
 				const controlId = this.page.getControlIdAt({
 					pageNumber: thisPage,

--- a/webui/src/Buttons/ButtonGridActions.tsx
+++ b/webui/src/Buttons/ButtonGridActions.tsx
@@ -86,7 +86,7 @@ export const ButtonGridActions = forwardRef<ButtonGridActionsRef, ButtonGridActi
 			`Are you sure you want to clear all buttons on page ${pageNumber}?\nThere's no going back from this.`,
 			'Reset',
 			() => {
-				socketEmitPromise(socket, 'loadsave:reset-page-clear', [pageNumber]).catch((e) => {
+				socketEmitPromise(socket, 'pages:reset-page-clear', [pageNumber]).catch((e) => {
 					console.error(`Clear page failed: ${e}`)
 				})
 			}
@@ -100,7 +100,7 @@ export const ButtonGridActions = forwardRef<ButtonGridActionsRef, ButtonGridActi
 			`Are you sure you want to reset navigation buttons? This will completely erase button ${pageNumber}/0/0, ${pageNumber}/1/0 and ${pageNumber}/2/0`,
 			'Reset',
 			() => {
-				socketEmitPromise(socket, 'loadsave:reset-page-nav', [pageNumber]).catch((e) => {
+				socketEmitPromise(socket, 'pages:reset-page-nav', [pageNumber]).catch((e) => {
 					console.error(`Reset nav failed: ${e}`)
 				})
 			}

--- a/webui/src/Buttons/ButtonGridHeader.tsx
+++ b/webui/src/Buttons/ButtonGridHeader.tsx
@@ -14,12 +14,14 @@ interface ButtonGridHeaderProps {
 	pageNumber: number
 	changePage?: (delta: number) => void
 	setPage?: (page: number) => void
+	newPageAtEnd?: boolean
 }
 
 export const ButtonGridHeader = memo<React.PropsWithChildren<ButtonGridHeaderProps>>(function ButtonGridHeader({
 	pageNumber,
 	changePage,
 	setPage,
+	newPageAtEnd,
 	children,
 }) {
 	const pagesContext = useContext(PagesContext)
@@ -42,13 +44,21 @@ export const ButtonGridHeader = memo<React.PropsWithChildren<ButtonGridHeaderPro
 	}, [changePage])
 
 	const pageOptions: SelectOption[] = useMemo(() => {
-		return Object.entries(pagesContext)
+		const pageOptions: SelectOption[] = Object.entries(pagesContext)
 			.filter((pg): pg is [string, PageModel] => !!pg[1])
 			.map(([index, value]) => ({
 				value: Number(index),
 				label: `${index} (${value.name})`,
 			}))
-	}, [pagesContext])
+
+		if (newPageAtEnd) {
+			pageOptions.push({
+				value: -1,
+				label: `Insert new page`,
+			})
+		}
+		return pageOptions
+	}, [pagesContext, newPageAtEnd])
 
 	const currentValue: SelectOption | undefined = useMemo(() => {
 		return (

--- a/webui/src/Buttons/ButtonGridPanel.tsx
+++ b/webui/src/Buttons/ButtonGridPanel.tsx
@@ -1,29 +1,6 @@
-import {
-	CAlert,
-	CButton,
-	CCol,
-	CForm,
-	CFormGroup,
-	CInput,
-	CLabel,
-	CModal,
-	CModalBody,
-	CModalFooter,
-	CModalHeader,
-	CRow,
-} from '@coreui/react'
-import React, {
-	FormEvent,
-	forwardRef,
-	memo,
-	useCallback,
-	useContext,
-	useEffect,
-	useImperativeHandle,
-	useRef,
-	useState,
-} from 'react'
-import { KeyReceiver, PagesContext, socketEmitPromise, SocketContext, UserConfigContext } from '../util.js'
+import { CAlert, CButton, CCol, CRow } from '@coreui/react'
+import React, { memo, useCallback, useContext, useEffect, useRef } from 'react'
+import { KeyReceiver, PagesContext, SocketContext, UserConfigContext } from '../util.js'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faFileExport, faHome, faPencil } from '@fortawesome/free-solid-svg-icons'
 import { ConfirmExportModal, ConfirmExportModalRef } from '../Components/ConfirmExportModal.js'
@@ -34,6 +11,7 @@ import { ButtonGridHeader } from './ButtonGridHeader.js'
 import { ButtonGridActions, ButtonGridActionsRef } from './ButtonGridActions.js'
 import type { ControlLocation } from '@companion/shared/Model/Common.js'
 import type { PageModel } from '@companion/shared/Model/PageModel.js'
+import { EditPagePropertiesModal, EditPagePropertiesModalRef } from './EditPageProperties.js'
 
 interface ButtonsGridPanelProps {
 	pageNumber: number
@@ -228,92 +206,3 @@ export const ButtonsGridPanel = memo(function ButtonsPage({
 		</KeyReceiver>
 	)
 })
-
-interface EditPagePropertiesModalRef {
-	show(pageNumber: number, pageInfo: PageModel | undefined): void
-}
-interface EditPagePropertiesModalProps {
-	// Nothing
-}
-
-const EditPagePropertiesModal = forwardRef<EditPagePropertiesModalRef, EditPagePropertiesModalProps>(
-	function EditPagePropertiesModal(_props, ref) {
-		const socket = useContext(SocketContext)
-		const [pageNumber, setPageNumber] = useState<number | null>(null)
-		const [show, setShow] = useState(false)
-
-		const [pageName, setName] = useState<string | null>(null)
-
-		const buttonRef = useRef<HTMLButtonElement>(null)
-
-		const buttonFocus = () => {
-			if (buttonRef.current) {
-				buttonRef.current.focus()
-			}
-		}
-
-		const doClose = useCallback(() => setShow(false), [])
-		const onClosed = useCallback(() => setPageNumber(null), [])
-		const doAction = useCallback(
-			(e: FormEvent) => {
-				if (e) e.preventDefault()
-
-				setPageNumber(null)
-				setShow(false)
-				setName(null)
-
-				if (pageNumber === null) return
-
-				socketEmitPromise(socket, 'pages:set-name', [pageNumber, pageName]).catch((e) => {
-					console.error('Failed to set name', e)
-				})
-			},
-			[pageNumber, pageName]
-		)
-
-		useImperativeHandle(
-			ref,
-			() => ({
-				show(pageNumber, pageInfo) {
-					setName(pageInfo?.name ?? null)
-					setPageNumber(pageNumber)
-					setShow(true)
-
-					// Focus the button asap. It also gets focused once the open is complete
-					setTimeout(buttonFocus, 50)
-				},
-			}),
-			[]
-		)
-
-		const onNameChange = useCallback((e) => {
-			setName(e.target.value)
-		}, [])
-
-		return (
-			<CModal show={show} onClose={doClose} onClosed={onClosed} onOpened={buttonFocus}>
-				<CModalHeader closeButton>
-					<h5>Configure Page {pageNumber}</h5>
-				</CModalHeader>
-				<CModalBody>
-					<CForm onSubmit={doAction}>
-						<CFormGroup>
-							<CLabel>Name</CLabel>
-							<CInput type="text" value={pageName || ''} onChange={onNameChange} />
-						</CFormGroup>
-
-						<CAlert color="info">You can use resize the grid in the Settings tab</CAlert>
-					</CForm>
-				</CModalBody>
-				<CModalFooter>
-					<CButton color="secondary" onClick={doClose}>
-						Cancel
-					</CButton>
-					<CButton innerRef={buttonRef} color="primary" onClick={doAction}>
-						Save
-					</CButton>
-				</CModalFooter>
-			</CModal>
-		)
-	}
-)

--- a/webui/src/Buttons/EditPageProperties.tsx
+++ b/webui/src/Buttons/EditPageProperties.tsx
@@ -43,9 +43,7 @@ export const EditPagePropertiesModal = forwardRef<EditPagePropertiesModalRef, Ed
 			(e: FormEvent) => {
 				if (e) e.preventDefault()
 
-				setPageNumber(null)
 				setShow(false)
-				setName(null)
 
 				if (pageNumber === null) return
 

--- a/webui/src/Buttons/EditPageProperties.tsx
+++ b/webui/src/Buttons/EditPageProperties.tsx
@@ -1,0 +1,104 @@
+import {
+	CAlert,
+	CButton,
+	CForm,
+	CFormGroup,
+	CInput,
+	CLabel,
+	CModal,
+	CModalBody,
+	CModalFooter,
+	CModalHeader,
+} from '@coreui/react'
+import React, { FormEvent, forwardRef, useCallback, useContext, useImperativeHandle, useRef, useState } from 'react'
+import { socketEmitPromise, SocketContext } from '../util.js'
+import type { PageModel } from '@companion/shared/Model/PageModel.js'
+
+export interface EditPagePropertiesModalRef {
+	show(pageNumber: number, pageInfo: PageModel | undefined): void
+}
+interface EditPagePropertiesModalProps {
+	// Nothing
+}
+
+export const EditPagePropertiesModal = forwardRef<EditPagePropertiesModalRef, EditPagePropertiesModalProps>(
+	function EditPagePropertiesModal(_props, ref) {
+		const socket = useContext(SocketContext)
+		const [pageNumber, setPageNumber] = useState<number | null>(null)
+		const [show, setShow] = useState(false)
+
+		const [pageName, setName] = useState<string | null>(null)
+
+		const buttonRef = useRef<HTMLButtonElement>(null)
+
+		const buttonFocus = () => {
+			if (buttonRef.current) {
+				buttonRef.current.focus()
+			}
+		}
+
+		const doClose = useCallback(() => setShow(false), [])
+		const onClosed = useCallback(() => setPageNumber(null), [])
+		const doAction = useCallback(
+			(e: FormEvent) => {
+				if (e) e.preventDefault()
+
+				setPageNumber(null)
+				setShow(false)
+				setName(null)
+
+				if (pageNumber === null) return
+
+				socketEmitPromise(socket, 'pages:set-name', [pageNumber, pageName]).catch((e) => {
+					console.error('Failed to set name', e)
+				})
+			},
+			[pageNumber, pageName]
+		)
+
+		useImperativeHandle(
+			ref,
+			() => ({
+				show(pageNumber, pageInfo) {
+					setName(pageInfo?.name ?? null)
+					setPageNumber(pageNumber)
+					setShow(true)
+
+					// Focus the button asap. It also gets focused once the open is complete
+					setTimeout(buttonFocus, 50)
+				},
+			}),
+			[]
+		)
+
+		const onNameChange = useCallback((e) => {
+			setName(e.target.value)
+		}, [])
+
+		return (
+			<CModal show={show} onClose={doClose} onClosed={onClosed} onOpened={buttonFocus}>
+				<CModalHeader closeButton>
+					<h5>Configure Page {pageNumber}</h5>
+				</CModalHeader>
+				<CModalBody>
+					<CForm onSubmit={doAction}>
+						<CFormGroup>
+							<CLabel>Name</CLabel>
+							<CInput type="text" value={pageName || ''} onChange={onNameChange} />
+						</CFormGroup>
+
+						<CAlert color="info">You can use resize the grid in the Settings tab</CAlert>
+					</CForm>
+				</CModalBody>
+				<CModalFooter>
+					<CButton color="secondary" onClick={doClose}>
+						Cancel
+					</CButton>
+					<CButton innerRef={buttonRef} color="primary" onClick={doAction}>
+						Save
+					</CButton>
+				</CModalFooter>
+			</CModal>
+		)
+	}
+)

--- a/webui/src/Buttons/Pages.tsx
+++ b/webui/src/Buttons/Pages.tsx
@@ -1,28 +1,70 @@
-import React, { useCallback, useContext } from 'react'
-import { CButton, CCol, CRow } from '@coreui/react'
-import { PagesContext } from '../util'
+import React, { useCallback, useContext, useRef } from 'react'
+import { CButton, CButtonGroup, CCol, CRow } from '@coreui/react'
+import { PagesContext, SocketContext, socketEmitPromise } from '../util'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faPlus, faTrash } from '@fortawesome/free-solid-svg-icons'
+import { PageModel } from '@companion/shared/Model/PageModel'
+import { GenericConfirmModal, GenericConfirmModalRef } from '../Components/GenericConfirmModal'
+import { usePageCount } from '../Hooks/usePagesInfoSubscription'
 
 interface PagesListProps {
 	setPageNumber: (page: number) => void
 }
 
 export function PagesList({ setPageNumber }: PagesListProps): JSX.Element {
+	const socket = useContext(SocketContext)
 	const pages = useContext(PagesContext)
+
+	const pageCount = usePageCount()
+
+	const deleteRef = useRef<GenericConfirmModalRef>(null)
 
 	const goToPage = useCallback(
 		(e: React.MouseEvent<HTMLButtonElement>) => {
-			const page = Number(e.currentTarget.getAttribute('data-page'))
-			if (!isNaN(page)) {
-				setPageNumber(page)
+			const pageNumber = Number(e.currentTarget.getAttribute('data-page'))
+			if (!isNaN(pageNumber)) {
+				setPageNumber(pageNumber)
 			}
-			console.log(page)
+			console.log(pageNumber)
 		},
 		[setPageNumber]
 	)
 
+	const doInsertPage = useCallback((e: React.MouseEvent<HTMLButtonElement>) => {
+		const pageNumber = Number(e.currentTarget.getAttribute('data-page'))
+		if (!isNaN(pageNumber)) {
+			socketEmitPromise(socket, 'loadsave:insert-page', [pageNumber]).catch((e) => {
+				console.error('Page insert failed', e)
+			})
+		}
+	}, [])
+
+	const doDeletePage = useCallback((e: React.MouseEvent<HTMLButtonElement>) => {
+		const pageNumber = Number(e.currentTarget.getAttribute('data-page'))
+		const pageName = e.currentTarget.getAttribute('data-name') ?? ''
+
+		if (isNaN(pageNumber)) return
+
+		deleteRef.current?.show(
+			'Delete page?',
+			[
+				`Are you sure you want to delete page ${pageNumber} "${pageName ?? 'PAGE'}"?`,
+				'This will delete all controls on the page, and will adjust the page numbers of all following pages',
+			],
+			'Delete',
+			() => {
+				socketEmitPromise(socket, 'loadsave:delete-page', [pageNumber]).catch((e) => {
+					console.error('Page delete failed', e)
+				})
+			}
+		)
+	}, [])
+
 	return (
 		<CRow>
 			<CCol xs={12}>
+				<GenericConfirmModal ref={deleteRef} />
+
 				<table className="table table-responsive-sm">
 					<thead>
 						<tr>
@@ -33,19 +75,76 @@ export function PagesList({ setPageNumber }: PagesListProps): JSX.Element {
 					</thead>
 					<tbody>
 						{Object.entries(pages).map(([id, info]) => (
-							<tr key={id}>
-								<td>
-									<CButton color="primary" variant="ghost" onClick={goToPage} data-page={id}>
-										{id}
-									</CButton>
-								</td>
-								<td>{info?.name ?? ''}</td>
-								<td></td>
-							</tr>
+							<PageListRow
+								key={id}
+								id={Number(id)}
+								info={info}
+								pageCount={pageCount}
+								goToPage={goToPage}
+								doInsertPage={doInsertPage}
+								doDeletePage={doDeletePage}
+							/>
 						))}
+						<tr>
+							<td></td>
+							<td></td>
+							<td>
+								<CButtonGroup>
+									<CButton
+										color="warning"
+										size="sm"
+										onClick={doInsertPage}
+										title="Insert page at end"
+										data-page={pageCount + 1}
+									>
+										<FontAwesomeIcon icon={faPlus} />
+									</CButton>
+								</CButtonGroup>
+							</td>
+						</tr>
 					</tbody>
 				</table>
 			</CCol>
 		</CRow>
+	)
+}
+
+interface PageListRowProps {
+	id: number
+	info: PageModel | undefined
+	pageCount: number
+	goToPage: (e: React.MouseEvent<HTMLButtonElement>) => void
+	doInsertPage: (e: React.MouseEvent<HTMLButtonElement>) => void
+	doDeletePage: (e: React.MouseEvent<HTMLButtonElement>) => void
+}
+
+function PageListRow({ id, info, pageCount, goToPage, doInsertPage, doDeletePage }: PageListRowProps) {
+	return (
+		<tr>
+			<td>
+				<CButton color="primary" variant="ghost" onClick={goToPage} data-page={id}>
+					{id}
+				</CButton>
+			</td>
+			<td>{info?.name ?? ''}</td>
+			<td>
+				<CButtonGroup>
+					<CButton color="warning" size="sm" onClick={doInsertPage} title="Insert page before" data-page={id}>
+						<FontAwesomeIcon icon={faPlus} />
+					</CButton>
+					<CButton
+						color="danger"
+						size="sm"
+						onClick={doDeletePage}
+						title="Delete"
+						data-page={id}
+						data-name={info?.name}
+						disabled={pageCount <= 1}
+					>
+						<FontAwesomeIcon icon={faTrash} />
+					</CButton>
+				</CButtonGroup>
+			</td>
+		</tr>
 	)
 }

--- a/webui/src/Buttons/Pages.tsx
+++ b/webui/src/Buttons/Pages.tsx
@@ -1,0 +1,51 @@
+import React, { useCallback, useContext } from 'react'
+import { CButton, CCol, CRow } from '@coreui/react'
+import { PagesContext } from '../util'
+
+interface PagesListProps {
+	setPageNumber: (page: number) => void
+}
+
+export function PagesList({ setPageNumber }: PagesListProps): JSX.Element {
+	const pages = useContext(PagesContext)
+
+	const goToPage = useCallback(
+		(e: React.MouseEvent<HTMLButtonElement>) => {
+			const page = Number(e.currentTarget.getAttribute('data-page'))
+			if (!isNaN(page)) {
+				setPageNumber(page)
+			}
+			console.log(page)
+		},
+		[setPageNumber]
+	)
+
+	return (
+		<CRow>
+			<CCol xs={12}>
+				<table className="table table-responsive-sm">
+					<thead>
+						<tr>
+							<th>NO</th>
+							<th>Name</th>
+							<th>&nbsp;</th>
+						</tr>
+					</thead>
+					<tbody>
+						{Object.entries(pages).map(([id, info]) => (
+							<tr key={id}>
+								<td>
+									<CButton color="primary" variant="ghost" onClick={goToPage} data-page={id}>
+										{id}
+									</CButton>
+								</td>
+								<td>{info?.name ?? ''}</td>
+								<td></td>
+							</tr>
+						))}
+					</tbody>
+				</table>
+			</CCol>
+		</CRow>
+	)
+}

--- a/webui/src/Buttons/Pages.tsx
+++ b/webui/src/Buttons/Pages.tsx
@@ -7,6 +7,7 @@ import { PageModel } from '@companion/shared/Model/PageModel.js'
 import { GenericConfirmModal, GenericConfirmModalRef } from '../Components/GenericConfirmModal.js'
 import { usePageCount } from '../Hooks/usePagesInfoSubscription.js'
 import { EditPagePropertiesModal, EditPagePropertiesModalRef } from './EditPageProperties.js'
+import { AddPagesModal, AddPagesModalRef } from './PagesAddModal.js'
 
 interface PagesListProps {
 	setPageNumber: (page: number) => void
@@ -18,6 +19,7 @@ export function PagesList({ setPageNumber }: PagesListProps): JSX.Element {
 
 	const pageCount = usePageCount()
 
+	const addRef = useRef<AddPagesModalRef>(null)
 	const deleteRef = useRef<GenericConfirmModalRef>(null)
 	const editRef = useRef<EditPagePropertiesModalRef>(null)
 
@@ -44,9 +46,7 @@ export function PagesList({ setPageNumber }: PagesListProps): JSX.Element {
 	const doInsertPage = useCallback((e: React.MouseEvent<HTMLButtonElement>) => {
 		const pageNumber = Number(e.currentTarget.getAttribute('data-page'))
 		if (!isNaN(pageNumber)) {
-			socketEmitPromise(socket, 'pages:insert-page', [pageNumber]).catch((e) => {
-				console.error('Page insert failed', e)
-			})
+			addRef.current?.show?.(pageNumber)
 		}
 	}, [])
 
@@ -75,6 +75,7 @@ export function PagesList({ setPageNumber }: PagesListProps): JSX.Element {
 		<CRow>
 			<CCol xs={12}>
 				<GenericConfirmModal ref={deleteRef} />
+				<AddPagesModal ref={addRef} />
 				<EditPagePropertiesModal ref={editRef} />
 
 				<table className="table table-responsive-sm">

--- a/webui/src/Buttons/Pages.tsx
+++ b/webui/src/Buttons/Pages.tsx
@@ -1,11 +1,12 @@
 import React, { useCallback, useContext, useRef } from 'react'
 import { CButton, CButtonGroup, CCol, CRow } from '@coreui/react'
-import { PagesContext, SocketContext, socketEmitPromise } from '../util'
+import { PagesContext, SocketContext, socketEmitPromise } from '../util.js'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faPlus, faTrash } from '@fortawesome/free-solid-svg-icons'
-import { PageModel } from '@companion/shared/Model/PageModel'
-import { GenericConfirmModal, GenericConfirmModalRef } from '../Components/GenericConfirmModal'
-import { usePageCount } from '../Hooks/usePagesInfoSubscription'
+import { faPlus, faTrash, faPencil } from '@fortawesome/free-solid-svg-icons'
+import { PageModel } from '@companion/shared/Model/PageModel.js'
+import { GenericConfirmModal, GenericConfirmModalRef } from '../Components/GenericConfirmModal.js'
+import { usePageCount } from '../Hooks/usePagesInfoSubscription.js'
+import { EditPagePropertiesModal, EditPagePropertiesModalRef } from './EditPageProperties.js'
 
 interface PagesListProps {
 	setPageNumber: (page: number) => void
@@ -18,6 +19,7 @@ export function PagesList({ setPageNumber }: PagesListProps): JSX.Element {
 	const pageCount = usePageCount()
 
 	const deleteRef = useRef<GenericConfirmModalRef>(null)
+	const editRef = useRef<EditPagePropertiesModalRef>(null)
 
 	const goToPage = useCallback(
 		(e: React.MouseEvent<HTMLButtonElement>) => {
@@ -30,10 +32,19 @@ export function PagesList({ setPageNumber }: PagesListProps): JSX.Element {
 		[setPageNumber]
 	)
 
+	const configurePage = useCallback((e: React.MouseEvent<HTMLButtonElement>) => {
+		const pageNumber = Number(e.currentTarget.getAttribute('data-page'))
+		const pageInfoRaw = e.currentTarget.getAttribute('data-page-info')
+		const pageInfo = pageInfoRaw ? JSON.parse(pageInfoRaw) : null
+		if (!isNaN(pageNumber) && pageInfo) {
+			editRef.current?.show(pageNumber, pageInfo)
+		}
+	}, [])
+
 	const doInsertPage = useCallback((e: React.MouseEvent<HTMLButtonElement>) => {
 		const pageNumber = Number(e.currentTarget.getAttribute('data-page'))
 		if (!isNaN(pageNumber)) {
-			socketEmitPromise(socket, 'loadsave:insert-page', [pageNumber]).catch((e) => {
+			socketEmitPromise(socket, 'pages:insert-page', [pageNumber]).catch((e) => {
 				console.error('Page insert failed', e)
 			})
 		}
@@ -53,7 +64,7 @@ export function PagesList({ setPageNumber }: PagesListProps): JSX.Element {
 			],
 			'Delete',
 			() => {
-				socketEmitPromise(socket, 'loadsave:delete-page', [pageNumber]).catch((e) => {
+				socketEmitPromise(socket, 'pages:delete-page', [pageNumber]).catch((e) => {
 					console.error('Page delete failed', e)
 				})
 			}
@@ -64,6 +75,7 @@ export function PagesList({ setPageNumber }: PagesListProps): JSX.Element {
 		<CRow>
 			<CCol xs={12}>
 				<GenericConfirmModal ref={deleteRef} />
+				<EditPagePropertiesModal ref={editRef} />
 
 				<table className="table table-responsive-sm">
 					<thead>
@@ -81,6 +93,7 @@ export function PagesList({ setPageNumber }: PagesListProps): JSX.Element {
 								info={info}
 								pageCount={pageCount}
 								goToPage={goToPage}
+								configurePage={configurePage}
 								doInsertPage={doInsertPage}
 								doDeletePage={doDeletePage}
 							/>
@@ -88,7 +101,7 @@ export function PagesList({ setPageNumber }: PagesListProps): JSX.Element {
 						<tr>
 							<td></td>
 							<td></td>
-							<td>
+							<td style={{ textAlign: 'center' }}>
 								<CButtonGroup>
 									<CButton
 										color="warning"
@@ -114,24 +127,36 @@ interface PageListRowProps {
 	info: PageModel | undefined
 	pageCount: number
 	goToPage: (e: React.MouseEvent<HTMLButtonElement>) => void
+	configurePage: (e: React.MouseEvent<HTMLButtonElement>) => void
 	doInsertPage: (e: React.MouseEvent<HTMLButtonElement>) => void
 	doDeletePage: (e: React.MouseEvent<HTMLButtonElement>) => void
 }
 
-function PageListRow({ id, info, pageCount, goToPage, doInsertPage, doDeletePage }: PageListRowProps) {
+function PageListRow({ id, info, pageCount, goToPage, configurePage, doInsertPage, doDeletePage }: PageListRowProps) {
 	return (
 		<tr>
-			<td>
+			<td style={{ width: 0 }}>
 				<CButton color="primary" variant="ghost" onClick={goToPage} data-page={id}>
 					{id}
 				</CButton>
 			</td>
 			<td>{info?.name ?? ''}</td>
-			<td>
+			<td style={{ width: 0 }}>
 				<CButtonGroup>
+					<CButton
+						color="info"
+						size="sm"
+						onClick={configurePage}
+						title="Edit page"
+						data-page={id}
+						data-page-info={JSON.stringify(info)}
+					>
+						<FontAwesomeIcon icon={faPencil} />
+					</CButton>
 					<CButton color="warning" size="sm" onClick={doInsertPage} title="Insert page before" data-page={id}>
 						<FontAwesomeIcon icon={faPlus} />
 					</CButton>
+
 					<CButton
 						color="danger"
 						size="sm"

--- a/webui/src/Buttons/PagesAddModal.tsx
+++ b/webui/src/Buttons/PagesAddModal.tsx
@@ -1,0 +1,209 @@
+import { CModal, CModalHeader, CInput, CModalBody, CModalFooter, CButton, CButtonGroup } from '@coreui/react'
+import { faPlus, faTrash } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import React, { forwardRef, useCallback, useContext, useImperativeHandle, useState } from 'react'
+import { SocketContext, socketEmitPromise } from '../util'
+
+interface AddPagesModalProps {
+	// addAction: (actionType: string) => void
+}
+export interface AddPagesModalRef {
+	show(beforePageNumber: number): void
+}
+
+const DEFAULT_PAGE_NAME = 'New Page'
+
+interface ModalState {
+	show: boolean
+
+	readonly beforePage: number
+	names: string[]
+}
+
+const defaultState: ModalState = {
+	show: false,
+
+	beforePage: 1,
+	names: [DEFAULT_PAGE_NAME],
+}
+
+export const AddPagesModal = forwardRef<AddPagesModalRef, AddPagesModalProps>(function AddPagesModal({}, ref) {
+	const socket = useContext(SocketContext)
+
+	const [state, setState] = useState<ModalState>(defaultState)
+
+	const doClose = useCallback(
+		() =>
+			setState((oldState) => {
+				return {
+					...oldState,
+					show: false,
+				}
+			}),
+		[]
+	)
+	const onClosed = useCallback(() => {
+		setState(defaultState)
+	}, [])
+
+	useImperativeHandle(
+		ref,
+		() => ({
+			show(beforePageNumber: number) {
+				setState({
+					...defaultState,
+					show: true,
+					beforePage: beforePageNumber,
+				})
+			},
+		}),
+		[]
+	)
+
+	const doSave = useCallback(() => {
+		socketEmitPromise(socket, 'pages:insert-pages', [state.beforePage, state.names]).catch((e) => {
+			console.error('Page insert failed', e)
+		})
+		setState((oldPage) => {
+			return {
+				...oldPage,
+				show: false,
+			}
+		})
+	}, [socket, state])
+
+	const changeName = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+		const pageNumber = Number(e.currentTarget.getAttribute('data-page'))
+		if (!isNaN(pageNumber)) {
+			const newName = e.currentTarget.value || ''
+			setState((oldState) => {
+				const newNames = [...oldState.names]
+				newNames[pageNumber] = newName
+				return { ...oldState, names: newNames }
+			})
+		}
+	}, [])
+	const doInsertPage = useCallback((e: React.MouseEvent<HTMLButtonElement>) => {
+		const pageNumber = Number(e.currentTarget.getAttribute('data-page'))
+		if (!isNaN(pageNumber)) {
+			setState((oldState) => {
+				const newNames = [...oldState.names]
+				newNames.splice(pageNumber, 0, DEFAULT_PAGE_NAME)
+				return { ...oldState, names: newNames }
+			})
+		}
+	}, [])
+	const doDeletePage = useCallback((e: React.MouseEvent<HTMLButtonElement>) => {
+		const pageNumber = Number(e.currentTarget.getAttribute('data-page'))
+		if (!isNaN(pageNumber)) {
+			setState((oldState) => {
+				const newNames = [...oldState.names]
+				newNames.splice(pageNumber, 1)
+				return { ...oldState, names: newNames }
+			})
+		}
+	}, [])
+
+	return (
+		<CModal show={state.show} onClose={doClose} onClosed={onClosed} size="lg" scrollable={true}>
+			<CModalHeader closeButton>
+				<h5>Add Pages</h5>
+			</CModalHeader>
+			<CModalBody className="shadow-inset">
+				<table className="table table-responsive-sm">
+					<thead>
+						<tr>
+							<th>Name</th>
+							<th>&nbsp;</th>
+						</tr>
+					</thead>
+					<tbody>
+						{state.names.map((name, index) => (
+							<AddPageRow
+								key={index}
+								index={Number(index)}
+								name={name}
+								canDelete={state.names.length > 1}
+								changeName={changeName}
+								doInsertPage={doInsertPage}
+								doDeletePage={doDeletePage}
+							/>
+						))}
+
+						<tr>
+							<td></td>
+							<td style={{ textAlign: 'left' }}>
+								<CButtonGroup>
+									<CButton
+										color="warning"
+										size="sm"
+										onClick={doInsertPage}
+										title="Add at end"
+										data-page={state.names.length + 1}
+									>
+										<FontAwesomeIcon icon={faPlus} />
+									</CButton>
+								</CButtonGroup>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</CModalBody>
+			<CModalFooter>
+				<CButton color="secondary" onClick={doClose}>
+					Cancel
+				</CButton>
+				<CButton color="primary" onClick={doSave}>
+					Add
+				</CButton>
+			</CModalFooter>
+		</CModal>
+	)
+})
+
+interface AddPageRowProps {
+	index: number
+	name: string
+	canDelete: boolean
+	changeName: (e: React.ChangeEvent<HTMLInputElement>) => void
+	doInsertPage: (e: React.MouseEvent<HTMLButtonElement>) => void
+	doDeletePage: (e: React.MouseEvent<HTMLButtonElement>) => void
+}
+
+function AddPageRow({ index, name, canDelete, changeName, doInsertPage, doDeletePage }: AddPageRowProps) {
+	return (
+		<tr>
+			<td>
+				<CInput type="text" value={name} onChange={changeName} data-page={index} />
+			</td>
+			<td style={{ width: 0 }}>
+				<CButtonGroup>
+					{/* <CButton
+						color="info"
+						size="sm"
+						onClick={configurePage}
+						title="Edit page"
+						data-page={id}
+						data-page-info={JSON.stringify(info)}
+					>
+						<FontAwesomeIcon icon={faPencil} />
+					</CButton> */}
+					<CButton color="warning" size="sm" onClick={doInsertPage} title="Add page before" data-page={index}>
+						<FontAwesomeIcon icon={faPlus} />
+					</CButton>
+
+					<CButton
+						color="danger"
+						size="sm"
+						onClick={doDeletePage}
+						title="Delete"
+						data-page={index}
+						disabled={!canDelete}
+					>
+						<FontAwesomeIcon icon={faTrash} />
+					</CButton>
+				</CButtonGroup>
+			</td>
+		</tr>
+	)
+}

--- a/webui/src/Buttons/index.tsx
+++ b/webui/src/Buttons/index.tsx
@@ -1,5 +1,5 @@
 import { CCol, CNav, CNavItem, CNavLink, CRow, CTabContent, CTabPane, CTabs } from '@coreui/react'
-import { faCalculator, faDollarSign, faGift, faVideoCamera } from '@fortawesome/free-solid-svg-icons'
+import { faCalculator, faDollarSign, faGift, faPaperPlane, faVideoCamera } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { nanoid } from 'nanoid'
 import { InstancePresets } from './Presets.js'
@@ -12,6 +12,7 @@ import { GenericConfirmModal, GenericConfirmModalRef } from '../Components/Gener
 import { ConnectionVariables } from './Variables.js'
 import { formatLocation } from '@companion/shared/ControlId.js'
 import { ControlLocation } from '@companion/shared/Model/Common.js'
+import { PagesList } from './Pages'
 
 interface ButtonsPageProps {
 	hotPress: boolean
@@ -24,7 +25,7 @@ export const ButtonsPage = memo(function ButtonsPage({ hotPress }: ButtonsPagePr
 	const clearModalRef = useRef<GenericConfirmModalRef>(null)
 
 	const [tabResetToken, setTabResetToken] = useState(nanoid())
-	const [activeTab, setActiveTab] = useState('presets')
+	const [activeTab, setActiveTab] = useState('pages')
 	const [selectedButton, setSelectedButton] = useState<ControlLocation | null>(null)
 	const [pageNumber, setPageNumber] = useState(1)
 	const [copyFromButton, setCopyFromButton] = useState<[ControlLocation, string] | null>(null)
@@ -56,7 +57,7 @@ export const ButtonsPage = memo(function ButtonsPage({ hotPress }: ButtonsPagePr
 		[socket, hotPress]
 	)
 	const clearSelectedButton = useCallback(() => {
-		doChangeTab('presets')
+		doChangeTab('pages')
 	}, [doChangeTab])
 
 	const handleKeyDownInButtons = useCallback(
@@ -232,6 +233,12 @@ export const ButtonsPage = memo(function ButtonsPage({ hotPress }: ButtonsPagePr
 									{selectedButton ? `${formatLocation(selectedButton)}` : '?'}
 								</CNavLink>
 							</CNavItem>
+
+							<CNavItem>
+								<CNavLink data-tab="pages">
+									<FontAwesomeIcon icon={faPaperPlane} /> Pages
+								</CNavLink>
+							</CNavItem>
 							<CNavItem>
 								<CNavLink data-tab="presets">
 									<FontAwesomeIcon icon={faGift} /> Presets
@@ -258,6 +265,11 @@ export const ButtonsPage = memo(function ButtonsPage({ hotPress }: ButtonsPagePr
 											onKeyUp={handleKeyDownInButtons}
 										/>
 									)}
+								</MyErrorBoundary>
+							</CTabPane>
+							<CTabPane data-tab="pages">
+								<MyErrorBoundary>
+									<PagesList setPageNumber={setPageNumber} />
 								</MyErrorBoundary>
 							</CTabPane>
 							<CTabPane data-tab="presets">

--- a/webui/src/Buttons/index.tsx
+++ b/webui/src/Buttons/index.tsx
@@ -13,6 +13,7 @@ import { ConnectionVariables } from './Variables.js'
 import { formatLocation } from '@companion/shared/ControlId.js'
 import { ControlLocation } from '@companion/shared/Model/Common.js'
 import { PagesList } from './Pages'
+import { usePageCount } from '../Hooks/usePagesInfoSubscription'
 
 interface ButtonsPageProps {
 	hotPress: boolean
@@ -21,6 +22,8 @@ interface ButtonsPageProps {
 export const ButtonsPage = memo(function ButtonsPage({ hotPress }: ButtonsPageProps) {
 	const socket = useContext(SocketContext)
 	const userConfig = useContext(UserConfigContext)
+
+	const pageCount = usePageCount()
 
 	const clearModalRef = useRef<GenericConfirmModalRef>(null)
 
@@ -131,7 +134,7 @@ export const ButtonsPage = memo(function ButtonsPage({ hotPress }: ButtonsPagePr
 					case 'PageUp':
 						setSelectedButton((selectedButton) => {
 							if (selectedButton) {
-								const newPageNumber = selectedButton.pageNumber >= 99 ? 1 : selectedButton.pageNumber + 1
+								const newPageNumber = selectedButton.pageNumber >= pageCount ? 1 : selectedButton.pageNumber + 1
 								setPageNumber(newPageNumber)
 								return {
 									...selectedButton,
@@ -145,7 +148,7 @@ export const ButtonsPage = memo(function ButtonsPage({ hotPress }: ButtonsPagePr
 					case 'PageDown':
 						setSelectedButton((selectedButton) => {
 							if (selectedButton) {
-								const newPageNumber = selectedButton.pageNumber <= 1 ? 99 : selectedButton.pageNumber - 1
+								const newPageNumber = selectedButton.pageNumber <= 1 ? pageCount : selectedButton.pageNumber - 1
 								setPageNumber(newPageNumber)
 								return {
 									...selectedButton,
@@ -202,7 +205,7 @@ export const ButtonsPage = memo(function ButtonsPage({ hotPress }: ButtonsPagePr
 				}
 			}
 		},
-		[socket, selectedButton, copyFromButton, userConfig?.gridSize]
+		[socket, selectedButton, copyFromButton, pageCount, userConfig?.gridSize]
 	)
 
 	return (

--- a/webui/src/Controls/InternalInstanceFields.tsx
+++ b/webui/src/Controls/InternalInstanceFields.tsx
@@ -139,10 +139,15 @@ function InternalPageDropdown({ isOnControl, includeDirection, value, setValue, 
 			choices.push({ id: 'back', label: 'Back' }, { id: 'forward', label: 'Forward' })
 		}
 
-		for (let i = 1; i <= 99; i++) {
-			const name = pages?.[i]
-			choices.push({ id: i, label: `${i}` + (name ? ` (${name?.name || ''})` : '') })
+		for (const [pageNumber, pageInfo] of Object.entries(pages || {})) {
+			if (!pageInfo) continue
+
+			choices.push({
+				id: pageNumber,
+				label: `${pageNumber}` + ` (${pageInfo?.name || ''})`,
+			})
 		}
+
 		return choices
 	}, [pages, isOnControl, includeDirection])
 

--- a/webui/src/Hooks/usePagesInfoSubscription.ts
+++ b/webui/src/Hooks/usePagesInfoSubscription.ts
@@ -4,7 +4,6 @@ import { Socket } from 'socket.io-client'
 import type { PageModel } from '@companion/shared/Model/PageModel.js'
 import jsonPatch, { Operation as JsonPatchOperation } from 'fast-json-patch'
 import { cloneDeep } from 'lodash-es'
-import { useMap } from 'usehooks-ts'
 
 export function usePagesInfoSubscription(
 	socket: Socket,

--- a/webui/src/Hooks/useUserConfigSubscription.ts
+++ b/webui/src/Hooks/useUserConfigSubscription.ts
@@ -39,10 +39,6 @@ export function useUserConfigSubscription(
 
 		return () => {
 			socket.off('set_userconfig_key', updateUserConfigValue)
-
-			// socketEmitPromise(socket, 'pages:unsubscribe', []).catch((e) => {
-			// 	console.error('Failed to cleanup web-buttons:', e)
-			// })
 		}
 	}, [retryToken, socket])
 

--- a/webui/src/ImportExport/Import/Page.tsx
+++ b/webui/src/ImportExport/Import/Page.tsx
@@ -131,7 +131,7 @@ export function ImportPageWizard({ snapshot, instanceRemap, setInstanceRemap, do
 								<FontAwesomeIcon icon={faHome} /> Home Position
 							</CButton>
 
-							<ButtonGridHeader pageNumber={pageNumber} changePage={changePage} setPage={setPageNumber} />
+							<ButtonGridHeader pageNumber={pageNumber} changePage={changePage} setPage={setPageNumber} newPageAtEnd />
 						</CCol>
 						<div className="buttongrid">
 							{hasBeenRendered && destinationGridSize && (
@@ -157,7 +157,7 @@ export function ImportPageWizard({ snapshot, instanceRemap, setInstanceRemap, do
 
 			<CCol xs={12}>
 				<CButton color="warning" onClick={doImport2} disabled={isRunning}>
-					Import to page {pageNumber}
+					{pageNumber == -1 ? 'Import to new page' : `Import to page ${pageNumber}`}
 				</CButton>
 			</CCol>
 		</CRow>

--- a/webui/src/TabletView/index.tsx
+++ b/webui/src/TabletView/index.tsx
@@ -21,7 +21,7 @@ export function TabletView() {
 		const rawParsedQuery = queryString.parse(queryUrl)
 
 		const pagesStr = Array.isArray(rawParsedQuery.pages) ? rawParsedQuery.pages[0] : rawParsedQuery.pages
-		const pagesRange = rangeParser(pagesStr ?? '').filter((p) => p >= 1 && p <= 99)
+		const pagesRange = rangeParser(pagesStr ?? '').filter((p) => p >= 1)
 
 		if (rawParsedQuery['max_col'] === undefined && rawParsedQuery['cols'])
 			rawParsedQuery['max_col'] = Number(rawParsedQuery['cols']) - 1 + ''


### PR DESCRIPTION
Support more or less than 99 pages.

Fresh companion installations will start with 1 page, it is intended that users add as many pages as they need. Existing installations are unchanged, to avoid risking impacting users without them expecting it.

There is a new 'pages' tab in the right panel, which lists the pages with links to jump to a page, as well as to insert/add a page (at any position), and remove any page.
![image](https://github.com/bitfocus/companion/assets/1327476/ee3a29a8-2704-4fe2-bb4b-2b32cc25ddfa)

When adding a page, a modal is shown, to allow easily adding multiple and to encourage giving each new page a name

![image](https://github.com/bitfocus/companion/assets/1327476/9dd370ee-d738-4643-b5aa-c1ed5016c643)


If when removing a page, a surface ends up out of bounds, it will be pushed to be within the new page count.

### TODO:
- [x] Importing a single page needs to be able to import to a new page (potentially just at the end for now?)
- [x] When adding a page, open a prompt to ask how many pages and the name to give each page

### Future:
* Some work should be done to make surfaces more sticky to pages when they are removed/reordered
* The actions/feedbacks should be improved to be able to reference a page by id. this is so that as the index of a page changes, actions and feedbacks can 'follow' that moving. (Import will need to take care to fix up these ids properly)
*  [Feature Request: Ability to rearrange existing pages #976](https://github.com/bitfocus/companion/issues/976)