### PR TITLE
fix: Add `NSAppleEventsUsageDescription`

### DIFF
--- a/launcher/package.json
+++ b/launcher/package.json
@@ -47,7 +47,8 @@
 			"category": "no.bitfocus.companion",
 			"extendInfo": {
 				"LSBackgroundOnly": 1,
-				"LSUIElement": 1
+				"LSUIElement": 1,
+				"NSAppleEventsUsageDescription": "Companion uses AppleEvents to control local applications."
 			},
 			"hardenedRuntime": "true",
 			"gatekeeperAssess": "false",


### PR DESCRIPTION
Companion was missing the usage description needed to send AppleEvents to application. This PR adds that description. 