### PR TITLE
feat: replace variable picker dropdown #2344

### DIFF
--- a/webui/package.json
+++ b/webui/package.json
@@ -59,7 +59,6 @@
     "sanitize-html": "^2.11.0",
     "sass": "^1.71.0",
     "socket.io-client": "^4.7.4",
-    "tributejs": "^5.1.3",
     "typescript": "~5.3.3",
     "use-deep-compare": "^1.2.1",
     "usehooks-ts": "^2.14.0",

--- a/webui/src/App.scss
+++ b/webui/src/App.scss
@@ -1,7 +1,6 @@
 @import 'scss/variables';
 
 @import '@coreui/coreui/scss/coreui';
-@import 'tributejs/src/tribute';
 @import 'scss/react-time-picker';
 
 @import 'scss/layout';

--- a/webui/src/Components/TextInputField.tsx
+++ b/webui/src/Components/TextInputField.tsx
@@ -226,20 +226,20 @@ function VariablesSelect({
 	const valueRef = useRef<string>()
 	valueRef.current = showValue
 
-	const onVariableSelect = useCallback(
-		(variable: DropdownChoiceInt | null) => {
-			const oldValue = valueRef.current
-			if (!variable || !oldValue) return
+	const cursorPositionRef = useRef<number | null>()
+	cursorPositionRef.current = cursorPosition
 
-			if (!cursorPosition) return // Nothing selected
+	const onVariableSelect = useCallback((variable: DropdownChoiceInt | null) => {
+		const oldValue = valueRef.current
+		if (!variable || !oldValue) return
 
-			const openIndex = FindVariableStartIndexFromCursor(oldValue, cursorPosition)
-			if (openIndex === -1) return
+		if (cursorPositionRef.current == null) return // Nothing selected
 
-			storeValue(oldValue.slice(0, openIndex) + `$(${variable.value})` + oldValue.slice(cursorPosition))
-		},
-		[cursorPosition] // TODO - this is very inefficient
-	)
+		const openIndex = FindVariableStartIndexFromCursor(oldValue, cursorPositionRef.current)
+		if (openIndex === -1) return
+
+		storeValue(oldValue.slice(0, openIndex) + `$(${variable.value})` + oldValue.slice(cursorPositionRef.current))
+	}, [])
 
 	const selectContext = {
 		value: showValue,

--- a/webui/src/Components/TextInputField.tsx
+++ b/webui/src/Components/TextInputField.tsx
@@ -79,8 +79,6 @@ export const TextInputField = observer(function TextInputField({
 
 	const storeValue = useCallback(
 		(value: string) => {
-			// const newValue = decode(e.currentTarget.value, { scope: 'strict' })
-			console.log('store', value)
 			setTmpValue(value)
 			setValue(value)
 			setValid?.(isValueValid(value))
@@ -99,19 +97,13 @@ export const TextInputField = observer(function TextInputField({
 	let isPickerOpen = false
 	let searchValue = ''
 
-	// const innerRef = useRef<HTMLInputElement>(null)
-	// if (innerRef.current) {
-	console.log('cursor', cursorPosition)
 	if (cursorPosition != null) {
 		// && innerRef.current.selectionStart === innerRef.current.selectionEnd) {
 		const lastOpen = FindVariableStartIndexFromCursor(showValue, cursorPosition)
 		isPickerOpen = lastOpen !== -1
-		console.log('open', lastOpen)
 
 		searchValue = showValue.slice(lastOpen + 2, cursorPosition)
-		console.log('search', searchValue)
 	}
-	// }
 
 	const valueRef = useRef<string>()
 	valueRef.current = showValue
@@ -130,12 +122,6 @@ export const TextInputField = observer(function TextInputField({
 		},
 		[cursorPosition] // TODO - this is very inefficient
 	)
-
-	// const [variableSearchOpen, setVariableSearchOpen] = useState(false)
-
-	// const onFocusChange = useCallback(() => {
-	// 	console.log('focus change')
-	// }, [])
 
 	const extraStyle = useMemo(
 		() => ({ color: !isValueValid(showValue) ? 'red' : undefined, ...style }),
@@ -341,7 +327,6 @@ const CustomValueContainer = (props: ValueContainerProps<DropdownChoiceInt>) => 
 	)
 	const onKeyDown = useCallback(
 		(e: React.KeyboardEvent<HTMLInputElement>) => {
-			console.log('keyu', e.code, context.value)
 			if (e.code === 'Escape') {
 				context.forceHideSuggestions(true)
 			} else {
@@ -389,6 +374,5 @@ function FindVariableStartIndexFromCursor(text: string, cursor: number): number 
 
 	// TODO - ensure contents is valid
 
-	console.log('open', previousOpen, 'close', previousClose)
 	return previousOpen
 }

--- a/webui/src/Components/TextInputField.tsx
+++ b/webui/src/Components/TextInputField.tsx
@@ -113,6 +113,9 @@ export const TextInputField = observer(function TextInputField({
 					storeValue={storeValue}
 					focusStoreValue={focusStoreValue}
 					blurClearValue={blurClearValue}
+					placeholder={placeholder}
+					title={tooltip}
+					disabled={disabled}
 				/>
 			) : (
 				<CInput
@@ -170,6 +173,9 @@ interface VariablesSelectProps {
 	storeValue: (value: string) => void
 	focusStoreValue: () => void
 	blurClearValue: () => void
+	placeholder: string | undefined
+	title: string | undefined
+	disabled: boolean | undefined
 }
 
 function VariablesSelect({
@@ -179,6 +185,9 @@ function VariablesSelect({
 	storeValue,
 	focusStoreValue,
 	blurClearValue,
+	placeholder,
+	title,
+	disabled,
 }: VariablesSelectProps) {
 	const variableDefinitionsContext = useContext(VariableDefinitionsContext)
 	const menuPortal = useContext(MenuPortalContext)
@@ -249,6 +258,8 @@ function VariablesSelect({
 		forceHideSuggestions: setIsForceHidden,
 		focusStoreValue,
 		blurClearValue,
+		title,
+		placeholder,
 	}
 
 	return (
@@ -261,6 +272,7 @@ function VariablesSelect({
 				menuPlacement="auto"
 				isSearchable
 				isMulti={false}
+				isDisabled={disabled}
 				options={options}
 				value={null}
 				inputValue={searchValue}
@@ -286,6 +298,8 @@ const VariablesSelectContext = React.createContext({
 	forceHideSuggestions: (_hidden: boolean) => {},
 	focusStoreValue: () => {},
 	blurClearValue: () => {},
+	title: undefined as string | undefined,
+	placeholder: undefined as string | undefined,
 })
 
 const CustomOption = (props: OptionProps<DropdownChoiceInt>) => {
@@ -368,17 +382,14 @@ const CustomValueContainer = (props: ValueContainerProps<DropdownChoiceInt>) => 
 	return (
 		<SelectComponents.ValueContainer {...props} isDisabled>
 			<CInput
-				// {...props.innerProps}
 				type="text"
-				// disabled={disabled}
 				style={context.extraStyle}
-				// title={tooltip}
+				title={context.title}
 				value={context.value}
 				onChange={doOnChange}
 				onFocus={onFocus}
 				onBlur={onBlur}
-				// placeholder={placeholder}
-
+				placeholder={context.placeholder}
 				onKeyUp={checkCursor}
 				onKeyDown={onKeyDown}
 				onMouseDown={checkCursor}

--- a/webui/src/Components/TextInputField.tsx
+++ b/webui/src/Components/TextInputField.tsx
@@ -238,6 +238,8 @@ function VariablesSelect({
 	const cursorPositionRef = useRef<number | null>()
 	cursorPositionRef.current = cursorPosition
 
+	const inputRef = useRef<HTMLInputElement | null>(null)
+
 	const onVariableSelect = useCallback((variable: DropdownChoiceInt | null) => {
 		const oldValue = valueRef.current
 		if (!variable || !oldValue) return
@@ -247,7 +249,19 @@ function VariablesSelect({
 		const openIndex = FindVariableStartIndexFromCursor(oldValue, cursorPositionRef.current)
 		if (openIndex === -1) return
 
+		// Propogate the new value
 		storeValue(oldValue.slice(0, openIndex) + `$(${variable.value})` + oldValue.slice(cursorPositionRef.current))
+
+		// This doesn't work properly, it causes the cursor to get a bit confused on where it is but avoids the glitch of setSelectionRange
+		// if (inputRef.current)
+		// 	inputRef.current.setRangeText(`$(${variable.value})`, openIndex, cursorPositionRef.current, 'end')
+
+		// Update the selection after mutating the value. This needs to be defered, although this causes a 'glitch' in the drawing
+		// It needs to be delayed, so that react can re-render first
+		const newSelection = openIndex + variable.value.length + 3
+		setTimeout(() => {
+			if (inputRef.current) inputRef.current.setSelectionRange(newSelection, newSelection)
+		}, 0)
 	}, [])
 
 	const selectContext = {
@@ -260,6 +274,7 @@ function VariablesSelect({
 		blurClearValue,
 		title,
 		placeholder,
+		inputRef,
 	}
 
 	return (
@@ -300,6 +315,7 @@ const VariablesSelectContext = React.createContext({
 	blurClearValue: () => {},
 	title: undefined as string | undefined,
 	placeholder: undefined as string | undefined,
+	inputRef: { current: null } as React.MutableRefObject<HTMLInputElement | null>,
 })
 
 const CustomOption = (props: OptionProps<DropdownChoiceInt>) => {
@@ -382,6 +398,7 @@ const CustomValueContainer = (props: ValueContainerProps<DropdownChoiceInt>) => 
 	return (
 		<SelectComponents.ValueContainer {...props} isDisabled>
 			<CInput
+				innerRef={context.inputRef}
 				type="text"
 				style={context.extraStyle}
 				title={context.title}

--- a/webui/src/Components/TextInputField.tsx
+++ b/webui/src/Components/TextInputField.tsx
@@ -3,7 +3,6 @@ import { CInput } from '@coreui/react'
 import { VariableDefinitionsContext } from '../util.js'
 import Select, {
 	ControlProps,
-	InputProps,
 	OptionProps,
 	components as SelectComponents,
 	ValueContainerProps,
@@ -149,32 +148,31 @@ export const TextInputField = observer(function TextInputField({
 		setValue: doOnChange,
 		setTmpValue: setTmpValue,
 		setCursorPosition: setCursorPosition,
+		extraStyle: { color: !isValueValid(tmpValue ?? value) ? 'red' : undefined, ...style }, // TODO - memo
 	}
 
 	// Render the input
-	const extraStyle = style || {}
 	return (
 		<>
 			<tempContext.Provider value={tmpVal}>
-				<CInput
-					// innerRef={innerRef}
-					type="text"
-					disabled={disabled}
-					value={tmpValue ?? value ?? ''}
-					style={{ color: !isValueValid(tmpValue ?? value) ? 'red' : undefined, ...extraStyle }}
-					title={tooltip}
-					onChange={doOnChange}
-					onFocus={() => setTmpValue(value ?? '')}
-					onBlur={() => setTmpValue(null)}
-					placeholder={placeholder}
-				/>
-				<p style={{ width: '1000px' }}>aa</p>
-				{useVariables && (
+				{useVariables ? (
 					<VariablesSelect
 						isOpen={isPickerOpen}
 						searchValue={searchValue}
 						onVariableSelect={onVariableSelect}
 						useLocationVariables={!!useLocationVariables}
+					/>
+				) : (
+					<CInput
+						type="text"
+						disabled={disabled}
+						value={tmpValue ?? value ?? ''}
+						style={{ color: !isValueValid(tmpValue ?? value) ? 'red' : undefined, ...style }}
+						title={tooltip}
+						onChange={doOnChange}
+						onFocus={() => setTmpValue(value ?? '')}
+						onBlur={() => setTmpValue(null)}
+						placeholder={placeholder}
 					/>
 				)}
 			</tempContext.Provider>
@@ -265,7 +263,7 @@ function VariablesSelect({ isOpen, searchValue, onVariableSelect, useLocationVar
 			components={{
 				Option: CustomOption,
 				ValueContainer: CustomValueContainer,
-				// Control: CustomControl /*Input: CustomInput*/,
+				Control: CustomControl /*Input: CustomInput*/,
 				IndicatorsContainer: EmptyComponent,
 			}}
 			filterOption={filterOption}
@@ -285,6 +283,7 @@ const tempContext = React.createContext({
 	setValue: (_e: React.ChangeEvent<HTMLInputElement>) => {},
 	setTmpValue: (_val: string | null) => {},
 	setCursorPosition: (_pos: number | null) => {},
+	extraStyle: {} as React.CSSProperties,
 })
 
 const CustomOption = (props: OptionProps<DropdownChoiceInt>) => {
@@ -301,40 +300,18 @@ const EmptyComponent = () => {
 	return null
 }
 
-// const CustomControl = (props: ControlProps<DropdownChoiceInt>) => {
-// 	// const { data } = props
-// 	const tempContext2 = useContext(tempContext)
+const CustomControl = (props: ControlProps<DropdownChoiceInt>) => {
+	// const { data } = props
+	// const tempContext2 = useContext(tempContext)
 
-// 	return (
-// 		<CInput
-// 			// innerRef={innerRef}
-// 			type="text"
-// 			// disabled={disabled}
-// 			// value={tmpValue ?? value ?? ''}
-// 			// style={{ color: !isValueValid(tmpValue ?? value) ? 'red' : undefined, ...extraStyle }}
-// 			// title={tooltip}
-// 			value={tempContext2.value}
-// 			onChange={tempContext2.setValue}
-// 			// onFocus={() => setTmpValue(value ?? '')}
-// 			// onBlur={() => setTmpValue(null)}
-// 			// placeholder={placeholder}
-
-// 		/>
-// 	)
-// }
-// const CustomInput = memo((props: InputProps<DropdownChoiceInt>) => {
-// 	const tempContext2 = useContext(tempContext)
-// 	const { children } = props
-// 	return (
-// 		<SelectComponents.Input {...props} value={tempContext2.value} onChange={tempContext2.setValue}>
-// 			{children}
-// 		</SelectComponents.Input>
-// 	)
-// })
+	return (
+		<SelectComponents.Control {...props} className={(props.className ?? '') + ' variables-text-input'}>
+			{props.children}
+		</SelectComponents.Control>
+	)
+}
 
 const CustomValueContainer = (props: ValueContainerProps<DropdownChoiceInt>) => {
-	const { children } = props
-
 	const tempContext2 = useContext(tempContext)
 
 	const checkCursor = useCallback(
@@ -376,7 +353,8 @@ const CustomValueContainer = (props: ValueContainerProps<DropdownChoiceInt>) => 
 	const onKeyDown = useCallback(
 		(e: React.KeyboardEvent<HTMLInputElement>) => {
 			if (e.code === 'Escape') {
-				tempContext2.setCursorPosition(null)
+				// TODO - force hide
+				// tempContext2.setCursorPosition(null)
 			} else {
 				checkCursor(e)
 			}
@@ -392,6 +370,7 @@ const CustomValueContainer = (props: ValueContainerProps<DropdownChoiceInt>) => 
 				type="text"
 				// disabled={disabled}
 				// value={tmpValue ?? value ?? ''}
+				style={tempContext2.extraStyle}
 				// style={{ color: !isValueValid(tmpValue ?? value) ? 'red' : undefined, ...extraStyle }}
 				// title={tooltip}
 				value={tempContext2.value}

--- a/webui/src/Components/TextInputField.tsx
+++ b/webui/src/Components/TextInputField.tsx
@@ -239,14 +239,9 @@ function VariablesSelect({ isOpen, searchValue, onVariableSelect, useLocationVar
 		return suggestions
 	}, [variableDefinitionsContext, useLocationVariables])
 
-	// const valueOption: DropdownChoiceInt = {
-	// 	value: searchValue,
-	// 	label: searchValue,
-	// }
-	console.log('s', searchValue)
-
 	return (
 		<Select
+			className="variable-select-root"
 			// classNamePrefix: 'select-control',
 			menuPortalTarget={menuPortal || document.body}
 			menuShouldBlockScroll={!!menuPortal} // The dropdown doesn't follow scroll when in a modal
@@ -255,7 +250,6 @@ function VariablesSelect({ isOpen, searchValue, onVariableSelect, useLocationVar
 			isSearchable
 			isMulti={false}
 			options={options}
-			// value={valueOption}
 			value={null}
 			inputValue={searchValue}
 			onChange={onVariableSelect}
@@ -263,7 +257,7 @@ function VariablesSelect({ isOpen, searchValue, onVariableSelect, useLocationVar
 			components={{
 				Option: CustomOption,
 				ValueContainer: CustomValueContainer,
-				Control: CustomControl /*Input: CustomInput*/,
+				Control: CustomControl,
 				IndicatorsContainer: EmptyComponent,
 			}}
 			filterOption={filterOption}
@@ -301,9 +295,6 @@ const EmptyComponent = () => {
 }
 
 const CustomControl = (props: ControlProps<DropdownChoiceInt>) => {
-	// const { data } = props
-	// const tempContext2 = useContext(tempContext)
-
 	return (
 		<SelectComponents.Control {...props} className={(props.className ?? '') + ' variables-text-input'}>
 			{props.children}
@@ -366,12 +357,10 @@ const CustomValueContainer = (props: ValueContainerProps<DropdownChoiceInt>) => 
 		<SelectComponents.ValueContainer {...props}>
 			<CInput
 				{...props.innerProps}
-				// innerRef={innerRef}
 				type="text"
 				// disabled={disabled}
 				// value={tmpValue ?? value ?? ''}
 				style={tempContext2.extraStyle}
-				// style={{ color: !isValueValid(tmpValue ?? value) ? 'red' : undefined, ...extraStyle }}
 				// title={tooltip}
 				value={tempContext2.value}
 				onChange={tempContext2.setValue}

--- a/webui/src/Controls/ButtonStyleConfig.tsx
+++ b/webui/src/Controls/ButtonStyleConfig.tsx
@@ -1,6 +1,6 @@
 import { CButton, CRow, CCol, CButtonGroup, CForm, CAlert, CInputGroup, CInputGroupAppend } from '@coreui/react'
 import React, { MutableRefObject, useCallback, useContext, useMemo, useState } from 'react'
-import { socketEmitPromise, SocketContext, PreventDefaultHandler } from '../util.js'
+import { socketEmitPromise, SocketContext, PreventDefaultHandler, VariableDefinitionsContext } from '../util.js'
 import {
 	AlignmentInputField,
 	ColorInputField,
@@ -14,6 +14,7 @@ import { faDollarSign, faFont, faQuestionCircle, faTrash } from '@fortawesome/fr
 import { SomeButtonModel } from '@companion-app/shared/Model/ButtonModel.js'
 import { ButtonStyleProperties } from '@companion-app/shared/Model/StyleModel.js'
 import { InputFeatureIcons, InputFeatureIconsProps } from './OptionsInputField.js'
+import { MenuPortalContext } from '../Components/DropdownInputField.js'
 
 interface ButtonStyleConfigProps {
 	controlId: string
@@ -206,6 +207,7 @@ export function ButtonStyleConfigFields({
 							</CButton>
 						</CInputGroupAppend>
 					</CInputGroup>
+					{/* <VariablesSelect /> */}
 				</div>
 			)}
 

--- a/webui/src/Controls/ButtonStyleConfig.tsx
+++ b/webui/src/Controls/ButtonStyleConfig.tsx
@@ -206,7 +206,6 @@ export function ButtonStyleConfigFields({
 							</CButton>
 						</CInputGroupAppend>
 					</CInputGroup>
-					{/* <VariablesSelect /> */}
 				</div>
 			)}
 

--- a/webui/src/Controls/ButtonStyleConfig.tsx
+++ b/webui/src/Controls/ButtonStyleConfig.tsx
@@ -1,6 +1,6 @@
 import { CButton, CRow, CCol, CButtonGroup, CForm, CAlert, CInputGroup, CInputGroupAppend } from '@coreui/react'
 import React, { MutableRefObject, useCallback, useContext, useMemo, useState } from 'react'
-import { socketEmitPromise, SocketContext, PreventDefaultHandler, VariableDefinitionsContext } from '../util.js'
+import { socketEmitPromise, SocketContext, PreventDefaultHandler } from '../util.js'
 import {
 	AlignmentInputField,
 	ColorInputField,
@@ -14,7 +14,6 @@ import { faDollarSign, faFont, faQuestionCircle, faTrash } from '@fortawesome/fr
 import { SomeButtonModel } from '@companion-app/shared/Model/ButtonModel.js'
 import { ButtonStyleProperties } from '@companion-app/shared/Model/StyleModel.js'
 import { InputFeatureIcons, InputFeatureIconsProps } from './OptionsInputField.js'
-import { MenuPortalContext } from '../Components/DropdownInputField.js'
 
 interface ButtonStyleConfigProps {
 	controlId: string

--- a/webui/src/scss/_controls.scss
+++ b/webui/src/scss/_controls.scss
@@ -28,14 +28,20 @@ label.disabled {
 }
 
 /* Style for autocomplete of variable */
-.tribute-container li span {
+.tribute-container li span,
+.variable-suggestion-option span {
 	display: block;
-}
-.tribute-container li span.var-label {
-	overflow: hidden;
-	font-weight: inherit;
-	text-overflow: ellipsis;
-	white-space: nowrap;
+
+	&.var-name {
+		font-weight: bold;
+	}
+
+	&.var-label {
+		overflow: hidden;
+		font-weight: inherit;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
 }
 
 .alignmentinput {

--- a/webui/src/scss/_controls.scss
+++ b/webui/src/scss/_controls.scss
@@ -44,6 +44,16 @@ label.disabled {
 	}
 }
 
+.variables-text-input {
+	& > div {
+		padding: 0 !important;
+	}
+
+	.form-control {
+		border: none;
+	}
+}
+
 .alignmentinput {
 	display: grid;
 	width: 60px;

--- a/webui/src/scss/_controls.scss
+++ b/webui/src/scss/_controls.scss
@@ -28,7 +28,6 @@ label.disabled {
 }
 
 /* Style for autocomplete of variable */
-.tribute-container li span,
 .variable-suggestion-option span {
 	display: block;
 
@@ -44,13 +43,20 @@ label.disabled {
 	}
 }
 
-.variables-text-input {
-	& > div {
-		padding: 0 !important;
-	}
+.variable-select-root {
+	display: flex;
+	flex-grow: 1;
 
-	.form-control {
-		border: none;
+	.variables-text-input {
+		flex-grow: 1;
+
+		& > div {
+			padding: 0 !important;
+		}
+
+		.form-control {
+			border: none;
+		}
 	}
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -572,7 +572,6 @@ __metadata:
     sanitize-html: "npm:^2.11.0"
     sass: "npm:^1.71.0"
     socket.io-client: "npm:^4.7.4"
-    tributejs: "npm:^5.1.3"
     typescript: "npm:~5.3.3"
     use-deep-compare: "npm:^1.2.1"
     usehooks-ts: "npm:^2.14.0"
@@ -12836,13 +12835,6 @@ asn1@evs-broadcast/node-asn1:
   bin:
     tree-kill: cli.js
   checksum: 10c0/7b1b7c7f17608a8f8d20a162e7957ac1ef6cd1636db1aba92f4e072dc31818c2ff0efac1e3d91064ede67ed5dc57c565420531a8134090a12ac10cf792ab14d2
-  languageName: node
-  linkType: hard
-
-"tributejs@npm:^5.1.3":
-  version: 5.1.3
-  resolution: "tributejs@npm:5.1.3"
-  checksum: 10c0/5d119edb613d1b5d3d2eb5710cf5e06499cf3698697fceb11f2990a1396c2e70e1e69d4ee9992bb1fd9aa15391aea8e873422710c494dd39387822bb90039d85
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This replaces uses of https://github.com/zurb/tribute which looks like it might no longer be maintained, and is not very react friendly with some custom wrapping around react-select, which we already use for simple dropdown fields.

This makes the ui a bit more consistent, as it matches the look of elsewhere, and avoids the bug of #2344 by locking the dropdown to always be below the text field, and to always be the full width
![image](https://github.com/bitfocus/companion/assets/1327476/65c92011-8913-44dc-aad2-a9b305344903)

It is possible that there are some unintentional quirks in this new implementation, as some of the features of react-select have to be bypassed, and some functionality you would expect from this kind of 'suggestion' input have to be implemented around what react-select offers.

But as a bonus of this, we have a bit more control over some of the behaviour, which resolves some existing quirks around the picker not opening if there is not a space in front of the `$(` sequence. 