### PR TITLE
fix: routes precedence #2820

### DIFF
--- a/companion/lib/Service/Controller.js
+++ b/companion/lib/Service/Controller.js
@@ -38,8 +38,7 @@ class ServiceController {
 	 * @param {import('../Registry.js').default} registry - the application core
 	 */
 	constructor(registry) {
-		this.httpApi = new ServiceHttpApi(registry, registry.ui.express.legacyApiRouter)
-		this.httpApi.bindToApp(registry.ui.express.app)
+		this.httpApi = new ServiceHttpApi(registry, registry.ui.express)
 		this.https = new ServiceHttps(registry, registry.ui.express)
 		this.oscSender = new ServiceOscSender(registry)
 		this.oscListener = new ServiceOscListener(registry)

--- a/companion/lib/Service/HttpApi.js
+++ b/companion/lib/Service/HttpApi.js
@@ -43,7 +43,7 @@ export class ServiceHttpApi extends CoreBase {
 
 	/**
 	 * @param {import('../Registry.js').default} registry - the application core
-	 * @param {import('../UI/Express.js').default} express - express 
+	 * @param {import('../UI/Express.js').default} express - express
 	 */
 	constructor(registry, express) {
 		super(registry, 'Service/HttpApi')
@@ -52,18 +52,16 @@ export class ServiceHttpApi extends CoreBase {
 		// @ts-ignore
 		this.#apiRouter = new Express.Router()
 
-		this.#apiRouter.use(
-			(_req, res, next) => {
-				// Check that the API is enabled
-				if (this.userconfig.getKey('http_api_enabled')) {
-					// Continue
-					next()
-				} else {
-					// Disabled
-					res.status(403).send()
-				}
+		this.#apiRouter.use((_req, res, next) => {
+			// Check that the API is enabled
+			if (this.userconfig.getKey('http_api_enabled')) {
+				// Continue
+				next()
+			} else {
+				// Disabled
+				res.status(403).send()
 			}
-		)
+		})
 
 		this.#setupNewHttpRoutes()
 		this.#setupLegacyHttpRoutes()
@@ -296,13 +294,13 @@ export class ServiceHttpApi extends CoreBase {
 		this.#apiRouter.post('/location/:page([0-9]{1,2})/:row(-?[0-9]+)/:column(-?[0-9]+)/style', this.#locationStyle)
 
 		// custom variables
-		this.#apiRouter.route('/custom-variable/:name/value')
+		this.#apiRouter
+			.route('/custom-variable/:name/value')
 			.post(this.#customVariableSetValue)
 			.get(this.#customVariableGetValue)
 
 		// surfaces
 		this.#apiRouter.post('/surfaces/rescan', this.#surfacesRescan)
-
 	}
 
 	/**

--- a/companion/lib/Service/HttpApi.js
+++ b/companion/lib/Service/HttpApi.js
@@ -1,8 +1,8 @@
 import CoreBase from '../Core/Base.js'
 import { ParseAlignment, parseColorToNumber, rgb } from '../Resources/Util.js'
 import express from 'express'
-import cors from 'cors'
 import { formatLocation } from '@companion-app/shared/ControlId.js'
+import Express from 'express'
 
 /**
  * Class providing the HTTP API.
@@ -27,41 +27,32 @@ import { formatLocation } from '@companion-app/shared/ControlId.js'
  */
 export class ServiceHttpApi extends CoreBase {
 	/**
-	 * Root express router
-	 * @type {import('express').Router}
-	 * @access private
-	 */
-	#legacyRouter
-
-	/**
-	 * Api router
+	 * new Api express router
 	 * @type {import('express').Router}
 	 * @access private
 	 */
 	#apiRouter
 
 	/**
-	 * @param {import('../Registry.js').default} registry - the application core
-	 * @param {import('express').Router} router - the http router
+	 * The web application framework
+	 * @type {import('../UI/Express.js').default}
+	 * @access protected
+	 * @readonly
 	 */
-	constructor(registry, router) {
-		super(registry, 'Service/HttpApi')
-
-		this.#legacyRouter = router
-		this.#apiRouter = express.Router()
-		this.#apiRouter.use(cors())
-
-		this.#setupLegacyHttpRoutes()
-		this.#setupNewHttpRoutes()
-	}
+	#express
 
 	/**
-	 *
-	 * @param {import('express').Application} app
+	 * @param {import('../Registry.js').default} registry - the application core
+	 * @param {import('../UI/Express.js').default} express - express 
 	 */
-	bindToApp(app) {
-		app.use(
-			'/api',
+	constructor(registry, express) {
+		super(registry, 'Service/HttpApi')
+
+		this.#express = express
+		// @ts-ignore
+		this.#apiRouter = new Express.Router()
+
+		this.#apiRouter.use(
 			(_req, res, next) => {
 				// Check that the API is enabled
 				if (this.userconfig.getKey('http_api_enabled')) {
@@ -71,9 +62,18 @@ export class ServiceHttpApi extends CoreBase {
 					// Disabled
 					res.status(403).send()
 				}
-			},
-			this.#apiRouter
+			}
 		)
+
+		this.#setupNewHttpRoutes()
+		this.#setupLegacyHttpRoutes()
+
+		// Finally, default all unhandled to 404
+		this.#apiRouter.use('*', (_req, res) => {
+			res.status(404).send('')
+		})
+
+		this.#express.apiRouter = this.#apiRouter
 	}
 
 	#isLegacyRouteAllowed() {
@@ -81,7 +81,7 @@ export class ServiceHttpApi extends CoreBase {
 	}
 
 	#setupLegacyHttpRoutes() {
-		this.#legacyRouter.options('/press/bank/*', (_req, res, _next) => {
+		this.#apiRouter.options('/press/bank/*', (_req, res, _next) => {
 			if (!this.#isLegacyRouteAllowed()) return res.status(403).send()
 
 			res.header('Access-Control-Allow-Origin', '*')
@@ -90,7 +90,7 @@ export class ServiceHttpApi extends CoreBase {
 			return res.send(200)
 		})
 
-		this.#legacyRouter.get('^/press/bank/:page([0-9]{1,2})/:bank([0-9]{1,2})', (req, res) => {
+		this.#apiRouter.get('/press/bank/:page([0-9]{1,2})/:bank([0-9]{1,2})', (req, res) => {
 			if (!this.#isLegacyRouteAllowed()) return res.status(403).send()
 
 			res.header('Access-Control-Allow-Origin', '*')
@@ -116,7 +116,7 @@ export class ServiceHttpApi extends CoreBase {
 			return res.send('ok')
 		})
 
-		this.#legacyRouter.get('^/press/bank/:page([0-9]{1,2})/:bank([0-9]{1,2})/:direction(down|up)', (req, res) => {
+		this.#apiRouter.get('/press/bank/:page([0-9]{1,2})/:bank([0-9]{1,2})/:direction(down|up)', (req, res) => {
 			if (!this.#isLegacyRouteAllowed()) return res.status(403).send()
 
 			res.header('Access-Control-Allow-Origin', '*')
@@ -156,7 +156,7 @@ export class ServiceHttpApi extends CoreBase {
 			return res.send('ok')
 		})
 
-		this.#legacyRouter.get('^/rescan', (_req, res) => {
+		this.#apiRouter.get('/rescan', (_req, res) => {
 			if (!this.#isLegacyRouteAllowed()) return res.status(403).send()
 
 			res.header('Access-Control-Allow-Origin', '*')
@@ -174,7 +174,7 @@ export class ServiceHttpApi extends CoreBase {
 			)
 		})
 
-		this.#legacyRouter.get('^/style/bank/:page([0-9]{1,2})/:bank([0-9]{1,2})', (req, res) => {
+		this.#apiRouter.get('/style/bank/:page([0-9]{1,2})/:bank([0-9]{1,2})', (req, res) => {
 			if (!this.#isLegacyRouteAllowed()) return res.status(403).send()
 
 			res.header('Access-Control-Allow-Origin', '*')
@@ -262,7 +262,7 @@ export class ServiceHttpApi extends CoreBase {
 			return res.send('ok')
 		})
 
-		this.#legacyRouter.get('^/set/custom-variable/:name', (req, res) => {
+		this.#apiRouter.get('/set/custom-variable/:name', (req, res) => {
 			if (!this.#isLegacyRouteAllowed()) return res.status(403).send()
 
 			res.header('Access-Control-Allow-Origin', '*')
@@ -296,16 +296,13 @@ export class ServiceHttpApi extends CoreBase {
 		this.#apiRouter.post('/location/:page([0-9]{1,2})/:row(-?[0-9]+)/:column(-?[0-9]+)/style', this.#locationStyle)
 
 		// custom variables
-		this.#apiRouter.post('/custom-variable/:name/value', this.#customVariableSetValue)
-		this.#apiRouter.get('/custom-variable/:name/value', this.#customVariableGetValue)
+		this.#apiRouter.route('/custom-variable/:name/value')
+			.post(this.#customVariableSetValue)
+			.get(this.#customVariableGetValue)
 
 		// surfaces
 		this.#apiRouter.post('/surfaces/rescan', this.#surfacesRescan)
 
-		// Finally, default all unhandled to 404
-		this.#apiRouter.use('*', (_req, res) => {
-			res.status(404).send('')
-		})
 	}
 
 	/**

--- a/companion/lib/UI/Express.js
+++ b/companion/lib/UI/Express.js
@@ -105,7 +105,7 @@ class UIExpress {
 		})
 
 		// Use the router #apiRouter to add API routes dynamically, this router can be redefined at runtime with setter
-		this.app.use('/api', (r,s,n) => this.#apiRouter(r,s,n))
+		this.app.use('/api', (r, s, n) => this.#apiRouter(r, s, n))
 
 		/**
 		 * @param {string} subpath
@@ -144,9 +144,9 @@ class UIExpress {
 
 	/**
 	 * Set a new router as the ApiRouter
-	 * @param {*} router 
+	 * @param {*} router
 	 */
-	set apiRouter (router) {
+	set apiRouter(router) {
 		this.#apiRouter = router
 	}
 }

--- a/companion/lib/UI/Express.js
+++ b/companion/lib/UI/Express.js
@@ -64,14 +64,13 @@ class UIExpress {
 	logger = LogController.createLogger('UI/Express')
 
 	app = Express()
+	#apiRouter = Express.Router()
 
 	/**
 	 * @param {import('../Registry.js').default} registry
 	 */
 	constructor(registry) {
 		this.registry = registry
-
-		this.legacyApiRouter = Express.Router()
 
 		this.app.use(cors())
 
@@ -105,7 +104,8 @@ class UIExpress {
 			}
 		})
 
-		this.app.use(this.legacyApiRouter)
+		// Use the router #apiRouter to add API routes dynamically, this router can be redefined at runtime with setter
+		this.app.use('/api', (r,s,n) => this.#apiRouter(r,s,n))
 
 		/**
 		 * @param {string} subpath
@@ -140,6 +140,14 @@ class UIExpress {
 			req.url = '/index.html'
 			return webuiServer(req, res, next)
 		})
+	}
+
+	/**
+	 * Set a new router as the ApiRouter
+	 * @param {*} router 
+	 */
+	set apiRouter (router) {
+		this.#apiRouter = router
 	}
 }
 


### PR DESCRIPTION
So far the express routes of the new http API have been pushed to the end of the routes of express app. This results in bug #2820 where the default catch all get requests and return index is served before the get of the api.
This PR changes the routing a little bit:
The api router is invoked with a base url from the app, so all urls are relative to the base url there. The router itself does not define a base url any more.
Legacy API routes and the new API routes are set up in one shared router. The router is added dynamically to the express app and can be swapped at runtime to make the logic consistent with the controller.
The new api routes are now parsed before the legacy routes.
The catch all 404 route for the api is not a part of the legacy or the new api routes any more but always at the end of all api routes.