### PR TITLE
feat: Preset text type

### DIFF
--- a/companion/lib/Instance/Definitions.js
+++ b/companion/lib/Instance/Definitions.js
@@ -457,32 +457,35 @@ class InstanceDefinitions extends CoreBase {
 							style: fb.style,
 							isInverted: !!fb.isInverted,
 						})),
-						steps: rawPreset.steps.length === 0 ? [{ action_sets: { down: [], up: [] } }] : rawPreset.steps.map((step) => {
-							const options = cloneDeep(ControlButtonNormal.DefaultStepOptions)
-							/** @type {PresetActionSets} */
-							const action_sets = {
-								down: [],
-								up: [],
-							}
+						steps:
+							rawPreset.steps.length === 0
+								? [{ action_sets: { down: [], up: [] } }]
+								: rawPreset.steps.map((step) => {
+										const options = cloneDeep(ControlButtonNormal.DefaultStepOptions)
+										/** @type {PresetActionSets} */
+										const action_sets = {
+											down: [],
+											up: [],
+										}
 
-							for (const [setId, set] of Object.entries(step)) {
-								/** @type {import('@companion-module/base').CompanionPresetAction[]} */
-								const setActions = Array.isArray(set) ? set : set.actions
-								if (!isNaN(Number(setId)) && set.options?.runWhileHeld) options.runWhileHeld.push(Number(setId))
+										for (const [setId, set] of Object.entries(step)) {
+											/** @type {import('@companion-module/base').CompanionPresetAction[]} */
+											const setActions = Array.isArray(set) ? set : set.actions
+											if (!isNaN(Number(setId)) && set.options?.runWhileHeld) options.runWhileHeld.push(Number(setId))
 
-								// @ts-ignore
-								action_sets[setId] = setActions.map((act) => ({
-									action: act.actionId,
-									options: act.options,
-									delay: act.delay,
-								}))
-							}
+											// @ts-ignore
+											action_sets[setId] = setActions.map((act) => ({
+												action: act.actionId,
+												options: act.options,
+												delay: act.delay,
+											}))
+										}
 
-							return {
-								options,
-								action_sets,
-							}
-						}),
+										return {
+											options,
+											action_sets,
+										}
+									}),
 					}
 				} else if (rawPreset.type === 'text') {
 					newPresets[id] = {
@@ -516,7 +519,7 @@ class InstanceDefinitions extends CoreBase {
 					id: preset.id,
 					label: preset.name,
 					category: preset.category,
-					type: 'button'
+					type: 'button',
 				}
 			} else if (preset.type === 'text') {
 				res[id] = {
@@ -524,7 +527,7 @@ class InstanceDefinitions extends CoreBase {
 					label: preset.name,
 					category: preset.category,
 					type: 'text',
-					text: preset.text
+					text: preset.text,
 				}
 			}
 		}
@@ -588,7 +591,6 @@ class InstanceDefinitions extends CoreBase {
 		 */
 		for (const preset of Object.values(presets)) {
 			if (preset.type !== 'text') {
-
 				if (preset.style) {
 					preset.style.text = replaceAllVariables(preset.style.text)
 				}

--- a/companion/lib/Instance/Definitions.js
+++ b/companion/lib/Instance/Definitions.js
@@ -554,7 +554,6 @@ class InstanceDefinitions extends CoreBase {
 	 * @param {Record<string, PresetDefinition>} presets
 	 */
 	#updateVariablePrefixesAndStoreDefinitions(connectionId, label, presets) {
-		console.log(123, 'updateVariablePrefixesAndStoreDefinitions')
 		const variableRegex = /\$\(([^:$)]+):([^)$]+)\)/
 
 		/**
@@ -604,7 +603,6 @@ class InstanceDefinitions extends CoreBase {
 				}
 			}
 		}
-		console.log(456, 'updateVariablePrefixesAndStoreDefinitions')
 
 		const lastPresetDefinitions = this.#presetDefinitions[connectionId]
 		this.#presetDefinitions[connectionId] = cloneDeep(presets)

--- a/companion/lib/Instance/Definitions.js
+++ b/companion/lib/Instance/Definitions.js
@@ -108,7 +108,7 @@ class InstanceDefinitions extends CoreBase {
 
 		client.onPromise('presets:preview_render', async (connectionId, presetId) => {
 			const definition = this.#presetDefinitions[connectionId]?.[presetId]
-			if (definition) {
+			if (definition && definition.type === 'button') {
 				const style = {
 					...(definition.previewStyle ? definition.previewStyle : definition.style),
 					style: definition.type,
@@ -306,7 +306,7 @@ class InstanceDefinitions extends CoreBase {
 	 */
 	importPresetToLocation(connectionId, presetId, location) {
 		const definition = this.#presetDefinitions[connectionId]?.[presetId]
-		if (!definition) return false
+		if (!definition || definition.type !== 'button') return false
 
 		/** @type {import('@companion-app/shared/Model/ButtonModel.js').NormalButtonModel} */
 		const result = {
@@ -442,55 +442,56 @@ class InstanceDefinitions extends CoreBase {
 
 		for (const [id, rawPreset] of Object.entries(rawPresets)) {
 			try {
-				newPresets[id] = {
-					id: id,
-					category: rawPreset.category,
-					name: rawPreset.name,
-					type: rawPreset.type,
-					style: rawPreset.style,
-					previewStyle: rawPreset.previewStyle,
-					options: rawPreset.options,
-					feedbacks: (rawPreset.feedbacks ?? []).map((fb) => ({
-						type: fb.feedbackId,
-						options: fb.options,
-						style: fb.style,
-						isInverted: !!fb.isInverted,
-					})),
-					steps: rawPreset.steps.map((step) => {
-						const options = cloneDeep(ControlButtonNormal.DefaultStepOptions)
-						/** @type {PresetActionSets} */
-						const action_sets = {
-							down: [],
-							up: [],
-						}
+				if (rawPreset.type === 'button') {
+					newPresets[id] = {
+						id: id,
+						category: rawPreset.category,
+						name: rawPreset.name,
+						type: rawPreset.type,
+						style: rawPreset.style,
+						previewStyle: rawPreset.previewStyle,
+						options: rawPreset.options,
+						feedbacks: (rawPreset.feedbacks ?? []).map((fb) => ({
+							type: fb.feedbackId,
+							options: fb.options,
+							style: fb.style,
+							isInverted: !!fb.isInverted,
+						})),
+						steps: rawPreset.steps.length === 0 ? [{ action_sets: { down: [], up: [] } }] : rawPreset.steps.map((step) => {
+							const options = cloneDeep(ControlButtonNormal.DefaultStepOptions)
+							/** @type {PresetActionSets} */
+							const action_sets = {
+								down: [],
+								up: [],
+							}
 
-						for (const [setId, set] of Object.entries(step)) {
-							/** @type {import('@companion-module/base').CompanionPresetAction[]} */
-							const setActions = Array.isArray(set) ? set : set.actions
-							if (!isNaN(Number(setId)) && set.options?.runWhileHeld) options.runWhileHeld.push(Number(setId))
+							for (const [setId, set] of Object.entries(step)) {
+								/** @type {import('@companion-module/base').CompanionPresetAction[]} */
+								const setActions = Array.isArray(set) ? set : set.actions
+								if (!isNaN(Number(setId)) && set.options?.runWhileHeld) options.runWhileHeld.push(Number(setId))
 
-							// @ts-ignore
-							action_sets[setId] = setActions.map((act) => ({
-								action: act.actionId,
-								options: act.options,
-								delay: act.delay,
-							}))
-						}
+								// @ts-ignore
+								action_sets[setId] = setActions.map((act) => ({
+									action: act.actionId,
+									options: act.options,
+									delay: act.delay,
+								}))
+							}
 
-						return {
-							options,
-							action_sets,
-						}
-					}),
-				}
-
-				if (!newPresets[id].steps.length) {
-					newPresets[id].steps.push({
-						action_sets: {
-							down: [],
-							up: [],
-						},
-					})
+							return {
+								options,
+								action_sets,
+							}
+						}),
+					}
+				} else if (rawPreset.type === 'text') {
+					newPresets[id] = {
+						id: id,
+						category: rawPreset.category,
+						name: rawPreset.name,
+						type: rawPreset.type,
+						text: rawPreset.text,
+					}
 				}
 			} catch (e) {
 				this.logger.warn(`${label} gave invalid preset "${id}": ${e}`)
@@ -510,10 +511,21 @@ class InstanceDefinitions extends CoreBase {
 		const res = {}
 
 		for (const [id, preset] of Object.entries(presets)) {
-			res[id] = {
-				id: preset.id,
-				label: preset.name,
-				category: preset.category,
+			if (preset.type === 'button') {
+				res[id] = {
+					id: preset.id,
+					label: preset.name,
+					category: preset.category,
+					type: 'button'
+				}
+			} else if (preset.type === 'text') {
+				res[id] = {
+					id: preset.id,
+					label: preset.name,
+					category: preset.category,
+					type: 'text',
+					text: preset.text
+				}
 			}
 		}
 
@@ -539,6 +551,7 @@ class InstanceDefinitions extends CoreBase {
 	 * @param {Record<string, PresetDefinition>} presets
 	 */
 	#updateVariablePrefixesAndStoreDefinitions(connectionId, label, presets) {
+		console.log(123, 'updateVariablePrefixesAndStoreDefinitions')
 		const variableRegex = /\$\(([^:$)]+):([^)$]+)\)/
 
 		/**
@@ -574,18 +587,22 @@ class InstanceDefinitions extends CoreBase {
 		 * demand that your presets MUST be dynamically generated.
 		 */
 		for (const preset of Object.values(presets)) {
-			if (preset.style) {
-				preset.style.text = replaceAllVariables(preset.style.text)
-			}
+			if (preset.type !== 'text') {
 
-			if (preset.feedbacks) {
-				for (const feedback of preset.feedbacks) {
-					if (feedback.style && feedback.style.text) {
-						feedback.style.text = replaceAllVariables(feedback.style.text)
+				if (preset.style) {
+					preset.style.text = replaceAllVariables(preset.style.text)
+				}
+
+				if (preset.feedbacks) {
+					for (const feedback of preset.feedbacks) {
+						if (feedback.style && feedback.style.text) {
+							feedback.style.text = replaceAllVariables(feedback.style.text)
+						}
 					}
 				}
 			}
 		}
+		console.log(456, 'updateVariablePrefixesAndStoreDefinitions')
 
 		const lastPresetDefinitions = this.#presetDefinitions[connectionId]
 		this.#presetDefinitions[connectionId] = cloneDeep(presets)
@@ -623,7 +640,7 @@ export default InstanceDefinitions
 /**
  * @typedef {{
  *   id: string
- * } & import('@companion-module/base').CompanionButtonPresetDefinition} PresetDefinitionTmp
+ * } & import('@companion-module/base').CompanionPresetDefinition} PresetDefinitionTmp
  */
 
 /**

--- a/shared-lib/lib/Model/Presets.ts
+++ b/shared-lib/lib/Model/Presets.ts
@@ -29,7 +29,9 @@ export interface PresetActionSteps {
 	action_sets: PresetActionSets
 }
 
-export interface PresetDefinition {
+export type PresetDefinition = PresetDefinitionButton | PresetDefinitionText
+
+export interface PresetDefinitionButton {
 	id: string
 	name: string
 	category: string
@@ -41,8 +43,27 @@ export interface PresetDefinition {
 	steps: PresetActionSteps[]
 }
 
-export interface UIPresetDefinition {
+export interface PresetDefinitionText {
+	id: string
+	name: string
+	category: string
+	type: 'text'
+	text: string
+}
+
+export type UIPresetDefinition = UIPresetDefinitionButton | UIPresetDefinitionText
+
+export interface UIPresetDefinitionButton {
 	id: string
 	label: string
 	category: string
+	type: 'button'
+}
+
+export interface UIPresetDefinitionText {
+	id: string
+	label: string
+	category: string
+	type: 'text'
+	text: string
 }

--- a/webui/src/Buttons/Presets.tsx
+++ b/webui/src/Buttons/Presets.tsx
@@ -253,9 +253,7 @@ function PresetsButtonList({
 						<PresetIconPreview key={i} connectionId={selectedConnectionId} presetId={preset.id} title={preset.label} />
 					)
 				} else if (preset.type === 'text') {
-					return (
-						<PresetText key={i} preset={preset} />
-					)
+					return <PresetText key={i} preset={preset} />
 				}
 				return null
 			})}
@@ -272,11 +270,9 @@ interface PresetTextProps {
 function PresetText({ preset }: PresetTextProps) {
 	return (
 		<div>
-		<h5>{preset.label}</h5>
-		<p>
-			{preset.text}
-		</p>
-	</div>
+			<h5>{preset.label}</h5>
+			<p>{preset.text}</p>
+		</div>
 	)
 }
 

--- a/webui/src/Buttons/Presets.tsx
+++ b/webui/src/Buttons/Presets.tsx
@@ -11,7 +11,7 @@ import { useDrag } from 'react-dnd'
 import { ButtonPreviewBase, RedImage } from '../Components/ButtonPreview.js'
 import { nanoid } from 'nanoid'
 import type { ClientConnectionConfig } from '@companion-app/shared/Model/Common.js'
-import type { UIPresetDefinition } from '@companion-app/shared/Model/Presets.js'
+import type { UIPresetDefinition, UIPresetDefinitionText } from '@companion-app/shared/Model/Presets.js'
 import type { Operation as JsonPatchOperation } from 'fast-json-patch'
 import { RootAppStoreContext } from '../Stores/RootAppStore.js'
 import { observer } from 'mobx-react-lite'
@@ -47,6 +47,7 @@ export const InstancePresets = observer(function InstancePresets({ resetToken }:
 
 		socketEmitPromise(socket, 'presets:subscribe', [])
 			.then((data) => {
+				console.log('presets:subscribe', data)
 				setPresetsMap(data)
 			})
 			.catch((e) => {
@@ -247,13 +248,35 @@ function PresetsButtonList({
 			<p>Drag and drop the preset buttons below into your buttons-configuration.</p>
 
 			{filteredPresets.map((preset, i) => {
-				return (
-					<PresetIconPreview key={i} connectionId={selectedConnectionId} presetId={preset.id} title={preset.label} />
-				)
+				if (preset.type === 'button') {
+					return (
+						<PresetIconPreview key={i} connectionId={selectedConnectionId} presetId={preset.id} title={preset.label} />
+					)
+				} else if (preset.type === 'text') {
+					return (
+						<PresetText key={i} preset={preset} />
+					)
+				}
+				return null
 			})}
 
 			<br style={{ clear: 'both' }} />
 		</div>
+	)
+}
+
+interface PresetTextProps {
+	preset: UIPresetDefinitionText
+}
+
+function PresetText({ preset }: PresetTextProps) {
+	return (
+		<div>
+		<h5>{preset.label}</h5>
+		<p>
+			{preset.text}
+		</p>
+	</div>
 	)
 }
 


### PR DESCRIPTION
This, along with a PR to Companion Module Base (https://github.com/bitfocus/companion-module-base/pull/80), will allow for the use of a `text` type preset as described in https://github.com/bitfocus/companion/issues/2843, and while not a full rework of the preset structure as suggested in that feature request the implementation of a text type does allow for modules to start utilizing it while consideration/changes to the preset structure take place at a later date.

The following is an example of some examples quickly placed in a module to show how they would be rendered when using something along the lines of
```js
{
  category: 'Mix 1',
  name: 'Test Header',
  type: 'text',
  text: 'Testing a text preset'
},
```
![companion-text-preset](https://github.com/bitfocus/companion-module-base/assets/12213790/51e065e5-213b-473d-b9e8-0be420468b13)

The `name` property takes the place of the header, while the `text` property will be in the paragraph below the header.

