### PR TITLE
feat: move custom variables to $(custom:...) with backward compatibility

### DIFF
--- a/companion/lib/Instance/CustomVariable.js
+++ b/companion/lib/Instance/CustomVariable.js
@@ -430,7 +430,7 @@ export default class InstanceCustomVariable {
 	 */
 	syncValueToDefault(name) {
 		if (this.#custom_variables[name]) {
-			const value = this.#base.getVariableValue('custom', fullname)
+			const value = this.#base.getVariableValue('custom', name)
 			this.#logger.silly(`Set default value "${name}":${value}`)
 			this.#custom_variables[name].defaultValue = value ?? ''
 

--- a/companion/lib/Instance/CustomVariable.js
+++ b/companion/lib/Instance/CustomVariable.js
@@ -18,8 +18,6 @@
 import LogController from '../Log/Controller.js'
 import { isCustomVariableValid } from '@companion-app/shared/CustomVariable.js'
 
-const custom_variable_prefix = `custom_`
-
 const CustomVariablesRoom = 'custom-variables'
 
 /** @typedef {import('@companion-module/base').CompanionVariableValue} CompanionVariableValue */
@@ -204,9 +202,9 @@ export default class InstanceCustomVariable {
 			/** @type {Record<string, CompanionVariableValue>} */
 			const newValues = {}
 			for (const [name, info] of Object.entries(this.#custom_variables)) {
-				newValues[`${custom_variable_prefix}${name}`] = info.defaultValue || ''
+				newValues[name] = info.defaultValue || ''
 			}
-			this.#base.setVariableValues('internal', newValues)
+			this.#base.setVariableValues('custom', newValues)
 		}
 	}
 
@@ -220,11 +218,11 @@ export default class InstanceCustomVariable {
 		const newValues = {}
 		// Mark the current variables as to be deleted
 		for (const name of Object.keys(this.#custom_variables || {})) {
-			newValues[`${custom_variable_prefix}${name}`] = undefined
+			newValues[name] = undefined
 		}
 		// Determine the initial values of the variables
 		for (const [name, info] of Object.entries(custom_variables || {})) {
-			newValues[`${custom_variable_prefix}${name}`] = info.defaultValue || ''
+			newValues[name] = info.defaultValue || ''
 		}
 
 		const namesBefore = Object.keys(this.#custom_variables)
@@ -233,7 +231,7 @@ export default class InstanceCustomVariable {
 		this.doSave()
 
 		// apply the default values
-		this.#base.setVariableValues('internal', newValues)
+		this.#base.setVariableValues('custom', newValues)
 
 		if (this.#io.countRoomMembers(CustomVariablesRoom) > 0) {
 			/** @type {import('@companion-app/shared/Model/CustomVariableModel.js').CustomVariableUpdate[]} **/
@@ -302,8 +300,7 @@ export default class InstanceCustomVariable {
 		this.#custom_variables[name].persistCurrentValue = !!persistent
 
 		if (this.#custom_variables[name].persistCurrentValue) {
-			const fullname = `${custom_variable_prefix}${name}`
-			const value = this.#base.getVariableValue('internal', fullname)
+			const value = this.#base.getVariableValue('custom', name)
 
 			this.#custom_variables[name].defaultValue = value ?? ''
 		}
@@ -383,8 +380,7 @@ export default class InstanceCustomVariable {
 	 * @returns {CompanionVariableValue | undefined}
 	 */
 	getValue(name) {
-		const fullname = `${custom_variable_prefix}${name}`
-		return this.#base.getVariableValue('internal', fullname)
+		return this.#base.getVariableValue('custom', name)
 	}
 
 	/**
@@ -409,9 +405,8 @@ export default class InstanceCustomVariable {
 	 * @param {CompanionVariableValue | undefined} value
 	 */
 	#setValueInner(name, value) {
-		const fullname = `${custom_variable_prefix}${name}`
-		this.#base.setVariableValues('internal', {
-			[fullname]: value,
+		this.#base.setVariableValues('custom', {
+			[name]: value,
 		})
 
 		this.#persistCustomVariableValue(name, value)
@@ -435,8 +430,7 @@ export default class InstanceCustomVariable {
 	 */
 	syncValueToDefault(name) {
 		if (this.#custom_variables[name]) {
-			const fullname = `${custom_variable_prefix}${name}`
-			const value = this.#base.getVariableValue('internal', fullname)
+			const value = this.#base.getVariableValue('custom', fullname)
 			this.#logger.silly(`Set default value "${name}":${value}`)
 			this.#custom_variables[name].defaultValue = value ?? ''
 

--- a/companion/lib/Instance/Variable.js
+++ b/companion/lib/Instance/Variable.js
@@ -171,7 +171,7 @@ class InstanceVariable extends CoreBase {
 			label = 'custom'
 			name = name.substring(7)
 		}
-		
+
 		return this.#variableValues[label]?.[name]
 	}
 

--- a/companion/lib/Instance/Variable.js
+++ b/companion/lib/Instance/Variable.js
@@ -68,8 +68,14 @@ export function parseVariablesInString(string, rawVariableValues, cachedVariable
 		}
 
 		const fullId = matches[0]
-		const connectionLabel = matches[1]
-		const variableId = matches[2]
+		let connectionLabel = matches[1]
+		let variableId = matches[2]
+
+		if (connectionLabel === 'internal' && variableId.substr(0, 7) === 'custom_') {
+			connectionLabel = 'custom'
+			variableId = variableId.substring(7)
+		}
+
 		referencedVariableIds.push(`${connectionLabel}:${variableId}`)
 
 		let cachedValue = cachedVariableValues[fullId]
@@ -161,6 +167,11 @@ class InstanceVariable extends CoreBase {
 	 * @returns {import('@companion-module/base').CompanionVariableValue | undefined}
 	 */
 	getVariableValue(label, name) {
+		if (label === 'internal' && name.substr(0, 7) == 'custom_') {
+			label = 'custom'
+			name = name.substring(7)
+		}
+		
 		return this.#variableValues[label]?.[name]
 	}
 
@@ -170,7 +181,7 @@ class InstanceVariable extends CoreBase {
 	 * @returns {import('@companion-module/base').CompanionVariableValue | undefined}
 	 */
 	getCustomVariableValue(name) {
-		return this.getVariableValue('internal', `custom_${name}`)
+		return this.getVariableValue('custom', name)
 	}
 
 	/**
@@ -414,7 +425,7 @@ class InstanceVariable extends CoreBase {
 
 				// Skip debug if it's just internal:time_* spamming.
 				if (this.logger.isSillyEnabled() && !(label === 'internal' && variable.startsWith('time_'))) {
-					this.logger.silly('Variable $(' + label + ':' + variable + ') is "' + value + '"')
+					this.logger.debug('Variable $(' + label + ':' + variable + ') is "' + value + '"')
 				}
 			}
 		}

--- a/webui/src/Buttons/CustomVariablesList.tsx
+++ b/webui/src/Buttons/CustomVariablesList.tsx
@@ -51,7 +51,7 @@ export const CustomVariablesList = observer(function CustomVariablesList({ setSh
 
 	useEffect(() => {
 		const doPoll = () => {
-			socketEmitPromise(socket, 'variables:instance-values', ['internal'])
+			socketEmitPromise(socket, 'variables:instance-values', ['custom'])
 				.then((values) => {
 					setVariableValues(values || {})
 				})
@@ -258,15 +258,12 @@ export const CustomVariablesList = observer(function CustomVariablesList({ setSh
 
 					{candidates &&
 						candidates.map((info, index) => {
-							const shortname = `custom_${info.name}`
-
 							return (
 								<CustomVariableRow
 									key={info.name}
 									index={index}
 									name={info.name}
-									shortname={shortname}
-									value={variableValues[shortname]}
+									value={variableValues[info.name]}
 									info={info}
 									onCopied={onCopied}
 									doDelete={doDelete}
@@ -316,7 +313,6 @@ interface CustomVariableDragStatus {
 interface CustomVariableRowProps {
 	index: number
 	name: string
-	shortname: string
 	value: any
 	info: CustomVariableDefinitionExt
 	onCopied: () => void
@@ -332,7 +328,6 @@ interface CustomVariableRowProps {
 function CustomVariableRow({
 	index,
 	name,
-	shortname,
 	value,
 	info,
 	onCopied,
@@ -344,7 +339,7 @@ function CustomVariableRow({
 	isCollapsed,
 	setCollapsed,
 }: CustomVariableRowProps) {
-	const fullname = `internal:${shortname}`
+	const fullname = `custom:${name}`
 
 	const doCollapse = useCallback(() => setCollapsed(name, true), [setCollapsed, name])
 	const doExpand = useCallback(() => setCollapsed(name, false), [setCollapsed, name])

--- a/webui/src/Buttons/Variables.tsx
+++ b/webui/src/Buttons/Variables.tsx
@@ -72,6 +72,10 @@ const VariablesConnectionList = observer(function VariablesConnectionList({
 			)
 		}
 
+		if (label === 'custom') {
+			return ''
+		}
+
 		const connectionId = connectionsLabelMap.get(label)
 		const connectionInfo = connectionId ? connectionsContext[connectionId] : undefined
 		const moduleInfo = connectionInfo ? modules.modules.get(connectionInfo.instance_type) : undefined

--- a/webui/src/Stores/VariablesStore.tsx
+++ b/webui/src/Stores/VariablesStore.tsx
@@ -102,6 +102,8 @@ export class VariablesStore {
 			definitions.push(...this.variableDefinitionsForLabel(label))
 		}
 
+		definitions.push(...this.customVariableDefinitions.get())
+
 		return definitions
 	})
 
@@ -122,10 +124,6 @@ export class VariablesStore {
 
 	public variableDefinitionsForLabel = (label: string): VariableDefinitionExt[] => {
 		const definitions: VariableDefinitionExt[] = []
-
-		if (label === 'custom') {
-			definitions.push(...this.customVariableDefinitions.get())
-		}
 
 		// Module variables
 		const variables = this.variables.get(label)

--- a/webui/src/Stores/VariablesStore.tsx
+++ b/webui/src/Stores/VariablesStore.tsx
@@ -112,8 +112,8 @@ export class VariablesStore {
 		for (const [id, info] of this.customVariables) {
 			definitions.push({
 				label: info.description,
-				connectionLabel: 'internal',
-				name: `custom_${id}`,
+				connectionLabel: 'custom',
+				name: id,
 			})
 		}
 
@@ -123,7 +123,7 @@ export class VariablesStore {
 	public variableDefinitionsForLabel = (label: string): VariableDefinitionExt[] => {
 		const definitions: VariableDefinitionExt[] = []
 
-		if (label === 'internal') {
+		if (label === 'custom') {
 			definitions.push(...this.customVariableDefinitions.get())
 		}
 


### PR DESCRIPTION
Responds, in part to #2812 by moving custom variables from `$(internal:custom_...)` to `$(custom:...)`.  Checks are added to maintain backwards compatibility with legacy names.

_If we want to move forward I'll get the rest of the action items executed._ 

My main reason for attempting this is that with the addition of `$(this:...)`, it seems logical to me to make this change.  The fact that `custom` isn't a reserved word in v2.x is concerning, but I think is quite the edge case for someone to completely rename an instance to `custom`.  But that can be investigated for upgrade mitigation ... though scrubbing the variables might become difficult.

TODO:

- [x] Validate basic functionality and backwards compatibility
- [ ] Validate custom variable internal actions
- [ ] Validate triggers
- [ ] Update documentation
- [ ] Update any labels, like indicated in #2812
- [ ] Investigate `custom` instance name mitigation in v2-v3 upgrade