### PR TITLE
feat: multiline expressions

### DIFF
--- a/companion/lib/Internal/Controls.js
+++ b/companion/lib/Internal/Controls.js
@@ -57,6 +57,7 @@ const CHOICES_DYNAMIC_LOCATION = [
 		useVariables: {
 			local: true,
 		},
+		isExpression: true,
 	}),
 ]
 
@@ -87,6 +88,7 @@ const CHOICES_STEP_WITH_VARIABLES = [
 		useVariables: {
 			local: true,
 		},
+		isExpression: true,
 	}),
 ]
 
@@ -278,6 +280,7 @@ export default class Controls {
 						useVariables: {
 							local: true,
 						},
+						isExpression: true,
 					},
 
 					...CHOICES_DYNAMIC_LOCATION,
@@ -523,6 +526,7 @@ export default class Controls {
 						useVariables: {
 							local: true,
 						},
+						isExpression: true,
 					}),
 					{
 						type: 'checkbox',
@@ -606,6 +610,7 @@ export default class Controls {
 						useVariables: {
 							local: true,
 						},
+						isExpression: true,
 					},
 					...CHOICES_DYNAMIC_LOCATION,
 					...CHOICES_STEP_WITH_VARIABLES,

--- a/companion/lib/Internal/CustomVariables.js
+++ b/companion/lib/Internal/CustomVariables.js
@@ -98,6 +98,7 @@ export default class CustomVariables {
 						useVariables: {
 							local: true,
 						},
+						isExpression: true,
 					},
 				],
 			},

--- a/companion/lib/Internal/Surface.js
+++ b/companion/lib/Internal/Surface.js
@@ -103,6 +103,7 @@ const CHOICES_PAGE_WITH_VARIABLES = [
 		useVariables: {
 			local: true,
 		},
+		isExpression: true,
 	}),
 ]
 

--- a/companion/lib/Internal/Variables.js
+++ b/companion/lib/Internal/Variables.js
@@ -164,6 +164,7 @@ export default class Variables {
 						useVariables: {
 							local: true,
 						},
+						isExpression: true,
 					},
 				],
 			},

--- a/docs/4_secondary_admin_controls/expressions/expressions.md
+++ b/docs/4_secondary_admin_controls/expressions/expressions.md
@@ -13,4 +13,14 @@ There are various functions that you can use. These can be used in the usual way
 
 Strings can be formed using `` `${$(internal:a)}dB` ``. You can use anything instead of `$(internal:a)`, even other templates and conditional logic.
 
+You can split your expression over multiple lines or statements, and create intermediary values too
+```
+myval = $(internal:a) + $(internal:b)
+myval / 2
+```
+Note: the parser is looser than js in how statements have to be written, it is valid for multiple to be on one line (eg `10 20 30`).  
+The value of the last statement will be taken as the output of the expression.
+
+And you can add either `/* block comments */` or `// end of line comments` to document your expressions.
+
 All of these features can be combined into long and complex expressions, and more is sure to be possible in the future. We look forward to seeing what you come up with!

--- a/docs/4_secondary_admin_controls/expressions/operators.md
+++ b/docs/4_secondary_admin_controls/expressions/operators.md
@@ -34,5 +34,22 @@ Supported operators include:
   - Define an object: `{ a: 1 }`
   - Define an array: `[1, 2]`
   - Object/array lookup: `$(my:var)['some-prop']`
+- Assignment of temporary variables:
+  - Assignment: `a = 1`
+  - Addition assignment: `a += 1`
+  - Subtraction assignment: `a -= 1`
+  - Multiplication assignment: `a *= 1`
+  - Division assignment: `a /= 1`
+  - Modulous assignment: `a %= 1`
+  - Increment: `a++` or `++a`
+  - Decrement: `a--` or `--a`
+  - Logical OR assignment: `a ||= 1`
+  - Logical AND assignment: `a &&= 1`
+  - Left shift assignment: `a <<= 1`
+  - Right shift assignment: `a >>= 1`
+  - Bitwise XOR assignment: `a ^= 1`
+  - Bitwise AND assignment: `a &= 1`
+  - Bitwise OR assignment: `a |= 1`
+  - Exponent assignment: `a **= 2`
 
 > **Note:** In the examples able `a` and `b` should be replaced with custom variables, module variables or number literals. They are only used here for brevity.

--- a/shared-lib/lib/Expression/ExpressionParse.js
+++ b/shared-lib/lib/Expression/ExpressionParse.js
@@ -2,11 +2,15 @@ import jsep from 'jsep'
 import jsepNumbers from '@jsep-plugin/numbers'
 import jsepObject from '@jsep-plugin/object'
 import jsepTemplateLiteral from '@jsep-plugin/template'
+import jsepComments from '@jsep-plugin/comment'
+// import jsepAssignment from '@jsep-plugin/assignment'
 
 // setup plugins
 jsep.plugins.register(jsepNumbers)
 jsep.plugins.register(jsepObject)
 jsep.plugins.register(jsepTemplateLiteral)
+jsep.plugins.register(jsepComments)
+// jsep.plugins.register(jsepAssignment)
 
 // remove some unwanted operators
 jsep.removeBinaryOp('<<<')

--- a/shared-lib/lib/Expression/ExpressionResolve.js
+++ b/shared-lib/lib/Expression/ExpressionResolve.js
@@ -172,6 +172,10 @@ export function ResolveExpression(node, getVariableValue, functions = {}) {
 						}
 						return obj
 					}
+					case 'ReturnStatement': {
+						// @ts-ignore
+						return resolve(node.argument)
+					}
 					// case 'Property':
 					// 	// @ts-ignore
 					// 	visitElements(node.key, visitor)

--- a/shared-lib/lib/Expression/Plugins/Assignment.js
+++ b/shared-lib/lib/Expression/Plugins/Assignment.js
@@ -1,0 +1,126 @@
+const PLUS_CODE = 43 // +
+const MINUS_CODE = 45 // -
+
+/**
+ * Forked from https://github.com/EricSmekens/jsep/blob/master/packages/assignment/src/index.js to fix an issue with --1 throwing an error
+ */
+export const AssignmentPlugin = {
+	name: 'assignment',
+
+	assignmentOperators: new Set([
+		'=',
+		'*=',
+		'**=',
+		'/=',
+		'%=',
+		'+=',
+		'-=',
+		'<<=',
+		'>>=',
+		/* '>>>=',*/
+		'&=',
+		'^=',
+		'|=',
+		'&&=',
+		'||=',
+	]),
+	updateOperators: [PLUS_CODE, MINUS_CODE],
+	assignmentPrecedence: 0.9,
+
+	init(/** @type {any} */ jsep) {
+		const updateNodeTypes = [jsep.IDENTIFIER, jsep.MEMBER_EXP]
+		AssignmentPlugin.assignmentOperators.forEach((op) =>
+			jsep.addBinaryOp(op, AssignmentPlugin.assignmentPrecedence, true)
+		)
+
+		jsep.hooks.add(
+			'gobble-token',
+			/**
+			 * TODO: this is bad, but necessary for now
+			 * @this {any}
+			 * @param {any} env
+			 */
+			function gobbleUpdatePrefix(env) {
+				const code = this.code
+				if (AssignmentPlugin.updateOperators.some((c) => c === code && c === this.expr.charCodeAt(this.index + 1))) {
+					this.index += 2
+
+					let identifier
+					try {
+						identifier = this.gobbleIdentifier()
+					} catch (e) {
+						// Let it be handled elsewhere
+						this.index -= 2
+					}
+					if (identifier) {
+						env.node = {
+							type: 'UpdateExpression',
+							operator: code === PLUS_CODE ? '++' : '--',
+							argument: this.gobbleTokenProperty(identifier),
+							prefix: true,
+						}
+						if (!env.node.argument || !updateNodeTypes.includes(env.node.argument.type)) {
+							this.throwError(`Unexpected ${env.node.operator}`)
+						}
+					}
+				}
+			}
+		)
+
+		jsep.hooks.add(
+			'after-token',
+			/**
+			 * TODO: this is bad, but necessary for now
+			 * @this {any}
+			 * @param {any} env
+			 */
+			function gobbleUpdatePostfix(env) {
+				if (env.node) {
+					const code = this.code
+					if (AssignmentPlugin.updateOperators.some((c) => c === code && c === this.expr.charCodeAt(this.index + 1))) {
+						if (!updateNodeTypes.includes(env.node.type)) {
+							this.throwError(`Unexpected ${env.node.operator}`)
+						}
+						this.index += 2
+						env.node = {
+							type: 'UpdateExpression',
+							operator: code === PLUS_CODE ? '++' : '--',
+							argument: env.node,
+							prefix: false,
+						}
+					}
+				}
+			}
+		)
+
+		jsep.hooks.add(
+			'after-expression',
+			/**
+			 * TODO: this is bad, but necessary for now
+			 * @this {any}
+			 * @param {any} env
+			 */ function gobbleAssignment(env) {
+				if (env.node) {
+					// Note: Binaries can be chained in a single expression to respect
+					// operator precedence (i.e. a = b = 1 + 2 + 3)
+					// Update all binary assignment nodes in the tree
+					updateBinariesToAssignments(env.node)
+				}
+			}
+		)
+
+		function updateBinariesToAssignments(/** @type {any} */ node) {
+			if (AssignmentPlugin.assignmentOperators.has(node.operator)) {
+				node.type = 'AssignmentExpression'
+				updateBinariesToAssignments(node.left)
+				updateBinariesToAssignments(node.right)
+			} else if (!node.operator) {
+				Object.values(node).forEach((val) => {
+					if (val && typeof val === 'object') {
+						updateBinariesToAssignments(val)
+					}
+				})
+			}
+		}
+	},
+}

--- a/shared-lib/lib/Expression/Plugins/CompanionVariables.js
+++ b/shared-lib/lib/Expression/Plugins/CompanionVariables.js
@@ -1,0 +1,32 @@
+import jsep from 'jsep'
+
+/** @type{jsep.IPlugin} */
+export const CompanionVariablesPlugin = {
+	name: 'companion variables plugin',
+	init(/** @type {any} */ jsep) {
+		// jsep.addIdentifierChar('$(')
+		jsep.hooks.add(
+			'gobble-token',
+			/**
+			 * TODO: this is bad, but necessary for now
+			 * @this {any}
+			 * @param {any} env
+			 */
+			function myPlugin(env) {
+				const tokenStart = this.expr.slice(this.index, this.index + 2)
+				if (tokenStart == '$(') {
+					const end = this.expr.indexOf(')', this.index + 2)
+
+					if (end !== -1) {
+						env.node = {
+							type: 'CompanionVariable',
+							name: this.expr.slice(this.index + 2, end),
+						}
+
+						this.index = end + 1
+					}
+				}
+			}
+		)
+	},
+}

--- a/shared-lib/lib/Model/Options.ts
+++ b/shared-lib/lib/Model/Options.ts
@@ -74,6 +74,8 @@ export type InternalInputField =
 
 export interface CompanionInputFieldTextInputExtended extends CompanionInputFieldTextInput {
 	placeholder?: string
+	/** A UI hint indicating the field is an expression */
+	isExpression?: boolean
 }
 export interface CompanionInputFieldMultiDropdownExtended extends CompanionInputFieldMultiDropdown {
 	allowCustom?: boolean

--- a/shared-lib/package.json
+++ b/shared-lib/package.json
@@ -9,7 +9,6 @@
     }
   },
   "dependencies": {
-    "@jsep-plugin/assignment": "^1.2.1",
     "@jsep-plugin/comment": "^1.0.3",
     "@jsep-plugin/numbers": "^1.0.1",
     "@jsep-plugin/object": "^1.2.1",

--- a/shared-lib/package.json
+++ b/shared-lib/package.json
@@ -9,6 +9,8 @@
     }
   },
   "dependencies": {
+    "@jsep-plugin/assignment": "^1.2.1",
+    "@jsep-plugin/comment": "^1.0.3",
     "@jsep-plugin/numbers": "^1.0.1",
     "@jsep-plugin/object": "^1.2.1",
     "@jsep-plugin/template": "^1.0.4",

--- a/shared-lib/test/expressions-parse.test.js
+++ b/shared-lib/test/expressions-parse.test.js
@@ -964,4 +964,51 @@ describe('parser', () => {
 			})
 		})
 	})
+
+	describe('assignment', () => {
+		it('basic assignment', () => {
+			const result = ParseExpression2('a = 1; a')
+			expect(result).toEqual({
+				expr: {
+					type: 'Compound',
+					body: [
+						{
+							type: 'AssignmentExpression',
+							operator: '=',
+							left: {
+								type: 'Identifier',
+								name: 'a',
+							},
+							right: {
+								type: 'Literal',
+								raw: '1',
+								value: 1,
+							},
+						},
+						{
+							type: 'Identifier',
+							name: 'a',
+						},
+					],
+				},
+				variableIds: [],
+			})
+		})
+
+		it('increment', () => {
+			const result = ParseExpression2('a++')
+			expect(result).toEqual({
+				expr: {
+					type: 'UpdateExpression',
+					operator: '++',
+					prefix: false,
+					argument: {
+						type: 'Identifier',
+						name: 'a',
+					},
+				},
+				variableIds: [],
+			})
+		})
+	})
 })

--- a/shared-lib/test/expressions-parse.test.js
+++ b/shared-lib/test/expressions-parse.test.js
@@ -751,4 +751,217 @@ describe('parser', () => {
 			})
 		})
 	})
+
+	describe('line terminator', () => {
+		it('multi-statement with semicolon', () => {
+			const result = ParseExpression2('1 + 2;3 + 4')
+			expect(result).toEqual({
+				expr: {
+					body: [
+						{
+							type: 'BinaryExpression',
+							operator: '+',
+							left: {
+								raw: '1',
+								type: 'Literal',
+								value: 1,
+							},
+							right: {
+								raw: '2',
+								type: 'Literal',
+								value: 2,
+							},
+						},
+						{
+							type: 'BinaryExpression',
+							operator: '+',
+							left: {
+								raw: '3',
+								type: 'Literal',
+								value: 3,
+							},
+							right: {
+								raw: '4',
+								type: 'Literal',
+								value: 4,
+							},
+						},
+					],
+					type: 'Compound',
+				},
+				variableIds: [],
+			})
+		})
+		it('multi-statement with line split', () => {
+			const result = ParseExpression2('1 + 2\n3 + 4')
+			expect(result).toEqual({
+				expr: {
+					body: [
+						{
+							type: 'BinaryExpression',
+							operator: '+',
+							left: {
+								raw: '1',
+								type: 'Literal',
+								value: 1,
+							},
+							right: {
+								raw: '2',
+								type: 'Literal',
+								value: 2,
+							},
+						},
+						{
+							type: 'BinaryExpression',
+							operator: '+',
+							left: {
+								raw: '3',
+								type: 'Literal',
+								value: 3,
+							},
+							right: {
+								raw: '4',
+								type: 'Literal',
+								value: 4,
+							},
+						},
+					],
+					type: 'Compound',
+				},
+				variableIds: [],
+			})
+		})
+
+		it('multi-statement with extra newlines', () => {
+			const result = ParseExpression2('1\n+ \n2\n3 +\n 4\n')
+			expect(result).toEqual({
+				expr: {
+					body: [
+						{
+							type: 'BinaryExpression',
+							operator: '+',
+							left: {
+								raw: '1',
+								type: 'Literal',
+								value: 1,
+							},
+							right: {
+								raw: '2',
+								type: 'Literal',
+								value: 2,
+							},
+						},
+						{
+							type: 'BinaryExpression',
+							operator: '+',
+							left: {
+								raw: '3',
+								type: 'Literal',
+								value: 3,
+							},
+							right: {
+								raw: '4',
+								type: 'Literal',
+								value: 4,
+							},
+						},
+					],
+					type: 'Compound',
+				},
+				variableIds: [],
+			})
+		})
+	})
+
+	describe('return statement', () => {
+		it('basic statement', () => {
+			const result = ParseExpression2('1\n+ \n2\n return 3 +\n 4\n')
+			expect(result).toEqual({
+				expr: {
+					body: [
+						{
+							type: 'BinaryExpression',
+							operator: '+',
+							left: {
+								raw: '1',
+								type: 'Literal',
+								value: 1,
+							},
+							right: {
+								raw: '2',
+								type: 'Literal',
+								value: 2,
+							},
+						},
+						{
+							type: 'ReturnStatement',
+							argument: {
+								type: 'BinaryExpression',
+								operator: '+',
+								left: {
+									raw: '3',
+									type: 'Literal',
+									value: 3,
+								},
+								right: {
+									raw: '4',
+									type: 'Literal',
+									value: 4,
+								},
+							},
+						},
+					],
+					type: 'Compound',
+				},
+				variableIds: [],
+			})
+		})
+
+		it('with brackets', () => {
+			const result = ParseExpression2('return (1 + 2)')
+			expect(result).toEqual({
+				expr: {
+					type: 'ReturnStatement',
+					argument: {
+						type: 'BinaryExpression',
+						operator: '+',
+						left: {
+							raw: '1',
+							type: 'Literal',
+							value: 1,
+						},
+						right: {
+							raw: '2',
+							type: 'Literal',
+							value: 2,
+						},
+					},
+				},
+				variableIds: [],
+			})
+		})
+
+		it('return statement complex', () => {
+			const result = ParseExpression2('return $(int:a)[1]')
+			expect(result).toEqual({
+				expr: {
+					type: 'ReturnStatement',
+					argument: {
+						computed: true,
+						object: {
+							name: 'int:a',
+							type: 'CompanionVariable',
+						},
+						property: {
+							raw: '1',
+							type: 'Literal',
+							value: 1,
+						},
+						type: 'MemberExpression',
+					},
+				},
+				variableIds: ['int:a'],
+			})
+		})
+	})
 })

--- a/shared-lib/test/expressions-parse.test.js
+++ b/shared-lib/test/expressions-parse.test.js
@@ -707,4 +707,48 @@ describe('parser', () => {
 			})
 		})
 	})
+
+	describe('comments', () => {
+		it('ignore end of line comments', () => {
+			const result = ParseExpression2('1 + 2 // test')
+			expect(result).toEqual({
+				expr: {
+					type: 'BinaryExpression',
+					operator: '+',
+					left: {
+						raw: '1',
+						type: 'Literal',
+						value: 1,
+					},
+					right: {
+						raw: '2',
+						type: 'Literal',
+						value: 2,
+					},
+				},
+				variableIds: [],
+			})
+		})
+
+		it('ignore middle of line comments', () => {
+			const result = ParseExpression2('1 /* Test */ + 2')
+			expect(result).toEqual({
+				expr: {
+					type: 'BinaryExpression',
+					operator: '+',
+					left: {
+						raw: '1',
+						type: 'Literal',
+						value: 1,
+					},
+					right: {
+						raw: '2',
+						type: 'Literal',
+						value: 2,
+					},
+				},
+				variableIds: [],
+			})
+		})
+	})
 })

--- a/shared-lib/test/expressions-resolver.test.js
+++ b/shared-lib/test/expressions-resolver.test.js
@@ -270,4 +270,33 @@ describe('resolver', function () {
 			expect(result).toEqual('c')
 		})
 	})
+
+	describe('return', () => {
+		it('return value', () => {
+			const result = resolve(parse('return 1'), undefined)
+			expect(result).toBe(1)
+		})
+
+		it('return formula', () => {
+			const result = resolve(parse('return 1 + 2 / 3'), undefined)
+			expect(result).toBe(1 + 2 / 3)
+		})
+
+		it('return brackets', () => {
+			const result = resolve(parse('return (1 / 2)'), undefined)
+			expect(result).toBe(1 / 2)
+		})
+
+		it('return variable', () => {
+			const getVariable = (id) => {
+				switch (id) {
+					case 'some:var':
+						return 'var1'
+				}
+			}
+
+			const result = resolve(parse('return $(some:var)'), getVariable)
+			expect(result).toBe('var1')
+		})
+	})
 })

--- a/shared-lib/test/expressions-resolver.test.js
+++ b/shared-lib/test/expressions-resolver.test.js
@@ -7,8 +7,8 @@ describe('resolver', function () {
 		for (const op of Object.keys(jsep.binary_ops)) {
 			if (op) {
 				it(`should handle "${op}" operator`, function () {
-					const result = resolve(parse(`1 ${op} 2`))
-					expect(typeof result).toMatch(/^number|boolean$/)
+					const result = resolve(parse(`a = 1 ; a ${op} 2`))
+					expect(typeof result).toMatch(/^(number|boolean)$/)
 				})
 			}
 		}
@@ -19,7 +19,7 @@ describe('resolver', function () {
 			if (op) {
 				it(`should handle "${op}" operator`, function () {
 					const result = resolve(parse(`${op}2`))
-					expect(typeof result).toMatch(/^number|boolean$/)
+					expect(typeof result).toMatch(/^(number|boolean)$/)
 				})
 			}
 		}
@@ -151,9 +151,9 @@ describe('resolver', function () {
 			expect(fn).toThrow(/Expected expression after/)
 		})
 
-		it('should detect extraneous operands', function () {
-			const fn = () => resolve(parse('10 + 10 20 30'))
-			expect(fn).toThrow(/Unknown node "Compound"/)
+		it('should treat extraneous operands as multiple statements', function () {
+			const value = resolve(parse('10 + 10 20 30'))
+			expect(value).toEqual(30)
 		})
 	})
 
@@ -297,6 +297,33 @@ describe('resolver', function () {
 
 			const result = resolve(parse('return $(some:var)'), getVariable)
 			expect(result).toBe('var1')
+		})
+
+		it('return in the middle', () => {
+			const result = resolve(parse('return 1\n return 2'), undefined)
+			expect(result).toBe(1)
+		})
+	})
+
+	describe('assignment', () => {
+		it('basic maths', () => {
+			const result = resolve(parse('a = 1\nb=2\nreturn a+b'), undefined)
+			expect(result).toBe(3)
+		})
+
+		it('basic maths with semicolons', () => {
+			const result = resolve(parse('a=1;b=2;return a+b;'), undefined)
+			expect(result).toBe(3)
+		})
+
+		it('no return', () => {
+			const result = resolve(parse('a = 1'), undefined)
+			expect(result).toBe(1)
+		})
+
+		it('no return with update', () => {
+			const result = resolve(parse('a = 1; ++a'), undefined)
+			expect(result).toBe(2)
 		})
 	})
 })

--- a/webui/src/Controls/ButtonStyleConfig.tsx
+++ b/webui/src/Controls/ButtonStyleConfig.tsx
@@ -194,6 +194,7 @@ export function ButtonStyleConfigFields({
 							value={values.text}
 							useVariables
 							useLocalVariables
+							isExpression={values.textExpression}
 							style={{ fontWeight: 'bold', fontSize: 18 }}
 						/>
 						<CInputGroupAppend>

--- a/webui/src/Controls/OptionsInputField.tsx
+++ b/webui/src/Controls/OptionsInputField.tsx
@@ -57,6 +57,7 @@ export function OptionsInputField({
 					placeholder={option.placeholder}
 					useVariables={features.variables}
 					useLocalVariables={features.local}
+					isExpression={option.isExpression}
 					disabled={readonly}
 					setValue={setValue2}
 				/>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1443,6 +1443,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@companion-app/shared@workspace:shared-lib"
   dependencies:
+    "@jsep-plugin/assignment": "npm:^1.2.1"
+    "@jsep-plugin/comment": "npm:^1.0.3"
     "@jsep-plugin/numbers": "npm:^1.0.1"
     "@jsep-plugin/object": "npm:^1.2.1"
     "@jsep-plugin/template": "npm:^1.0.4"
@@ -2452,6 +2454,15 @@ __metadata:
   peerDependencies:
     jsep: ^0.4.0||^1.0.0
   checksum: 10c0/f056a318c4a545ef2376f0dc248f0f9f43548e792fd7f6260b04c93985a1985aeb734af6712b90c9cb09cf74cf092f45492ca0b066db2973a5c949567aceb7fc
+  languageName: node
+  linkType: hard
+
+"@jsep-plugin/comment@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "@jsep-plugin/comment@npm:1.0.3"
+  peerDependencies:
+    jsep: ^0.4.0||^1.0.0
+  checksum: 10c0/5727099eea05d53372560aa0ffc2bc9d554f3b7d3e5e94d9844eb23e5982e5070342c5abc6db15eb62f179ef4ec6a31ffb65c515fd7b04962d12730678029f61
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1443,7 +1443,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@companion-app/shared@workspace:shared-lib"
   dependencies:
-    "@jsep-plugin/assignment": "npm:^1.2.1"
     "@jsep-plugin/comment": "npm:^1.0.3"
     "@jsep-plugin/numbers": "npm:^1.0.1"
     "@jsep-plugin/object": "npm:^1.2.1"


### PR DESCRIPTION
This provides a bunch of improvements to expressions.

The most visible difference is that expression input fields are now displayed as multiline:
![image](https://github.com/bitfocus/companion/assets/1327476/621a71dc-585e-48fd-b5de-acda6632815c)

Expression input fields will now validate their expression in the ui, and will show as red when it failed to parse (execution is not tested)

Additionally, to make this more friendly, it includes some new syntax:
* Comments are now allowed. Same as javascript, both `//` and `/* ... */`
* Expressions can be multiline. Arbitrary line breaks are allowed, which allows for better formatting.
* `return` is a supported operation. Not exactly useful right now, but this can be nice to make an expression more readable in what the output value is
* It is possible to define intermediary variable inside an expression. Something such as `a = 1 ; return a + 2` is now valid and will compute a value of `3`. The values of these are not persisted outside of the execution the expression.
* The 'full' range of assignment operators is functional, including things like `+=`, and `++`

Combine all of these, and you can now break up long complex expressions into multiple stages, with comments and intermediary variables.
The value of the last statement is taken as the output. eg `10 20 30` is 3 statements, and the result will be `30`.

The statement parsing isn't perfect js, the parser is allowing multiple statements on a single line separated by only a space. I worry that this could result in the parsing being more brittle, but I'm not sure if we should be worried about that.

Maybe next could be support for full if statements, or loops, but not as part of this PR.


