### PR TITLE
feat: Time Expression Functions

### DIFF
--- a/docs/4_secondary_admin_controls/expressions/functions.md
+++ b/docs/4_secondary_admin_controls/expressions/functions.md
@@ -51,18 +51,6 @@ Finds the largest of the provided values.
 
 Finds the smallest of the provided values.
 
-**unixNow()**
-
-Get the current unix time in milliseconds.
-
-**timestampToSeconds(timestamp)**
-
-Convert a timestamp of format 'HH:MM:SS' into the number of seconds it represents.
-
-eg `00:10:15` gives 615
-
-You can do the reverse of this with `secondsToTimestamp(str)`
-
 **randomInt(min, max)**
 
 Generate a random integer in the specified range (inclusive).
@@ -148,33 +136,6 @@ Decode a string from the requested format ('hex','base64'). If `enc` is missing,
 
 eg `decode("436f6d70616e696f6e","hex")` gives `"Companion"`
 
-**secondsToTimestamp(seconds, format)**
-
-Convert a number of seconds into a timestamp of format 'HH:mm:ss'.
-
-Note: If the value is less than 0, it will report 0. There is no limit to the number of hours shown, it will display values greater than 24.
-
-By supplying the format parameter, you can choose which components will be included in the output string.
-
-The following components are allowed:
-* `HH` / `hh` - hours
-* `mm` - minutes
-* `ss` - seconds
-
-**msToTimestamp(milliseconds, format)**
-
-Convert a number of milliseconds into a timestamp of format 'HH:mm:ss.SSS'.
-
-Note: If the value is less than 0, it will report 0. There is no limit to the number of hours shown, it will display values greater than 24.
-
-By supplying the format parameter, you can choose which components will be included in the output string.
-
-The following components are allowed:
-* `HH` / `hh` - hours
-* `mm` - minutes
-* `ss` - seconds
-* `.S` / `.SS` / `.SSS` - milliseconds, in varying levels of accuracy. Must be at the end of the string
-
 **parseVariables(string)**
 
 In some scenarios it can be beneficial to have nested variables. This is not supported in the expression syntax.
@@ -220,3 +181,62 @@ Convert an object into a json string.
 If this enounters invalid input, it will return null instead of throwing an error.
 
 eg: `jsonstringify({ a: 1 })` will be a string containing `{"a":1}`
+
+##### Time operations
+
+**unixNow()**
+
+Get the current unix time in milliseconds.
+
+**timestampToSeconds(timestamp)**
+
+Convert a timestamp of format 'HH:MM:SS' into the number of seconds it represents.
+
+eg `00:10:15` gives 615
+
+You can do the reverse of this with `secondsToTimestamp(str)`
+
+
+**secondsToTimestamp(seconds, format)**
+
+Convert a number of seconds into a timestamp of format 'HH:mm:ss'.
+
+Note: If the value is less than 0, it will report 0. There is no limit to the number of hours shown, it will display values greater than 24.
+
+By supplying the format parameter, you can choose which components will be included in the output string.
+
+The following components are allowed:
+* `HH` / `hh` - hours
+* `mm` - minutes
+* `ss` - seconds
+
+**msToTimestamp(milliseconds, format)**
+
+Convert a number of milliseconds into a timestamp of format 'HH:mm:ss.SSS'.
+
+Note: If the value is less than 0, it will report 0. There is no limit to the number of hours shown, it will display values greater than 24.
+
+By supplying the format parameter, you can choose which components will be included in the output string.
+
+The following components are allowed:
+* `HH` / `hh` - hours
+* `mm` - minutes
+* `ss` - seconds
+* `.S` / `.SS` / `.SSS` - milliseconds, in varying levels of accuracy. Must be at the end of the string
+
+**timeOffset(timestamp, offset, 12hour)**
+
+Offset a provided timestamp (supporting `hours:minutes` or `hours:minutes:seconds`) by a given number of hours, minutes, or seconds, and optionally return in 12 hour format.
+
+eg `timeOffset($(internal:time_hms), -5)` will return the hours, minutes, and seconds, of 5 hours prior to the current time.
+
+The offset also supports a timestamp, so  `timeOffset($(internal:time_hms), "01:30:00", true)` will add 1 hour and 30 minutes to the current time, and return a 12 hour clock adjusted to that time.
+
+**timeDiff(fromTime, toTime)**
+
+Return the number of seconds between 2 timestamps. Timestamps support `hours:minutes`, `hours:minutes:seconds`, and `YYYY-MM-DDTHH:mm:ss.sssZ`.
+
+eg `timeDiff($(internal:time_hms), "18:00:00")` will return the seconds until `18:00:00` on the same day, and after that time will return a negative value.
+An example using a Date Time String could be `timeDiff($(internal:time_hms), "2024-07-04T20:00-04:00")` which would return the number of seconds from the current Companion time until 4th July 2024, 8pm, in the UTC-4 Timezone.
+
+The returned seconds can also be used within `secondsToTimestamp` to format the result as needed.

--- a/shared-lib/lib/Expression/ExpressionFunctions.js
+++ b/shared-lib/lib/Expression/ExpressionFunctions.js
@@ -16,15 +16,6 @@ export const ExpressionFunctions = {
 	isNumber: (v) => !isNaN(v),
 	max: (...args) => Math.max(...args),
 	min: (...args) => Math.min(...args),
-	unixNow: () => Date.now(),
-	timestampToSeconds: (str) => {
-		const match = (str + '').match(/^(\d+)\:(\d+)\:(\d+)$/i)
-		if (match) {
-			return Number(match[1]) * 3600 + Number(match[2]) * 60 + Number(match[3])
-		} else {
-			return 0
-		}
-	},
 	randomInt: (min = 0, max = 10) => {
 		min = Number(min)
 		max = Number(max)
@@ -78,49 +69,6 @@ export const ExpressionFunctions = {
 		}
 		return Buffer.from('' + str).toString(enc)
 	},
-	secondsToTimestamp: (v, type) => {
-		v = Math.max(0, v)
-
-		const seconds = pad(Math.floor(v) % 60, '0', 2)
-		const minutes = pad(Math.floor(v / 60) % 60, '0', 2)
-		const hours = pad(Math.floor(v / 3600), '0', 2)
-
-		if (!type) return `${hours}:${minutes}:${seconds}`
-
-		const timestamp = []
-		if (type.includes('HH') || type.includes('hh')) timestamp.push(hours)
-		if (type.includes('mm')) timestamp.push(minutes)
-		if (type.includes('ss')) timestamp.push(seconds)
-
-		return timestamp.join(':')
-	},
-	msToTimestamp: (v, type) => {
-		v = Math.max(0, v)
-
-		const ms = v % 1000
-		const seconds = pad(Math.floor(v / 1000) % 60, '0', 2)
-		const minutes = pad(Math.floor(v / 60000) % 60, '0', 2)
-		const hours = pad(Math.floor(v / 3600000), '0', 2)
-
-		if (!type) return `${minutes}:${seconds}.${Math.floor(ms / 100)}`
-
-		const timestamp = []
-		if (type.includes('HH') || type.includes('hh')) timestamp.push(hours)
-		if (type.includes('mm')) timestamp.push(minutes)
-		if (type.includes('ss')) timestamp.push(seconds)
-
-		let timestampStr = timestamp.join(':')
-		if (type.endsWith('.ms') || type.endsWith('.S')) {
-			timestampStr += `.${Math.floor(ms / 100)}`
-		} else if (type.endsWith('.SS')) {
-			timestampStr += `.${pad(Math.floor(ms / 10), '0', 2)}`
-		} else if (type.endsWith('.SSS')) {
-			timestampStr += `.${pad(ms, '0', 3)}`
-		}
-
-		return timestampStr
-	},
-	// parseVariables is filled in from the caller
 
 	// Bool operations
 	bool: (v) => !!v && v !== 'false' && v !== '0',
@@ -152,7 +100,6 @@ export const ExpressionFunctions = {
 
 		return value
 	},
-
 	jsonparse: (str) => {
 		try {
 			return JSON.parse(str + '')
@@ -160,12 +107,139 @@ export const ExpressionFunctions = {
 			return null
 		}
 	},
-
 	jsonstringify: (obj) => {
 		try {
 			return JSON.stringify(obj)
 		} catch (_e) {
 			return null
 		}
+	},
+
+	// Time operations
+	unixNow: () => Date.now(),
+	timestampToSeconds: (str) => {
+		const match = (str + '').match(/^(\d+)\:(\d+)\:(\d+)$/i)
+		if (match) {
+			return Number(match[1]) * 3600 + Number(match[2]) * 60 + Number(match[3])
+		} else {
+			return 0
+		}
+	},
+	secondsToTimestamp: (v, type) => {
+		let negative = v < 0
+		v = Math.abs(v)
+
+		const seconds = pad(Math.floor(v) % 60, '0', 2)
+		const minutes = pad(Math.floor(v / 60) % 60, '0', 2)
+		const hours = pad(Math.floor(v / 3600), '0', 2)
+
+		if (!type) return `${negative ? '-' : ''}${hours}:${minutes}:${seconds}`
+
+		const timestamp = []
+		if (type.includes('HH') || type.includes('hh')) timestamp.push(hours)
+		if (type.includes('mm')) timestamp.push(minutes)
+		if (type.includes('ss')) timestamp.push(seconds)
+
+		return (negative ? '-' : '') + timestamp.join(':')
+	},
+	msToTimestamp: (v, type) => {
+		v = Math.max(0, v)
+
+		const ms = v % 1000
+		const seconds = pad(Math.floor(v / 1000) % 60, '0', 2)
+		const minutes = pad(Math.floor(v / 60000) % 60, '0', 2)
+		const hours = pad(Math.floor(v / 3600000), '0', 2)
+
+		if (!type) return `${minutes}:${seconds}.${Math.floor(ms / 100)}`
+
+		const timestamp = []
+		if (type.includes('HH') || type.includes('hh')) timestamp.push(hours)
+		if (type.includes('mm')) timestamp.push(minutes)
+		if (type.includes('ss')) timestamp.push(seconds)
+
+		let timestampStr = timestamp.join(':')
+		if (type.endsWith('.ms') || type.endsWith('.S')) {
+			timestampStr += `.${Math.floor(ms / 100)}`
+		} else if (type.endsWith('.SS')) {
+			timestampStr += `.${pad(Math.floor(ms / 10), '0', 2)}`
+		} else if (type.endsWith('.SSS')) {
+			timestampStr += `.${pad(ms, '0', 3)}`
+		}
+
+		return timestampStr
+	},
+	timeOffset: (time, offset, hr12 = false) => {
+		const date = new Date()
+
+		date.setHours(time.split(':')[0])
+		date.setMinutes(time.split(':')[1])
+		date.setSeconds(time.split(':')[2] || 0)
+
+		let diff = offset
+
+		if (typeof offset === 'string') {
+			let hours = 0
+			let minutes = 0
+			let seconds = 0
+			let negative = diff.startsWith('-')
+
+			if (diff.startsWith('+') || diff.startsWith('-')) {
+				diff = diff.substr(1)
+			}
+
+			if (offset.includes(':')) {
+				const split = diff.split(':')
+				hours = parseInt(split[0]) || 0
+				minutes = parseInt(split[1]) || 0
+				seconds = parseInt(split[2]) || 0
+			} else {
+				hours = parseInt(diff) || 0
+			}
+
+			date.setHours(date.getHours() + (negative ? -hours : hours))
+			date.setMinutes(date.getMinutes() + (negative ? -minutes : minutes))
+			date.setSeconds(date.getSeconds() + (negative ? -seconds : seconds))
+		} else {
+			date.setHours(date.getHours() + diff)
+		}
+
+		const displayHours = pad(date.getHours() > 12 && hr12 ? date.getHours() - 12 : date.getHours(), '0', 2)
+		const displayMinutes = pad(date.getMinutes(), '0', 2)
+		const displaySeconds = pad(date.getSeconds(), '0', 2)
+
+		if (time.split(':').length === 2) {
+			return `${displayHours}:${displayMinutes}`
+		} else if (time.split(':').length === 3) {
+			return `${displayHours}:${displayMinutes}:${displaySeconds}`
+		} else {
+			return ''
+		}
+	},
+	timeDiff: (from, to) => {
+		let diff = 0
+		let fromDate = new Date()
+		let toDate = new Date()
+
+		if (from.includes('T')) {
+			fromDate = new Date(from)
+		} else {
+			fromDate.setHours(from.split(':')[0])
+			fromDate.setMinutes(from.split(':')[1])
+			fromDate.setSeconds(from.split(':')[2] || 0)
+		}
+
+		if (to.includes('T')) {
+			toDate = new Date(to)
+		} else {
+			toDate.setHours(to.split(':')[0])
+			toDate.setMinutes(to.split(':')[1])
+			toDate.setSeconds(to.split(':')[2] || 0)
+		}
+
+		diff = toDate.getTime() - fromDate.getTime()
+
+		if (isNaN(diff)) return 'ERR'
+
+		return Math.round(diff / 1000)
 	},
 }

--- a/shared-lib/test/expressions-functions.test.js
+++ b/shared-lib/test/expressions-functions.test.js
@@ -395,7 +395,7 @@ describe('functions', () => {
 		})
 
 		it('timeDiff', () => {
-			expect(ExpressionFunctions.timeDiff('2024-05-23T12:00', '2024-05-23T18:00-04:00')).toBe(39600)
+			expect(ExpressionFunctions.timeDiff('2024-05-23T12:00Z', '2024-05-23T18:00-04:00')).toBe(36000)
 			expect(ExpressionFunctions.timeDiff('12:00', '18:00')).toBe(21600)
 		})
 	})

--- a/shared-lib/test/expressions-functions.test.js
+++ b/shared-lib/test/expressions-functions.test.js
@@ -95,22 +95,6 @@ describe('functions', () => {
 			expect(ExpressionFunctions.min('a', 1, 9)).toBe(NaN)
 		})
 
-		it('unixNow', () => {
-			const value = ExpressionFunctions.unixNow()
-			expect(value / 10).toBeCloseTo(Date.now() / 10, 0)
-		})
-
-		it('timestampToSeconds', () => {
-			expect(ExpressionFunctions.timestampToSeconds('00:00:11')).toBe(11)
-			expect(ExpressionFunctions.timestampToSeconds('00:16:39')).toBe(999)
-			expect(ExpressionFunctions.timestampToSeconds('02:46:39')).toBe(9999)
-			expect(ExpressionFunctions.timestampToSeconds('342:56:07')).toBe(1234567)
-
-			expect(ExpressionFunctions.timestampToSeconds('00:00_11')).toBe(0)
-			expect(ExpressionFunctions.timestampToSeconds(false)).toBe(0)
-			expect(ExpressionFunctions.timestampToSeconds(99)).toBe(0)
-		})
-
 		it('randomInt', () => {
 			for (let i = 0; i < 50; i++) {
 				const result = ExpressionFunctions.randomInt()
@@ -266,54 +250,6 @@ describe('functions', () => {
 			expect(ExpressionFunctions.encode('Companion', 'base64')).toBe('Q29tcGFuaW9u')
 			expect(ExpressionFunctions.encode('Companion')).toBe('Companion')
 		})
-
-		it('secondsToTimestamp', () => {
-			expect(ExpressionFunctions.secondsToTimestamp(11)).toBe('00:00:11')
-			expect(ExpressionFunctions.secondsToTimestamp(999)).toBe('00:16:39')
-			expect(ExpressionFunctions.secondsToTimestamp(9999)).toBe('02:46:39')
-			expect(ExpressionFunctions.secondsToTimestamp(1234567)).toBe('342:56:07')
-
-			expect(ExpressionFunctions.secondsToTimestamp('99')).toBe('00:01:39')
-			expect(ExpressionFunctions.secondsToTimestamp(false)).toBe('00:00:00')
-			expect(ExpressionFunctions.secondsToTimestamp(-11)).toBe('00:00:00')
-
-			// hh:mm:ss
-			expect(ExpressionFunctions.secondsToTimestamp(11, 'hh:mm:ss')).toBe('00:00:11')
-			expect(ExpressionFunctions.secondsToTimestamp(9999, 'hh:mm:ss')).toBe('02:46:39')
-			expect(ExpressionFunctions.secondsToTimestamp(1234567, 'hh:mm:ss')).toBe('342:56:07')
-
-			// hh:ss
-			expect(ExpressionFunctions.secondsToTimestamp(11, 'hh:ss')).toBe('00:11')
-			expect(ExpressionFunctions.secondsToTimestamp(9999, 'hh:ss')).toBe('02:39')
-			expect(ExpressionFunctions.secondsToTimestamp(1234567, 'hh:ss')).toBe('342:07')
-
-			// hh:mm
-			expect(ExpressionFunctions.secondsToTimestamp(11, 'hh:mm')).toBe('00:00')
-			expect(ExpressionFunctions.secondsToTimestamp(9999, 'hh:mm')).toBe('02:46')
-			expect(ExpressionFunctions.secondsToTimestamp(1234567, 'hh:mm')).toBe('342:56')
-
-			// mm:ss
-			expect(ExpressionFunctions.secondsToTimestamp(11, 'mm:ss')).toBe('00:11')
-			expect(ExpressionFunctions.secondsToTimestamp(9999, 'mm:ss')).toBe('46:39')
-			expect(ExpressionFunctions.secondsToTimestamp(1234567, 'mm:ss')).toBe('56:07')
-		})
-
-		it('msToTimestamp', () => {
-			expect(ExpressionFunctions.msToTimestamp(1100)).toBe('00:01.1')
-			expect(ExpressionFunctions.msToTimestamp(999123)).toBe('16:39.1')
-			expect(ExpressionFunctions.msToTimestamp(1234567)).toBe('20:34.5')
-
-			expect(ExpressionFunctions.msToTimestamp('9900')).toBe('00:09.9')
-			expect(ExpressionFunctions.msToTimestamp(false)).toBe('00:00.0')
-			expect(ExpressionFunctions.msToTimestamp(-11)).toBe('00:00.0')
-
-			// TODO - format
-
-			// // hh:mm:ss
-			// expect(ExpressionFunctions.msToTimestamp(11, 'hh:mm:ss')).toBe('00:00:11')
-			// expect(ExpressionFunctions.msToTimestamp(9999, 'hh:mm:ss')).toBe('02:46:39')
-			// expect(ExpressionFunctions.msToTimestamp(1234567, 'hh:mm:ss')).toBe('342:56:07')
-		})
 	})
 
 	describe('boolean', () => {
@@ -382,6 +318,85 @@ describe('functions', () => {
 
 			expect(ExpressionFunctions.jsonstringify({ a: 1 })).toEqual('{"a":1}')
 			expect(ExpressionFunctions.jsonstringify([1, 2, 3])).toEqual('[1,2,3]')
+		})
+	})
+
+	describe('time', () => {
+		it('unixNow', () => {
+			const value = ExpressionFunctions.unixNow()
+			expect(value / 10).toBeCloseTo(Date.now() / 10, 0)
+		})
+
+		it('secondsToTimestamp', () => {
+			expect(ExpressionFunctions.secondsToTimestamp(11)).toBe('00:00:11')
+			expect(ExpressionFunctions.secondsToTimestamp(999)).toBe('00:16:39')
+			expect(ExpressionFunctions.secondsToTimestamp(9999)).toBe('02:46:39')
+			expect(ExpressionFunctions.secondsToTimestamp(1234567)).toBe('342:56:07')
+
+			expect(ExpressionFunctions.secondsToTimestamp('99')).toBe('00:01:39')
+			expect(ExpressionFunctions.secondsToTimestamp(false)).toBe('00:00:00')
+			expect(ExpressionFunctions.secondsToTimestamp(-11)).toBe('-00:00:11')
+
+			// hh:mm:ss
+			expect(ExpressionFunctions.secondsToTimestamp(11, 'hh:mm:ss')).toBe('00:00:11')
+			expect(ExpressionFunctions.secondsToTimestamp(9999, 'hh:mm:ss')).toBe('02:46:39')
+			expect(ExpressionFunctions.secondsToTimestamp(1234567, 'hh:mm:ss')).toBe('342:56:07')
+
+			// hh:ss
+			expect(ExpressionFunctions.secondsToTimestamp(11, 'hh:ss')).toBe('00:11')
+			expect(ExpressionFunctions.secondsToTimestamp(9999, 'hh:ss')).toBe('02:39')
+			expect(ExpressionFunctions.secondsToTimestamp(1234567, 'hh:ss')).toBe('342:07')
+
+			// hh:mm
+			expect(ExpressionFunctions.secondsToTimestamp(11, 'hh:mm')).toBe('00:00')
+			expect(ExpressionFunctions.secondsToTimestamp(9999, 'hh:mm')).toBe('02:46')
+			expect(ExpressionFunctions.secondsToTimestamp(1234567, 'hh:mm')).toBe('342:56')
+
+			// mm:ss
+			expect(ExpressionFunctions.secondsToTimestamp(11, 'mm:ss')).toBe('00:11')
+			expect(ExpressionFunctions.secondsToTimestamp(9999, 'mm:ss')).toBe('46:39')
+			expect(ExpressionFunctions.secondsToTimestamp(1234567, 'mm:ss')).toBe('56:07')
+		})
+
+		it('timestampToSeconds', () => {
+			expect(ExpressionFunctions.timestampToSeconds('00:00:11')).toBe(11)
+			expect(ExpressionFunctions.timestampToSeconds('00:16:39')).toBe(999)
+			expect(ExpressionFunctions.timestampToSeconds('02:46:39')).toBe(9999)
+			expect(ExpressionFunctions.timestampToSeconds('342:56:07')).toBe(1234567)
+
+			expect(ExpressionFunctions.timestampToSeconds('00:00_11')).toBe(0)
+			expect(ExpressionFunctions.timestampToSeconds(false)).toBe(0)
+			expect(ExpressionFunctions.timestampToSeconds(99)).toBe(0)
+		})
+
+		it('msToTimestamp', () => {
+			expect(ExpressionFunctions.msToTimestamp(1100)).toBe('00:01.1')
+			expect(ExpressionFunctions.msToTimestamp(999123)).toBe('16:39.1')
+			expect(ExpressionFunctions.msToTimestamp(1234567)).toBe('20:34.5')
+
+			expect(ExpressionFunctions.msToTimestamp('9900')).toBe('00:09.9')
+			expect(ExpressionFunctions.msToTimestamp(false)).toBe('00:00.0')
+			expect(ExpressionFunctions.msToTimestamp(-11)).toBe('00:00.0')
+
+			expect(ExpressionFunctions.msToTimestamp(11000, 'hh:mm:ss')).toBe('00:00:11')
+			expect(ExpressionFunctions.msToTimestamp(9999000, 'hh:mm:ss')).toBe('02:46:39')
+			expect(ExpressionFunctions.msToTimestamp(1234567890, 'hh:mm:ss')).toBe('342:56:07')
+
+			expect(ExpressionFunctions.msToTimestamp(11000, 'hh:mm')).toBe('00:00')
+			expect(ExpressionFunctions.msToTimestamp(9999000, 'hh:mm')).toBe('02:46')
+			expect(ExpressionFunctions.msToTimestamp(1234567890, 'hh:mm')).toBe('342:56')
+		})
+
+		it('timeOffset', () => {
+			expect(ExpressionFunctions.timeOffset('15:00:00', +5)).toBe('20:00:00')
+			expect(ExpressionFunctions.timeOffset('15:00:00', -5)).toBe('10:00:00')
+			expect(ExpressionFunctions.timeOffset('15:00:00', '-02:00:00', true)).toBe('01:00:00')
+			expect(ExpressionFunctions.timeOffset('15:00', -5)).toBe('10:00')
+		})
+
+		it('timeDiff', () => {
+			expect(ExpressionFunctions.timeDiff('2024-05-23T12:00', '2024-05-23T18:00-04:00')).toBe(39600)
+			expect(ExpressionFunctions.timeDiff('12:00', '18:00')).toBe(21600)
 		})
 	})
 })


### PR DESCRIPTION
Adds `timeOffset` and `timeDiff` Expression functions, as well as change the Expression Function documentation to create a `Time operations` section to group up these, and the previous time related functions.

`timeOffset` allows taking in a timestamp an offset, and optionally a 12 hour clock boolean, and outputting the time with that offset in the same format it came in with (eg, if hh:mm:ss is provided, then hh:mm:ss is returned, if seconds are omitted then likewise in the return value).

`timeDiff` compares 2 times, either in `hh:mm:ss` style format, or a Date Time String, eg `YYYY-MM-DDTHH:mm:ss.sssZ`, with the return value in seconds. This allows for easy creation of countdowns, formatting of the seconds can easily be done with the existing `msToTimestamp` Expression Function, and because the return value is a number it also makes it easy to do things like triggers when the value is less than 30 seconds, or when it becomes negative to show when over-running etc....

These sort of basic time functions should help with the growing use of Expression Funcitons and Triggers for more complex automation. I had considered an additional function that would allow a timezone instead of an offset, but with the frequent confusion around time zones due to DST (eg, people referring to EST instead of EDT, or GMT instead of BST) using a numerical or timestamp offset in `timeOffset` should be a more reliable option.