### PR TITLE
Some updates to satellite API

### DIFF
--- a/companion/lib/Resources/Util.js
+++ b/companion/lib/Resources/Util.js
@@ -162,6 +162,18 @@ export const isFalsey = (val) => {
 }
 
 /**
+ * Check if Satellite API value is truthy
+ * @param {any} val
+ * @returns {boolean}
+ */
+export const isTruthy = (val) => {
+	return (
+		!isFalsey(val) &&
+		((typeof val === 'string' && (val.toLowerCase() == 'true' || val.toLowerCase() == 'yes')) || Number(val) >= 1)
+	)
+}
+
+/**
  * @typedef {Record<string, string | true | undefined>} ParsedParams
  */
 
@@ -229,6 +241,26 @@ export function parseLineParameters(line) {
 	}
 
 	return res
+}
+
+/**
+ * Checks if parameter is one of the list and returns it if so.
+ * If it is not in the list but a trueish value, the defaultVal will be returned.
+ * Otherwise returnes null.
+ * @param {string[]} list
+ * @param {string} defaultVal
+ * @param {unknown} parameter
+ * @returns {string | null}
+ */
+export function parseStringParamWithBooleanFallback(list, defaultVal, parameter) {
+	const param = String(parameter)
+	if (list.includes(param)) {
+		return param
+	}
+	if (isTruthy(parameter)) {
+		return defaultVal
+	}
+	return null
 }
 
 /**

--- a/companion/lib/Service/Satellite.js
+++ b/companion/lib/Service/Satellite.js
@@ -13,8 +13,13 @@ import LogController from '../Log/Controller.js'
  * 1.4.0 - Add TEXT_STYLE as ADD-DEVICE flags with FONT_SIZE as KEY-STATE property
  * 1.5.0 - Specify desired bitmap size with BITMAPS parameter when adding device
  * 1.5.1 - Remove surface size limit
+ * 1.6.0 - Allow for row/column notation,
+ * 		 - add streaming of text color when color is requested,
+ * 		 - allow choice of returned color format
+ * 		 - compatibility with internal CSS colors,
+ * 		 - allow buttons > 32
  */
-const API_VERSION = '1.5.1'
+const API_VERSION = '1.6.0'
 
 /**
  * Class providing the Satellite/Remote Surface api.
@@ -125,7 +130,10 @@ class ServiceSatellite extends ServiceBase {
 			}
 		}
 
-		const streamColors = params.COLORS !== undefined && !isFalsey(params.COLORS)
+		const streamColors =
+			params.COLORS && ['01', '1', 'true', 'hex', 'rgb'].includes(params.COLORS.toString().toLowerCase())
+				? params.COLORS.toString().toLowerCase()
+				: false
 		const streamText = params.TEXT !== undefined && !isFalsey(params.TEXT)
 		const streamTextStyle = params.TEXT_STYLE !== undefined && !isFalsey(params.TEXT_STYLE)
 
@@ -292,31 +300,41 @@ class ServiceSatellite extends ServiceBase {
 			socket.write(`KEY-PRESS ERROR MESSAGE="Missing DEVICEID"\n`)
 			return
 		}
+		const id = `${params.DEVICEID}`
+		const device = this.#devices.get(id)
+		if (device === undefined || device.socket !== socket) {
+			socket.write(`KEY-PRESS ERROR DEVICEID="${id}" MESSAGE="Device not found"\n`)
+			return
+		}
 		if (!params.KEY) {
-			socket.write(`KEY-PRESS ERROR DEVICEID="${params.DEVICEID}" MESSAGE="Missing KEY"\n`)
+			socket.write(`KEY-PRESS ERROR DEVICEID="${id}" MESSAGE="Missing KEY"\n`)
 			return
 		}
 		if (!params.PRESSED) {
-			socket.write(`KEY-PRESS ERROR DEVICEID="${params.DEVICEID}" MESSAGE="Missing PRESSED"\n`)
+			socket.write(`KEY-PRESS ERROR DEVICEID="${id}" MESSAGE="Missing PRESSED"\n`)
 			return
 		}
-
-		const key = Number(params.KEY)
-		if (isNaN(key) || key > LEGACY_MAX_BUTTONS || key < 0) {
-			socket.write(`KEY-PRESS ERROR DEVICEID="${params.DEVICEID}" MESSAGE="Invalid KEY"\n`)
-			return
-		}
-
 		const pressed = !isFalsey(params.PRESSED)
 
-		const id = `${params.DEVICEID}`
-		const device = this.#devices.get(id)
+		const keynum = Number(params.KEY)
+		const keyParse = params.KEY.toString().match(/^\+?(\d+)\/\+?(\d+)$/)
 
-		if (device && device.socket === socket) {
-			device.device.doButton(key, pressed)
+		if (
+			Array.isArray(keyParse) &&
+			Number(keyParse[1]) < device.device.gridSize.rows &&
+			Number(keyParse[2]) < device.device.gridSize.columns
+		) {
+			this.emit('click', Number(keyParse[2]), Number(keyParse[1]), pressed)
+			socket.write(`KEY-PRESS OK\n`)
+		} else if (
+			!isNaN(keynum) &&
+			keynum <= device.device.gridSize.columns * device.device.gridSize.rows &&
+			keynum >= 0
+		) {
+			device.device.doButton(keynum, pressed)
 			socket.write(`KEY-PRESS OK\n`)
 		} else {
-			socket.write(`KEY-PRESS ERROR DEVICEID="${params.DEVICEID}" MESSAGE="Device not found"\n`)
+			socket.write(`KEY-PRESS ERROR DEVICEID="${id}" MESSAGE="Invalid KEY"\n`)
 		}
 	}
 
@@ -330,30 +348,38 @@ class ServiceSatellite extends ServiceBase {
 			socket.write(`KEY-ROTATE ERROR MESSAGE="Missing DEVICEID"\n`)
 			return
 		}
+		const id = `${params.DEVICEID}`
+		const device = this.#devices.get(id)
+		if (device === undefined || device.socket !== socket) {
+			socket.write(`KEY-ROTATE ERROR DEVICEID="${id}" MESSAGE="Device not found"\n`)
+			return
+		}
 		if (!params.KEY) {
-			socket.write(`KEY-ROTATE ERROR DEVICEID="${params.DEVICEID}" MESSAGE="Missing KEY"\n`)
+			socket.write(`KEY-ROTATE ERROR DEVICEID="${id}" MESSAGE="Missing KEY"\n`)
 			return
 		}
 		if (!params.DIRECTION) {
-			socket.write(`KEY-ROTATE ERROR DEVICEID="${params.DEVICEID}" MESSAGE="Missing DIRECTION"\n`)
-			return
-		}
-
-		const key = Number(params.KEY)
-		if (isNaN(key) || key > LEGACY_MAX_BUTTONS || key < 0) {
-			socket.write(`KEY-ROTATE ERROR DEVICEID="${params.DEVICEID}" MESSAGE="Invalid KEY"\n`)
+			socket.write(`KEY-ROTATE ERROR DEVICEID="${id}" MESSAGE="Missing DIRECTION"\n`)
 			return
 		}
 
 		const direction = params.DIRECTION >= '1'
 
-		const id = `${params.DEVICEID}`
-		const device = this.#devices.get(id)
-		if (device && device.socket === socket) {
-			device.device.doRotate(key, direction)
+		const keynum = Number(params.KEY)
+		const keyParse = params.KEY.toString().match(/^([+-]?\d+)\/([+-]?\d+)$/)
+
+		if (Array.isArray(keyParse)) {
+			this.emit('rotate', Number(keyParse[2]), Number(keyParse[1]), direction)
+			socket.write(`KEY-ROTATE OK\n`)
+		} else if (
+			!isNaN(keynum) &&
+			keynum <= device.device.gridSize.columns * device.device.gridSize.rows &&
+			keynum >= 0
+		) {
+			device.device.doRotate(keynum, direction)
 			socket.write(`KEY-ROTATE OK\n`)
 		} else {
-			socket.write(`KEY-ROTATE ERROR DEVICEID="${params.DEVICEID}" MESSAGE="Device not found"\n`)
+			socket.write(`KEY-ROTATE ERROR DEVICEID="${id}" MESSAGE="Invalid KEY"\n`)
 		}
 	}
 

--- a/companion/lib/Surface/IP/Satellite.js
+++ b/companion/lib/Surface/IP/Satellite.js
@@ -199,6 +199,28 @@ class SurfaceIPSatellite extends EventEmitter {
 	}
 
 	/**
+	 * parses a received key parameter
+	 * @param {string} key either as key number in legacy format starting at 0 or in row/column format starting at 0/0 top left
+	 * @returns {[x: number, y: number] | null} local key position in [x,y] format or null if input is not valid
+	 */
+	parseKeyParam(key) {
+		const keynum = Number(key)
+		const keyParse = key.match(/^\+?(\d+)\/\+?(\d+)$/)
+
+		if (
+			Array.isArray(keyParse) &&
+			Number(keyParse[1]) < this.gridSize.rows &&
+			Number(keyParse[2]) < this.gridSize.columns
+		) {
+			return [Number(keyParse[2]), Number(keyParse[1])]
+		} else if (!isNaN(keynum) && keynum < this.gridSize.columns * this.gridSize.rows && keynum >= 0) {
+			return convertPanelIndexToXY(Number(key), this.gridSize)
+		} else {
+			return null
+		}
+	}
+
+	/**
 	 * Draw a button
 	 * @param {number} x
 	 * @param {number} y
@@ -219,26 +241,22 @@ class SurfaceIPSatellite extends EventEmitter {
 
 	/**
 	 * Produce a click event
-	 * @param {number} key
+	 * @param {number} column
+	 * @param {number} row
 	 * @param {boolean} state
 	 */
-	doButton(key, state) {
-		const xy = convertPanelIndexToXY(key, this.gridSize)
-		if (xy) {
-			this.emit('click', ...xy, state)
-		}
+	doButton(column, row, state) {
+		this.emit('click', column, row, state)
 	}
 
 	/**
 	 * Produce a rotation event
-	 * @param {number} key
+	 * @param {number} column
+	 * @param {number} row
 	 * @param {boolean} direction
 	 */
-	doRotate(key, direction) {
-		const xy = convertPanelIndexToXY(key, this.gridSize)
-		if (xy) {
-			this.emit('rotate', ...xy, direction)
-		}
+	doRotate(column, row, direction) {
+		this.emit('rotate', column, row, direction)
 	}
 
 	clearDeck() {

--- a/webui/src/UserConfig/AdminPasswordConfig.tsx
+++ b/webui/src/UserConfig/AdminPasswordConfig.tsx
@@ -51,46 +51,50 @@ export const AdminPasswordConfig = observer(function AdminPasswordConfig({
 					</CButton>
 				</td>
 			</tr>
-			{ config.admin_lockout && (<tr>
-				<td>Session Timeout (minutes, 0 for no timeout)</td>
-				<td>
-					<div className="form-check form-check-inline mr-1">
-						<CInput
-							type="number"
-							value={config.admin_timeout}
-							min={0}
-							step={1}
-							onChange={(e) => {
-								let value = Math.floor(e.currentTarget.value)
-								value = Math.max(value, 0)
-								setValue('admin_timeout', value)
-							}}
-						/>
-					</div>
-				</td>
-				<td>
-					<CButton onClick={() => resetValue('admin_timeout')} title="Reset to default">
-						<FontAwesomeIcon icon={faUndo} />
-					</CButton>
-				</td>
-			</tr>)}
-			{ config.admin_lockout && (<tr>
-				<td>Password</td>
-				<td>
-					<div className="form-check form-check-inline mr-1">
-						<CInput
-							type="text"
-							value={config.admin_password}
-							onChange={(e) => setValue('admin_password', e.currentTarget.value)}
-						/>
-					</div>
-				</td>
-				<td>
-					<CButton onClick={() => resetValue('admin_password')} title="Reset to default">
-						<FontAwesomeIcon icon={faUndo} />
-					</CButton>
-				</td>
-			</tr>)}
+			{config.admin_lockout && (
+				<tr>
+					<td>Session Timeout (minutes, 0 for no timeout)</td>
+					<td>
+						<div className="form-check form-check-inline mr-1">
+							<CInput
+								type="number"
+								value={config.admin_timeout}
+								min={0}
+								step={1}
+								onChange={(e) => {
+									let value = Math.floor(e.currentTarget.value)
+									value = Math.max(value, 0)
+									setValue('admin_timeout', value)
+								}}
+							/>
+						</div>
+					</td>
+					<td>
+						<CButton onClick={() => resetValue('admin_timeout')} title="Reset to default">
+							<FontAwesomeIcon icon={faUndo} />
+						</CButton>
+					</td>
+				</tr>
+			)}
+			{config.admin_lockout && (
+				<tr>
+					<td>Password</td>
+					<td>
+						<div className="form-check form-check-inline mr-1">
+							<CInput
+								type="text"
+								value={config.admin_password}
+								onChange={(e) => setValue('admin_password', e.currentTarget.value)}
+							/>
+						</div>
+					</td>
+					<td>
+						<CButton onClick={() => resetValue('admin_password')} title="Reset to default">
+							<FontAwesomeIcon icon={faUndo} />
+						</CButton>
+					</td>
+				</tr>
+			)}
 		</>
 	)
 })

--- a/webui/src/UserConfig/ArtnetConfig.tsx
+++ b/webui/src/UserConfig/ArtnetConfig.tsx
@@ -39,55 +39,59 @@ export const ArtnetConfig = observer(function ArtnetConfig({ config, setValue, r
 				</td>
 			</tr>
 
-			{ config.artnet_enabled && (<tr>
-				<td>Artnet Universe (first is 0)</td>
-				<td>
-					<div className="form-check form-check-inline mr-1">
-						<CInput
-							type="number"
-							value={config.artnet_universe}
-							min={0}
-							max={20055}
-							onChange={(e) => {
-								let value = Math.floor(e.currentTarget.value)
-								value = Math.min(value, 255)
-								value = Math.max(value, 0)
-								setValue('artnet_universe', value)
-							}}
-						/>
-					</div>
-				</td>
-				<td>
-					<CButton onClick={() => resetValue('artnet_universe')} title="Reset to default">
-						<FontAwesomeIcon icon={faUndo} />
-					</CButton>
-				</td>
-			</tr>)}
+			{config.artnet_enabled && (
+				<tr>
+					<td>Artnet Universe (first is 0)</td>
+					<td>
+						<div className="form-check form-check-inline mr-1">
+							<CInput
+								type="number"
+								value={config.artnet_universe}
+								min={0}
+								max={20055}
+								onChange={(e) => {
+									let value = Math.floor(e.currentTarget.value)
+									value = Math.min(value, 255)
+									value = Math.max(value, 0)
+									setValue('artnet_universe', value)
+								}}
+							/>
+						</div>
+					</td>
+					<td>
+						<CButton onClick={() => resetValue('artnet_universe')} title="Reset to default">
+							<FontAwesomeIcon icon={faUndo} />
+						</CButton>
+					</td>
+				</tr>
+			)}
 
-			{ config.artnet_enabled && (<tr>
-				<td>Artnet Channel</td>
-				<td>
-					<div className="form-check form-check-inline mr-1">
-						<CInput
-							type="number"
-							value={config.artnet_channel}
-							min={1}
-							max={509}
-							onChange={(e) => {
-								let value = Math.floor(e.currentTarget.value)
-								value = Math.min(value, 509)
-								value = Math.max(value, 1)
-								setValue('artnet_channel', value)
-							}}
-						/>
-					</div>
-				</td>
-				<td>
-					<CButton onClick={() => resetValue('artnet_channel')} title="Reset to default">
-						<FontAwesomeIcon icon={faUndo} />
-					</CButton>
-				</td>
-			</tr>)}
+			{config.artnet_enabled && (
+				<tr>
+					<td>Artnet Channel</td>
+					<td>
+						<div className="form-check form-check-inline mr-1">
+							<CInput
+								type="number"
+								value={config.artnet_channel}
+								min={1}
+								max={509}
+								onChange={(e) => {
+									let value = Math.floor(e.currentTarget.value)
+									value = Math.min(value, 509)
+									value = Math.max(value, 1)
+									setValue('artnet_channel', value)
+								}}
+							/>
+						</div>
+					</td>
+					<td>
+						<CButton onClick={() => resetValue('artnet_channel')} title="Reset to default">
+							<FontAwesomeIcon icon={faUndo} />
+						</CButton>
+					</td>
+				</tr>
+			)}
 		</>
 	)
 })

--- a/webui/src/UserConfig/CompanionConfig.tsx
+++ b/webui/src/UserConfig/CompanionConfig.tsx
@@ -34,9 +34,9 @@ export const CompanionConfig = observer(function CompanionConfig({
 					</div>
 				</td>
 				<td>
-					<div 
+					<div
 						style={{
-							minWidth: '8em' // provide minimum width for second column
+							minWidth: '8em', // provide minimum width for second column
 						}}
 					></div>
 				</td>

--- a/webui/src/UserConfig/EmberPlusConfig.tsx
+++ b/webui/src/UserConfig/EmberPlusConfig.tsx
@@ -42,11 +42,13 @@ export const EmberPlusConfig = observer(function EmberPlusConfig({
 					</CButton>
 				</td>
 			</tr>
-			{ config.emberplus_enabled && (<tr>
-				<td>Ember+ Listen Port</td>
-				<td>9092</td>
-				<td></td>
-			</tr>)}
+			{config.emberplus_enabled && (
+				<tr>
+					<td>Ember+ Listen Port</td>
+					<td>9092</td>
+					<td></td>
+				</tr>
+			)}
 		</>
 	)
 })

--- a/webui/src/UserConfig/HttpsConfig.tsx
+++ b/webui/src/UserConfig/HttpsConfig.tsx
@@ -66,52 +66,56 @@ export const HttpsConfig = observer(function HttpsConfig({ config, setValue, res
 				</td>
 			</tr>
 
-			{ config.https_enabled && (<tr>
-				<td>HTTPS Port</td>
-				<td>
-					<div className="form-check form-check-inline mr-1">
-						<CInput
-							type="number"
-							value={config.https_port}
-							min={1024}
-							max={65535}
-							onChange={(e) => {
-								let value = Math.floor(e.currentTarget.value)
-								value = Math.min(value, 65535)
-								value = Math.max(value, 1024)
-								setValue('https_port', value)
-							}}
-						/>
-					</div>
-				</td>
-				<td>
-					<CButton onClick={() => resetValue('https_port')} title="Reset to default">
-						<FontAwesomeIcon icon={faUndo} />
-					</CButton>
-				</td>
-			</tr>)}
+			{config.https_enabled && (
+				<tr>
+					<td>HTTPS Port</td>
+					<td>
+						<div className="form-check form-check-inline mr-1">
+							<CInput
+								type="number"
+								value={config.https_port}
+								min={1024}
+								max={65535}
+								onChange={(e) => {
+									let value = Math.floor(e.currentTarget.value)
+									value = Math.min(value, 65535)
+									value = Math.max(value, 1024)
+									setValue('https_port', value)
+								}}
+							/>
+						</div>
+					</td>
+					<td>
+						<CButton onClick={() => resetValue('https_port')} title="Reset to default">
+							<FontAwesomeIcon icon={faUndo} />
+						</CButton>
+					</td>
+				</tr>
+			)}
 
-			{ config.https_enabled && (<tr>
-				<td>Certificate Type</td>
-				<td>
-					<div className="form-check form-check-inline mr-1">
-						<CDropdown className="mt-2" style={{ display: 'inline-block' }}>
-							<CDropdownToggle>{config.https_cert_type === 'external' ? 'External' : 'Self Signed'}</CDropdownToggle>
-							<CDropdownMenu>
-								<CDropdownItem onClick={() => setValue('https_cert_type', 'self')}>Self Signed</CDropdownItem>
-								<CDropdownItem onClick={() => setValue('https_cert_type', 'external')}>External</CDropdownItem>
-							</CDropdownMenu>
-						</CDropdown>
-					</div>
-				</td>
-				<td>
-					<CButton onClick={() => resetValue('https_cert_type')} title="Reset to default">
-						<FontAwesomeIcon icon={faUndo} />
-					</CButton>
-				</td>
-			</tr>)}
+			{config.https_enabled && (
+				<tr>
+					<td>Certificate Type</td>
+					<td>
+						<div className="form-check form-check-inline mr-1">
+							<CDropdown className="mt-2" style={{ display: 'inline-block' }}>
+								<CDropdownToggle>{config.https_cert_type === 'external' ? 'External' : 'Self Signed'}</CDropdownToggle>
+								<CDropdownMenu>
+									<CDropdownItem onClick={() => setValue('https_cert_type', 'self')}>Self Signed</CDropdownItem>
+									<CDropdownItem onClick={() => setValue('https_cert_type', 'external')}>External</CDropdownItem>
+								</CDropdownMenu>
+							</CDropdown>
+						</div>
+					</td>
+					<td>
+						<CButton onClick={() => resetValue('https_cert_type')} title="Reset to default">
+							<FontAwesomeIcon icon={faUndo} />
+						</CButton>
+					</td>
+				</tr>
+			)}
 
-			{ config.https_enabled && config.https_cert_type === 'self' && (
+			{config.https_enabled && config.https_cert_type === 'self' && (
 				<tr>
 					<td colSpan={3}>
 						<table className="table table-responsive-sm">
@@ -205,7 +209,7 @@ export const HttpsConfig = observer(function HttpsConfig({ config, setValue, res
 				</tr>
 			)}
 
-			{ config.https_enabled && config.https_cert_type === 'external' && (
+			{config.https_enabled && config.https_cert_type === 'external' && (
 				<tr>
 					<td colSpan={3}>
 						<table className="table table-responsive-sm">

--- a/webui/src/UserConfig/OscConfig.tsx
+++ b/webui/src/UserConfig/OscConfig.tsx
@@ -60,28 +60,30 @@ export const OscConfig = observer(function OscConfig({ config, setValue, resetVa
 					</CButton>
 				</td>
 			</tr>
-			{ (config.osc_enabled || config.osc_legacy_api_enabled) && (<tr>
-				<td>OSC Listen Port</td>
-				<td>
-					<div className="form-check form-check-inline mr-1">
-						<CInput
-							type="number"
-							value={config.osc_listen_port}
-							onChange={(e) => {
-								let value = Math.floor(e.currentTarget.value)
-								value = Math.min(value, 65535)
-								value = Math.max(value, 1024)
-								setValue('osc_listen_port', value)
-							}}
-						/>
-					</div>
-				</td>
-				<td>
-					<CButton onClick={() => resetValue('osc_listen_port')} title="Reset to default">
-						<FontAwesomeIcon icon={faUndo} />
-					</CButton>
-				</td>
-			</tr>)}
+			{(config.osc_enabled || config.osc_legacy_api_enabled) && (
+				<tr>
+					<td>OSC Listen Port</td>
+					<td>
+						<div className="form-check form-check-inline mr-1">
+							<CInput
+								type="number"
+								value={config.osc_listen_port}
+								onChange={(e) => {
+									let value = Math.floor(e.currentTarget.value)
+									value = Math.min(value, 65535)
+									value = Math.max(value, 1024)
+									setValue('osc_listen_port', value)
+								}}
+							/>
+						</div>
+					</td>
+					<td>
+						<CButton onClick={() => resetValue('osc_listen_port')} title="Reset to default">
+							<FontAwesomeIcon icon={faUndo} />
+						</CButton>
+					</td>
+				</tr>
+			)}
 		</>
 	)
 })

--- a/webui/src/UserConfig/PinLockoutConfig.tsx
+++ b/webui/src/UserConfig/PinLockoutConfig.tsx
@@ -43,64 +43,66 @@ export const PinLockoutConfig = observer(function PinLockoutConfig({
 				</td>
 			</tr>
 
-			{ config.pin_enable && (<>
-				<tr>
-					<td>Link Lockouts</td>
-					<td>
-						<div className="form-check form-check-inline mr-1 float-right">
-							<CSwitch
-								color="success"
-								checked={config.link_lockouts}
-								size={'lg'}
-								onChange={(e) => setValue('link_lockouts', e.currentTarget.checked)}
-							/>
-						</div>
-					</td>
-					<td>
-						<CButton onClick={() => resetValue('link_lockouts')} title="Reset to default">
-							<FontAwesomeIcon icon={faUndo} />
-						</CButton>
-					</td>
-				</tr>
+			{config.pin_enable && (
+				<>
+					<tr>
+						<td>Link Lockouts</td>
+						<td>
+							<div className="form-check form-check-inline mr-1 float-right">
+								<CSwitch
+									color="success"
+									checked={config.link_lockouts}
+									size={'lg'}
+									onChange={(e) => setValue('link_lockouts', e.currentTarget.checked)}
+								/>
+							</div>
+						</td>
+						<td>
+							<CButton onClick={() => resetValue('link_lockouts')} title="Reset to default">
+								<FontAwesomeIcon icon={faUndo} />
+							</CButton>
+						</td>
+					</tr>
 
-				<tr>
-					<td>Pin Code</td>
-					<td>
-						<div className="form-check form-check-inline mr-1">
-							<CInput type="text" value={config.pin} onChange={(e) => setValue('pin', e.currentTarget.value)} />
-						</div>
-					</td>
-					<td>
-						<CButton onClick={() => resetValue('pin')} title="Reset to default">
-							<FontAwesomeIcon icon={faUndo} />
-						</CButton>
-					</td>
-				</tr>
+					<tr>
+						<td>Pin Code</td>
+						<td>
+							<div className="form-check form-check-inline mr-1">
+								<CInput type="text" value={config.pin} onChange={(e) => setValue('pin', e.currentTarget.value)} />
+							</div>
+						</td>
+						<td>
+							<CButton onClick={() => resetValue('pin')} title="Reset to default">
+								<FontAwesomeIcon icon={faUndo} />
+							</CButton>
+						</td>
+					</tr>
 
-				<tr>
-					<td>Pin Timeout (seconds, 0 to turn off)</td>
-					<td>
-						<div className="form-check form-check-inline mr-1">
-							<CInput
-								type="number"
-								value={config.pin_timeout}
-								min={0}
-								step={1}
-								onChange={(e) => {
-								let value = Math.floor(e.currentTarget.value)
-								value = Math.max(value, 0)
-								setValue('pin_timeout', value)
-							}}
-							/>
-						</div>
-					</td>
-					<td>
-						<CButton onClick={() => resetValue('pin_timeout')} title="Reset to default">
-							<FontAwesomeIcon icon={faUndo} />
-						</CButton>
-					</td>
-				</tr>
-			</>)}
+					<tr>
+						<td>Pin Timeout (seconds, 0 to turn off)</td>
+						<td>
+							<div className="form-check form-check-inline mr-1">
+								<CInput
+									type="number"
+									value={config.pin_timeout}
+									min={0}
+									step={1}
+									onChange={(e) => {
+										let value = Math.floor(e.currentTarget.value)
+										value = Math.max(value, 0)
+										setValue('pin_timeout', value)
+									}}
+								/>
+							</div>
+						</td>
+						<td>
+							<CButton onClick={() => resetValue('pin_timeout')} title="Reset to default">
+								<FontAwesomeIcon icon={faUndo} />
+							</CButton>
+						</td>
+					</tr>
+				</>
+			)}
 		</>
 	)
 })

--- a/webui/src/UserConfig/RosstalkConfig.tsx
+++ b/webui/src/UserConfig/RosstalkConfig.tsx
@@ -38,11 +38,13 @@ export const RosstalkConfig = observer(function RosstalkConfig({ config, setValu
 					</CButton>
 				</td>
 			</tr>
-			{ config.rosstalk_enabled && (<tr>
-				<td>Rosstalk Listen Port</td>
-				<td>7788</td>
-				<td></td>
-			</tr>)}
+			{config.rosstalk_enabled && (
+				<tr>
+					<td>Rosstalk Listen Port</td>
+					<td>7788</td>
+					<td></td>
+				</tr>
+			)}
 		</>
 	)
 })

--- a/webui/src/UserConfig/TcpConfig.tsx
+++ b/webui/src/UserConfig/TcpConfig.tsx
@@ -60,31 +60,33 @@ export const TcpConfig = observer(function TcpConfig({ config, setValue, resetVa
 					</CButton>
 				</td>
 			</tr>
-			{ (config.tcp_enabled || config.tcp_legacy_api_enabled) && (<tr>
-				<td>TCP Listen Port</td>
-				<td>
-					<div className="form-check form-check-inline mr-1">
-						<CInput
-							type="number"
-							value={config.tcp_listen_port}
-							min={1024}
-							max={65535}
-							step={1}
-							onChange={(e) => {
-								let value = Math.floor(e.currentTarget.value)
-								value = Math.min(value, 65535)
-								value = Math.max(value, 1024)
-								setValue('tcp_listen_port', value)
-							}}
-						/>
-					</div>
-				</td>
-				<td>
-					<CButton onClick={() => resetValue('tcp_listen_port')} title="Reset to default">
-						<FontAwesomeIcon icon={faUndo} />
-					</CButton>
-				</td>
-			</tr>)}
+			{(config.tcp_enabled || config.tcp_legacy_api_enabled) && (
+				<tr>
+					<td>TCP Listen Port</td>
+					<td>
+						<div className="form-check form-check-inline mr-1">
+							<CInput
+								type="number"
+								value={config.tcp_listen_port}
+								min={1024}
+								max={65535}
+								step={1}
+								onChange={(e) => {
+									let value = Math.floor(e.currentTarget.value)
+									value = Math.min(value, 65535)
+									value = Math.max(value, 1024)
+									setValue('tcp_listen_port', value)
+								}}
+							/>
+						</div>
+					</td>
+					<td>
+						<CButton onClick={() => resetValue('tcp_listen_port')} title="Reset to default">
+							<FontAwesomeIcon icon={faUndo} />
+						</CButton>
+					</td>
+				</tr>
+			)}
 		</>
 	)
 })

--- a/webui/src/UserConfig/UdpConfig.tsx
+++ b/webui/src/UserConfig/UdpConfig.tsx
@@ -60,31 +60,33 @@ export const UdpConfig = observer(function UdpConfig({ config, setValue, resetVa
 					</CButton>
 				</td>
 			</tr>
-			{ (config.udp_enabled || config.udp_legacy_api_enabled) && (<tr>
-				<td>UDP Listen Port</td>
-				<td>
-					<div className="form-check form-check-inline mr-1">
-						<CInput
-							type="number"
-							value={config.udp_listen_port}
-							min={1024}
-							max={65535}
-							step={1}
-							onChange={(e) => {
-								let value = Math.floor(e.currentTarget.value)
-								value = Math.min(value, 65535)
-								value = Math.max(value, 1024)
-								setValue('udp_listen_port', value)
-							}}
-						/>
-					</div>
-				</td>
-				<td>
-					<CButton onClick={() => resetValue('udp_listen_port')} title="Reset to default">
-						<FontAwesomeIcon icon={faUndo} />
-					</CButton>
-				</td>
-			</tr>)}
+			{(config.udp_enabled || config.udp_legacy_api_enabled) && (
+				<tr>
+					<td>UDP Listen Port</td>
+					<td>
+						<div className="form-check form-check-inline mr-1">
+							<CInput
+								type="number"
+								value={config.udp_listen_port}
+								min={1024}
+								max={65535}
+								step={1}
+								onChange={(e) => {
+									let value = Math.floor(e.currentTarget.value)
+									value = Math.min(value, 65535)
+									value = Math.max(value, 1024)
+									setValue('udp_listen_port', value)
+								}}
+							/>
+						</div>
+					</td>
+					<td>
+						<CButton onClick={() => resetValue('udp_listen_port')} title="Reset to default">
+							<FontAwesomeIcon icon={faUndo} />
+						</CButton>
+					</td>
+				</tr>
+			)}
 		</>
 	)
 })


### PR DESCRIPTION
This PR:
- allows use of more than 32 buttons
- adds the text color if client requests colors (unfortunately the original API uses `color` for background color instead of `bgcolor`, so I use `textcolor` for text color instead of `color`)
- adds the option to read back colors in css rgb notation
- allows optionally to use button numbers in row/column format. The surface buttons start at 0/0 in that aspect, streamed button numbers are unchanged

API version is increased to 1.6.0  
as clients are required to actually parse parameter names and not only rely on positions, I consider the addition of textcolor parameter not a breaking change

This PR also has a bunch of completely unrelated formatting