### PR TITLE
feat: view as surface

### DIFF
--- a/companion/lib/Surface/Controller.js
+++ b/companion/lib/Surface/Controller.js
@@ -658,6 +658,10 @@ class SurfaceController extends CoreBase {
 				location: null,
 				xOffset: config.config?.xOffset ?? 0,
 				yOffset: config.config?.yOffset ?? 0,
+				layout: {
+					rows: 0,
+					columns: 0,
+				},
 			}
 
 			if (surfaceHandler) {
@@ -666,6 +670,11 @@ class SurfaceController extends CoreBase {
 
 				surfaceInfo.location = location || null
 				surfaceInfo.configFields = surfaceHandler.panel.info.configFields || []
+
+				surfaceInfo.layout = {
+					rows: surfaceHandler.panelGridSize.rows,
+					columns: surfaceHandler.panelGridSize.columns,
+				}
 			}
 
 			return surfaceInfo

--- a/companion/lib/Surface/Controller.js
+++ b/companion/lib/Surface/Controller.js
@@ -674,6 +674,18 @@ class SurfaceController extends CoreBase {
 				layout: config.layout ?? null,
 			}
 
+			// If the surface has a cached grid size, a crude layout can be generated
+			if (config.gridSize && !surfaceInfo.layout) {
+				surfaceInfo.layout = {
+					id: '__auto__',
+					name: surfaceInfo.displayName,
+
+					type: 'grid',
+					rows: config.gridSize.rows,
+					columns: config.gridSize.columns,
+				}
+			}
+
 			if (surfaceHandler) {
 				let location = surfaceHandler.panel.info.location
 				if (location && location.startsWith('::ffff:')) location = location.substring(7)
@@ -682,7 +694,7 @@ class SurfaceController extends CoreBase {
 				surfaceInfo.configFields = surfaceHandler.panel.info.configFields || []
 
 				surfaceInfo.layout = {
-					id: surfaceInfo.id,
+					id: '__auto__',
 					name: surfaceInfo.displayName,
 
 					type: 'grid',

--- a/companion/lib/Surface/Controller.js
+++ b/companion/lib/Surface/Controller.js
@@ -685,6 +685,7 @@ class SurfaceController extends CoreBase {
 					id: surfaceInfo.id,
 					name: surfaceInfo.displayName,
 
+					type: 'grid',
 					rows: surfaceHandler.panelGridSize.rows,
 					columns: surfaceHandler.panelGridSize.columns,
 				}

--- a/companion/lib/Surface/Controller.js
+++ b/companion/lib/Surface/Controller.js
@@ -422,6 +422,11 @@ class SurfaceController extends CoreBase {
 			for (let surface of this.#surfaceHandlers.values()) {
 				if (surface && surface.surfaceId == id) {
 					surface.setPanelConfig(config)
+
+					setImmediate(() => {
+						this.updateDevicesList()
+					})
+
 					return surface.getPanelConfig()
 				}
 			}
@@ -651,6 +656,8 @@ class SurfaceController extends CoreBase {
 				isConnected: !!surfaceHandler,
 				displayName: getSurfaceName(config, id),
 				location: null,
+				xOffset: config.config?.xOffset ?? 0,
+				yOffset: config.config?.yOffset ?? 0,
 			}
 
 			if (surfaceHandler) {

--- a/companion/lib/Surface/LayoutRegistry.js
+++ b/companion/lib/Surface/LayoutRegistry.js
@@ -41,6 +41,12 @@ export class SurfaceLayoutRegistry {
 				name: 'Stream Deck: XL',
 				rows: 4,
 				columns: 8,
+			},
+			{
+				id: 'streamdeck-mini',
+				name: 'Stream Deck: Mini',
+				rows: 2,
+				columns: 3,
 			}
 			// TODO - add more layouts
 		)

--- a/companion/lib/Surface/LayoutRegistry.js
+++ b/companion/lib/Surface/LayoutRegistry.js
@@ -25,31 +25,137 @@ export class SurfaceLayoutRegistry {
 	#layouts = []
 
 	constructor() {
+		this.#addCountourShuttleLayouts()
 		this.#addStreamdeckLayouts()
+		this.#addLoupedeckLayouts()
+		this.#addInfinittonLayouts()
+		this.#addVideohubLayouts()
+		this.#addXKeysLayouts()
+
+		// Sort by name
+		this.#layouts.sort((a, b) => a.name.localeCompare(b.name))
+	}
+
+	#addCountourShuttleLayouts() {
+		// TODO
 	}
 
 	#addStreamdeckLayouts() {
 		this.#layouts.push(
 			{
 				id: 'streamdeck-15',
-				name: 'Stream Deck: Original',
+				name: 'Elgato Streamdeck Original',
+				type: 'grid',
 				rows: 3,
 				columns: 5,
 			},
 			{
 				id: 'streamdeck-xl',
-				name: 'Stream Deck: XL',
+				name: 'Elgato Streamdeck XL',
+				type: 'grid',
 				rows: 4,
 				columns: 8,
 			},
 			{
 				id: 'streamdeck-mini',
-				name: 'Stream Deck: Mini',
+				name: 'Elgato Streamdeck Mini',
+				type: 'grid',
 				rows: 2,
 				columns: 3,
+			},
+			{
+				id: 'streamdeck-plus',
+				name: 'Elgato Streamdeck +',
+				type: 'grid',
+				rows: 4,
+				columns: 4,
+			},
+			{
+				id: 'streamdeck-pedal',
+				name: 'Elgato Streamdeck Pedal',
+				type: 'grid',
+				rows: 1,
+				columns: 3,
+			},
+			{
+				id: 'streamdeck-neo',
+				name: 'Elgato Streamdeck Neo',
+				type: 'grid',
+				rows: 3,
+				columns: 4,
 			}
-			// TODO - add more layouts
 		)
+	}
+
+	#addLoupedeckLayouts() {
+		this.#layouts.push(
+			{
+				id: 'loupedeck-live',
+				name: 'Loupedeck Live',
+				type: 'grid',
+				rows: 4,
+				columns: 8,
+			},
+			{
+				id: 'loupedeck-live-s',
+				name: 'Loupedeck Live S',
+				type: 'grid',
+				rows: 3,
+				columns: 7,
+			},
+			{
+				id: 'razer-stream-controller',
+				name: 'Razer Stream Controller',
+				type: 'grid',
+				rows: 4,
+				columns: 8,
+			},
+			{
+				id: 'razer-stream-controller-x',
+				name: 'Razer Stream Controller X',
+				type: 'grid',
+				rows: 3,
+				columns: 5,
+			},
+			{
+				id: 'loupedeck-ct',
+				name: 'Loupedeck CT',
+				type: 'grid',
+				rows: 8, // TODO verify
+				columns: 8,
+			}
+		)
+	}
+
+	#addInfinittonLayouts() {
+		this.#layouts.push({
+			id: 'infinitton-idisplay',
+			name: 'Infinitton idisplay',
+			type: 'grid',
+			rows: 3,
+			columns: 5,
+		})
+	}
+
+	#addVideohubLayouts() {
+		this.#layouts.push({
+			id: 'blackmagic-videohub-smart-control',
+			name: 'Videohub Smart Control',
+			type: 'grid',
+			rows: 2,
+			columns: 20,
+		})
+	}
+
+	#addXKeysLayouts() {
+		// TODO
+		// this.#layouts.push({
+		// 	id: 'blackmagic-videohub-smart-control',
+		// 	name: 'Videohub Smart Control',
+		// 	type: 'grid',
+		// 	rows: 2,
+		// 	columns: 20,
+		// })
 	}
 
 	/**

--- a/companion/lib/Surface/LayoutRegistry.js
+++ b/companion/lib/Surface/LayoutRegistry.js
@@ -15,6 +15,9 @@
  *
  */
 
+import { PRODUCTS as XKeysProducts } from 'xkeys'
+import { contourShuttleXpressInfo, contourShuttleProV1Info, contourShuttleProV2Info } from './USB/ContourShuttle.js'
+
 export class SurfaceLayoutRegistry {
 	/**
 	 * The list of known surface layouts
@@ -37,7 +40,29 @@ export class SurfaceLayoutRegistry {
 	}
 
 	#addCountourShuttleLayouts() {
-		// TODO
+		this.#layouts.push(
+			{
+				id: 'contour-shuttle-xpress',
+				name: 'Contour Shuttle Xpress',
+				type: 'grid',
+				rows: contourShuttleXpressInfo.totalRows,
+				columns: contourShuttleXpressInfo.totalCols,
+			},
+			{
+				id: 'contour-shuttle-pro-v1',
+				name: 'Contour Shuttle Pro v1',
+				type: 'grid',
+				rows: contourShuttleProV1Info.totalRows,
+				columns: contourShuttleProV1Info.totalCols,
+			},
+			{
+				id: 'contour-shuttle-pro-v2',
+				name: 'Contour Shuttle Pro v2',
+				type: 'grid',
+				rows: contourShuttleProV2Info.totalRows,
+				columns: contourShuttleProV2Info.totalCols,
+			}
+		)
 	}
 
 	#addStreamdeckLayouts() {
@@ -148,14 +173,16 @@ export class SurfaceLayoutRegistry {
 	}
 
 	#addXKeysLayouts() {
-		// TODO
-		// this.#layouts.push({
-		// 	id: 'blackmagic-videohub-smart-control',
-		// 	name: 'Videohub Smart Control',
-		// 	type: 'grid',
-		// 	rows: 2,
-		// 	columns: 20,
-		// })
+		for (const [id, product] of Object.entries(XKeysProducts)) {
+			this.#layouts.push({
+				id: `xkeys-${id}`,
+				name: `XKeys ${product.name}`,
+				type: 'grid',
+
+				rows: product.rowCount,
+				columns: product.colCount,
+			})
+		}
 	}
 
 	/**

--- a/companion/lib/Surface/LayoutRegistry.js
+++ b/companion/lib/Surface/LayoutRegistry.js
@@ -1,0 +1,55 @@
+/*
+ * This file is part of the Companion project
+ * Copyright (c) 2018 Bitfocus AS
+ * Authors: William Viker <william@bitfocus.io>, Håkon Nessjøen <haakon@bitfocus.io>
+ *
+ * This program is free software.
+ * You should have received a copy of the MIT licence as well as the Bitfocus
+ * Individual Contributor License Agreement for companion along with
+ * this program.
+ *
+ * You can be released from the requirements of the license by purchasing
+ * a commercial license. Buying such a license is mandatory as soon as you
+ * develop commercial activities involving the Companion software without
+ * disclosing the source code of your own applications.
+ *
+ */
+
+export class SurfaceLayoutRegistry {
+	/**
+	 * The list of known surface layouts
+	 * @type {import("@companion-app/shared/Model/Surfaces.js").SurfaceLayoutSchema[]}
+	 * @access private
+	 * @readonly
+	 */
+	#layouts = []
+
+	constructor() {
+		this.#addStreamdeckLayouts()
+	}
+
+	#addStreamdeckLayouts() {
+		this.#layouts.push(
+			{
+				id: 'streamdeck-15',
+				name: 'Stream Deck: Original',
+				rows: 3,
+				columns: 5,
+			},
+			{
+				id: 'streamdeck-xl',
+				name: 'Stream Deck: XL',
+				rows: 4,
+				columns: 8,
+			}
+			// TODO - add more layouts
+		)
+	}
+
+	/**
+	 * @returns {import("@companion-app/shared/Model/Surfaces.js").SurfaceLayoutSchema[]}
+	 */
+	getLayouts() {
+		return this.#layouts
+	}
+}

--- a/companion/lib/Surface/USB/ContourShuttle.js
+++ b/companion/lib/Surface/USB/ContourShuttle.js
@@ -20,7 +20,7 @@ import EventEmitter from 'events'
 import shuttleControlUSB from 'shuttle-control-usb'
 import LogController from '../../Log/Controller.js'
 
-const contourShuttleXpressInfo = {
+export const contourShuttleXpressInfo = {
 	// Treat as:
 	// 3 buttons
 	// button, two encoders (jog and shuttle), button
@@ -40,7 +40,7 @@ const contourShuttleXpressInfo = {
 		[3, 1],
 	],
 }
-const contourShuttleProV1Info = {
+export const contourShuttleProV1Info = {
 	// Same as Pro V2 only without the buttons either side of the encoders
 	// Map the same for consistency and compatibility
 	totalCols: 5,
@@ -72,7 +72,7 @@ const contourShuttleProV1Info = {
 		[2, 3],
 	],
 }
-const contourShuttleProV2Info = {
+export const contourShuttleProV2Info = {
 	// 4 buttons
 	// 5 buttons
 	// button, two encoders (jog and shuttle), button

--- a/shared-lib/lib/Model/Surfaces.ts
+++ b/shared-lib/lib/Model/Surfaces.ts
@@ -9,6 +9,9 @@ export interface ClientSurfaceItem {
 	isConnected: boolean
 	displayName: string
 	location: string | null
+
+	xOffset: number
+	yOffset: number
 }
 
 export interface ClientDevicesListItem {

--- a/shared-lib/lib/Model/Surfaces.ts
+++ b/shared-lib/lib/Model/Surfaces.ts
@@ -12,6 +12,7 @@ export interface ClientSurfaceItem {
 
 	xOffset: number
 	yOffset: number
+	layout: SurfaceLayoutSchema
 }
 
 export interface ClientDevicesListItem {
@@ -48,4 +49,9 @@ export interface SurfacesUpdateUpdateOp {
 	itemId: string
 
 	patch: JsonPatchOperation[]
+}
+
+export interface SurfaceLayoutSchema {
+	rows: number
+	columns: number
 }

--- a/shared-lib/lib/Model/Surfaces.ts
+++ b/shared-lib/lib/Model/Surfaces.ts
@@ -12,7 +12,7 @@ export interface ClientSurfaceItem {
 
 	xOffset: number
 	yOffset: number
-	layout: SurfaceLayoutSchema
+	layout: SurfaceLayoutSchema | null
 }
 
 export interface ClientDevicesListItem {
@@ -52,6 +52,9 @@ export interface SurfacesUpdateUpdateOp {
 }
 
 export interface SurfaceLayoutSchema {
+	id: string
+	name: string
+
 	rows: number
 	columns: number
 }

--- a/shared-lib/lib/Model/Surfaces.ts
+++ b/shared-lib/lib/Model/Surfaces.ts
@@ -51,10 +51,31 @@ export interface SurfacesUpdateUpdateOp {
 	patch: JsonPatchOperation[]
 }
 
-export interface SurfaceLayoutSchema {
+export type SurfaceLayoutSchema = SurfaceLayoutSchemaGrid | SurfaceLayoutSchemaComplex
+
+export interface SurfaceLayoutSchemaBase {
+	id: string
+	name: string
+}
+
+export interface SurfaceLayoutSchemaGrid {
 	id: string
 	name: string
 
+	type: 'grid'
+
 	rows: number
 	columns: number
+}
+
+export interface SurfaceLayoutSchemaComplex {
+	id: string
+	name: string
+
+	type: 'complex'
+
+	/**
+	 * Background image, recommended to be a svg when possible
+	 */
+	backgroundImage: string
 }

--- a/shared-lib/lib/SocketIO.ts
+++ b/shared-lib/lib/SocketIO.ts
@@ -16,7 +16,13 @@ import type {
 	HelpDescription,
 	WrappedImage,
 } from './Model/Common.js'
-import type { ClientDevicesListItem, SurfaceGroupConfig, SurfacePanelConfig, SurfacesUpdate } from './Model/Surfaces.js'
+import type {
+	ClientDevicesListItem,
+	SurfaceGroupConfig,
+	SurfaceLayoutSchema,
+	SurfacePanelConfig,
+	SurfacesUpdate,
+} from './Model/Surfaces.js'
 import type {
 	ClientImportObject,
 	ClientImportSelection,
@@ -223,6 +229,7 @@ export interface ClientToBackendEventsMap {
 	'surfaces:config-get': (surfaceId: string) => SurfacePanelConfig | null
 	'surfaces:config-set': (surfaceId: string, panelConfig: SurfacePanelConfig) => SurfacePanelConfig | string
 	'surfaces:group-config-get': (groupId: string) => SurfaceGroupConfig
+	'surfaces:get-layouts': () => SurfaceLayoutSchema[]
 
 	'emulator:startup': (emulatorId: string) => EmulatorConfig
 	'emulator:press': (emulatorId: string, column: number, row: number) => void

--- a/webui/src/Buttons/ButtonGridPanel.tsx
+++ b/webui/src/Buttons/ButtonGridPanel.tsx
@@ -27,6 +27,7 @@ import { ButtonGridZoomControl } from './ButtonGridZoomControl.js'
 import { GridZoomController } from './GridZoom.js'
 import { CModalExt } from '../Components/CModalExt.js'
 import { GridViewSelectedSurfaceInfo, GridViewSpecialSurface } from './GridViewAs.js'
+import { ButtonGridViewAsSurfaceControl } from './ButtonGridViewAsSurfaceControl.js'
 
 interface ButtonsGridPanelProps {
 	pageNumber: number
@@ -146,6 +147,7 @@ export const ButtonsGridPanel = observer(function ButtonsPage({
 								gridZoomValue={gridZoomValue}
 								gridZoomController={gridZoomController}
 							/>
+							<ButtonGridViewAsSurfaceControl useCompactButtons={true} />
 						</ButtonGridHeader>
 					</CCol>
 				</CRow>

--- a/webui/src/Buttons/ButtonGridPanel.tsx
+++ b/webui/src/Buttons/ButtonGridPanel.tsx
@@ -26,7 +26,7 @@ import { observer } from 'mobx-react-lite'
 import { ButtonGridZoomControl } from './ButtonGridZoomControl.js'
 import { GridZoomController } from './GridZoom.js'
 import { CModalExt } from '../Components/CModalExt.js'
-import { GridViewSelectedSurfaceInfo, GridViewSpecialSurface } from './GridViewAs.js'
+import { GridViewAsController, GridViewSelectedSurfaceInfo } from './GridViewAs.js'
 import { ButtonGridViewAsSurfaceControl } from './ButtonGridViewAsSurfaceControl.js'
 
 interface ButtonsGridPanelProps {
@@ -39,7 +39,7 @@ interface ButtonsGridPanelProps {
 	clearSelectedButton: () => void
 	gridZoomValue: number
 	gridZoomController: GridZoomController
-	gridViewAsSurface: GridViewSelectedSurfaceInfo
+	gridViewAsController: GridViewAsController
 }
 
 export const ButtonsGridPanel = observer(function ButtonsPage({
@@ -52,7 +52,7 @@ export const ButtonsGridPanel = observer(function ButtonsPage({
 	clearSelectedButton,
 	gridZoomValue,
 	gridZoomController,
-	gridViewAsSurface,
+	gridViewAsController,
 }: ButtonsGridPanelProps) {
 	const { pages } = useContext(RootAppStoreContext)
 
@@ -147,14 +147,14 @@ export const ButtonsGridPanel = observer(function ButtonsPage({
 								gridZoomValue={gridZoomValue}
 								gridZoomController={gridZoomController}
 							/>
-							<ButtonGridViewAsSurfaceControl useCompactButtons={true} />
+							<ButtonGridViewAsSurfaceControl gridViewAsController={gridViewAsController} />
 						</ButtonGridHeader>
 					</CCol>
 				</CRow>
 			</div>
 			<div className="button-grid-panel-content">
 				{hasBeenInView &&
-					(gridViewAsSurface.id !== GridViewSpecialSurface.None ? (
+					(gridViewAsController.enabled ? (
 						<ButtonViewAsLayout
 							gridRef={gridRef}
 							isHot={isHot}
@@ -162,7 +162,7 @@ export const ButtonsGridPanel = observer(function ButtonsPage({
 							buttonClick={buttonClick}
 							selectedButton={selectedButton}
 							gridZoomValue={gridZoomValue}
-							gridViewAsSurface={gridViewAsSurface}
+							gridViewAsSurface={gridViewAsController.selectedSurface}
 						/>
 					) : (
 						<ButtonFullGridLayout

--- a/webui/src/Buttons/ButtonGridViewAsSurfaceControl.tsx
+++ b/webui/src/Buttons/ButtonGridViewAsSurfaceControl.tsx
@@ -1,50 +1,38 @@
-import { CDropdown, CDropdownMenu, CDropdownToggle } from '@coreui/react'
-import { faMobileScreen } from '@fortawesome/free-solid-svg-icons'
+import { CButton } from '@coreui/react'
+import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
 import React from 'react'
+import { GridViewAsController } from './GridViewAs.js'
 
 export interface ButtonGridViewAsSurfaceControlProps {
-	useCompactButtons: boolean
-	// gridZoomValue: number
-	// gridZoomController: GridZoomController
+	gridViewAsController: GridViewAsController
 }
 
 export const ButtonGridViewAsSurfaceControl = observer(function ButtonGridViewAsSurfaceControl({
-	useCompactButtons,
+	gridViewAsController,
 }: ButtonGridViewAsSurfaceControlProps) {
-	return (
-		<CDropdown className="dropdown-zoom btn-right" autoClose="outside" title="View Scale">
-			<CDropdownToggle caret={!useCompactButtons} color="light">
-				<span className="sr-only">View Scale</span>
-				<FontAwesomeIcon icon={faMobileScreen} /> {useCompactButtons ? '' : 'View As'}
-			</CDropdownToggle>
-			<CDropdownMenu>
-				{/* <CInputGroup>
-					<CButton onClick={() => gridZoomController.zoomOut()}>
-						<FontAwesomeIcon icon={faMinus} />
-					</CButton>
-					<CFormRange
-						name="scale"
-						min={ZOOM_MIN}
-						max={ZOOM_MAX}
-						step={ZOOM_STEP}
-						title="Scale"
-						value={gridZoomValue}
-						onChange={(e) => gridZoomController.setZoom(parseInt(e.currentTarget.value))}
-					/>
-					<CButton onClick={() => gridZoomController.zoomIn()}>
-						<FontAwesomeIcon icon={faPlus} />
-					</CButton>
-				</CInputGroup>
-				<CInputGroup className="dropdown-item-padding">
-					<NumberInputField value={gridZoomValue} setValue={gridZoomController.setZoom} min={ZOOM_MIN} max={ZOOM_MAX} />
-					<CInputGroupText>%</CInputGroupText>
-				</CInputGroup>
-				<CLink className="dropdown-item" onClick={gridZoomController.zoomReset}>
-					Scale to 100%
-				</CLink> */}
-			</CDropdownMenu>
-		</CDropdown>
-	)
+	if (gridViewAsController.enabled) {
+		return (
+			<CButton
+				color="primary"
+				onClick={() => gridViewAsController.setEnabled(false)}
+				title="View Full Grid"
+				className="btn-right"
+			>
+				<FontAwesomeIcon icon={faEye} />
+			</CButton>
+		)
+	} else {
+		return (
+			<CButton
+				color="light"
+				onClick={() => gridViewAsController.setEnabled(true)}
+				title="View As Surface"
+				className="btn-right"
+			>
+				<FontAwesomeIcon icon={faEyeSlash} />
+			</CButton>
+		)
+	}
 })

--- a/webui/src/Buttons/ButtonGridViewAsSurfaceControl.tsx
+++ b/webui/src/Buttons/ButtonGridViewAsSurfaceControl.tsx
@@ -1,0 +1,50 @@
+import { CDropdown, CDropdownMenu, CDropdownToggle } from '@coreui/react'
+import { faMobileScreen } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { observer } from 'mobx-react-lite'
+import React from 'react'
+
+export interface ButtonGridViewAsSurfaceControlProps {
+	useCompactButtons: boolean
+	// gridZoomValue: number
+	// gridZoomController: GridZoomController
+}
+
+export const ButtonGridViewAsSurfaceControl = observer(function ButtonGridViewAsSurfaceControl({
+	useCompactButtons,
+}: ButtonGridViewAsSurfaceControlProps) {
+	return (
+		<CDropdown className="dropdown-zoom btn-right" autoClose="outside" title="View Scale">
+			<CDropdownToggle caret={!useCompactButtons} color="light">
+				<span className="sr-only">View Scale</span>
+				<FontAwesomeIcon icon={faMobileScreen} /> {useCompactButtons ? '' : 'View As'}
+			</CDropdownToggle>
+			<CDropdownMenu>
+				{/* <CInputGroup>
+					<CButton onClick={() => gridZoomController.zoomOut()}>
+						<FontAwesomeIcon icon={faMinus} />
+					</CButton>
+					<CFormRange
+						name="scale"
+						min={ZOOM_MIN}
+						max={ZOOM_MAX}
+						step={ZOOM_STEP}
+						title="Scale"
+						value={gridZoomValue}
+						onChange={(e) => gridZoomController.setZoom(parseInt(e.currentTarget.value))}
+					/>
+					<CButton onClick={() => gridZoomController.zoomIn()}>
+						<FontAwesomeIcon icon={faPlus} />
+					</CButton>
+				</CInputGroup>
+				<CInputGroup className="dropdown-item-padding">
+					<NumberInputField value={gridZoomValue} setValue={gridZoomController.setZoom} min={ZOOM_MIN} max={ZOOM_MAX} />
+					<CInputGroupText>%</CInputGroupText>
+				</CInputGroup>
+				<CLink className="dropdown-item" onClick={gridZoomController.zoomReset}>
+					Scale to 100%
+				</CLink> */}
+			</CDropdownMenu>
+		</CDropdown>
+	)
+})

--- a/webui/src/Buttons/GridViewAs.tsx
+++ b/webui/src/Buttons/GridViewAs.tsx
@@ -1,16 +1,31 @@
-import { useContext, useMemo, useState } from 'react'
+import { useCallback, useContext, useMemo, useState } from 'react'
 import { RootAppStoreContext } from '../Stores/RootAppStore.js'
 import { useComputed } from '../util.js'
 import { DropdownChoice } from '@companion-module/base'
 import { ClientSurfaceItem, SurfaceLayoutSchema } from '@companion-app/shared/Model/Surfaces.js'
-
-export const ZOOM_MIN = 20
-export const ZOOM_MAX = 200
-export const ZOOM_STEP = 10
+import { cloneDeep } from 'lodash-es'
 
 export enum GridViewSpecialSurface {
 	None = '__none__',
 	Custom = '__custom__',
+}
+
+interface GridViewAsStore {
+	surfaceId: GridViewSpecialSurface | string
+	custom: {
+		type: string
+		xOffset: number
+		yOffset: number
+	}
+}
+
+const DEFAULT_STORED_VALUE = {
+	surfaceId: GridViewSpecialSurface.None,
+	custom: {
+		type: 'streamdeck-xl',
+		xOffset: 0,
+		yOffset: 0,
+	},
 }
 
 export interface GridViewSelectedSurfaceInfo {
@@ -26,24 +41,46 @@ export interface GridViewAsController {
 	surfaceChoices: DropdownChoice[]
 
 	setSelectedSurface: (surface: GridViewSpecialSurface | string) => void
-}
 
-function storeZoomValue(id: string, value: number) {
-	// Cache the value for future page loads
-	window.localStorage.setItem(`grid-zoom-scale:${id}`, value + '')
+	setCustomType: (type: string) => void
+	setCustomXOffset: (xOffset: number) => void
+	setCustomYOffset: (yOffset: number) => void
 }
 
 export function useGridViewAs(): GridViewAsController {
 	const { surfaces } = useContext(RootAppStoreContext)
 
-	// const [gridZoom, setGridZoom] = useState(() => {
-	// 	// load the cached value, or start with default
-	// 	const storedZoom = Number(window.localStorage.getItem(`grid-zoom-scale:${id}`))
-	// 	return storedZoom && !isNaN(storedZoom) ? storedZoom : 100
-	// })
+	const [storedData, setStoredData] = useState<GridViewAsStore>(() => {
+		try {
+			// // load the cached value, or start with default
+			const storedValue = JSON.parse(window.localStorage.getItem(`grid-view-as`) + '')
 
-	const [selectedSurfaceId, setSelectedSurfaceId] = useState<GridViewSpecialSurface | string>(
-		GridViewSpecialSurface.None
+			// Load and ensure it looks sane
+			return {
+				surfaceId: storedValue.surfaceId || DEFAULT_STORED_VALUE.surfaceId,
+				custom: {
+					type: storedValue.custom.type || DEFAULT_STORED_VALUE.custom.type,
+					xOffset: Number(storedValue.custom.xOffset) || DEFAULT_STORED_VALUE.custom.xOffset,
+					yOffset: Number(storedValue.custom.yOffset) || DEFAULT_STORED_VALUE.custom.yOffset,
+				},
+			}
+		} catch {
+			// Ignore the error,
+			return cloneDeep(DEFAULT_STORED_VALUE)
+		}
+	})
+	const updateStoredData = useCallback(
+		(update: (oldValue: GridViewAsStore) => GridViewAsStore) => {
+			return setStoredData((oldValue) => {
+				const newValue = update(oldValue)
+
+				// Cache the value for future page loads
+				window.localStorage.setItem(`grid-view-as`, JSON.stringify(newValue))
+
+				return newValue
+			})
+		},
+		[setStoredData]
 	)
 
 	const surfaceChoices = useComputed(() => {
@@ -66,35 +103,90 @@ export function useGridViewAs(): GridViewAsController {
 	}, [surfaces])
 
 	const controller = useMemo<Omit<GridViewAsController, 'selectedSurface' | 'surfaceChoices'>>(() => {
+		const updateCustomValue = (update: (oldValue: GridViewAsStore['custom']) => GridViewAsStore['custom']) => {
+			updateStoredData((oldStore) => {
+				if (oldStore.surfaceId !== GridViewSpecialSurface.Custom) return oldStore
+
+				return {
+					...oldStore,
+					custom: update(oldStore.custom),
+				}
+			})
+		}
+
 		return {
 			setSelectedSurface: (surfaceId: GridViewSpecialSurface | string): void => {
-				setSelectedSurfaceId(surfaceId)
+				updateStoredData((oldStore) => ({
+					...oldStore,
+					surfaceId,
+				}))
+			},
+
+			setCustomType: (type: string): void => {
+				updateCustomValue((oldCustom) => {
+					return {
+						...oldCustom,
+						type,
+					}
+				})
+			},
+			setCustomXOffset: (xOffset: number): void => {
+				updateCustomValue((oldCustom) => {
+					return {
+						...oldCustom,
+						xOffset,
+					}
+				})
+			},
+			setCustomYOffset: (yOffset: number): void => {
+				updateCustomValue((oldCustom) => {
+					return {
+						...oldCustom,
+						yOffset,
+					}
+				})
 			},
 		}
-	}, [])
+	}, [updateStoredData])
 
-	const selectedSurfaceInfo = surfaces.getSurfaceItem(selectedSurfaceId)
+	const selectedSurfaceInfo = surfaces.getSurfaceItem(storedData.surfaceId)
 
 	return {
 		...controller,
-		selectedSurface: {
-			id: selectedSurfaceId,
-			type: getSurfaceType(selectedSurfaceId, selectedSurfaceInfo),
-			xOffset: selectedSurfaceInfo?.xOffset ?? 0,
-			yOffset: selectedSurfaceInfo?.yOffset ?? 0,
-			layout: selectedSurfaceInfo?.layout ?? null,
-		},
+		selectedSurface: getSelectedSurface(storedData, selectedSurfaceInfo, surfaces.layouts),
 		surfaceChoices,
 	}
 }
 
-function getSurfaceType(id: GridViewSpecialSurface | string, surfaceInfo: ClientSurfaceItem | undefined): string {
-	switch (id) {
+function getSelectedSurface(
+	storedData: GridViewAsStore,
+	surfaceInfo: ClientSurfaceItem | undefined,
+	surfaceLayouts: SurfaceLayoutSchema[]
+): GridViewSelectedSurfaceInfo {
+	switch (storedData.surfaceId) {
 		case GridViewSpecialSurface.None:
-			return 'Full Grid'
+			return {
+				id: storedData.surfaceId,
+				type: 'Full Grid',
+				xOffset: 0,
+				yOffset: 0,
+				layout: null,
+			}
 		case GridViewSpecialSurface.Custom:
-			return 'Custom' // TODO is this needed?
+			return {
+				id: storedData.surfaceId,
+				type: storedData.custom.type,
+				xOffset: storedData.custom.xOffset,
+				yOffset: storedData.custom.yOffset,
+				layout: surfaceLayouts.find((layout) => layout.id === storedData.custom.type) ?? null,
+			}
 		default:
-			return surfaceInfo?.type ?? 'Unknown'
+			return {
+				id: storedData.surfaceId,
+				type: surfaceInfo?.type ?? 'Unknown',
+				xOffset: surfaceInfo?.xOffset ?? 0,
+				yOffset: surfaceInfo?.yOffset ?? 0,
+				layout: surfaceInfo?.layout ?? null,
+			}
 	}
 }

--- a/webui/src/Buttons/GridViewAs.tsx
+++ b/webui/src/Buttons/GridViewAs.tsx
@@ -83,6 +83,15 @@ export function useGridViewAs(): GridViewAsController {
 		[setStoredData]
 	)
 
+	const selectedSurfaceIsValid =
+		storedData.surfaceId === GridViewSpecialSurface.None ||
+		storedData.surfaceId === GridViewSpecialSurface.Custom ||
+		surfaces.getSurfaceItem(storedData.surfaceId) !== undefined
+	if (!selectedSurfaceIsValid) {
+		// If the selected surface is invalid, reset to the default
+		updateStoredData((oldStore) => ({ ...oldStore, surfaceId: GridViewSpecialSurface.None }))
+	}
+
 	const surfaceChoices = useComputed(() => {
 		return [
 			{

--- a/webui/src/Buttons/GridViewAs.tsx
+++ b/webui/src/Buttons/GridViewAs.tsx
@@ -79,8 +79,8 @@ export function useGridViewAs(): GridViewAsController {
 		selectedSurface: {
 			id: selectedSurfaceId,
 			type: getSurfaceType(selectedSurfaceId, selectedSurfaceInfo),
-			xOffset: 0, // TODO
-			yOffset: 0, // TODO
+			xOffset: selectedSurfaceInfo?.xOffset ?? 0,
+			yOffset: selectedSurfaceInfo?.yOffset ?? 0,
 		},
 		surfaceChoices,
 	}

--- a/webui/src/Buttons/GridViewAs.tsx
+++ b/webui/src/Buttons/GridViewAs.tsx
@@ -1,0 +1,98 @@
+import { useContext, useMemo, useState } from 'react'
+import { RootAppStoreContext } from '../Stores/RootAppStore.js'
+import { useComputed } from '../util.js'
+import { DropdownChoice } from '@companion-module/base'
+import { ClientSurfaceItem } from '@companion-app/shared/Model/Surfaces.js'
+
+export const ZOOM_MIN = 20
+export const ZOOM_MAX = 200
+export const ZOOM_STEP = 10
+
+export enum GridViewSpecialSurface {
+	None = '__none__',
+	Custom = '__custom__',
+}
+
+export interface GridViewSelectedSurfaceInfo {
+	id: GridViewSpecialSurface | string
+	type: string
+	xOffset: number
+	yOffset: number
+}
+
+export interface GridViewAsController {
+	selectedSurface: GridViewSelectedSurfaceInfo
+	surfaceChoices: DropdownChoice[]
+
+	setSelectedSurface: (surface: GridViewSpecialSurface | string) => void
+}
+
+function storeZoomValue(id: string, value: number) {
+	// Cache the value for future page loads
+	window.localStorage.setItem(`grid-zoom-scale:${id}`, value + '')
+}
+
+export function useGridViewAs(): GridViewAsController {
+	const { surfaces } = useContext(RootAppStoreContext)
+
+	// const [gridZoom, setGridZoom] = useState(() => {
+	// 	// load the cached value, or start with default
+	// 	const storedZoom = Number(window.localStorage.getItem(`grid-zoom-scale:${id}`))
+	// 	return storedZoom && !isNaN(storedZoom) ? storedZoom : 100
+	// })
+
+	const [selectedSurfaceId, setSelectedSurfaceId] = useState<GridViewSpecialSurface | string>(
+		GridViewSpecialSurface.None
+	)
+
+	const surfaceChoices = useComputed(() => {
+		return [
+			{
+				id: GridViewSpecialSurface.None,
+				label: 'Full Grid',
+			},
+			{
+				id: GridViewSpecialSurface.Custom,
+				label: 'Custom Surface',
+			},
+			...Array.from(surfaces.store.values()).flatMap((surfaceGroup): DropdownChoice[] =>
+				surfaceGroup.surfaces.map((surface) => ({
+					id: surface.id,
+					label: surface.displayName,
+				}))
+			),
+		]
+	}, [surfaces])
+
+	const controller = useMemo<Omit<GridViewAsController, 'selectedSurface' | 'surfaceChoices'>>(() => {
+		return {
+			setSelectedSurface: (surfaceId: GridViewSpecialSurface | string): void => {
+				setSelectedSurfaceId(surfaceId)
+			},
+		}
+	}, [])
+
+	const selectedSurfaceInfo = surfaces.getSurfaceItem(selectedSurfaceId)
+
+	return {
+		...controller,
+		selectedSurface: {
+			id: selectedSurfaceId,
+			type: getSurfaceType(selectedSurfaceId, selectedSurfaceInfo),
+			xOffset: 0, // TODO
+			yOffset: 0, // TODO
+		},
+		surfaceChoices,
+	}
+}
+
+function getSurfaceType(id: GridViewSpecialSurface | string, surfaceInfo: ClientSurfaceItem | undefined): string {
+	switch (id) {
+		case GridViewSpecialSurface.None:
+			return 'Full Grid'
+		case GridViewSpecialSurface.Custom:
+			return 'Custom' // TODO is this needed?
+		default:
+			return surfaceInfo?.type ?? 'Unknown'
+	}
+}

--- a/webui/src/Buttons/GridViewAs.tsx
+++ b/webui/src/Buttons/GridViewAs.tsx
@@ -2,7 +2,7 @@ import { useContext, useMemo, useState } from 'react'
 import { RootAppStoreContext } from '../Stores/RootAppStore.js'
 import { useComputed } from '../util.js'
 import { DropdownChoice } from '@companion-module/base'
-import { ClientSurfaceItem } from '@companion-app/shared/Model/Surfaces.js'
+import { ClientSurfaceItem, SurfaceLayoutSchema } from '@companion-app/shared/Model/Surfaces.js'
 
 export const ZOOM_MIN = 20
 export const ZOOM_MAX = 200
@@ -18,6 +18,7 @@ export interface GridViewSelectedSurfaceInfo {
 	type: string
 	xOffset: number
 	yOffset: number
+	layout: SurfaceLayoutSchema | null
 }
 
 export interface GridViewAsController {
@@ -81,6 +82,7 @@ export function useGridViewAs(): GridViewAsController {
 			type: getSurfaceType(selectedSurfaceId, selectedSurfaceInfo),
 			xOffset: selectedSurfaceInfo?.xOffset ?? 0,
 			yOffset: selectedSurfaceInfo?.yOffset ?? 0,
+			layout: selectedSurfaceInfo?.layout ?? null,
 		},
 		surfaceChoices,
 	}

--- a/webui/src/Buttons/GridViewAsPanel.tsx
+++ b/webui/src/Buttons/GridViewAsPanel.tsx
@@ -31,8 +31,6 @@ export const GridViewAsPanel = observer(function GridViewAsPanel({ gridViewAsCon
 		}
 	}, [surfaces, gridViewAsController.selectedSurface.id])
 
-	console.log(gridViewAsController.selectedSurface, surfaceTypeChoices)
-
 	return (
 		<div>
 			<h5>View Grid As</h5>

--- a/webui/src/Buttons/GridViewAsPanel.tsx
+++ b/webui/src/Buttons/GridViewAsPanel.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback, useContext, useEffect, useState } from 'react'
-import { CAlert, CButton, CRow } from '@coreui/react'
-import { ConnectionsContext, useComputed } from '../util.js'
+import React, { useContext } from 'react'
+import { CAlert } from '@coreui/react'
+import { useComputed } from '../util.js'
 import { RootAppStoreContext } from '../Stores/RootAppStore.js'
 import { observer } from 'mobx-react-lite'
 import { GridViewAsController, GridViewSpecialSurface } from './GridViewAs.js'
@@ -13,19 +13,6 @@ interface GridViewAsPanelProps {
 
 export const GridViewAsPanel = observer(function GridViewAsPanel({ gridViewAsController }: GridViewAsPanelProps) {
 	const { surfaces } = useContext(RootAppStoreContext)
-
-	// const options = Object.entries(presets).map(([id, vals]) => {
-	// 	if (!vals || Object.values(vals).length === 0) return ''
-
-	// 	const connectionInfo = connectionsContext[id]
-	// 	const moduleInfo = connectionInfo ? modules.modules.get(connectionInfo.instance_type) : undefined
-
-	// 	return (
-	// 		<CButton key={id} color="danger" onClick={() => setConnectionAndCategory([id, null])}>
-	// 			{moduleInfo?.name ?? '?'} ({connectionInfo?.label ?? id})
-	// 		</CButton>
-	// 	)
-	// })
 
 	const surfaceTypeChoices: DropdownChoice[] = useComputed(() => {
 		if (gridViewAsController.selectedSurface.id === GridViewSpecialSurface.Custom) {

--- a/webui/src/Buttons/GridViewAsPanel.tsx
+++ b/webui/src/Buttons/GridViewAsPanel.tsx
@@ -5,6 +5,7 @@ import { RootAppStoreContext } from '../Stores/RootAppStore.js'
 import { observer } from 'mobx-react-lite'
 import { GridViewAsController, GridViewSpecialSurface } from './GridViewAs.js'
 import { DropdownInputField, NumberInputField } from '../Components/index.js'
+import { DropdownChoice } from '@companion-module/base'
 
 interface GridViewAsPanelProps {
 	gridViewAsController: GridViewAsController
@@ -26,9 +27,12 @@ export const GridViewAsPanel = observer(function GridViewAsPanel({ gridViewAsCon
 	// 	)
 	// })
 
-	const surfaceTypeChoices = useComputed(() => {
+	const surfaceTypeChoices: DropdownChoice[] = useComputed(() => {
 		if (gridViewAsController.selectedSurface.id === GridViewSpecialSurface.Custom) {
-			return []
+			return surfaces.layouts.map((layout) => ({
+				id: layout.id,
+				label: layout.name,
+			}))
 		} else {
 			// Field is disabled, show just the current value
 			return [
@@ -52,6 +56,11 @@ export const GridViewAsPanel = observer(function GridViewAsPanel({ gridViewAsCon
 				value={gridViewAsController.selectedSurface.id}
 				setValue={(value) => gridViewAsController.setSelectedSurface(value as GridViewSpecialSurface | string)}
 			/>
+
+			{gridViewAsController.selectedSurface.id !== GridViewSpecialSurface.None &&
+				!gridViewAsController.selectedSurface.layout && (
+					<CAlert color="warning">The layout of this surface is not known, the full grid will be shown instead</CAlert>
+				)}
 
 			<DropdownInputField
 				label="Surface Type"

--- a/webui/src/Buttons/GridViewAsPanel.tsx
+++ b/webui/src/Buttons/GridViewAsPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react'
-import { CAlert } from '@coreui/react'
-import { useComputed } from '../util.js'
+import { CAlert, CCol, CForm, CFormLabel } from '@coreui/react'
+import { PreventDefaultHandler, useComputed } from '../util.js'
 import { RootAppStoreContext } from '../Stores/RootAppStore.js'
 import { observer } from 'mobx-react-lite'
 import { GridViewAsController, GridViewSpecialSurface } from './GridViewAs.js'
@@ -36,41 +36,59 @@ export const GridViewAsPanel = observer(function GridViewAsPanel({ gridViewAsCon
 			<h5>View Grid As</h5>
 			<p>Here you can change how the grid is displayed, to view it as a particular surface.</p>
 
-			<DropdownInputField
-				label="Surface"
-				choices={gridViewAsController.surfaceChoices}
-				multiple={false}
-				value={gridViewAsController.selectedSurface.id}
-				setValue={(value) => gridViewAsController.setSelectedSurface(value as GridViewSpecialSurface | string)}
-			/>
+			<CForm className="row g-3" onSubmit={PreventDefaultHandler}>
+				<CFormLabel className="col-sm-2 col-form-label col-form-label-sm">Surface</CFormLabel>
+				<CCol sm={9}>
+					<DropdownInputField
+						choices={gridViewAsController.surfaceChoices}
+						multiple={false}
+						value={gridViewAsController.selectedSurface.id}
+						setValue={(value) => gridViewAsController.setSelectedSurface(value as GridViewSpecialSurface | string)}
+					/>
+				</CCol>
+				<CCol sm={1}></CCol>
 
-			{gridViewAsController.selectedSurface.id !== GridViewSpecialSurface.None &&
-				!gridViewAsController.selectedSurface.layout && (
-					<CAlert color="warning">The layout of this surface is not known, the full grid will be shown instead</CAlert>
-				)}
+				{gridViewAsController.selectedSurface.id !== GridViewSpecialSurface.None &&
+					!gridViewAsController.selectedSurface.layout && (
+						<CCol sm={12}>
+							<CAlert color="warning">
+								The layout of this surface is not known, the full grid will be shown instead
+							</CAlert>
+						</CCol>
+					)}
 
-			<DropdownInputField
-				label="Surface Type"
-				choices={surfaceTypeChoices}
-				multiple={false}
-				disabled={gridViewAsController.selectedSurface.id !== GridViewSpecialSurface.Custom}
-				value={gridViewAsController.selectedSurface.type}
-				setValue={(value) => gridViewAsController.setCustomType(value as string)}
-			/>
+				<CFormLabel className="col-sm-2 col-form-label col-form-label-sm">Surface Type</CFormLabel>
+				<CCol sm={9}>
+					<DropdownInputField
+						choices={surfaceTypeChoices}
+						multiple={false}
+						disabled={gridViewAsController.selectedSurface.id !== GridViewSpecialSurface.Custom}
+						value={gridViewAsController.selectedSurface.type}
+						setValue={(value) => gridViewAsController.setCustomType(value as string)}
+					/>
+				</CCol>
+				<CCol sm={1}></CCol>
 
-			<NumberInputField
-				label="X Offset"
-				value={gridViewAsController.selectedSurface.xOffset}
-				disabled={gridViewAsController.selectedSurface.id !== GridViewSpecialSurface.Custom}
-				setValue={gridViewAsController.setCustomXOffset}
-			/>
+				<CFormLabel className="col-sm-2 col-form-label col-form-label-sm">X Offset</CFormLabel>
+				<CCol sm={9}>
+					<NumberInputField
+						value={gridViewAsController.selectedSurface.xOffset}
+						disabled={gridViewAsController.selectedSurface.id !== GridViewSpecialSurface.Custom}
+						setValue={gridViewAsController.setCustomXOffset}
+					/>
+				</CCol>
+				<CCol sm={1}></CCol>
 
-			<NumberInputField
-				label="Y Offset"
-				value={gridViewAsController.selectedSurface.yOffset}
-				disabled={gridViewAsController.selectedSurface.id !== GridViewSpecialSurface.Custom}
-				setValue={gridViewAsController.setCustomYOffset}
-			/>
+				<CFormLabel className="col-sm-2 col-form-label col-form-label-sm">Y Offset</CFormLabel>
+				<CCol sm={9}>
+					<NumberInputField
+						value={gridViewAsController.selectedSurface.yOffset}
+						disabled={gridViewAsController.selectedSurface.id !== GridViewSpecialSurface.Custom}
+						setValue={gridViewAsController.setCustomYOffset}
+					/>
+				</CCol>
+				<CCol sm={1}></CCol>
+			</CForm>
 		</div>
 	)
 })

--- a/webui/src/Buttons/GridViewAsPanel.tsx
+++ b/webui/src/Buttons/GridViewAsPanel.tsx
@@ -1,0 +1,80 @@
+import React, { useCallback, useContext, useEffect, useState } from 'react'
+import { CAlert, CButton, CRow } from '@coreui/react'
+import { ConnectionsContext, useComputed } from '../util.js'
+import { RootAppStoreContext } from '../Stores/RootAppStore.js'
+import { observer } from 'mobx-react-lite'
+import { GridViewSpecialSurface, useGridViewAs } from './GridViewAs.js'
+import { DropdownInputField, NumberInputField } from '../Components/index.js'
+
+export const GridViewAsPanel = observer(function GridViewAsPanel() {
+	const { socket, surfaces } = useContext(RootAppStoreContext)
+
+	const viewController = useGridViewAs()
+
+	// const options = Object.entries(presets).map(([id, vals]) => {
+	// 	if (!vals || Object.values(vals).length === 0) return ''
+
+	// 	const connectionInfo = connectionsContext[id]
+	// 	const moduleInfo = connectionInfo ? modules.modules.get(connectionInfo.instance_type) : undefined
+
+	// 	return (
+	// 		<CButton key={id} color="danger" onClick={() => setConnectionAndCategory([id, null])}>
+	// 			{moduleInfo?.name ?? '?'} ({connectionInfo?.label ?? id})
+	// 		</CButton>
+	// 	)
+	// })
+
+	const surfaceTypeChoices = useComputed(() => {
+		if (viewController.selectedSurface.id === GridViewSpecialSurface.Custom) {
+			return []
+		} else {
+			// Field is disabled, show just the current value
+			return [
+				{
+					id: viewController.selectedSurface.type,
+					label: viewController.selectedSurface.type,
+				},
+			]
+		}
+	}, [surfaces, viewController.selectedSurface.id])
+
+	return (
+		<div>
+			<h5>View Grid As</h5>
+			<p>Here you can change how the grid is displayed, to view it as a particular surface.</p>
+
+			<DropdownInputField
+				label="Surface"
+				choices={viewController.surfaceChoices}
+				multiple={false}
+				value={viewController.selectedSurface.id}
+				setValue={(value) => viewController.setSelectedSurface(value as GridViewSpecialSurface | string)}
+			/>
+
+			<DropdownInputField
+				label="Surface Type"
+				choices={surfaceTypeChoices}
+				multiple={false}
+				disabled={viewController.selectedSurface.id !== GridViewSpecialSurface.Custom}
+				value={viewController.selectedSurface.type}
+				setValue={(value) => {
+					console.log('type', value)
+				}}
+			/>
+
+			<NumberInputField
+				label="X Offset"
+				value={viewController.selectedSurface.xOffset}
+				disabled={viewController.selectedSurface.id !== GridViewSpecialSurface.Custom}
+				setValue={() => {}}
+			/>
+
+			<NumberInputField
+				label="Y Offset"
+				value={viewController.selectedSurface.yOffset}
+				disabled={viewController.selectedSurface.id !== GridViewSpecialSurface.Custom}
+				setValue={() => {}}
+			/>
+		</div>
+	)
+})

--- a/webui/src/Buttons/GridViewAsPanel.tsx
+++ b/webui/src/Buttons/GridViewAsPanel.tsx
@@ -3,13 +3,15 @@ import { CAlert, CButton, CRow } from '@coreui/react'
 import { ConnectionsContext, useComputed } from '../util.js'
 import { RootAppStoreContext } from '../Stores/RootAppStore.js'
 import { observer } from 'mobx-react-lite'
-import { GridViewSpecialSurface, useGridViewAs } from './GridViewAs.js'
+import { GridViewAsController, GridViewSpecialSurface } from './GridViewAs.js'
 import { DropdownInputField, NumberInputField } from '../Components/index.js'
 
-export const GridViewAsPanel = observer(function GridViewAsPanel() {
-	const { socket, surfaces } = useContext(RootAppStoreContext)
+interface GridViewAsPanelProps {
+	gridViewAsController: GridViewAsController
+}
 
-	const viewController = useGridViewAs()
+export const GridViewAsPanel = observer(function GridViewAsPanel({ gridViewAsController }: GridViewAsPanelProps) {
+	const { surfaces } = useContext(RootAppStoreContext)
 
 	// const options = Object.entries(presets).map(([id, vals]) => {
 	// 	if (!vals || Object.values(vals).length === 0) return ''
@@ -25,18 +27,18 @@ export const GridViewAsPanel = observer(function GridViewAsPanel() {
 	// })
 
 	const surfaceTypeChoices = useComputed(() => {
-		if (viewController.selectedSurface.id === GridViewSpecialSurface.Custom) {
+		if (gridViewAsController.selectedSurface.id === GridViewSpecialSurface.Custom) {
 			return []
 		} else {
 			// Field is disabled, show just the current value
 			return [
 				{
-					id: viewController.selectedSurface.type,
-					label: viewController.selectedSurface.type,
+					id: gridViewAsController.selectedSurface.type,
+					label: gridViewAsController.selectedSurface.type,
 				},
 			]
 		}
-	}, [surfaces, viewController.selectedSurface.id])
+	}, [surfaces, gridViewAsController.selectedSurface.id])
 
 	return (
 		<div>
@@ -45,18 +47,18 @@ export const GridViewAsPanel = observer(function GridViewAsPanel() {
 
 			<DropdownInputField
 				label="Surface"
-				choices={viewController.surfaceChoices}
+				choices={gridViewAsController.surfaceChoices}
 				multiple={false}
-				value={viewController.selectedSurface.id}
-				setValue={(value) => viewController.setSelectedSurface(value as GridViewSpecialSurface | string)}
+				value={gridViewAsController.selectedSurface.id}
+				setValue={(value) => gridViewAsController.setSelectedSurface(value as GridViewSpecialSurface | string)}
 			/>
 
 			<DropdownInputField
 				label="Surface Type"
 				choices={surfaceTypeChoices}
 				multiple={false}
-				disabled={viewController.selectedSurface.id !== GridViewSpecialSurface.Custom}
-				value={viewController.selectedSurface.type}
+				disabled={gridViewAsController.selectedSurface.id !== GridViewSpecialSurface.Custom}
+				value={gridViewAsController.selectedSurface.type}
 				setValue={(value) => {
 					console.log('type', value)
 				}}
@@ -64,15 +66,15 @@ export const GridViewAsPanel = observer(function GridViewAsPanel() {
 
 			<NumberInputField
 				label="X Offset"
-				value={viewController.selectedSurface.xOffset}
-				disabled={viewController.selectedSurface.id !== GridViewSpecialSurface.Custom}
+				value={gridViewAsController.selectedSurface.xOffset}
+				disabled={gridViewAsController.selectedSurface.id !== GridViewSpecialSurface.Custom}
 				setValue={() => {}}
 			/>
 
 			<NumberInputField
 				label="Y Offset"
-				value={viewController.selectedSurface.yOffset}
-				disabled={viewController.selectedSurface.id !== GridViewSpecialSurface.Custom}
+				value={gridViewAsController.selectedSurface.yOffset}
+				disabled={gridViewAsController.selectedSurface.id !== GridViewSpecialSurface.Custom}
 				setValue={() => {}}
 			/>
 		</div>

--- a/webui/src/Buttons/GridViewAsPanel.tsx
+++ b/webui/src/Buttons/GridViewAsPanel.tsx
@@ -44,6 +44,8 @@ export const GridViewAsPanel = observer(function GridViewAsPanel({ gridViewAsCon
 		}
 	}, [surfaces, gridViewAsController.selectedSurface.id])
 
+	console.log(gridViewAsController.selectedSurface, surfaceTypeChoices)
+
 	return (
 		<div>
 			<h5>View Grid As</h5>
@@ -68,23 +70,21 @@ export const GridViewAsPanel = observer(function GridViewAsPanel({ gridViewAsCon
 				multiple={false}
 				disabled={gridViewAsController.selectedSurface.id !== GridViewSpecialSurface.Custom}
 				value={gridViewAsController.selectedSurface.type}
-				setValue={(value) => {
-					console.log('type', value)
-				}}
+				setValue={(value) => gridViewAsController.setCustomType(value as string)}
 			/>
 
 			<NumberInputField
 				label="X Offset"
 				value={gridViewAsController.selectedSurface.xOffset}
 				disabled={gridViewAsController.selectedSurface.id !== GridViewSpecialSurface.Custom}
-				setValue={() => {}}
+				setValue={gridViewAsController.setCustomXOffset}
 			/>
 
 			<NumberInputField
 				label="Y Offset"
 				value={gridViewAsController.selectedSurface.yOffset}
 				disabled={gridViewAsController.selectedSurface.id !== GridViewSpecialSurface.Custom}
-				setValue={() => {}}
+				setValue={gridViewAsController.setCustomYOffset}
 			/>
 		</div>
 	)

--- a/webui/src/Buttons/GridViewAsPanel.tsx
+++ b/webui/src/Buttons/GridViewAsPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react'
-import { CAlert, CCol, CForm, CFormLabel } from '@coreui/react'
+import { CAlert, CCol, CForm, CFormLabel, CFormSwitch } from '@coreui/react'
 import { PreventDefaultHandler, useComputed } from '../util.js'
 import { RootAppStoreContext } from '../Stores/RootAppStore.js'
 import { observer } from 'mobx-react-lite'
@@ -37,6 +37,16 @@ export const GridViewAsPanel = observer(function GridViewAsPanel({ gridViewAsCon
 			<p>Here you can change how the grid is displayed, to view it as a particular surface.</p>
 
 			<CForm className="row g-3" onSubmit={PreventDefaultHandler}>
+				<CFormLabel className="col-sm-2 col-form-label col-form-label-sm">View Enabled</CFormLabel>
+				<CCol sm={9}>
+					<CFormSwitch
+						checked={gridViewAsController.enabled}
+						onChange={(e) => gridViewAsController.setEnabled(!!e.currentTarget.checked)}
+						size="xl"
+					/>
+				</CCol>
+				<CCol sm={1}></CCol>
+
 				<CFormLabel className="col-sm-2 col-form-label col-form-label-sm">Surface</CFormLabel>
 				<CCol sm={9}>
 					<DropdownInputField
@@ -48,14 +58,13 @@ export const GridViewAsPanel = observer(function GridViewAsPanel({ gridViewAsCon
 				</CCol>
 				<CCol sm={1}></CCol>
 
-				{gridViewAsController.selectedSurface.id !== GridViewSpecialSurface.None &&
-					!gridViewAsController.selectedSurface.layout && (
-						<CCol sm={12}>
-							<CAlert color="warning">
-								The layout of this surface is not known, the full grid will be shown instead
-							</CAlert>
-						</CCol>
-					)}
+				{!gridViewAsController.selectedSurface.layout && (
+					<CCol sm={12}>
+						<CAlert color="warning">
+							The layout of this surface is not known, the full grid will be shown instead
+						</CAlert>
+					</CCol>
+				)}
 
 				<CFormLabel className="col-sm-2 col-form-label col-form-label-sm">Surface Type</CFormLabel>
 				<CCol sm={9}>

--- a/webui/src/Buttons/GridViewAsPanel.tsx
+++ b/webui/src/Buttons/GridViewAsPanel.tsx
@@ -78,7 +78,7 @@ export const GridViewAsPanel = observer(function GridViewAsPanel({ gridViewAsCon
 				</CCol>
 				<CCol sm={1}></CCol>
 
-				<CFormLabel className="col-sm-2 col-form-label col-form-label-sm">X Offset</CFormLabel>
+				<CFormLabel className="col-sm-2 col-form-label col-form-label-sm">Horizontal Offset</CFormLabel>
 				<CCol sm={9}>
 					<NumberInputField
 						value={gridViewAsController.selectedSurface.xOffset}
@@ -88,7 +88,7 @@ export const GridViewAsPanel = observer(function GridViewAsPanel({ gridViewAsCon
 				</CCol>
 				<CCol sm={1}></CCol>
 
-				<CFormLabel className="col-sm-2 col-form-label col-form-label-sm">Y Offset</CFormLabel>
+				<CFormLabel className="col-sm-2 col-form-label col-form-label-sm">Vertical Offset</CFormLabel>
 				<CCol sm={9}>
 					<NumberInputField
 						value={gridViewAsController.selectedSurface.yOffset}

--- a/webui/src/Buttons/index.tsx
+++ b/webui/src/Buttons/index.tsx
@@ -17,6 +17,7 @@ import classNames from 'classnames'
 import { useGridZoom } from './GridZoom.js'
 import { NavigateFunction, useLocation, useNavigate } from 'react-router-dom'
 import { GridViewAsPanel } from './GridViewAsPanel.js'
+import { useGridViewAs } from './GridViewAs.js'
 
 export const BUTTONS_PAGE_PREFIX = '/buttons'
 const SESSION_STORAGE_LAST_BUTTONS_PAGE = 'lastButtonsPage'
@@ -55,6 +56,7 @@ export const ButtonsPage = observer(function ButtonsPage({ hotPress }: ButtonsPa
 
 	const clearModalRef = useRef<GenericConfirmModalRef>(null)
 	const [gridZoomController, gridZoomValue] = useGridZoom('grid')
+	const gridViewAsController = useGridViewAs()
 
 	const [tabResetToken, setTabResetToken] = useState(nanoid())
 	const [activeTab, setActiveTab] = useState('presets')
@@ -271,6 +273,7 @@ export const ButtonsPage = observer(function ButtonsPage({ hotPress }: ButtonsPa
 						clearSelectedButton={clearSelectedButton}
 						gridZoomController={gridZoomController}
 						gridZoomValue={gridZoomValue}
+						gridViewAsSurface={gridViewAsController.selectedSurface}
 					/>
 				</MyErrorBoundary>
 			</CCol>
@@ -323,7 +326,7 @@ export const ButtonsPage = observer(function ButtonsPage({ hotPress }: ButtonsPa
 						</CTabPane>
 						<CTabPane visible={activeTab === 'view-as'}>
 							<MyErrorBoundary>
-								<GridViewAsPanel />
+								<GridViewAsPanel gridViewAsController={gridViewAsController} />
 							</MyErrorBoundary>
 						</CTabPane>
 						<CTabPane visible={activeTab === 'action-recorder'}>

--- a/webui/src/Buttons/index.tsx
+++ b/webui/src/Buttons/index.tsx
@@ -273,7 +273,7 @@ export const ButtonsPage = observer(function ButtonsPage({ hotPress }: ButtonsPa
 						clearSelectedButton={clearSelectedButton}
 						gridZoomController={gridZoomController}
 						gridZoomValue={gridZoomValue}
-						gridViewAsSurface={gridViewAsController.selectedSurface}
+						gridViewAsController={gridViewAsController}
 					/>
 				</MyErrorBoundary>
 			</CCol>

--- a/webui/src/Buttons/index.tsx
+++ b/webui/src/Buttons/index.tsx
@@ -1,5 +1,5 @@
 import { CCol, CNav, CNavItem, CNavLink, CRow, CTabContent, CTabPane } from '@coreui/react'
-import { faCalculator, faGift, faVideoCamera } from '@fortawesome/free-solid-svg-icons'
+import { faCalculator, faEye, faGift, faVideoCamera } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { nanoid } from 'nanoid'
 import { InstancePresets } from './Presets.js'
@@ -16,6 +16,7 @@ import { RootAppStoreContext } from '../Stores/RootAppStore.js'
 import classNames from 'classnames'
 import { useGridZoom } from './GridZoom.js'
 import { NavigateFunction, useLocation, useNavigate } from 'react-router-dom'
+import { GridViewAsPanel } from './GridViewAsPanel.js'
 
 export const BUTTONS_PAGE_PREFIX = '/buttons'
 const SESSION_STORAGE_LAST_BUTTONS_PAGE = 'lastButtonsPage'
@@ -293,6 +294,11 @@ export const ButtonsPage = observer(function ButtonsPage({ hotPress }: ButtonsPa
 							</CNavLink>
 						</CNavItem>
 						<CNavItem>
+							<CNavLink active={activeTab === 'view-as'} onClick={() => doChangeTab('view-as')}>
+								<FontAwesomeIcon icon={faEye} /> Grid View
+							</CNavLink>
+						</CNavItem>
+						<CNavItem>
 							<CNavLink active={activeTab === 'action-recorder'} onClick={() => doChangeTab('action-recorder')}>
 								<FontAwesomeIcon icon={faVideoCamera} /> Recorder
 							</CNavLink>
@@ -313,6 +319,11 @@ export const ButtonsPage = observer(function ButtonsPage({ hotPress }: ButtonsPa
 						<CTabPane visible={activeTab === 'presets'}>
 							<MyErrorBoundary>
 								<InstancePresets resetToken={tabResetToken} />
+							</MyErrorBoundary>
+						</CTabPane>
+						<CTabPane visible={activeTab === 'view-as'}>
+							<MyErrorBoundary>
+								<GridViewAsPanel />
 							</MyErrorBoundary>
 						</CTabPane>
 						<CTabPane visible={activeTab === 'action-recorder'}>

--- a/webui/src/ContextData.tsx
+++ b/webui/src/ContextData.tsx
@@ -26,6 +26,7 @@ import { UserConfigStore } from './Stores/UserConfigStore.js'
 import { VariablesStore } from './Stores/VariablesStore.js'
 import { useCustomVariablesSubscription } from './Hooks/useCustomVariablesSubscription.js'
 import { useVariablesSubscription } from './Hooks/useVariablesSubscription.js'
+import { useSurfaceLayoutsSubscription } from './Hooks/useSurfaceLayoutsSubscription.js'
 
 interface ContextDataProps {
 	children: (progressPercent: number, loadingComplete: boolean) => React.JSX.Element | React.JSX.Element[]
@@ -73,6 +74,7 @@ export function ContextData({ children }: Readonly<ContextDataProps>) {
 	const pagesReady = usePagesInfoSubscription(socket, rootStore.pages)
 	const userConfigReady = useUserConfigSubscription(socket, rootStore.userConfig)
 	const surfacesReady = useSurfacesSubscription(socket, rootStore.surfaces)
+	const surfaceLayoutsReady = useSurfaceLayoutsSubscription(socket, rootStore.surfaces)
 	const variablesReady = useVariablesSubscription(socket, rootStore.variablesStore)
 	const customVariablesReady = useCustomVariablesSubscription(socket, rootStore.variablesStore)
 
@@ -140,6 +142,7 @@ export function ContextData({ children }: Readonly<ContextDataProps>) {
 		customVariablesReady,
 		userConfigReady,
 		surfacesReady,
+		surfaceLayoutsReady,
 		pagesReady,
 		triggersListReady,
 		activeLearnRequestsReady,

--- a/webui/src/Hooks/useSurfaceLayoutsSubscription.ts
+++ b/webui/src/Hooks/useSurfaceLayoutsSubscription.ts
@@ -1,0 +1,36 @@
+import { useState, useEffect } from 'react'
+import type { SurfacesStore } from '../Stores/SurfacesStore.js'
+import { CompanionSocketType, socketEmitPromise } from '../util.js'
+
+export function useSurfaceLayoutsSubscription(
+	socket: CompanionSocketType,
+	store: SurfacesStore,
+	setLoadError?: ((error: string | null) => void) | undefined,
+	retryToken?: string
+): boolean {
+	const [ready, setReady] = useState(false)
+
+	useEffect(() => {
+		setLoadError?.(null)
+		store.reset(null)
+		setReady(false)
+
+		socketEmitPromise(socket, 'surfaces:get-layouts', [])
+			.then((surfaceLayouts) => {
+				setLoadError?.(null)
+				store.resetLayouts(surfaceLayouts)
+				setReady(true)
+			})
+			.catch((e) => {
+				setLoadError?.(`Failed to load surface layouts list`)
+				console.error('Failed to load surface layouts list:', e)
+				store.reset(null)
+			})
+
+		return () => {
+			store.resetLayouts(null)
+		}
+	}, [socket, store, setLoadError, retryToken])
+
+	return ready
+}

--- a/webui/src/Stores/SurfacesStore.tsx
+++ b/webui/src/Stores/SurfacesStore.tsx
@@ -1,4 +1,9 @@
-import { ClientDevicesListItem, ClientSurfaceItem, SurfacesUpdate } from '@companion-app/shared/Model/Surfaces.js'
+import {
+	ClientDevicesListItem,
+	ClientSurfaceItem,
+	SurfaceLayoutSchema,
+	SurfacesUpdate,
+} from '@companion-app/shared/Model/Surfaces.js'
 import { action, observable } from 'mobx'
 import { assertNever } from '../util.js'
 import { applyPatch } from 'fast-json-patch'
@@ -6,6 +11,7 @@ import { cloneDeep } from 'lodash-es'
 
 export class SurfacesStore {
 	readonly store = observable.map<string, ClientDevicesListItem>()
+	readonly layouts = observable.array<SurfaceLayoutSchema>()
 
 	public getSurfaceItem(id: string): ClientSurfaceItem | undefined {
 		for (const surfaceGroup of this.store.values()) {
@@ -28,6 +34,14 @@ export class SurfacesStore {
 					this.store.set(id, item)
 				}
 			}
+		}
+	})
+
+	public resetLayouts = action((newData: SurfaceLayoutSchema[] | null): void => {
+		this.layouts.clear()
+
+		if (newData) {
+			this.layouts.push(...newData)
 		}
 	})
 

--- a/webui/src/Stores/SurfacesStore.tsx
+++ b/webui/src/Stores/SurfacesStore.tsx
@@ -1,4 +1,4 @@
-import { ClientDevicesListItem, SurfacesUpdate } from '@companion-app/shared/Model/Surfaces.js'
+import { ClientDevicesListItem, ClientSurfaceItem, SurfacesUpdate } from '@companion-app/shared/Model/Surfaces.js'
 import { action, observable } from 'mobx'
 import { assertNever } from '../util.js'
 import { applyPatch } from 'fast-json-patch'
@@ -6,6 +6,18 @@ import { cloneDeep } from 'lodash-es'
 
 export class SurfacesStore {
 	readonly store = observable.map<string, ClientDevicesListItem>()
+
+	public getSurfaceItem(id: string): ClientSurfaceItem | undefined {
+		for (const surfaceGroup of this.store.values()) {
+			for (const surface of surfaceGroup.surfaces) {
+				if (surface.id === id) {
+					return surface
+				}
+			}
+		}
+
+		return undefined
+	}
 
 	public reset = action((newData: Record<string, ClientDevicesListItem | undefined> | null): void => {
 		this.store.clear()


### PR DESCRIPTION
Related: #1352 #2189

This adds the ability to view the button grid as a particular surface.
For now this is limited to reducing the buttons shown to the ones displayed by a surface, it will later be extended to support showing 'custom' layouts and graphics for surface types that define them.

The selection is remembered across page reloads/refreshes.

There is a toggle button added above the grid to quickly enable/disable this for the current surface, the main configuration for this tool is a panel on the right.

The 'Surface' dropdown offers every surface as shown in the surfaces tab of companion. We already cache the dimensions of these, so know what size grid to show, even when they are not connected

![image](https://github.com/bitfocus/companion/assets/1327476/6dc3b608-145d-4a5d-817b-8483f4a1b499)

In some cases, we don't have dimensions (surface hasn't been connected since we started storing that), then a warning is displayed and no size change takes effect
![image](https://github.com/bitfocus/companion/assets/1327476/0385cbc0-f70d-4bee-bad4-ff5a0961005b)

You can also choose 'Custom' in the 'Surface' dropdown, which enabled the 'Surface Type' dropdown which is configured with every surface type that companion natively supports.
You can also manually adjust the x&y offsets to position as desired.

![image](https://github.com/bitfocus/companion/assets/1327476/6cb92aff-b38f-4f2b-afed-79217bbc963e)

