### PR TITLE
fix: cleaner preset button text

### DIFF
--- a/webui/src/Buttons/Presets/Presets.tsx
+++ b/webui/src/Buttons/Presets/Presets.tsx
@@ -87,9 +87,7 @@ export const InstancePresets = observer(function InstancePresets({ resetToken }:
 				<PresetsButtonList
 					presets={presets}
 					selectedConnectionId={connectionAndCategory[0]}
-					selectedConnectionLabel={
-						(moduleInfo?.name ?? '?') + ' (' + connectionInfo?.label || connectionAndCategory[0] + ')'
-					}
+					selectedConnectionLabel={connectionInfo?.label || connectionAndCategory[0]}
 					selectedCategory={connectionAndCategory[1]}
 					setConnectionAndCategory={setConnectionAndCategory}
 				/>

--- a/webui/src/Buttons/Presets/PresetsCategoryList.tsx
+++ b/webui/src/Buttons/Presets/PresetsCategoryList.tsx
@@ -16,7 +16,6 @@ interface PresetsCategoryListProps {
 export function PresetsCategoryList({
 	presets,
 	connectionInfo,
-	moduleInfo,
 	selectedConnectionId,
 	setConnectionAndCategory,
 }: Readonly<PresetsCategoryListProps>) {
@@ -51,7 +50,7 @@ export function PresetsCategoryList({
 						&nbsp; Go back
 					</CButton>
 					<CButton color="secondary" disabled>
-						{moduleInfo?.name || '?'} ({connectionInfo?.label || selectedConnectionId})
+						{connectionInfo?.label || selectedConnectionId}
 					</CButton>
 				</CButtonGroup>
 			</div>

--- a/webui/src/Buttons/Presets/PresetsConnectionList.tsx
+++ b/webui/src/Buttons/Presets/PresetsConnectionList.tsx
@@ -26,7 +26,7 @@ export const PresetsConnectionList = observer(function PresetsConnectionList({
 		const compactName = moduleInfo?.name?.replace(/\;.*/, '...')
 
 		return (
-			<CButton title={compactName} key={id} color="primary" onClick={() => setConnectionAndCategory([id, null])}>
+			<CButton title={moduleInfo?.name} key={id} color="primary" onClick={() => setConnectionAndCategory([id, null])}>
 				<h6>{connectionInfo?.label ?? id}</h6> <small>{compactName ?? '?'}</small>
 			</CButton>
 		)

--- a/webui/src/Buttons/Presets/PresetsConnectionList.tsx
+++ b/webui/src/Buttons/Presets/PresetsConnectionList.tsx
@@ -23,10 +23,11 @@ export const PresetsConnectionList = observer(function PresetsConnectionList({
 
 		const connectionInfo = connectionsContext[id]
 		const moduleInfo = connectionInfo ? modules.modules.get(connectionInfo.instance_type) : undefined
+		const compactName = moduleInfo?.name?.replace(/\;.*/, '...')
 
 		return (
-			<CButton key={id} color="primary" onClick={() => setConnectionAndCategory([id, null])}>
-				{moduleInfo?.name ?? '?'} ({connectionInfo?.label ?? id})
+			<CButton title={compactName} key={id} color="primary" onClick={() => setConnectionAndCategory([id, null])}>
+				<h6>{connectionInfo?.label ?? id}</h6> <small>{compactName ?? '?'}</small>
 			</CButton>
 		)
 	})

--- a/webui/src/Variables/index.tsx
+++ b/webui/src/Variables/index.tsx
@@ -71,10 +71,11 @@ const VariablesConnectionList = observer(function VariablesConnectionList({
 		const connectionId = connectionsLabelMap.get(label)
 		const connectionInfo = connectionId ? connectionsContext[connectionId] : undefined
 		const moduleInfo = connectionInfo ? modules.modules.get(connectionInfo.instance_type) : undefined
+		const compactName = moduleInfo?.name?.replace(/\;.*/, '...')
 
 		return (
 			<CButton key={connectionId} color="primary" onClick={() => setConnectionId(connectionId ?? null)}>
-				{moduleInfo?.name ?? moduleInfo?.name ?? '?'} ({label ?? connectionId})
+				<h6>{label ?? connectionId}</h6> <small>{compactName ?? '?'}</small>
 			</CButton>
 		)
 	})


### PR DESCRIPTION
Partially solves https://github.com/bitfocus/companion/issues/2999
This highlights the connection's given name and truncates the product list if it's longer than one item.
This doesn't solve any sort of sorting change discussed in that issue.