### PR TITLE
feat: 'variables' in satellite api

### DIFF
--- a/companion/lib/Service/Satellite.js
+++ b/companion/lib/Service/Satellite.js
@@ -19,6 +19,7 @@ import LogController from '../Log/Controller.js'
  * 		 - compatibility with internal CSS colors,
  * 		 - allow buttons > 32
  * 1.7.0 - Support for transferable values. This allows surfaces to emit and consume values that don't align with a control in the grid.
+ *       - allow surface to opt out of brightness slider and messages
  */
 const API_VERSION = '1.7.0'
 
@@ -116,6 +117,11 @@ class ServiceSatellite extends ServiceBase {
 
 		socketLogger.debug(`add surface "${id}"`)
 
+		let supportsBrightness = true
+		if (params.BRIGHTNESS !== undefined && !isTruthy(params.BRIGHTNESS)) {
+			supportsBrightness = false
+		}
+
 		let streamBitmapSize = null
 		if (params.BITMAPS !== undefined && !isFalsey(params.BITMAPS)) {
 			streamBitmapSize = Number(params.BITMAPS)
@@ -146,6 +152,7 @@ class ServiceSatellite extends ServiceBase {
 			socket,
 			deviceId: id,
 			productName: `${params.PRODUCT_NAME}`,
+			supportsBrightness,
 			streamBitmapSize,
 			streamColors,
 			streamText,

--- a/companion/lib/Service/Satellite.js
+++ b/companion/lib/Service/Satellite.js
@@ -18,8 +18,9 @@ import LogController from '../Log/Controller.js'
  * 		 - allow choice of returned color format
  * 		 - compatibility with internal CSS colors,
  * 		 - allow buttons > 32
+ * 1.7.0 - Support for transferable values. This allows surfaces to emit and consume values that don't align with a control in the grid.
  */
-const API_VERSION = '1.6.0'
+const API_VERSION = '1.7.0'
 
 /**
  * Class providing the Satellite/Remote Surface api.

--- a/companion/lib/Service/Satellite.js
+++ b/companion/lib/Service/Satellite.js
@@ -117,11 +117,6 @@ class ServiceSatellite extends ServiceBase {
 
 		socketLogger.debug(`add surface "${id}"`)
 
-		let supportsBrightness = true
-		if (params.BRIGHTNESS !== undefined && !isTruthy(params.BRIGHTNESS)) {
-			supportsBrightness = false
-		}
-
 		let streamBitmapSize = null
 		if (params.BITMAPS !== undefined && !isFalsey(params.BITMAPS)) {
 			streamBitmapSize = Number(params.BITMAPS)
@@ -134,6 +129,7 @@ class ServiceSatellite extends ServiceBase {
 		const streamColors = parseStringParamWithBooleanFallback(['hex', 'rgb'], 'hex', params.COLORS) || false
 		const streamText = params.TEXT !== undefined && isTruthy(params.TEXT)
 		const streamTextStyle = params.TEXT_STYLE !== undefined && isTruthy(params.TEXT_STYLE)
+		const supportsBrightness = params.BRIGHTNESS === undefined || isTruthy(params.BRIGHTNESS)
 
 		/** @type {import('../Surface/IP/Satellite.js').SatelliteTransferableValue[]} */
 		let transferVariables

--- a/companion/lib/Surface/Controller.js
+++ b/companion/lib/Surface/Controller.js
@@ -975,7 +975,7 @@ class SurfaceController extends CoreBase {
 	addSatelliteDevice(deviceInfo) {
 		this.removeDevice(deviceInfo.path)
 
-		const device = new SurfaceIPSatellite(deviceInfo)
+		const device = new SurfaceIPSatellite(deviceInfo, this.#surfaceExecuteExpression.bind(this))
 
 		this.#createSurfaceHandler(deviceInfo.path, 'satellite', device)
 

--- a/companion/lib/Surface/IP/Satellite.js
+++ b/companion/lib/Surface/IP/Satellite.js
@@ -37,6 +37,7 @@ import { VARIABLE_UNKNOWN_VALUE } from '../../Variables/Util.js'
  *   path: string
  *   socket: import('net').Socket
  *   gridSize: import('../Util.js').GridSize
+ *   supportsBrightness:boolean
  *   streamBitmapSize: number | null
  *   streamColors: string | boolean
  *   streamText: boolean
@@ -70,12 +71,11 @@ import { VARIABLE_UNKNOWN_VALUE } from '../../Variables/Util.js'
  */
 function generateConfigFields(deviceInfo, legacyRotation, inputVariables, outputVariables) {
 	/** @type {import('@companion-app/shared/Model/Surfaces.js').CompanionSurfaceConfigField[]} */
-	const fields = [
-		...OffsetConfigFields,
-		BrightnessConfigField,
-		legacyRotation ? LegacyRotationConfigField : RotationConfigField,
-		...LockConfigFields,
-	]
+	const fields = [...OffsetConfigFields]
+	if (deviceInfo.supportsBrightness) {
+		fields.push(BrightnessConfigField)
+	}
+	fields.push(legacyRotation ? LegacyRotationConfigField : RotationConfigField, ...LockConfigFields)
 
 	for (const variable of deviceInfo.transferVariables) {
 		if (variable.type === 'input') {


### PR DESCRIPTION
This adds support for 'variables' in the satellite api.

The satellite device can provide a basic description of any input (satellite to companion) and output (companion to satellite) variables it supports. These can then be mapped internally in the same way as used by #3012.  

This is needed for proper operation of https://github.com/bitfocus/companion-satellite/pull/147

This will allow for adding xkeys, shuttle and matching loupedeck-ct support in satellite, as these all update variables for portions which are not properly supported in companions grid view of surfaces.