### PR TITLE
feat: allow custom export file name

### DIFF
--- a/companion/lib/Data/ImportExport.ts
+++ b/companion/lib/Data/ImportExport.ts
@@ -351,8 +351,10 @@ export class DataImportExport extends CoreBase {
 			// @ts-expect-error
 			const exp = generateCustomExport(req.query)
 
-			const filename = encodeURI(`${os.hostname()}_custom-config_${getTimestamp()}.companionconfig`)
-
+			const filename = req.query.filename
+				? encodeURI(`${req.query.filename}.companionconfig`)
+				: encodeURI(`${os.hostname()}_custom-config_${getTimestamp()}.companionconfig`)
+		
 			downloadBlob(this.logger, res, next, exp, filename, parseDownloadFormat(req.query.format))
 		})
 

--- a/companion/lib/Data/ImportExport.ts
+++ b/companion/lib/Data/ImportExport.ts
@@ -350,9 +350,9 @@ export class DataImportExport extends CoreBase {
 		this.registry.api_router.get('/export/custom', (req, res, next) => {
 			// @ts-expect-error
 			const exp = generateCustomExport(req.query)
-
-			const filename = req.query.filename
-				? encodeURI(`${req.query.filename}.companionconfig`)
+			let parsedName = this.variablesController.values.parseVariables(`${req.query.filename}`, null).text
+			const filename = parsedName
+				? encodeURI(`${parsedName}.companionconfig`)
 				: encodeURI(`${os.hostname()}_custom-config_${getTimestamp()}.companionconfig`)
 
 			downloadBlob(this.logger, res, next, exp, filename, parseDownloadFormat(req.query.format))

--- a/companion/lib/Data/ImportExport.ts
+++ b/companion/lib/Data/ImportExport.ts
@@ -177,7 +177,7 @@ export class DataImportExport extends CoreBase {
 		//Parse variables and generate filename based on export type
 		const generateFilename = (filename: string, exportType: string, fileExt: string): string => {
 			//If the user isn't using their default file name, don't append any extra info in file name since it was a manual choice
-			const useDefault = filename == this.userconfig.getKey('default_export_filename') ? true : false
+			const useDefault = filename == this.userconfig.getKey('default_export_filename')
 			const parsedName = this.variablesController.values.parseVariables(filename, null).text
 
 			return parsedName && parsedName !== 'undefined'

--- a/companion/lib/Data/ImportExport.ts
+++ b/companion/lib/Data/ImportExport.ts
@@ -174,6 +174,17 @@ export class DataImportExport extends CoreBase {
 			return instancesExport
 		}
 
+		//Parse variables and generate filename based on export type
+		const generateFilename = (filename: string, exportType: string, fileExt: string): string => {
+			//If the user isn't using their default file name, don't append any extra info in file name since it was a manual choice
+			const useDefault = filename == this.userconfig.getKey('default_export_filename') ? true : false
+			const parsedName = this.variablesController.values.parseVariables(filename, null).text
+
+			return parsedName && parsedName !== 'undefined'
+				? encodeURI(`${parsedName}${exportType && useDefault ? '_' + exportType : ''}.${fileExt}`)
+				: encodeURI(`${os.hostname()}_${getTimestamp()}_${exportType}.${fileExt}`)
+		}
+
 		const generate_export_for_triggers = (triggerControls: ControlTrigger[]): ExportTriggersListv4 => {
 			const triggersExport: ExportTriggerContentv4 = {}
 			const referencedConnectionIds = new Set<string>()
@@ -204,7 +215,7 @@ export class DataImportExport extends CoreBase {
 			const triggerControls = this.controls.getAllTriggers()
 			const exp = generate_export_for_triggers(triggerControls)
 
-			const filename = encodeURI(`${os.hostname()}_trigger_list_${getTimestamp()}.companionconfig`)
+			const filename = generateFilename(String(req.query.filename), 'trigger_list', 'companionconfig')
 
 			downloadBlob(this.logger, res, next, exp, filename, parseDownloadFormat(req.query.format))
 		})
@@ -214,11 +225,8 @@ export class DataImportExport extends CoreBase {
 			if (control) {
 				const exp = generate_export_for_triggers([control])
 
-				const filename = encodeURI(
-					`${os.hostname()}_trigger_${control.options.name
-						.toLowerCase()
-						.replace(/\W/, '')}_${getTimestamp()}.companionconfig`
-				)
+				const triggerName = control.options.name.toLowerCase().replace(/\W/, '')
+				const filename = generateFilename(String(req.query.filename), `trigger_${triggerName}`, 'companionconfig')
 
 				downloadBlob(this.logger, res, next, exp, filename, parseDownloadFormat(req.query.format))
 			} else {
@@ -253,7 +261,7 @@ export class DataImportExport extends CoreBase {
 					oldPageNumber: page,
 				}
 
-				const filename = encodeURI(`${os.hostname()}_page${page}_${getTimestamp()}.companionconfig`)
+				const filename = generateFilename(String(req.query.filename), `page${page}`, 'companionconfig')
 
 				downloadBlob(this.logger, res, next, exp, filename, parseDownloadFormat(req.query.format))
 			}
@@ -350,10 +358,8 @@ export class DataImportExport extends CoreBase {
 		this.registry.api_router.get('/export/custom', (req, res, next) => {
 			// @ts-expect-error
 			const exp = generateCustomExport(req.query)
-			let parsedName = this.variablesController.values.parseVariables(`${req.query.filename}`, null).text
-			const filename = parsedName
-				? encodeURI(`${parsedName}.companionconfig`)
-				: encodeURI(`${os.hostname()}_custom-config_${getTimestamp()}.companionconfig`)
+
+			const filename = generateFilename(String(req.query.filename), '', 'companionconfig')
 
 			downloadBlob(this.logger, res, next, exp, filename, parseDownloadFormat(req.query.format))
 		})
@@ -361,7 +367,11 @@ export class DataImportExport extends CoreBase {
 		this.registry.api_router.get('/export/full', (req, res, next) => {
 			const exp = generateCustomExport(null)
 
-			const filename = encodeURI(`${os.hostname()}full-config_${getTimestamp()}.companionconfig`)
+			const filename = generateFilename(
+				String(this.userconfig.getKey('default_export_filename')),
+				'full_config',
+				'companionconfig'
+			)
 
 			downloadBlob(this.logger, res, next, exp, filename, parseDownloadFormat(req.query.format))
 		})
@@ -369,7 +379,11 @@ export class DataImportExport extends CoreBase {
 		this.registry.api_router.get('/export/log', (_req, res, _next) => {
 			const logs = LogController.getAllLines()
 
-			const filename = encodeURI(`${os.hostname()}_companion_log_${getTimestamp()}.csv`)
+			const filename = generateFilename(
+				String(this.userconfig.getKey('default_export_filename')),
+				'companion_log',
+				'csv'
+			)
 
 			res.status(200)
 			res.set({
@@ -399,7 +413,12 @@ export class DataImportExport extends CoreBase {
 			})
 
 			//set the archive name
-			res.attachment(os.hostname() + '_companion-config_' + getTimestamp() + '.zip')
+			const filename = generateFilename(
+				String(this.userconfig.getKey('default_export_filename')),
+				'companion-config',
+				'zip'
+			)
+			res.attachment(filename)
 
 			//this is the streaming magic
 			archive.pipe(res)

--- a/companion/lib/Data/ImportExport.ts
+++ b/companion/lib/Data/ImportExport.ts
@@ -354,7 +354,7 @@ export class DataImportExport extends CoreBase {
 			const filename = req.query.filename
 				? encodeURI(`${req.query.filename}.companionconfig`)
 				: encodeURI(`${os.hostname()}_custom-config_${getTimestamp()}.companionconfig`)
-		
+
 			downloadBlob(this.logger, res, next, exp, filename, parseDownloadFormat(req.query.format))
 		})
 

--- a/companion/lib/Data/UserConfig.ts
+++ b/companion/lib/Data/UserConfig.ts
@@ -106,8 +106,7 @@ export class DataUserConfig extends CoreBase {
 		gridSizePromptGrow: true,
 
 		installName: '',
-		default_export_filename:
-			'$(internal:hostname)_custom-config_$(internal:date_iso)-$(internal:time_h)$(internal:time_m)',
+		default_export_filename: '$(internal:hostname)_$(internal:date_iso)-$(internal:time_h)$(internal:time_m)',
 
 		discoveryEnabled: true,
 	}

--- a/companion/lib/Data/UserConfig.ts
+++ b/companion/lib/Data/UserConfig.ts
@@ -106,6 +106,8 @@ export class DataUserConfig extends CoreBase {
 		gridSizePromptGrow: true,
 
 		installName: '',
+		default_export_filename:
+			'$(internal:hostname)_custom-config_$(internal:date_iso)-$(internal:time_h)$(internal:time_m)',
 
 		discoveryEnabled: true,
 	}

--- a/shared-lib/lib/Model/ImportExport.ts
+++ b/shared-lib/lib/Model/ImportExport.ts
@@ -16,8 +16,8 @@ export interface ClientExportSelection {
 	customVariables: boolean
 	connections: boolean
 	surfaces: boolean
-
 	format: ExportFormat
+	filename?: string
 }
 
 export interface ClientImportSelection {

--- a/shared-lib/lib/Model/UserConfigModel.ts
+++ b/shared-lib/lib/Model/UserConfigModel.ts
@@ -69,6 +69,7 @@ export interface UserConfigModel {
 	gridSizePromptGrow: boolean
 
 	installName: string
+	default_export_filename: string
 
 	/** Whether to run the mdns  */
 	discoveryEnabled: boolean

--- a/webui/src/Components/ConfirmExportModal.tsx
+++ b/webui/src/Components/ConfirmExportModal.tsx
@@ -1,8 +1,10 @@
 import { CButton, CCol, CForm, CFormLabel, CModal, CModalBody, CModalFooter, CModalHeader } from '@coreui/react'
-import React, { forwardRef, useCallback, useImperativeHandle, useRef, useState } from 'react'
+import React, { forwardRef, useCallback, useImperativeHandle, useRef, useState, useContext } from 'react'
 import { ExportFormatDefault, SelectExportFormat } from '../ImportExport/ExportFormat.js'
 import { MenuPortalContext } from './DropdownInputField.js'
 import { windowLinkOpen } from '../Helpers/Window.js'
+import { TextInputField } from './TextInputField.js'
+import { RootAppStoreContext } from '../Stores/RootAppStore.js'
 
 export interface ConfirmExportModalRef {
 	show(url: string): void
@@ -14,9 +16,12 @@ interface ConfirmExportModalProps {
 
 export const ConfirmExportModal = forwardRef<ConfirmExportModalRef, ConfirmExportModalProps>(
 	function ConfirmExportModal(props, ref) {
+		const { userConfig } = useContext(RootAppStoreContext)
+
 		const [data, setData] = useState<string | null>(null)
 		const [show, setShow] = useState(false)
 		const [format, setFormat] = useState(ExportFormatDefault)
+		const [filename, setFilename] = useState(String(userConfig.properties?.default_export_filename))
 
 		const buttonRef = useRef<HTMLButtonElement>(null)
 
@@ -43,10 +48,11 @@ export const ConfirmExportModal = forwardRef<ConfirmExportModalRef, ConfirmExpor
 			if (data) {
 				const url = new URL(data, window.location.origin)
 				url.searchParams.set('format', format)
+				url.searchParams.set('filename', filename)
 
 				windowLinkOpen({ href: url.toString() })
 			}
-		}, [data, format])
+		}, [data, format, filename])
 
 		useImperativeHandle(
 			ref,
@@ -77,6 +83,12 @@ export const ConfirmExportModal = forwardRef<ConfirmExportModalRef, ConfirmExpor
 							</CFormLabel>
 							<CCol sm={9}>
 								<SelectExportFormat value={format} setValue={setFormat} />
+							</CCol>
+							<CFormLabel htmlFor="colFormLabelSm" className="col-sm-3 col-form-label col-form-label-sm">
+								File name
+							</CFormLabel>
+							<CCol sm={9}>
+								<TextInputField value={filename} setValue={setFilename} useVariables={true} />
 							</CCol>
 						</CForm>
 					</CModalBody>

--- a/webui/src/Components/ConfirmExportModal.tsx
+++ b/webui/src/Components/ConfirmExportModal.tsx
@@ -21,7 +21,7 @@ export const ConfirmExportModal = forwardRef<ConfirmExportModalRef, ConfirmExpor
 		const [data, setData] = useState<string | null>(null)
 		const [show, setShow] = useState(false)
 		const [format, setFormat] = useState(ExportFormatDefault)
-		const [filename, setFilename] = useState(String(userConfig.properties?.default_export_filename))
+		const [filename, setFilename] = useState<string>('')
 
 		const buttonRef = useRef<HTMLButtonElement>(null)
 
@@ -60,6 +60,9 @@ export const ConfirmExportModal = forwardRef<ConfirmExportModalRef, ConfirmExpor
 				show(url) {
 					setData(url)
 					setShow(true)
+
+					// Reset to default filename each time modal is opened
+					setFilename(String(userConfig.properties?.default_export_filename))
 
 					// Focus the button asap. It also gets focused once the open is complete
 					setTimeout(buttonFocus, 50)

--- a/webui/src/ImportExport/Export.tsx
+++ b/webui/src/ImportExport/Export.tsx
@@ -1,10 +1,11 @@
 import React, { FormEvent, forwardRef, useCallback, useImperativeHandle, useState, useContext } from 'react'
-import { CButton, CForm, CFormCheck, CFormInput, CModal, CModalBody, CModalFooter, CModalHeader } from '@coreui/react'
+import { CButton, CForm, CFormCheck, CModal, CModalBody, CModalFooter, CModalHeader } from '@coreui/react'
 import { PreventDefaultHandler } from '../util.js'
 import { ExportFormatDefault, SelectExportFormat } from './ExportFormat.js'
 import { MenuPortalContext } from '../Components/DropdownInputField.js'
 import { ClientExportSelection } from '@companion-app/shared/Model/ImportExport.js'
 import { RootAppStoreContext } from '../Stores/RootAppStore.js'
+import { TextInputField } from '../Components/TextInputField.js'
 
 interface ExportWizardModalProps {}
 export interface ExportWizardModalRef {
@@ -13,6 +14,8 @@ export interface ExportWizardModalRef {
 
 export const ExportWizardModal = forwardRef<ExportWizardModalRef, ExportWizardModalProps>(
 	function ExportWizardModal(_props, ref) {
+		const { userConfig } = useContext(RootAppStoreContext)
+
 		const [show, setShow] = useState(false)
 		const [config, setConfig] = useState<ClientExportSelection>({
 			connections: true,
@@ -22,7 +25,7 @@ export const ExportWizardModal = forwardRef<ExportWizardModalRef, ExportWizardMo
 			customVariables: true,
 			// userconfig: true,
 			format: ExportFormatDefault,
-			filename: '',
+			filename: userConfig.properties?.default_export_filename,
 		})
 
 		const doClose = useCallback(() => {
@@ -60,7 +63,7 @@ export const ExportWizardModal = forwardRef<ExportWizardModalRef, ExportWizardMo
 				[key]: value,
 			}))
 		}
-		const { userConfig } = useContext(RootAppStoreContext)
+
 		useImperativeHandle(
 			ref,
 			() => ({
@@ -120,7 +123,7 @@ interface ExportOptionsStepProps {
 }
 
 function ExportOptionsStep({ config, setValue }: ExportOptionsStepProps) {
-	const { userConfig } = useContext(RootAppStoreContext)
+	const updateProp = useCallback((val: string) => setValue('filename', val), [setValue])
 	return (
 		<div>
 			<h5>Export Options</h5>
@@ -174,17 +177,11 @@ function ExportOptionsStep({ config, setValue }: ExportOptionsStepProps) {
 					label='Settings'
 				/>
 			</div> */}
-			<br></br>
-			<div>
+			<div style={{ paddingTop: '1em' }}>
 				<SelectExportFormat value={config.format} setValue={(val) => setValue('format', val)} label="File format" />
 			</div>
-			<br></br>
-			<div>
-				<CFormInput
-					onChange={(e) => setValue('filename', e.currentTarget.value)}
-					defaultValue={String(userConfig.properties?.default_export_filename)}
-					label="File name"
-				/>
+			<div style={{ paddingTop: '1em' }}>
+				<TextInputField value={String(config.filename)} setValue={updateProp} label="File name" useVariables={true} />
 			</div>
 		</div>
 	)

--- a/webui/src/ImportExport/Export.tsx
+++ b/webui/src/ImportExport/Export.tsx
@@ -1,9 +1,10 @@
-import React, { FormEvent, forwardRef, useCallback, useImperativeHandle, useState } from 'react'
+import React, { FormEvent, forwardRef, useCallback, useImperativeHandle, useState, useContext } from 'react'
 import { CButton, CForm, CFormCheck, CFormInput, CModal, CModalBody, CModalFooter, CModalHeader } from '@coreui/react'
 import { PreventDefaultHandler } from '../util.js'
 import { ExportFormatDefault, SelectExportFormat } from './ExportFormat.js'
 import { MenuPortalContext } from '../Components/DropdownInputField.js'
 import { ClientExportSelection } from '@companion-app/shared/Model/ImportExport.js'
+import { RootAppStoreContext } from '../Stores/RootAppStore.js'
 
 interface ExportWizardModalProps {}
 export interface ExportWizardModalRef {
@@ -21,6 +22,7 @@ export const ExportWizardModal = forwardRef<ExportWizardModalRef, ExportWizardMo
 			customVariables: true,
 			// userconfig: true,
 			format: ExportFormatDefault,
+			filename: '',
 		})
 
 		const doClose = useCallback(() => {
@@ -58,7 +60,7 @@ export const ExportWizardModal = forwardRef<ExportWizardModalRef, ExportWizardMo
 				[key]: value,
 			}))
 		}
-
+		const { userConfig } = useContext(RootAppStoreContext)
 		useImperativeHandle(
 			ref,
 			() => ({
@@ -71,6 +73,7 @@ export const ExportWizardModal = forwardRef<ExportWizardModalRef, ExportWizardMo
 						customVariables: true,
 						// userconfig: true,
 						format: ExportFormatDefault,
+						filename: userConfig.properties?.default_export_filename,
 					})
 
 					setShow(true)
@@ -117,6 +120,7 @@ interface ExportOptionsStepProps {
 }
 
 function ExportOptionsStep({ config, setValue }: ExportOptionsStepProps) {
+	const { userConfig } = useContext(RootAppStoreContext)
 	return (
 		<div>
 			<h5>Export Options</h5>
@@ -176,7 +180,11 @@ function ExportOptionsStep({ config, setValue }: ExportOptionsStepProps) {
 			</div>
 			<br></br>
 			<div>
-				<CFormInput onChange={(e) => setValue('filename', e.currentTarget.value)} label="File name (Optional)" />
+				<CFormInput
+					onChange={(e) => setValue('filename', e.currentTarget.value)}
+					defaultValue={String(userConfig.properties?.default_export_filename)}
+					label="File name"
+				/>
 			</div>
 		</div>
 	)

--- a/webui/src/ImportExport/Export.tsx
+++ b/webui/src/ImportExport/Export.tsx
@@ -1,5 +1,5 @@
 import React, { FormEvent, forwardRef, useCallback, useImperativeHandle, useState } from 'react'
-import { CButton, CForm, CFormCheck, CModal, CModalBody, CModalFooter, CModalHeader } from '@coreui/react'
+import { CButton, CForm, CFormCheck, CFormInput, CModal, CModalBody, CModalFooter, CModalHeader } from '@coreui/react'
 import { PreventDefaultHandler } from '../util.js'
 import { ExportFormatDefault, SelectExportFormat } from './ExportFormat.js'
 import { MenuPortalContext } from '../Components/DropdownInputField.js'
@@ -120,7 +120,7 @@ function ExportOptionsStep({ config, setValue }: ExportOptionsStepProps) {
 	return (
 		<div>
 			<h5>Export Options</h5>
-			<p>Please select the components you'd like to export.</p>
+			<p>Please select the components you'd like to export:</p>
 			<div className="indent3">
 				<CFormCheck
 					id="wizard_connections"
@@ -170,9 +170,13 @@ function ExportOptionsStep({ config, setValue }: ExportOptionsStepProps) {
 					label='Settings'
 				/>
 			</div> */}
-
+			<br></br>
 			<div>
 				<SelectExportFormat value={config.format} setValue={(val) => setValue('format', val)} label="File format" />
+			</div>
+			<br></br>
+			<div>
+				<CFormInput onChange={(e) => setValue('filename', e.currentTarget.value)} label="File name (Optional)" />
 			</div>
 		</div>
 	)

--- a/webui/src/UserConfig/CompanionConfig.tsx
+++ b/webui/src/UserConfig/CompanionConfig.tsx
@@ -1,34 +1,15 @@
 import React from 'react'
 import { observer } from 'mobx-react-lite'
 import { UserConfigHeadingRow } from './Components/UserConfigHeadingRow.js'
-import { ResetButton, UserConfigProps } from './Components/Common.js'
-import { TextInputField } from '../Components/TextInputField.js'
+import { UserConfigProps } from './Components/Common.js'
+import { UserConfigTextInputRow } from './Components/UserConfigTextInputRow.js'
 
 export const CompanionConfig = observer(function CompanionConfig(props: UserConfigProps) {
 	return (
 		<>
-			<UserConfigHeadingRow label="Installation Name" />
-
-			<tr>
-				<td>
-					<div className="mr-1">
-						<TextInputField
-							value={String(props.config.installName)}
-							setValue={(value) => props.setValue('installName', value)}
-						/>
-					</div>
-				</td>
-				<td>
-					<div
-						style={{
-							minWidth: '8em', // provide minimum width for second column
-						}}
-					></div>
-				</td>
-				<td>
-					<ResetButton userConfig={props} field="installName" />
-				</td>
-			</tr>
+			<UserConfigHeadingRow label="Installation Settings" />
+			<UserConfigTextInputRow userConfig={props} label="Installation Name" field="installName" />
+			<UserConfigTextInputRow userConfig={props} label="Default Export File Name" field="default_export_filename" />
 		</>
 	)
 })

--- a/webui/src/UserConfig/CompanionConfig.tsx
+++ b/webui/src/UserConfig/CompanionConfig.tsx
@@ -9,7 +9,12 @@ export const CompanionConfig = observer(function CompanionConfig(props: UserConf
 		<>
 			<UserConfigHeadingRow label="Installation Settings" />
 			<UserConfigTextInputRow userConfig={props} label="Installation Name" field="installName" />
-			<UserConfigTextInputRow userConfig={props} label="Default Export File Name" field="default_export_filename" />
+			<UserConfigTextInputRow
+				userConfig={props}
+				useVariables={true}
+				label="Default Export File Name"
+				field="default_export_filename"
+			/>
 		</>
 	)
 })

--- a/webui/src/UserConfig/Components/UserConfigTextInputRow.tsx
+++ b/webui/src/UserConfig/Components/UserConfigTextInputRow.tsx
@@ -8,11 +8,13 @@ interface UserConfigTextInputRowProps {
 	userConfig: UserConfigProps
 	label: string | React.ReactNode
 	field: keyof UserConfigModel
+	useVariables?: boolean
 }
 export const UserConfigTextInputRow = observer(function UserConfigTextInputRow({
 	userConfig,
 	label,
 	field,
+	useVariables,
 }: UserConfigTextInputRowProps) {
 	return (
 		<tr>
@@ -21,6 +23,7 @@ export const UserConfigTextInputRow = observer(function UserConfigTextInputRow({
 				<TextInputField
 					value={String(userConfig.config[field])}
 					setValue={(value) => userConfig.setValue(field, value)}
+					useVariables={useVariables}
 				/>
 			</td>
 			<td>


### PR DESCRIPTION
This adds the a config field to customize export file names to aid with organization of config exports.
It partially addresses https://github.com/bitfocus/companion/issues/3075

<img width="541" alt="Screenshot 2024-10-15 at 8 55 15 PM" src="https://github.com/user-attachments/assets/07f92efe-a507-4353-a33f-ba62b5c4c39c">
