### PR TITLE
feat: add one-time event trigger

### DIFF
--- a/companion/lib/Controls/ControlTypes/Triggers/Trigger.ts
+++ b/companion/lib/Controls/ControlTypes/Triggers/Trigger.ts
@@ -431,6 +431,9 @@ export class ControlTrigger
 					case 'timeofday':
 						eventStrings.push(this.#timerEvents.getTimeOfDayDescription(event))
 						break
+					case 'specificDate':
+						eventStrings.push(this.#timerEvents.getSpecificDateDescription(event))
+						break
 					case 'sun_event':
 						eventStrings.push(this.#timerEvents.getSunDescription(event))
 						break
@@ -538,6 +541,9 @@ export class ControlTrigger
 				case 'timeofday':
 					this.#timerEvents.setTimeOfDay(event.id, event.options)
 					break
+				case 'specificDate':
+					this.#timerEvents.setSpecificDate(event.id, event.options)
+					break
 				case 'sun_event':
 					this.#timerEvents.setSun(event.id, event.options)
 					break
@@ -596,6 +602,9 @@ export class ControlTrigger
 				break
 			case 'timeofday':
 				this.#timerEvents.clearTimeOfDay(event.id)
+				break
+			case 'specificDate':
+				this.#timerEvents.clearSpecificDate(event.id)
 				break
 			case 'sun_event':
 				this.#timerEvents.clearSun(event.id)

--- a/companion/lib/Resources/EventDefinitions.ts
+++ b/companion/lib/Resources/EventDefinitions.ts
@@ -63,6 +63,21 @@ export const EventDefinitions: Record<string, EventDefinition> = {
 			},
 		],
 	},
+	specificDate: {
+		name: 'Once on Specific Date & Time',
+		options: [
+			{
+				id: 'date',
+				label: 'Date',
+				type: 'internal:date',
+			},
+			{
+				id: 'time',
+				label: 'Time',
+				type: 'internal:time',
+			},
+		],
+	},
 	sun_event: {
 		name: 'On Sunrise/Sunset',
 		options: [

--- a/shared-lib/lib/Model/Options.ts
+++ b/shared-lib/lib/Model/Options.ts
@@ -16,6 +16,7 @@ export type IsVisibleFunction = Required<CompanionInputFieldBase>['isVisible']
 
 export type InternalInputFieldType =
 	| 'internal:time'
+	| 'internal:date'
 	| 'internal:variable'
 	| 'internal:custom_variable'
 	| 'internal:trigger'
@@ -29,6 +30,9 @@ export interface CompanionInputFieldBaseExtended extends Omit<CompanionInputFiel
 
 export interface InternalInputFieldTime extends CompanionInputFieldBaseExtended {
 	type: 'internal:time'
+}
+export interface InternalInputFieldDate extends CompanionInputFieldBaseExtended {
+	type: 'internal:date'
 }
 export interface InternalInputFieldVariable extends CompanionInputFieldBaseExtended {
 	type: 'internal:variable'
@@ -65,6 +69,7 @@ export interface InternalInputFieldPage extends CompanionInputFieldBaseExtended 
 
 export type InternalInputField =
 	| EncodeIsVisible2<InternalInputFieldTime>
+	| EncodeIsVisible2<InternalInputFieldDate>
 	| EncodeIsVisible2<InternalInputFieldVariable>
 	| EncodeIsVisible2<InternalInputFieldCustomVariable>
 	| EncodeIsVisible2<InternalInputFieldTrigger>

--- a/webui/package.json
+++ b/webui/package.json
@@ -40,6 +40,7 @@
     "query-string": "^9.1.1",
     "react": "^18.3.1",
     "react-copy-to-clipboard": "^5.1.0",
+    "react-date-picker": "^11.0.0",
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",
     "react-dnd-touch-backend": "^16.0.1",

--- a/webui/src/App.scss
+++ b/webui/src/App.scss
@@ -2,6 +2,7 @@
 
 @import '@coreui/coreui/scss/coreui';
 @import 'scss/react-time-picker';
+@import 'scss/react-date-picker';
 
 @import 'scss/layout';
 @import 'scss/common';

--- a/webui/src/Controls/InternalInstanceFields.tsx
+++ b/webui/src/Controls/InternalInstanceFields.tsx
@@ -2,6 +2,7 @@ import React, { useContext, useMemo } from 'react'
 import { DropdownInputField } from '../Components/index.js'
 import { ConnectionsContext, useComputed } from '../util.js'
 import TimePicker from 'react-time-picker'
+import DatePicker from 'react-date-picker'
 import { InternalInputField } from '@companion-app/shared/Model/Options.js'
 import { DropdownChoice } from '@companion-module/base'
 import { RootAppStoreContext } from '../Stores/RootAppStore.js'
@@ -78,6 +79,8 @@ export function InternalInstanceField(
 			)
 		case 'internal:time':
 			return <InternalTimePicker label={label} disabled={readonly} value={value} setValue={setValue} />
+		case 'internal:date':
+			return <InternalDatePicker label={label} disabled={readonly} value={value} setValue={setValue} />
 		default:
 			// Use fallback
 			return null
@@ -459,6 +462,35 @@ function InternalTimePicker({ label, value, setValue, disabled }: InternalTimePi
 				onChange={setValue}
 				className={''}
 				openClockOnFocus={false}
+			/>
+		</>
+	)
+}
+
+interface InternalDatePickerProps {
+	label: React.ReactNode
+	value: any
+	setValue: (value: any) => void
+	disabled: boolean
+}
+
+function InternalDatePicker({ label, value, setValue, disabled }: InternalDatePickerProps) {
+	return (
+		<>
+			{label ? <CFormLabel>{label}</CFormLabel> : null}
+			<DatePicker
+				disabled={disabled}
+				format="yyyy-M-dd"
+				minDate={new Date()}
+				required
+				value={value}
+				onChange={setValue}
+				className={''}
+				showLeadingZeros={true}
+				calendarIcon={null}
+				yearPlaceholder="yyyy"
+				monthPlaceholder="mm"
+				dayPlaceholder="dd"
 			/>
 		</>
 	)

--- a/webui/src/scss/_react-date-picker.scss
+++ b/webui/src/scss/_react-date-picker.scss
@@ -1,0 +1,41 @@
+@import 'react-date-picker/dist/DatePicker.css';
+@import 'react-calendar/dist/Calendar.css';
+
+.react-date-picker {
+	display: block;
+	width: 100%;
+
+	.react-date-picker__wrapper {
+		@extend .form-control;
+	}
+
+	.react-date-picker__clear-button,
+	.react-date-picker__clock-button {
+		// Temporary?
+		display: none;
+	}
+}
+.react-date-picker__calendar {
+	border: var(--cui-border-width) solid var(--cui-border-color);
+	border-radius: var(--cui-border-radius);
+}
+.react-date-picker__calendar--open {
+	border-radius: 20px;
+}
+.react-calendar__tile--active {
+	color: white;
+	background-color: $primary;
+	&:enabled:hover {
+		background: $primary;
+	}
+}
+.react-calendar__month-view__days__day--weekend {
+	color: black;
+}
+.react-calendar__tile--now {
+	color: white;
+	background-color: $info;
+	&:enabled:hover {
+		background: $info;
+	}
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1489,6 +1489,7 @@ __metadata:
     query-string: "npm:^9.1.1"
     react: "npm:^18.3.1"
     react-copy-to-clipboard: "npm:^5.1.0"
+    react-date-picker: "npm:^11.0.0"
     react-dnd: "npm:^16.0.1"
     react-dnd-html5-backend: "npm:^16.0.1"
     react-dnd-touch-backend: "npm:^16.0.1"
@@ -11737,6 +11738,25 @@ asn1@evs-broadcast/node-asn1:
   languageName: node
   linkType: hard
 
+"react-calendar@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "react-calendar@npm:5.0.0"
+  dependencies:
+    "@wojtekmaj/date-utils": "npm:^1.1.3"
+    clsx: "npm:^2.0.0"
+    get-user-locale: "npm:^2.2.1"
+    warning: "npm:^4.0.0"
+  peerDependencies:
+    "@types/react": ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/d0b393b22fb1607dd2a7743f104f6d7fe2f3dba39bfbce301b5100d35bed239f51a7b08eec2a7fea77d88af60aecc0b36c2435f36d0e07b88f4a826a67c5a91e
+  languageName: node
+  linkType: hard
+
 "react-clock@npm:^5.0.0":
   version: 5.0.0
   resolution: "react-clock@npm:5.0.0"
@@ -11764,6 +11784,28 @@ asn1@evs-broadcast/node-asn1:
   peerDependencies:
     react: ^15.3.0 || 16 || 17 || 18
   checksum: 10c0/de70d9f9c2d17cee207888ed791d4a042c300e5ca732503434d49e6745cff56c0d5ebcc82ab86237e9c2248e636d1d031b9f9cf9913ecec61d82a0e5ebc93881
+  languageName: node
+  linkType: hard
+
+"react-date-picker@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "react-date-picker@npm:11.0.0"
+  dependencies:
+    "@wojtekmaj/date-utils": "npm:^1.1.3"
+    clsx: "npm:^2.0.0"
+    get-user-locale: "npm:^2.2.1"
+    make-event-props: "npm:^1.6.0"
+    react-calendar: "npm:^5.0.0"
+    react-fit: "npm:^2.0.0"
+    update-input-width: "npm:^1.4.0"
+  peerDependencies:
+    "@types/react": ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/de51915831d16ebcf0f1bb5ff67d41792848c2b36a9a3c8e6e2f652b3a5f2e6751d866095fb234f92e3790ffc1d2557b5f92e839b03b11acead1ecc7d50e2dde
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes https://github.com/bitfocus/companion/issues/1951

Adds a new trigger type, "Once on Specific Date/Time", which allows the user to specify a date and time that executes a trigger only once.

<img width="1347" alt="Screenshot 2024-10-23 at 9 22 14 PM" src="https://github.com/user-attachments/assets/d2aa81d4-6467-4f61-8854-70ee6c5dcd41">


<img width="566" alt="Screenshot 2024-10-23 at 9 21 35 PM" src="https://github.com/user-attachments/assets/3202fbd0-dd9b-4a4f-a9cf-0d245349781c">
