### PR TITLE
feat: make connection of action changeable, closes #1498

### DIFF
--- a/companion/lib/Controls/ControlTypes/Button/Normal.ts
+++ b/companion/lib/Controls/ControlTypes/Button/Normal.ts
@@ -271,6 +271,18 @@ export class ControlButtonNormal
 	}
 
 	/**
+	 * Set the connection of an action
+	 */
+	actionSetConnection(stepId: string, setId: string, id: string, connectionId: string): boolean {
+		const step = this.steps[stepId]
+		if (step) {
+			return step.actionSetConnection(setId, id, connectionId)
+		} else {
+			return false
+		}
+	}
+
+	/**
 	 * Set the delay of an action
 	 */
 	actionSetDelay(stepId: string, setId: string, id: string, delay: number): boolean {

--- a/companion/lib/Controls/ControlTypes/Triggers/Trigger.ts
+++ b/companion/lib/Controls/ControlTypes/Triggers/Trigger.ts
@@ -270,6 +270,13 @@ export class ControlTrigger
 	}
 
 	/**
+	 * Set the connection of an action
+	 */
+	actionSetConnection(_stepId: string, _setId: string, id: string, connectionId: string): boolean {
+		return this.actions.actionSetConnection('0', id, connectionId)
+	}
+
+	/**
 	 * Set the delay of an action
 	 */
 	actionSetDelay(_stepId: string, _setId: string, id: string, delay: number): boolean {

--- a/companion/lib/Controls/Controller.ts
+++ b/companion/lib/Controls/Controller.ts
@@ -548,6 +548,17 @@ export class ControlsController extends CoreBase {
 			}
 		})
 
+		client.onPromise('controls:action:set-connection', (controlId, stepId, setId, id, connectionId) => {
+			const control = this.getControl(controlId)
+			if (!control) return false
+
+			if (control.supportsActions) {
+				return control.actionSetConnection(stepId, setId, id, connectionId)
+			} else {
+				throw new Error(`Control "${controlId}" does not support actions`)
+			}
+		})
+
 		client.onPromise('controls:action:set-delay', (controlId, stepId, setId, id, delay) => {
 			const control = this.getControl(controlId)
 			if (!control) return false

--- a/companion/lib/Controls/Fragments/FragmentActions.ts
+++ b/companion/lib/Controls/Fragments/FragmentActions.ts
@@ -313,6 +313,35 @@ export class FragmentActions {
 	}
 
 	/**
+	 * Set the connection of an action
+	 * @param setId the action_set id
+	 * @param id the action id
+	 * @param connectionId the id of the new connection
+	 */
+	actionSetConnection(setId: string, id: string, connectionId: string): boolean {
+		if (connectionId == '') return false
+		const action_set = this.action_sets[setId]
+		if (action_set) {
+			for (const action of action_set) {
+				if (action && action.id === id) {
+					// remove action from old instance
+					this.cleanupAction(action)
+					// change instance
+					action.instance = connectionId
+					// subscribe action at new instance
+					this.#actionSubscribe(action)
+
+					this.#commitChange(false)
+
+					return true
+				}
+			}
+		}
+
+		return false
+	}
+
+	/**
 	 * Set the delay of an action
 	 * @param setId the action_set id
 	 * @param id the action id

--- a/companion/lib/Controls/IControlFragments.ts
+++ b/companion/lib/Controls/IControlFragments.ts
@@ -187,6 +187,11 @@ export interface ControlWithActions extends ControlBase<any> {
 	actionReplaceAll(stepId: string, setId: string, newActions: ActionInstance[]): boolean
 
 	/**
+	 * Set the connection of an action
+	 */
+	actionSetConnection(stepId: string, setId: string, id: string, connectionId: string): boolean
+
+	/**
 	 * Set the delay of an action
 	 */
 	actionSetDelay(stepId: string, setId: string, id: string, delay: number): boolean

--- a/shared-lib/lib/SocketIO.ts
+++ b/shared-lib/lib/SocketIO.ts
@@ -146,6 +146,13 @@ export interface ClientToBackendEventsMap {
 	'controls:action:learn': (controlId: string, stepId: string, setId: string, actionId: string) => boolean
 	'controls:action:duplicate': (controlId: string, stepId: string, setId: string, actionId: string) => string | null
 	'controls:action:remove': (controlId: string, stepId: string, setId: string, actionId: string) => boolean
+	'controls:action:set-connection': (
+		controlId: string,
+		stepId: string,
+		setId: string,
+		actionId: string,
+		connectionId: string
+	) => boolean
 	'controls:action:set-delay': (
 		controlId: string,
 		stepId: string,

--- a/webui/src/Controls/ActionSetEditor.tsx
+++ b/webui/src/Controls/ActionSetEditor.tsx
@@ -31,7 +31,6 @@ import {
 import { RootAppStoreContext } from '../Stores/RootAppStore.js'
 import { observer } from 'mobx-react-lite'
 import classNames from 'classnames'
-import { DropdownChoiceInt } from 'src/LocalVariableDefinitions.js'
 
 interface ControlActionSetEditorProps {
 	controlId: string

--- a/webui/src/Controls/ActionSetEditor.tsx
+++ b/webui/src/Controls/ActionSetEditor.tsx
@@ -406,10 +406,12 @@ const ActionTableRow = observer(function ActionTableRow({
 							<div className="cell-connection">
 								<DropdownInputField
 									label="Connection"
-									choices={connectionsWithSameType.map((connection) => {
-										const [id, info] = connection
-										return { id, label: info.label }
-									})}
+									choices={connectionsWithSameType
+										.sort((connectionA, connectionB) => connectionA[1].sortOrder - connectionB[1].sortOrder)
+										.map((connection) => {
+											const [id, info] = connection
+											return { id, label: info.label }
+										})}
 									multiple={false}
 									value={action.instance}
 									setValue={service.setConnection}

--- a/webui/src/Controls/ActionSetEditor.tsx
+++ b/webui/src/Controls/ActionSetEditor.tsx
@@ -10,7 +10,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import React, { memo, useCallback, useContext, useMemo, useRef, useState } from 'react'
-import { NumberInputField, TextInputField } from '../Components/index.js'
+import { DropdownInputField, NumberInputField, TextInputField } from '../Components/index.js'
 import { DragState, MyErrorBoundary, PreventDefaultHandler, checkDragState } from '../util.js'
 import { OptionsInputField } from './OptionsInputField.js'
 import { useDrag, useDrop } from 'react-dnd'
@@ -31,6 +31,7 @@ import {
 import { RootAppStoreContext } from '../Stores/RootAppStore.js'
 import { observer } from 'mobx-react-lite'
 import classNames from 'classnames'
+import { DropdownChoiceInt } from 'src/LocalVariableDefinitions.js'
 
 interface ControlActionSetEditorProps {
 	controlId: string
@@ -320,6 +321,7 @@ const ActionTableRow = observer(function ActionTableRow({
 	const connectionInfo = connections.getInfo(action.instance)
 	// const module = instance ? modules[instance.instance_type] : undefined
 	const connectionLabel = connectionInfo?.label ?? action.instance
+	const connectionsWithSameType = connectionInfo ? connections.getAllOfType(connectionInfo.instance_type) : []
 
 	const showButtonPreview = action?.instance === 'internal' && actionSpec?.showButtonPreview
 
@@ -397,6 +399,21 @@ const ActionTableRow = observer(function ActionTableRow({
 						{showButtonPreview && (
 							<div className="cell-button-preview">
 								<OptionButtonPreview location={location} options={action.options} />
+							</div>
+						)}
+
+						{connectionsWithSameType.length > 1 && (
+							<div className="cell-connection">
+								<DropdownInputField
+									label="Connection"
+									choices={connectionsWithSameType.map((connection) => {
+										const [id, info] = connection
+										return { id, label: info.label }
+									})}
+									multiple={false}
+									value={action.instance}
+									setValue={service.setConnection}
+								></DropdownInputField>
 							</div>
 						)}
 

--- a/webui/src/Controls/ActionSetEditor.tsx
+++ b/webui/src/Controls/ActionSetEditor.tsx
@@ -401,24 +401,24 @@ const ActionTableRow = observer(function ActionTableRow({
 							</div>
 						)}
 
-						{connectionsWithSameType.length > 1 && (
-							<div className="cell-connection">
-								<DropdownInputField
-									label="Connection"
-									choices={connectionsWithSameType
-										.sort((connectionA, connectionB) => connectionA[1].sortOrder - connectionB[1].sortOrder)
-										.map((connection) => {
-											const [id, info] = connection
-											return { id, label: info.label }
-										})}
-									multiple={false}
-									value={action.instance}
-									setValue={service.setConnection}
-								></DropdownInputField>
-							</div>
-						)}
+						<div className="cell-left-main">
+							{connectionsWithSameType.length > 1 && (
+								<div className="option-field">
+									<DropdownInputField
+										label="Connection"
+										choices={connectionsWithSameType
+											.sort((connectionA, connectionB) => connectionA[1].sortOrder - connectionB[1].sortOrder)
+											.map((connection) => {
+												const [id, info] = connection
+												return { id, label: info.label }
+											})}
+										multiple={false}
+										value={action.instance}
+										setValue={service.setConnection}
+									></DropdownInputField>
+								</div>
+							)}
 
-						<div className="cell-delay">
 							<CForm onSubmit={PreventDefaultHandler}>
 								<label>Delay</label>
 								<CInputGroup>

--- a/webui/src/Controls/FeedbackEditor.tsx
+++ b/webui/src/Controls/FeedbackEditor.tsx
@@ -511,7 +511,7 @@ const FeedbackEditor = observer(function FeedbackEditor({
 					)}
 
 					{feedbackSpec?.type === 'boolean' && feedbackSpec.showInvert !== false && (
-						<div className="cell-invert">
+						<div className="cell-left-main">
 							<MyErrorBoundary>
 								<CForm onSubmit={PreventDefaultHandler}>
 									<div style={{ paddingLeft: 20 }}>

--- a/webui/src/Services/Controls/ControlActionsService.ts
+++ b/webui/src/Services/Controls/ControlActionsService.ts
@@ -9,7 +9,7 @@ export interface IActionEditorService {
 	setValue: (actionId: string, action: ActionInstance | undefined, key: string, val: any) => void
 	performDelete: (actionId: string) => void
 	performDuplicate: (actionId: string) => void
-	setConnection: (actionId: string, connectionId: string | number) => void | undefined
+	setConnection: (actionId: string, connectionId: string | number) => void
 	setDelay: (actionId: string, delay: number) => void
 	moveCard: (dragStepId: string, dragSetId: string | number, dragIndex: number, dropIndex: number) => void
 	performLearn: ((actionId: string) => void) | undefined
@@ -21,7 +21,7 @@ export interface IActionEditorActionService {
 	setValue: (key: string, val: any) => void
 	performDelete: () => void
 	performDuplicate: () => void
-	setConnection: (connectionId: string | number) => void | undefined
+	setConnection: (connectionId: string | number) => void
 	setDelay: (delay: number) => void
 	performLearn: (() => void) | undefined
 	setEnabled: ((enabled: boolean) => void) | undefined
@@ -164,7 +164,9 @@ export function useActionRecorderActionService(sessionId: string): IActionEditor
 				)
 			},
 
-			setConnection: undefined,
+			setConnection: (_actionId: string, _connectionId: string | number) => {
+				// Not implemented in action recorder
+			},
 
 			setDelay: (actionId: string, delay: number) => {
 				socketEmitPromise(socket, 'action-recorder:session:action-delay', [sessionId, actionId, delay]).catch((e) => {
@@ -208,7 +210,7 @@ export function useControlActionService(
 			setValue: (key: string, val: any) => serviceFactory.setValue(actionId, actionRef.current, key, val),
 			performDelete: () => serviceFactory.performDelete(actionId),
 			performDuplicate: () => serviceFactory.performDuplicate(actionId),
-			setConnection: (connectionId: string) => serviceFactory.setConnection(actionId, connectionId),
+			setConnection: (connectionId: string | number) => serviceFactory.setConnection(actionId, connectionId),
 			setDelay: (delay: number) => serviceFactory.setDelay(actionId, delay),
 			performLearn: serviceFactory.performLearn ? () => serviceFactory.performLearn?.(actionId) : undefined,
 			setEnabled: serviceFactory.setEnabled

--- a/webui/src/Services/Controls/ControlActionsService.ts
+++ b/webui/src/Services/Controls/ControlActionsService.ts
@@ -9,6 +9,7 @@ export interface IActionEditorService {
 	setValue: (actionId: string, action: ActionInstance | undefined, key: string, val: any) => void
 	performDelete: (actionId: string) => void
 	performDuplicate: (actionId: string) => void
+	setConnection: (actionId: string, connectionId: string | number) => void | undefined
 	setDelay: (actionId: string, delay: number) => void
 	moveCard: (dragStepId: string, dragSetId: string | number, dragIndex: number, dropIndex: number) => void
 	performLearn: ((actionId: string) => void) | undefined
@@ -20,6 +21,7 @@ export interface IActionEditorActionService {
 	setValue: (key: string, val: any) => void
 	performDelete: () => void
 	performDuplicate: () => void
+	setConnection: (connectionId: string | number) => void | undefined
 	setDelay: (delay: number) => void
 	performLearn: (() => void) | undefined
 	setEnabled: ((enabled: boolean) => void) | undefined
@@ -72,6 +74,18 @@ export function useControlActionsEditorService(
 						console.error('Failed to set control action option', e)
 					})
 				}
+			},
+
+			setConnection: (actionId: string, connectionId: string | number) => {
+				socketEmitPromise(socket, 'controls:action:set-connection', [
+					controlId,
+					stepId,
+					setId + '',
+					actionId,
+					connectionId + '',
+				]).catch((e) => {
+					console.error('Failed to set control action connection', e)
+				})
 			},
 
 			setDelay: (actionId: string, delay: number) => {
@@ -150,6 +164,8 @@ export function useActionRecorderActionService(sessionId: string): IActionEditor
 				)
 			},
 
+			setConnection: undefined,
+
 			setDelay: (actionId: string, delay: number) => {
 				socketEmitPromise(socket, 'action-recorder:session:action-delay', [sessionId, actionId, delay]).catch((e) => {
 					console.error(e)
@@ -192,6 +208,7 @@ export function useControlActionService(
 			setValue: (key: string, val: any) => serviceFactory.setValue(actionId, actionRef.current, key, val),
 			performDelete: () => serviceFactory.performDelete(actionId),
 			performDuplicate: () => serviceFactory.performDuplicate(actionId),
+			setConnection: (connectionId: string) => serviceFactory.setConnection(actionId, connectionId),
 			setDelay: (delay: number) => serviceFactory.setDelay(actionId, delay),
 			performLearn: serviceFactory.performLearn ? () => serviceFactory.performLearn?.(actionId) : undefined,
 			setEnabled: serviceFactory.setEnabled

--- a/webui/src/scss/_button-edit.scss
+++ b/webui/src/scss/_button-edit.scss
@@ -160,8 +160,7 @@ table.feedback-table {
 			}
 		}
 
-		.cell-delay,
-		.cell-invert {
+		.cell-left-main {
 			grid-row: 3;
 			grid-column: 1;
 


### PR DESCRIPTION
This adds the possibility to change the connection of an action after creation.
A dropdown with all connections of the matching type is shown only if there are multiple connections of that type.
Upon change of the connection unsubscribe is called for the old instance and subscribe is called for the new instance.

![image](https://github.com/user-attachments/assets/8769e580-617f-417e-95f6-bae30df1c536)

Todo: improve positioning
