### PR TITLE
feat: make connection of feedback changeable

### DIFF
--- a/companion/lib/Controls/Controller.ts
+++ b/companion/lib/Controls/Controller.ts
@@ -397,6 +397,19 @@ export class ControlsController extends CoreBase {
 			}
 		})
 
+		client.onPromise('controls:feedback:set-connection', (controlId, feedbackId, connectionId) => {
+			const control = this.getControl(controlId)
+			if (!control) return false
+
+			if (control.supportsFeedbacks) {
+				return control.feedbacks.feedbackSetConnection(feedbackId, connectionId)
+			} else {
+				throw new Error(
+					`Trying to set connection of feedback ${feedbackId} to ${connectionId} but control ${controlId} does not support feedbacks`
+				)
+			}
+		})
+
 		client.onPromise('controls:feedback:set-inverted', (controlId, id, isInverted) => {
 			const control = this.getControl(controlId)
 			if (!control) return false

--- a/companion/lib/Controls/Fragments/FragmentFeedbackInstance.ts
+++ b/companion/lib/Controls/Fragments/FragmentFeedbackInstance.ts
@@ -225,6 +225,20 @@ export class FragmentFeedbackInstance {
 	}
 
 	/**
+	 * Set the connection instance of this feedback
+	 */
+	setInstance(instanceId: string | number): void {
+		const instance = `${instanceId}`
+
+		// first unsubscribe feedback from old instance
+		this.cleanup()
+		// next change instance
+		this.#data.instance_id = instance
+		// last subscribe to new instance
+		this.subscribe(true, instance)
+	}
+
+	/**
 	 * Set whether this feedback is inverted
 	 */
 	setInverted(isInverted: boolean): void {

--- a/companion/lib/Controls/Fragments/FragmentFeedbacks.ts
+++ b/companion/lib/Controls/Fragments/FragmentFeedbacks.ts
@@ -321,6 +321,24 @@ export class FragmentFeedbacks {
 	}
 
 	/**
+	 * Set a new connection instance for a feedback
+	 * @param id the id of the feedback
+	 * @param connectionId the id of the new connection
+	 */
+	feedbackSetConnection(id: string, connectionId: string | number): boolean {
+		const feedback = this.#feedbacks.findById(id)
+		if (feedback) {
+			feedback.setInstance(connectionId)
+
+			this.#commitChange()
+
+			return true
+		}
+
+		return false
+	}
+
+	/**
 	 * Set whether a boolean feedback should be inverted
 	 * @param id the id of the feedback
 	 * @param isInverted the new value

--- a/shared-lib/lib/SocketIO.ts
+++ b/shared-lib/lib/SocketIO.ts
@@ -114,6 +114,7 @@ export interface ClientToBackendEventsMap {
 	'controls:feedback:learn': (controlId: string, feedbackId: string) => boolean
 	'controls:feedback:duplicate': (controlId: string, feedbackId: string) => boolean
 	'controls:feedback:remove': (controlId: string, feedbackId: string) => boolean
+	'controls:feedback:set-connection': (controlId: string, feedbackId: string, connectionId: string | number) => boolean
 	'controls:feedback:set-inverted': (controlId: string, feedbackId: string, isInverted: boolean) => boolean
 	'controls:feedback:set-option': (controlId: string, feedbackId: string, key: string, val: any) => boolean
 	'controls:feedback:move': (

--- a/webui/src/Controls/FeedbackEditor.tsx
+++ b/webui/src/Controls/FeedbackEditor.tsx
@@ -359,6 +359,7 @@ const FeedbackEditor = observer(function FeedbackEditor({
 
 	const connectionInfo = connections.getInfo(feedback.instance_id)
 	const connectionLabel = connectionInfo?.label ?? feedback.instance_id
+	const connectionsWithSameType = connectionInfo ? connections.getAllOfType(connectionInfo.instance_type) : []
 
 	const feedbackSpec = feedbackDefinitions.connections.get(feedback.instance_id)?.get(feedback.type)
 
@@ -510,8 +511,24 @@ const FeedbackEditor = observer(function FeedbackEditor({
 						</div>
 					)}
 
-					{feedbackSpec?.type === 'boolean' && feedbackSpec.showInvert !== false && (
-						<div className="cell-left-main">
+					<div className="cell-left-main">
+						{connectionsWithSameType.length > 1 && (
+							<div className="option-field">
+								<DropdownInputField
+									label="Connection"
+									choices={connectionsWithSameType
+										.sort((connectionA, connectionB) => connectionA[1].sortOrder - connectionB[1].sortOrder)
+										.map((connection) => {
+											const [id, info] = connection
+											return { id, label: info.label }
+										})}
+									multiple={false}
+									value={feedback.instance_id}
+									setValue={service.setConnection}
+								></DropdownInputField>
+							</div>
+						)}
+						{feedbackSpec?.type === 'boolean' && feedbackSpec.showInvert !== false && (
 							<MyErrorBoundary>
 								<CForm onSubmit={PreventDefaultHandler}>
 									<div style={{ paddingLeft: 20 }}>
@@ -527,8 +544,8 @@ const FeedbackEditor = observer(function FeedbackEditor({
 									</div>
 								</CForm>
 							</MyErrorBoundary>
-						</div>
-					)}
+						)}
+					</div>
 
 					{!booleanOnly && (
 						<>

--- a/webui/src/Services/Controls/ControlFeedbacksService.ts
+++ b/webui/src/Services/Controls/ControlFeedbacksService.ts
@@ -8,6 +8,7 @@ export interface IFeedbackEditorService {
 	moveCard: (dragId: string, hoverParentId: string | null, hoverIndex: number) => void
 
 	setValue: (feedbackId: string, feedback: FeedbackInstance | undefined, key: string, value: any) => void
+	setConnection: (feedbackId: string, connectionId: string | number) => void
 	setInverted: (feedbackId: string, inverted: boolean) => void
 	performDelete: (feedbackId: string) => void
 	performDuplicate: (feedbackId: string) => void
@@ -20,6 +21,7 @@ export interface IFeedbackEditorService {
 
 export interface IFeedbackEditorFeedbackService {
 	setValue: (key: string, value: any) => void
+	setConnection: (connectionId: string | number) => void
 	setInverted: (inverted: boolean) => void
 	performDelete: () => void
 	performDuplicate: () => void
@@ -64,6 +66,14 @@ export function useControlFeedbacksEditorService(
 						console.error(`Set-option failed: ${e}`)
 					})
 				}
+			},
+
+			setConnection: (feedbackId: string, connectionId: string | number) => {
+				socketEmitPromise(socket, 'controls:feedback:set-connection', [controlId, feedbackId, connectionId]).catch(
+					(e) => {
+						console.error(`Set-connection failed: ${e}`)
+					}
+				)
 			},
 
 			setInverted: (feedbackId: string, isInverted: boolean) => {
@@ -138,6 +148,7 @@ export function useControlFeedbackService(
 	return useMemo(
 		() => ({
 			setValue: (key: string, val: any) => serviceFactory.setValue(feedbackId, feedbackRef.current, key, val),
+			setConnection: (connectionId: string | number) => serviceFactory.setConnection(feedbackId, connectionId),
 			setInverted: (isInverted: boolean) => serviceFactory.setInverted(feedbackId, isInverted),
 			performDelete: () => serviceFactory.performDelete(feedbackId),
 			performDuplicate: () => serviceFactory.performDuplicate(feedbackId),


### PR DESCRIPTION
Same as with the actions this now adds the possibility to change the connection of a feedback.
Again the dropdown is only shown if there are multiple connections of the same type.
Again it is possible to also change to/from disabled connections.

![image](https://github.com/user-attachments/assets/eabdb601-c108-4111-a80e-437199eaa596)
