### PR TITLE
feat: YAML export-import improvements

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,14 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"EditorConfig.EditorConfig",
+		"esbenp.prettier-vscode"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+		
+	]
+}

--- a/companion/lib/Controls/ControlBase.ts
+++ b/companion/lib/Controls/ControlBase.ts
@@ -201,7 +201,7 @@ export abstract class ControlBase<TJson> extends CoreBase {
 	/**
 	 * Execute a press of a control
 	 * @param pressed Whether the control is pressed
-	 * @param surfaceId The surface that intiated this press
+	 * @param surfaceId The surface that initiated this press
 	 * @param force Trigger actions even if already in the state
 	 */
 	abstract pressControl(pressed: boolean, surfaceId: string | undefined, force?: boolean): void

--- a/companion/lib/Controls/ControlTypes/Button/Normal.ts
+++ b/companion/lib/Controls/ControlTypes/Button/Normal.ts
@@ -295,7 +295,7 @@ export class ControlButtonNormal
 	}
 
 	/**
-	 * Set an opton of an action
+	 * Set an option of an action
 	 */
 	actionSetOption(stepId: string, setId: string, id: string, key: string, value: any): boolean {
 		const step = this.steps[stepId]
@@ -565,7 +565,7 @@ export class ControlButtonNormal
 	/**
 	 * Execute a press of this control
 	 * @param pressed Whether the control is pressed
-	 * @param surfaceId The surface that intiated this press
+	 * @param surfaceId The surface that initiated this press
 	 * @param force Trigger actions even if already in the state
 	 */
 	pressControl(pressed: boolean, surfaceId: string | undefined, force: boolean): void {
@@ -669,7 +669,7 @@ export class ControlButtonNormal
 	/**
 	 * Execute a rotate of this control
 	 * @param direction Whether the control was rotated to the right
-	 * @param surfaceId The surface that intiated this rotate
+	 * @param surfaceId The surface that initiated this rotate
 	 */
 	rotateControl(direction: boolean, surfaceId: string | undefined): void {
 		const [this_step_id] = this.#validateCurrentStepId()

--- a/companion/lib/Controls/ControlTypes/PageDown.ts
+++ b/companion/lib/Controls/ControlTypes/PageDown.ts
@@ -108,7 +108,7 @@ export class ControlButtonPageDown
 	/**
 	 * Execute a press of this control
 	 * @param pressed Whether the control is pressed
-	 * @param surfaceId The surface that intiated this press
+	 * @param surfaceId The surface that initiated this press
 	 */
 	pressControl(pressed: boolean, surfaceId: string | undefined): void {
 		if (pressed && surfaceId) {

--- a/companion/lib/Controls/ControlTypes/PageNumber.ts
+++ b/companion/lib/Controls/ControlTypes/PageNumber.ts
@@ -109,7 +109,7 @@ export class ControlButtonPageNumber
 	/**
 	 * Execute a press of this control
 	 * @param pressed Whether the control is pressed
-	 * @param surfaceId The surface that intiated this press
+	 * @param surfaceId The surface that initiated this press
 	 */
 	pressControl(pressed: boolean, surfaceId: string | undefined): void {
 		if (pressed && surfaceId) {

--- a/companion/lib/Controls/ControlTypes/PageUp.ts
+++ b/companion/lib/Controls/ControlTypes/PageUp.ts
@@ -108,7 +108,7 @@ export class ControlButtonPageUp
 	/**
 	 * Execute a press of this control
 	 * @param pressed Whether the control is pressed
-	 * @param surfaceId The surface that intiated this press
+	 * @param surfaceId The surface that initiated this press
 	 */
 	pressControl(pressed: boolean, surfaceId: string | undefined) {
 		if (pressed && surfaceId) {

--- a/companion/lib/Controls/ControlTypes/Triggers/Trigger.ts
+++ b/companion/lib/Controls/ControlTypes/Triggers/Trigger.ts
@@ -284,7 +284,7 @@ export class ControlTrigger
 	}
 
 	/**
-	 * Set an opton of an action
+	 * Set an option of an action
 	 */
 	actionSetOption(_stepId: string, _setId: string, id: string, key: string, value: any): boolean {
 		return this.actions.actionSetOption('0', id, key, value)

--- a/companion/lib/Controls/Controller.ts
+++ b/companion/lib/Controls/Controller.ts
@@ -1007,7 +1007,7 @@ export class ControlsController extends CoreBase {
 			return false
 		}
 
-		// Delete old control at the coordintae
+		// Delete old control at the coordinate
 		const oldControlId = this.page.getControlIdAt(location)
 		if (oldControlId) {
 			this.deleteControl(oldControlId)
@@ -1089,7 +1089,7 @@ export class ControlsController extends CoreBase {
 	 * Execute a press of a control
 	 * @param controlId Id of the control
 	 * @param pressed Whether the control is pressed
-	 * @param surfaceId The surface that intiated this press
+	 * @param surfaceId The surface that initiated this press
 	 * @param force Trigger actions even if already in the state
 	 */
 	pressControl(controlId: string, pressed: boolean, surfaceId: string | undefined, force?: boolean): boolean {
@@ -1109,7 +1109,7 @@ export class ControlsController extends CoreBase {
 	 * Execute rotation of a control
 	 * @param controlId Id of the control
 	 * @param direction Whether the control is rotated to the right
-	 * @param surfaceId The surface that intiated this rotate
+	 * @param surfaceId The surface that initiated this rotate
 	 */
 	rotateControl(controlId: string, direction: boolean, surfaceId: string | undefined): boolean {
 		const control = this.getControl(controlId)

--- a/companion/lib/Controls/Fragments/FragmentActions.ts
+++ b/companion/lib/Controls/Fragments/FragmentActions.ts
@@ -368,7 +368,7 @@ export class FragmentActions {
 	}
 
 	/**
-	 * Set an opton of an action
+	 * Set an option of an action
 	 * @param setId the action_set id
 	 * @param id the action id
 	 * @param key the desired option to set

--- a/companion/lib/Controls/Fragments/FragmentFeedbacks.ts
+++ b/companion/lib/Controls/Fragments/FragmentFeedbacks.ts
@@ -246,7 +246,7 @@ export class FragmentFeedbacks {
 	}
 
 	/**
-	 * Move a feedback within the heirarchy
+	 * Move a feedback within the hierarchy
 	 * @param moveFeedbackId the id of the feedback to move
 	 * @param newParentId the target parentId of the feedback
 	 * @param newIndex the target index of the feedback

--- a/companion/lib/Controls/IControlFragments.ts
+++ b/companion/lib/Controls/IControlFragments.ts
@@ -197,7 +197,7 @@ export interface ControlWithActions extends ControlBase<any> {
 	actionSetDelay(stepId: string, setId: string, id: string, delay: number): boolean
 
 	/**
-	 * Set an opton of an action
+	 * Set an option of an action
 	 */
 	actionSetOption(stepId: string, setId: string, id: string, key: string, value: any): boolean
 
@@ -302,7 +302,7 @@ export interface ControlWithActionSets extends ControlBase<any> {
 	/**
 	 * Execute a rotate of this control
 	 * @param direction Whether the control was rotated to the right
-	 * @param surfaceId The surface that intiated this rotate
+	 * @param surfaceId The surface that initiated this rotate
 	 */
 	rotateControl(direction: boolean, surfaceId: string | undefined): void
 }

--- a/companion/lib/Graphics/Image.ts
+++ b/companion/lib/Graphics/Image.ts
@@ -370,7 +370,7 @@ export class Image {
 
 	/**
 	 * draws a single line of left aligned text
-	 * the line lenght is not wrapped or limited and may extend beyond the canvas
+	 * the line length is not wrapped or limited and may extend beyond the canvas
 	 * @param x left position where to start the line
 	 * @param y top position where to start the line
 	 * @param text
@@ -523,7 +523,7 @@ export class Image {
 				) ?? 6
 		}
 
-		lineheight = Math.floor(fontheight * 1.1) // this lineheight is not the real lineheight needed for the font, but it is calclulated to match the existing font size / lineheight ratio of the bitmap fonts
+		lineheight = Math.floor(fontheight * 1.1) // this lineheight is not the real lineheight needed for the font, but it is calculated to match the existing font size / lineheight ratio of the bitmap fonts
 
 		// breakup text in pieces
 		let lines = []
@@ -566,7 +566,7 @@ export class Image {
 			// how many chars fit probably in one line
 			let chars = Math.round(w / nWidth)
 
-			diff = w - this.context2d.measureText(substring(text, 0, chars)).width // check our guessed lenght
+			diff = w - this.context2d.measureText(substring(text, 0, chars)).width // check our guessed length
 
 			if (Math.abs(diff) > nWidth) {
 				// we seem to be off by more than one char
@@ -645,7 +645,7 @@ export class Image {
 			// check if remaining text fits in line
 			let { maxCodepoints, ascent, descent } = findLastChar(textArr.slice(lastDrawnByte).join(''))
 
-			//console.log(`check text "${textArr.slice(lastDrawnByte).join('')}" arr=${textArr} lenght=${textArr.length - lastDrawnByte} max=${maxCodepoints}`)
+			//console.log(`check text "${textArr.slice(lastDrawnByte).join('')}" arr=${textArr} length=${textArr.length - lastDrawnByte} max=${maxCodepoints}`)
 			if (maxCodepoints >= textArr.length - lastDrawnByte) {
 				let buf = []
 				for (let i = lastDrawnByte; i < textArr.length; i += 1) {

--- a/companion/lib/Resources/Util.ts
+++ b/companion/lib/Resources/Util.ts
@@ -237,7 +237,7 @@ export function parseLineParameters(line: string): ParsedParams {
 /**
  * Checks if parameter is one of the list and returns it if so.
  * If it is not in the list but a trueish value, the defaultVal will be returned.
- * Otherwise returnes null.
+ * Otherwise returns null.
  */
 export function parseStringParamWithBooleanFallback(
 	list: string[],

--- a/companion/lib/Service/HttpApi.ts
+++ b/companion/lib/Service/HttpApi.ts
@@ -476,7 +476,7 @@ export class ServiceHttpApi extends CoreBase {
 	 */
 	#locationStyle = (req: express.Request, res: express.Response): void => {
 		const { location, controlId } = this.#locationParse(req)
-		this.logger.info(`Got HTTP control syle ${formatLocation(location)} - ${controlId}`)
+		this.logger.info(`Got HTTP control style ${formatLocation(location)} - ${controlId}`)
 
 		if (!controlId) {
 			res.status(204).send('No control')

--- a/companion/lib/Surface/IP/Satellite.ts
+++ b/companion/lib/Surface/IP/Satellite.ts
@@ -333,7 +333,7 @@ export class SurfaceIPSatellite extends EventEmitter<SurfacePanelEvents> impleme
 		if (this.socket !== undefined) {
 			this.socket.write(`KEYS-CLEAR DEVICEID=${this.deviceId}\n`)
 		} else {
-			this.#logger.debug('trying to emit to nonexistant socket: ', this.deviceId)
+			this.#logger.debug('trying to emit to nonexistent socket: ', this.deviceId)
 		}
 	}
 
@@ -347,7 +347,7 @@ export class SurfaceIPSatellite extends EventEmitter<SurfacePanelEvents> impleme
 			for (const variable of allChangedVariables.values()) {
 				if (!outputVariable.lastReferencedVariables.has(variable)) continue
 
-				// There is a change, recalcuate and send the value
+				// There is a change, recalculate and send the value
 
 				this.#triggerOutputVariable(name, outputVariable)
 				break
@@ -381,7 +381,7 @@ export class SurfaceIPSatellite extends EventEmitter<SurfacePanelEvents> impleme
 						const base64Value = Buffer.from(expressionResult?.toString() ?? '').toString('base64')
 						this.socket.write(`VARIABLE-VALUE DEVICEID=${this.deviceId} VARIABLE="${name}" VALUE="${base64Value}"\n`)
 					} else {
-						this.#logger.debug('trying to emit to nonexistant socket: ', this.deviceId)
+						this.#logger.debug('trying to emit to nonexistent socket: ', this.deviceId)
 					}
 				},
 				{

--- a/companion/lib/Surface/USB/XKeys.ts
+++ b/companion/lib/Surface/USB/XKeys.ts
@@ -262,7 +262,7 @@ export class SurfaceUSBXKeys extends EventEmitter<SurfacePanelEvents> implements
 		const panel = await setupXkeysPanel(devicePath)
 
 		try {
-			const deviceId = `xkeys:${panel.info.productId}-${panel.info.unitId}` // TODO - this needs some additional uniqueness to the sufix
+			const deviceId = `xkeys:${panel.info.productId}-${panel.info.unitId}` // TODO - this needs some additional uniqueness to the suffix
 			// (${devicePath.slice(0, -1).slice(-10)})` // This suffix produces `dev/hidraw` on linux, which is not useful.
 
 			const self = new SurfaceUSBXKeys(devicePath, panel, deviceId, options || {})

--- a/companion/lib/Variables/CustomVariable.ts
+++ b/companion/lib/Variables/CustomVariable.ts
@@ -380,7 +380,7 @@ export class VariablesCustomVariable {
 	}
 
 	/**
-	 * Propogate the current value of a custom variable to be the new default value
+	 * Propagate the current value of a custom variable to be the new default value
 	 */
 	syncValueToDefault(name: string): void {
 		if (this.#custom_variables[name]) {

--- a/companion/lib/main.ts
+++ b/companion/lib/main.ts
@@ -55,7 +55,7 @@ program.command('start', { isDefault: true, hidden: true }).action(() => {
 		for (const [ifname, ifgroup] of Object.entries(interfaces)) {
 			if (!ifgroup) continue
 			for (const ifAddr of ifgroup) {
-				// onlt show non-ipv4 addresses for now
+				// only show non-ipv4 addresses for now
 				if ('IPv4' === ifAddr.family) {
 					console.error(ifname, ifAddr.address)
 				}

--- a/companion/test/Service/SharedUdpManager.test.ts
+++ b/companion/test/Service/SharedUdpManager.test.ts
@@ -107,7 +107,7 @@ describe('SharedUdpManager', () => {
 
 			mockSocket.bind.mockImplementation(() => {
 				setImmediate(() => {
-					// Emit an erorr instead
+					// Emit an error instead
 					mockSocket.emit('error', new Error('Bind Error'))
 				})
 			})

--- a/docs/4_secondary_admin_controls/expressions/functions.md
+++ b/docs/4_secondary_admin_controls/expressions/functions.md
@@ -178,7 +178,7 @@ You can see examples of how to use this at: https://jsonpath.com/
 
 Parse a string of json into an object.
 
-If this enounters invalid input, it will return null instead of throwing an error.
+If this encounters invalid input, it will return null instead of throwing an error.
 
 eg: `jsonparse('{"a":1}')` will be an object `{ a: 1 }`
 
@@ -186,7 +186,7 @@ eg: `jsonparse('{"a":1}')` will be an object `{ a: 1 }`
 
 Convert an object into a json string.
 
-If this enounters invalid input, it will return null instead of throwing an error.
+If this encounters invalid input, it will return null instead of throwing an error.
 
 eg: `jsonstringify({ a: 1 })` will be a string containing `{"a":1}`
 

--- a/webui/src/Components/AlignmentInputField.tsx
+++ b/webui/src/Components/AlignmentInputField.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import classnames from 'classnames'
 import type { CompanionAlignment } from '@companion-module/base'
 
-const ALIGMENT_OPTIONS: CompanionAlignment[] = [
+const ALIGNMENT_OPTIONS: CompanionAlignment[] = [
 	'left:top',
 	'center:top',
 	'right:top',
@@ -22,7 +22,7 @@ interface AlignmentInputFieldProps {
 export function AlignmentInputField({ value, setValue }: AlignmentInputFieldProps) {
 	return (
 		<div className="alignmentinput">
-			{ALIGMENT_OPTIONS.map((align) => {
+			{ALIGNMENT_OPTIONS.map((align) => {
 				return (
 					<div key={align} className={classnames({ selected: align === value })} onClick={() => setValue(align)}>
 						&nbsp;

--- a/webui/src/Components/TextInputField.tsx
+++ b/webui/src/Components/TextInputField.tsx
@@ -255,14 +255,14 @@ const VariablesSelect = observer(function VariablesSelect({
 		const openIndex = FindVariableStartIndexFromCursor(oldValue, cursorPositionRef.current)
 		if (openIndex === -1) return
 
-		// Propogate the new value
+		// Propagate the new value
 		storeValue(oldValue.slice(0, openIndex) + `$(${variable.value})` + oldValue.slice(cursorPositionRef.current))
 
 		// This doesn't work properly, it causes the cursor to get a bit confused on where it is but avoids the glitch of setSelectionRange
 		// if (inputRef.current)
 		// 	inputRef.current.setRangeText(`$(${variable.value})`, openIndex, cursorPositionRef.current, 'end')
 
-		// Update the selection after mutating the value. This needs to be defered, although this causes a 'glitch' in the drawing
+		// Update the selection after mutating the value. This needs to be deferred, although this causes a 'glitch' in the drawing
 		// It needs to be delayed, so that react can re-render first
 		const newSelection = openIndex + variable.value.length + 3
 		setTimeout(() => {

--- a/webui/src/Connections/ConnectionList.tsx
+++ b/webui/src/Connections/ConnectionList.tsx
@@ -338,7 +338,7 @@ const ConnectionsTableRow = observer(function ConnectionsTableRow({
 						style={{ backgroundColor: 'white' }}
 						content={
 							<>
-								{/* Note: the popover closing due to focus loss stops mouseup/click events propogating */}
+								{/* Note: the popover closing due to focus loss stops mouseup/click events propagating */}
 								<CButtonGroup vertical>
 									<CButton
 										onMouseDown={doShowHelp}

--- a/webui/src/ImportExport/index.tsx
+++ b/webui/src/ImportExport/index.tsx
@@ -139,7 +139,7 @@ export const ImportExport = observer(function ImportExport() {
 									type="file"
 									onChange={loadSnapshot}
 									style={{ display: 'none' }}
-									accept=".companionconfig,.companionconfig.yaml"
+									accept=".companionconfig,.yaml"
 								/>
 							</label>
 						</div>

--- a/webui/src/Wizard/GridStep.tsx
+++ b/webui/src/Wizard/GridStep.tsx
@@ -43,11 +43,12 @@ export function GridStep({ rows, columns, setValue }: GridStepProps) {
 				<h5>Button Grid Size</h5>
 				<p>
 					By default Companion makes a grid of buttons sized for the Stream Deck XL. This can be made larger (or
-					smaller) to accomodate individual surfaces of any size, such as an X-Keys XKE-128 (8 rows x 16 columns).
+					smaller) to accommodate individual surfaces of any size, such as an X-Keys XKE-128 (8 rows x 16 columns).
 				</p>
 				<p>
 					The grid can also be enlarged to group multiple control surfaces together to create a larger control surface.
-					For example, to accomodate two Stream Deck XL's side-by-side you can set the grid size as 4 rows x 16 columns.
+					For example, to accommodate two Stream Deck XL's side-by-side you can set the grid size as 4 rows x 16
+					columns.
 				</p>
 			</CCol>
 


### PR DESCRIPTION
* Reformat and split Base64 encoded PNGs in YAML over multiple lines
* Change acceptable file extension for uploading to just .yaml instead of .companionconfig.yaml
  * Two part file extensions don’t seem to work in all browsers, so YAML couldn't be loaded without manually selecting "all files"

Also:

* Recommend editorconfig and prettier VSCode extensions
  * The config for both of theses linters is present, we should encourage people to use it
* Fix typos, mostly in comments e.g. `intiated` should be `initiated`