### PR TITLE
feat: show custom variable in collapsed view, ui tweaks

### DIFF
--- a/webui/src/Components/CheckboxInputField.tsx
+++ b/webui/src/Components/CheckboxInputField.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useCallback } from 'react'
 import { CFormCheck, CFormLabel } from '@coreui/react'
 import { InlineHelp } from './InlineHelp.js'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faCircleQuestion } from '@fortawesome/free-solid-svg-icons'
 
 interface CheckboxInputFieldProps {
 	tooltip?: string
@@ -10,6 +12,7 @@ interface CheckboxInputFieldProps {
 	setValid?: (valid: boolean) => void
 	disabled?: boolean
 	helpText?: string
+	inline?: boolean
 }
 
 export function CheckboxInputField({
@@ -20,6 +23,7 @@ export function CheckboxInputField({
 	setValid,
 	disabled,
 	helpText,
+	inline,
 }: CheckboxInputFieldProps) {
 	// If the value is undefined, populate with the default. Also inform the parent about the validity
 	useEffect(() => {
@@ -38,14 +42,35 @@ export function CheckboxInputField({
 		<>
 			<>
 				{helpText ? (
-					<InlineHelp help={helpText}>{label ? <CFormLabel>{label}</CFormLabel> : ''}</InlineHelp>
+					<InlineHelp help={helpText}>
+						{label ? (
+							<CFormLabel>
+								{label} <FontAwesomeIcon size="sm" icon={faCircleQuestion} />
+							</CFormLabel>
+						) : (
+							''
+						)}
+					</InlineHelp>
 				) : label ? (
 					<>{label ? <CFormLabel>{label}</CFormLabel> : ''}</>
 				) : (
 					''
 				)}
 			</>
-			<div className="form-check">
+			<div
+				className="form-check"
+				style={
+					inline
+						? {
+								display: 'inline-block',
+								verticalAlign: 'middle',
+								marginLeft: '1em',
+								paddingBottom: '.5em',
+								paddingTop: '.3em',
+							}
+						: {}
+				}
+			>
 				<CFormCheck
 					type="checkbox"
 					disabled={disabled}

--- a/webui/src/Components/VariablesTable.tsx
+++ b/webui/src/Components/VariablesTable.tsx
@@ -197,8 +197,10 @@ const VariablesTableRow = observer(function VariablesTableRow({
 								backgroundColor: 'rgba(0,0,200,0.1)',
 								color: 'rgba(0,0,200,1)',
 								fontWeight: 'normal',
-								padding: '1px 3px',
 								fontSize: 14,
+								padding: '4px',
+								lineHeight: '2em',
+								borderRadius: '6px',
 							}}
 							title={value}
 						>

--- a/webui/src/Variables/CustomVariablesList.tsx
+++ b/webui/src/Variables/CustomVariablesList.tsx
@@ -210,12 +210,12 @@ export const CustomVariablesList = observer(function CustomVariablesList({ setSh
 					</CButton>
 					{!hasNoVariables && panelCollapseHelper.canExpandAll() && (
 						<CButton color="secondary" onClick={panelCollapseHelper.setAllExpanded} title="Expand all">
-							<FontAwesomeIcon icon={faExpandArrowsAlt} /> Expand
+							<FontAwesomeIcon icon={faExpandArrowsAlt} /> Expand All
 						</CButton>
 					)}
 					{!hasNoVariables && panelCollapseHelper.canCollapseAll() && (
 						<CButton color="secondary" onClick={panelCollapseHelper.setAllCollapsed} title="Collapse all">
-							<FontAwesomeIcon icon={faCompressArrowsAlt} /> Collapse
+							<FontAwesomeIcon icon={faCompressArrowsAlt} /> Collapse All
 						</CButton>
 					)}
 				</CButtonGroup>
@@ -236,7 +236,15 @@ export const CustomVariablesList = observer(function CustomVariablesList({ setSh
 				</CButton>
 			</CInputGroup>
 
-			<table className="table variables-table">
+			<table className="table table-responsive-sm variables-table">
+				<thead>
+					<tr>
+						<th>&nbsp;</th>
+						<th>Variable</th>
+						<th>Value</th>
+						<th>&nbsp;</th>
+					</tr>
+				</thead>
 				<tbody>
 					{!hasNoVariables && errorMsg && (
 						<tr>
@@ -278,7 +286,7 @@ export const CustomVariablesList = observer(function CustomVariablesList({ setSh
 					)}
 				</tbody>
 			</table>
-
+			<br></br>
 			<h5>Create custom variable</h5>
 			<div>
 				<CForm onSubmit={doCreateNew}>
@@ -385,64 +393,85 @@ function CustomVariableRow({
 			<td ref={drag} className="td-reorder">
 				<FontAwesomeIcon icon={faSort} />
 			</td>
-			<td style={{ paddingRight: 0 }}>
+			<td style={{ verticalAlign: 'middle' }}>
+				<span className="variable-style">$({fullname})</span>
+				<CopyToClipboard text={`$(${fullname})`} onCopy={onCopied}>
+					<CButton size="sm" title="Copy variable name">
+						<FontAwesomeIcon icon={faCopy} />
+					</CButton>
+				</CopyToClipboard>
+			</td>
+			<td style={{ verticalAlign: 'middle' }}>
+				{isCollapsed && (
+					<>
+						<code
+							style={{
+								backgroundColor: 'rgba(0,0,200,0.1)',
+								color: 'rgba(0,0,200,1)',
+								fontWeight: 'normal',
+								fontSize: 14,
+								padding: '4px',
+								lineHeight: '2em',
+								borderRadius: '6px',
+							}}
+							title={value}
+						>
+							{value?.length > 100 ? `${value.substring(0, 100)}...` : value}
+						</code>
+					</>
+				)}
+				{!isCollapsed && (
+					<>
+						<div className="cell-values">
+							<CForm onSubmit={PreventDefaultHandler}>
+								<TextInputField
+									label="Current value: "
+									value={value ?? ''}
+									setValue={(val) => setCurrentValue(name, val)}
+									style={{ marginBottom: '0.5rem' }}
+								/>
+								<CheckboxInputField
+									label="Persist current value"
+									value={info.persistCurrentValue}
+									setValue={(val) => setPersistenceValue(name, val)}
+									helpText="If enabled, the current value will be saved and restored when Companion restarts."
+									inline={true}
+								/>
+								<br></br>
+								<TextInputField
+									label="Startup value: "
+									disabled={!!info.persistCurrentValue}
+									value={info.defaultValue + ''}
+									setValue={(val) => setStartupValue(name, val)}
+								/>
+							</CForm>
+						</div>
+					</>
+				)}
+			</td>
+			<td style={{ paddingRight: 0, paddingLeft: '2.5em', verticalAlign: 'middle' }}>
 				<div className="editor-grid">
 					<div className="cell-header">
-						<CopyToClipboard text={`$(${fullname})`} onCopy={onCopied}>
-							<span className="variable-style">$({fullname})</span>
-						</CopyToClipboard>
-						<CButtonGroup className="right" size={isCollapsed ? 'sm' : undefined}>
+						<CButtonGroup className="right">
 							{isCollapsed ? (
-								<CButton onClick={doExpand} title="Expand variable view">
+								<CButton onClick={doExpand} size="sm" title="Expand variable view">
 									<FontAwesomeIcon icon={faExpandArrowsAlt} />
 								</CButton>
 							) : (
-								<CButton onClick={doCollapse} title="Collapse variable view">
+								<CButton onClick={doCollapse} size="sm" title="Collapse variable view">
 									<FontAwesomeIcon icon={faCompressArrowsAlt} />
 								</CButton>
 							)}
-							<CopyToClipboard text={`$(${fullname})`} onCopy={onCopied}>
-								<CButton>
+							<CopyToClipboard text={`${value?.length > 0 ? value : ' '}`} onCopy={onCopied}>
+								<CButton size="sm" title="Copy current variable value">
 									<FontAwesomeIcon icon={faCopy} />
 								</CButton>
 							</CopyToClipboard>
-							<CButton onClick={() => doDelete(name)}>
+							<CButton onClick={() => doDelete(name)} size="sm" title="Delete custom variable">
 								<FontAwesomeIcon icon={faTrash} />
 							</CButton>
 						</CButtonGroup>
 					</div>
-
-					{!isCollapsed && (
-						<>
-							<div className="cell-options">
-								<CForm onSubmit={PreventDefaultHandler}>
-									<CheckboxInputField
-										label="Persist value"
-										value={info.persistCurrentValue}
-										setValue={(val) => setPersistenceValue(name, val)}
-										helpText="If enabled, the current value will be saved and restored when Companion restarts."
-									/>
-								</CForm>
-							</div>
-
-							<div className="cell-values">
-								<CForm onSubmit={PreventDefaultHandler}>
-									<TextInputField
-										label="Current value: "
-										value={value ?? ''}
-										setValue={(val) => setCurrentValue(name, val)}
-									/>
-
-									<TextInputField
-										label="Startup value: "
-										disabled={!!info.persistCurrentValue}
-										value={info.defaultValue + ''}
-										setValue={(val) => setStartupValue(name, val)}
-									/>
-								</CForm>
-							</div>
-						</>
-					)}
 				</div>
 			</td>
 		</tr>


### PR DESCRIPTION
This PR resolves https://github.com/bitfocus/companion/issues/3064 and now displays the current custom variable value in the collapsed state.

It also cleans up the custom variable page UI to better match the other variable tabs, including:

- Adding copy button next to variable name for clearer interaction / consistency with other variable pages
- Change the copy button to the right of the value to copy the current value (consistency with other variable pages)
- Rearrange custom fields so that persist follows "current value", so it's more clear what is being persisted
- Added icon to help discoverability of tooltip for persist value

In these screenshots, old page is on the left and new is on the right 

<img width="2298" alt="Screenshot 2024-11-03 at 5 24 44 PM" src="https://github.com/user-attachments/assets/ac47ea06-4b1e-47d2-bbd8-8b392351ab24">

<img width="2291" alt="Screenshot 2024-11-03 at 5 25 17 PM" src="https://github.com/user-attachments/assets/bdebeb6e-9722-4472-a84c-f1f99706fb87">

