### PR TITLE
feat: standardize status to icons

### DIFF
--- a/webui/src/Connections/ConnectionList.tsx
+++ b/webui/src/Connections/ConnectionList.tsx
@@ -1,5 +1,5 @@
 import React, { RefObject, useCallback, useContext, useRef } from 'react'
-import { CButton, CButtonGroup, CFormSwitch, CPopover } from '@coreui/react'
+import { CButton, CButtonGroup, CFormSwitch, CPopover, CSpinner } from '@coreui/react'
 import { socketEmitPromise } from '../util.js'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
@@ -439,7 +439,11 @@ function ModuleStatusCall({ isEnabled, status }: ModuleStatusCallProps) {
 					</InlineHelp>
 				)
 			case 'error':
-				return (
+				return status?.level === 'Connecting' ? (
+					<InlineHelp help={`${status.level ?? 'Error'}${messageStr ? ': ' + messageStr : ''}`}>
+						<CSpinner color="warning"></CSpinner>
+					</InlineHelp>
+				) : (
 					<InlineHelp help={`${status.level ?? 'Error'}${messageStr ? ': ' + messageStr : ''}`}>
 						<FontAwesomeIcon icon={faTriangleExclamation} color={'#d50215'} size="2xl" />
 					</InlineHelp>

--- a/webui/src/Connections/ConnectionList.tsx
+++ b/webui/src/Connections/ConnectionList.tsx
@@ -14,6 +14,8 @@ import {
 	faTrash,
 	faEllipsisV,
 	faPlug,
+	faTriangleExclamation,
+	faPowerOff,
 } from '@fortawesome/free-solid-svg-icons'
 import { ConnectionVariablesModal, ConnectionVariablesModalRef } from './ConnectionVariablesModal.js'
 import { GenericConfirmModal, GenericConfirmModalRef } from '../Components/GenericConfirmModal.js'
@@ -27,6 +29,7 @@ import { NonIdealState } from '../Components/NonIdealState.js'
 import { Tuck } from '../Components/Tuck.js'
 import { useTableVisibilityHelper, VisibilityButton } from '../Components/TableVisibility.js'
 import { ClientConnectionConfig } from '@companion-app/shared/Model/Connections.js'
+import { InlineHelp } from '../Components/InlineHelp.js'
 
 interface VisibleConnectionsState {
 	disabled: boolean
@@ -155,7 +158,7 @@ export const ConnectionsList = observer(function ConnectionsList({
 					{hiddenCount > 0 && (
 						<tr>
 							<td colSpan={4} style={{ padding: '10px 5px' }}>
-								<FontAwesomeIcon icon={faEyeSlash} style={{ marginRight: '0.5em', color: 'red' }} />
+								<FontAwesomeIcon icon={faEyeSlash} style={{ marginRight: '0.5em', color: 'gray' }} />
 								<strong>{hiddenCount} Connections are hidden</strong>
 							</td>
 						</tr>
@@ -318,7 +321,9 @@ const ConnectionsTableRow = observer(function ConnectionsTableRow({
 					connection.instance_type
 				)}
 			</td>
-			<ModuleStatusCall isEnabled={isEnabled} status={connectionStatus} onClick={doEdit} />
+			<td className="hand" onClick={doEdit}>
+				<ModuleStatusCall isEnabled={isEnabled} status={connectionStatus} />
+			</td>
 			<td className="action-buttons">
 				<div style={{ display: 'flex' }}>
 					<div>
@@ -414,10 +419,9 @@ const ConnectionsTableRow = observer(function ConnectionsTableRow({
 interface ModuleStatusCallProps {
 	isEnabled: boolean
 	status: ConnectionStatusEntry | undefined
-	onClick?: () => void
 }
 
-function ModuleStatusCall({ isEnabled, status, onClick }: ModuleStatusCallProps) {
+function ModuleStatusCall({ isEnabled, status }: ModuleStatusCallProps) {
 	if (isEnabled) {
 		const messageStr =
 			!!status &&
@@ -427,41 +431,28 @@ function ModuleStatusCall({ isEnabled, status, onClick }: ModuleStatusCallProps)
 
 		switch (status?.category) {
 			case 'good':
-				return (
-					<td className="hand" onClick={onClick}>
-						<FontAwesomeIcon icon={faCheckCircle} color={'#33aa33'} size="2xl" />
-					</td>
-				)
+				return <FontAwesomeIcon icon={faCheckCircle} color={'#33aa33'} size="2xl" />
 			case 'warning':
 				return (
-					<td className="connection-status-warn hand" onClick={onClick}>
-						{status.level || 'Warning'}
-						<br />
-						{messageStr}
-					</td>
+					<InlineHelp help={`${status.level ?? 'Warning'}${messageStr ? ': ' + messageStr : ''}`}>
+						<FontAwesomeIcon icon={faTriangleExclamation} color={'#fab92c'} size="2xl" />
+					</InlineHelp>
 				)
 			case 'error':
 				return (
-					<td className="connection-status-error hand" onClick={onClick}>
-						{status.level || 'ERROR'}
-						<br />
-						{messageStr}
-					</td>
+					<InlineHelp help={`${status.level ?? 'Error'}${messageStr ? ': ' + messageStr : ''}`}>
+						<FontAwesomeIcon icon={faTriangleExclamation} color={'#d50215'} size="2xl" />
+					</InlineHelp>
 				)
+
 			default:
 				return (
-					<td className="connection-status-error hand" onClick={onClick}>
-						Unknown
-						<br />
-						{messageStr}
-					</td>
+					<InlineHelp help={`Unknown${messageStr ? ': ' + messageStr : ''}`}>
+						<FontAwesomeIcon icon={faTriangleExclamation} color={'#fab92c'} size="2xl" />
+					</InlineHelp>
 				)
 		}
 	} else {
-		return (
-			<td onClick={onClick} className="hand">
-				Disabled
-			</td>
-		)
+		return <FontAwesomeIcon icon={faPowerOff} color={'gray'} size="2xl" />
 	}
 }


### PR DESCRIPTION
This looks to resolve https://github.com/bitfocus/companion/issues/2816 by implementing the strategy outlined in the first [comment ](https://github.com/bitfocus/companion/issues/2816#issuecomment-2019266064).

Basically, this moves all statuses to icons (previously only OK was an icon, and the rest could be any amount of text determined by the module). This uses icons to consistently and cleanly get across the status state. More info can be found by hovering over the icons, which prints out the status level and additional messages from the module.

<img width="547" alt="Screenshot 2024-11-06 at 5 27 22 PM" src="https://github.com/user-attachments/assets/9efbeefe-58f5-4d55-b360-379d95c0425e">

<img width="541" alt="Screenshot 2024-11-06 at 5 27 33 PM" src="https://github.com/user-attachments/assets/558ec787-e445-43aa-a9a0-b693c00975b9">
