### PR TITLE
feat: add 'Conditionalise existing feedbacks' feedback

### DIFF
--- a/companion/lib/Controls/Controller.ts
+++ b/companion/lib/Controls/Controller.ts
@@ -323,7 +323,7 @@ export class ControlsController extends CoreBase {
 			}
 		})
 
-		client.onPromise('controls:feedback:add', (controlId, parentId, connectionId, feedbackId) => {
+		client.onPromise('controls:feedback:add', (controlId, ownerId, connectionId, feedbackId) => {
 			const control = this.getControl(controlId)
 			if (!control) return false
 
@@ -334,7 +334,7 @@ export class ControlsController extends CoreBase {
 					control.feedbacks.isBooleanOnly
 				)
 				if (feedbackItem) {
-					return control.feedbacks.feedbackAdd(feedbackItem, parentId)
+					return control.feedbacks.feedbackAdd(feedbackItem, ownerId)
 				} else {
 					return false
 				}
@@ -450,14 +450,15 @@ export class ControlsController extends CoreBase {
 			}
 		})
 
-		client.onPromise('controls:feedback:move', (controlId, moveFeedbackId, newParentId, newIndex) => {
+		client.onPromise('controls:feedback:move', (controlId, moveFeedbackId, newOwnerId, newIndex) => {
 			const control = this.getControl(controlId)
 			if (!control) return false
 
-			if (moveFeedbackId === newParentId) throw new Error('Cannot move feedback to itself')
+			if (newOwnerId && moveFeedbackId === newOwnerId.parentFeedbackId)
+				throw new Error('Cannot move feedback to itself')
 
 			if (control.supportsFeedbacks) {
-				return control.feedbacks.feedbackMoveTo(moveFeedbackId, newParentId, newIndex)
+				return control.feedbacks.feedbackMoveTo(moveFeedbackId, newOwnerId, newIndex)
 			} else {
 				throw new Error(`Control "${controlId}" does not support feedbacks`)
 			}

--- a/companion/lib/Controls/Fragments/FeedbackStyleBuilder.ts
+++ b/companion/lib/Controls/Fragments/FeedbackStyleBuilder.ts
@@ -1,0 +1,58 @@
+import type { ButtonStyleProperties, UnparsedButtonStyle } from '@companion-app/shared/Model/StyleModel.js'
+
+/**
+ * A simple class to help combine multiple styles into one that can be drawn
+ */
+export class FeedbackStyleBuilder {
+	#combinedStyle: UnparsedButtonStyle
+
+	get style(): UnparsedButtonStyle {
+		return this.#combinedStyle
+	}
+
+	constructor(baseStyle: ButtonStyleProperties) {
+		this.#combinedStyle = {
+			...baseStyle,
+			imageBuffers: [],
+		}
+	}
+
+	/**
+	 * Apply a simple layer of style
+	 */
+	applySimpleStyle(style: Partial<ButtonStyleProperties> | undefined) {
+		this.#combinedStyle = {
+			...this.#combinedStyle,
+			...style,
+		}
+	}
+
+	applyComplexStyle(rawValue: any) {
+		if (typeof rawValue === 'object' && rawValue !== undefined) {
+			// Prune off some special properties
+			const prunedValue = { ...rawValue }
+			delete prunedValue.imageBuffer
+			delete prunedValue.imageBufferPosition
+
+			// Ensure `textExpression` is set at the same times as `text`
+			delete prunedValue.textExpression
+			if ('text' in prunedValue) {
+				prunedValue.textExpression = rawValue.textExpression || false
+			}
+
+			this.#combinedStyle = {
+				...this.#combinedStyle,
+				...prunedValue,
+			}
+
+			// Push the imageBuffer into an array
+			if (rawValue.imageBuffer) {
+				this.#combinedStyle.imageBuffers.push({
+					...rawValue.imageBufferPosition,
+					...rawValue.imageBufferEncoding,
+					buffer: rawValue.imageBuffer,
+				})
+			}
+		}
+	}
+}

--- a/companion/lib/Controls/Fragments/FragmentFeedbackInstance.ts
+++ b/companion/lib/Controls/Fragments/FragmentFeedbackInstance.ts
@@ -48,6 +48,10 @@ export class FragmentFeedbackInstance {
 		return !!this.#data.disabled
 	}
 
+	get feedbackId(): string {
+		return this.#data.type
+	}
+
 	/**
 	 * Get the id of the connection this feedback belongs to
 	 */
@@ -183,7 +187,6 @@ export class FragmentFeedbackInstance {
 		if (this.#data.disabled) return false
 
 		const definition = this.getDefinition()
-		if (!definition || definition.type !== 'boolean') return false
 
 		// Special case to handle the internal 'logic' operators, which need to be executed live
 		if (this.connectionId === 'internal' && this.#data.type.startsWith('logic_')) {
@@ -192,6 +195,8 @@ export class FragmentFeedbackInstance {
 
 			return this.#internalModule.executeLogicFeedback(this.asFeedbackInstance(), childValues)
 		}
+
+		if (!definition || definition.type !== 'boolean') return false
 
 		if (typeof this.#cachedValue === 'boolean') {
 			if (definition.showInvert && this.#data.isInverted) return !this.#cachedValue
@@ -550,6 +555,13 @@ export class FragmentFeedbackInstance {
 		}
 
 		return feedbacks
+	}
+
+	/**
+	 * Recursively get all the feedbacks
+	 */
+	getChildrenOfGroup(groupId: FeedbackChildGroup): FragmentFeedbackInstance[] {
+		return this.#children.get(groupId)?.getFeedbacks() ?? []
 	}
 
 	/**

--- a/companion/lib/Controls/Fragments/FragmentFeedbackInstance.ts
+++ b/companion/lib/Controls/Fragments/FragmentFeedbackInstance.ts
@@ -28,7 +28,7 @@ export class FragmentFeedbackInstance {
 	 */
 	readonly #controlId: string
 
-	readonly #data: Omit<FeedbackInstance, 'children'>
+	readonly #data: Omit<FeedbackInstance, 'children' | 'advancedChildren'>
 
 	#children = new Map<FeedbackChildGroup, FragmentFeedbackList>()
 

--- a/companion/lib/Controls/Fragments/FragmentFeedbacks.ts
+++ b/companion/lib/Controls/Fragments/FragmentFeedbacks.ts
@@ -424,7 +424,7 @@ export class FragmentFeedbacks {
 	 * Get all the feedback instances
 	 * @param onlyConnectionId Optionally, only for a specific connection
 	 */
-	getFlattenedFeedbackInstances(onlyConnectionId?: string): Omit<FeedbackInstance, 'children'>[] {
+	getFlattenedFeedbackInstances(onlyConnectionId?: string): Omit<FeedbackInstance, 'children' | 'advancedChildren'>[] {
 		const instances: FeedbackInstance[] = []
 
 		const extractInstances = (feedbacks: FeedbackInstance[]) => {
@@ -433,12 +433,12 @@ export class FragmentFeedbacks {
 					instances.push({
 						...feedback,
 						children: undefined,
+						advancedChildren: undefined,
 					})
 				}
 
-				if (feedback.children) {
-					extractInstances(feedback.children)
-				}
+				if (feedback.children) extractInstances(feedback.children)
+				if (feedback.advancedChildren) extractInstances(feedback.advancedChildren)
 			}
 		}
 

--- a/companion/lib/Controls/Fragments/FragmentFeedbacks.ts
+++ b/companion/lib/Controls/Fragments/FragmentFeedbacks.ts
@@ -7,6 +7,7 @@ import type { InstanceDefinitions } from '../../Instance/Definitions.js'
 import type { InternalController } from '../../Internal/Controller.js'
 import type { ModuleHost } from '../../Instance/Host.js'
 import type { FeedbackInstance, FeedbackOwner } from '@companion-app/shared/Model/FeedbackModel.js'
+import { FeedbackStyleBuilder } from './FeedbackStyleBuilder.js'
 
 /**
  * Helper for ControlTypes with feedbacks
@@ -451,7 +452,9 @@ export class FragmentFeedbacks {
 	 * Note: Does not clone the style
 	 */
 	getUnparsedStyle(): UnparsedButtonStyle {
-		return this.#feedbacks.getUnparsedStyle(this.baseStyle)
+		const styleBuilder = new FeedbackStyleBuilder(this.baseStyle)
+		this.#feedbacks.buildStyle(styleBuilder)
+		return styleBuilder.style
 	}
 
 	/**

--- a/companion/lib/ImportExport/Controller.ts
+++ b/companion/lib/ImportExport/Controller.ts
@@ -1182,6 +1182,10 @@ function fixupFeedbacksRecursive(instanceIdMap: InstanceAppliedRemappings, feedb
 					feedback.instance_id === 'internal' && feedback.children
 						? fixupFeedbacksRecursive(instanceIdMap, feedback.children)
 						: undefined,
+				advancedChildren:
+					feedback.instance_id === 'internal' && feedback.advancedChildren
+						? fixupFeedbacksRecursive(instanceIdMap, feedback.advancedChildren)
+						: undefined,
 			})
 		}
 	}

--- a/companion/lib/Internal/BuildingBlocks.ts
+++ b/companion/lib/Internal/BuildingBlocks.ts
@@ -85,7 +85,7 @@ export class InternalBuildingBlocks implements InternalModuleFragment {
 				learnTimeout: undefined,
 				supportsChildFeedbacks: true,
 			},
-			conditionalise_advanced: {
+			logic_conditionalise_advanced: {
 				type: 'advanced',
 				label: 'Conditionalise existing feedbacks',
 				description: "Make 'advanced' feedbacks conditional",
@@ -147,7 +147,7 @@ export class InternalBuildingBlocks implements InternalModuleFragment {
 	 * Execute a logic feedback
 	 */
 	executeLogicFeedback(feedback: FeedbackInstance, childValues: boolean[]): boolean {
-		if (feedback.type === 'logic_and') {
+		if (feedback.type === 'logic_and' || feedback.type === 'logic_conditionalise_advanced') {
 			if (childValues.length === 0) return !!feedback.isInverted
 
 			return childValues.reduce((acc, val) => acc && val, true) === !feedback.isInverted
@@ -156,9 +156,6 @@ export class InternalBuildingBlocks implements InternalModuleFragment {
 		} else if (feedback.type === 'logic_xor') {
 			const isSingleTrue = childValues.reduce((acc, val) => acc + (val ? 1 : 0), 0) === 1
 			return isSingleTrue === !feedback.isInverted
-		} else if (feedback.type === 'conditionalise_advanced') {
-			console.log('TODO', feedback)
-			return false
 		} else {
 			this.#logger.warn(`Unexpected logic feedback type "${feedback.type}"`)
 			return false

--- a/companion/lib/Internal/BuildingBlocks.ts
+++ b/companion/lib/Internal/BuildingBlocks.ts
@@ -85,6 +85,18 @@ export class InternalBuildingBlocks implements InternalModuleFragment {
 				learnTimeout: undefined,
 				supportsChildFeedbacks: true,
 			},
+			conditionalise_advanced: {
+				type: 'advanced',
+				label: 'Conditionalise existing feedbacks',
+				description: "Make 'advanced' feedbacks conditional",
+				style: undefined,
+				showInvert: false,
+				options: [],
+				hasLearn: false,
+				learnTimeout: undefined,
+				supportsChildFeedbacks: true,
+				supportsAdvancedChildFeedbacks: true,
+			},
 		}
 	}
 
@@ -144,6 +156,9 @@ export class InternalBuildingBlocks implements InternalModuleFragment {
 		} else if (feedback.type === 'logic_xor') {
 			const isSingleTrue = childValues.reduce((acc, val) => acc + (val ? 1 : 0), 0) === 1
 			return isSingleTrue === !feedback.isInverted
+		} else if (feedback.type === 'conditionalise_advanced') {
+			console.log('TODO', feedback)
+			return false
 		} else {
 			this.#logger.warn(`Unexpected logic feedback type "${feedback.type}"`)
 			return false

--- a/companion/lib/Internal/Controller.ts
+++ b/companion/lib/Internal/Controller.ts
@@ -438,6 +438,7 @@ export class InternalController {
 
 						showButtonPreview: feedback.showButtonPreview ?? false,
 						supportsChildFeedbacks: feedback.supportsChildFeedbacks ?? false,
+						supportsAdvancedChildFeedbacks: feedback.supportsAdvancedChildFeedbacks ?? false,
 					}
 				}
 			}

--- a/companion/lib/Internal/Types.ts
+++ b/companion/lib/Internal/Types.ts
@@ -82,5 +82,5 @@ export type InternalActionDefinition = SetOptional<
 
 export type InternalFeedbackDefinition = SetOptional<
 	FeedbackDefinition,
-	'hasLearn' | 'learnTimeout' | 'showButtonPreview' | 'supportsChildFeedbacks'
+	'hasLearn' | 'learnTimeout' | 'showButtonPreview' | 'supportsChildFeedbacks' | 'supportsAdvancedChildFeedbacks'
 >

--- a/shared-lib/lib/Model/FeedbackDefinitionModel.ts
+++ b/shared-lib/lib/Model/FeedbackDefinitionModel.ts
@@ -14,6 +14,7 @@ export interface FeedbackDefinition {
 
 	showButtonPreview: boolean
 	supportsChildFeedbacks: boolean
+	supportsAdvancedChildFeedbacks: boolean
 }
 
 export type ClientFeedbackDefinition = FeedbackDefinition

--- a/shared-lib/lib/Model/FeedbackModel.ts
+++ b/shared-lib/lib/Model/FeedbackModel.ts
@@ -12,4 +12,12 @@ export interface FeedbackInstance {
 	style?: Partial<ButtonStyleProperties>
 
 	children?: FeedbackInstance[]
+	advancedChildren?: FeedbackInstance[]
+}
+
+export type FeedbackChildGroup = 'children' | 'advancedChildren'
+
+export interface FeedbackOwner {
+	parentFeedbackId: string
+	childGroup: FeedbackChildGroup
 }

--- a/shared-lib/lib/SocketIO.ts
+++ b/shared-lib/lib/SocketIO.ts
@@ -45,6 +45,7 @@ import type { CloudControllerState, CloudRegionState } from './Model/Cloud.js'
 import type { ModuleInfoUpdate, ModuleDisplayInfo } from './Model/ModuleInfo.js'
 import type { ClientConnectionsUpdate, ClientConnectionConfig } from './Model/Connections.js'
 import type { ActionOwner, ActionSetId } from './Model/ActionModel.js'
+import type { FeedbackOwner } from './Model/FeedbackModel.js'
 
 export interface ClientToBackendEventsMap {
 	disconnect: () => never // Hack because type is missing
@@ -121,12 +122,12 @@ export interface ClientToBackendEventsMap {
 	'controls:feedback:move': (
 		controlId: string,
 		dragFeedbackId: string,
-		hoverParentId: string | null,
+		hoverOwnerId: FeedbackOwner | null,
 		hoverIndex: number
 	) => boolean
 	'controls:feedback:add': (
 		controlId: string,
-		parentId: string | null,
+		ownerId: FeedbackOwner | null,
 		connectionId: string,
 		feedbackType: string
 	) => boolean

--- a/webui/src/Buttons/EditButton.tsx
+++ b/webui/src/Buttons/EditButton.tsx
@@ -559,7 +559,7 @@ function TabsSection({ style, controlId, location, steps, runtimeProps, rotaryAc
 								controlId={controlId}
 								feedbacks={feedbacks}
 								location={location}
-								booleanOnly={false}
+								onlyType={null}
 								addPlaceholder="+ Add feedback"
 							/>
 						</MyErrorBoundary>

--- a/webui/src/Controls/AddModal.tsx
+++ b/webui/src/Controls/AddModal.tsx
@@ -80,6 +80,7 @@ export const AddActionsModal = observer(
 							key={connectionId}
 							connectionId={connectionId}
 							items={actions}
+							onlyType={null}
 							itemName="actions"
 							expanded={!!filter || expanded[connectionId]}
 							filter={filter}
@@ -100,7 +101,7 @@ export const AddActionsModal = observer(
 
 interface AddFeedbacksModalProps {
 	addFeedback: (feedbackType: string) => void
-	booleanOnly: boolean
+	onlyType: 'boolean' | 'advanced' | null
 	entityType: string
 }
 export interface AddFeedbacksModalRef {
@@ -109,7 +110,7 @@ export interface AddFeedbacksModalRef {
 
 export const AddFeedbacksModal = observer(
 	forwardRef<AddFeedbacksModalRef, AddFeedbacksModalProps>(function AddFeedbacksModal(
-		{ addFeedback, booleanOnly, entityType },
+		{ addFeedback, onlyType, entityType },
 		ref
 	) {
 		const { feedbackDefinitions, recentlyAddedFeedbacks } = useContext(RootAppStoreContext)
@@ -175,7 +176,7 @@ export const AddFeedbacksModal = observer(
 							itemName="feedbacks"
 							expanded={!!filter || expanded[connectionId]}
 							filter={filter}
-							booleanOnly={booleanOnly}
+							onlyType={onlyType}
 							doToggle={toggleExpanded}
 							doAdd={addFeedback2}
 						/>
@@ -205,7 +206,7 @@ interface ConnectionCollapseProps<TDef> {
 	itemName: string
 	expanded: boolean
 	filter: string
-	booleanOnly?: boolean
+	onlyType: string | null
 	doToggle: (connectionId: string) => void
 	doAdd: (itemId: string) => void
 }
@@ -216,7 +217,7 @@ const ConnectionCollapse = observer(function ConnectionCollapse<TDef extends TDe
 	itemName,
 	expanded,
 	filter,
-	booleanOnly,
+	onlyType,
 	doToggle,
 	doAdd,
 }: ConnectionCollapseProps<TDef>) {
@@ -231,7 +232,8 @@ const ConnectionCollapse = observer(function ConnectionCollapse<TDef extends TDe
 
 		return Array.from(items.entries())
 			.map(([id, info]) => {
-				if (!info || !info.label || (booleanOnly && (!('type' in info) || info.type !== 'boolean'))) return null
+				if (!info || !info.label) return null
+				if (onlyType && (!('type' in info) || info.type !== onlyType)) return null
 
 				return {
 					fullId: `${connectionId}:${id}`,
@@ -240,7 +242,7 @@ const ConnectionCollapse = observer(function ConnectionCollapse<TDef extends TDe
 				}
 			})
 			.filter((v): v is ConnectionItem => !!v)
-	}, [items, booleanOnly])
+	}, [items, onlyType])
 
 	const searchResults = filter
 		? fuzzySearch(filter, allValues, {

--- a/webui/src/Controls/FeedbackEditor.tsx
+++ b/webui/src/Controls/FeedbackEditor.tsx
@@ -7,6 +7,7 @@ import {
 	faCopy,
 	faFolderOpen,
 	faPencil,
+	faQuestionCircle,
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import React, { useCallback, useContext, useMemo, useRef, useState } from 'react'
@@ -507,7 +508,17 @@ const FeedbackEditor = observer(function FeedbackEditor({
 							<CForm onSubmit={PreventDefaultHandler}>
 								<InlineFeedbacksEditor
 									controlId={controlId}
-									heading={feedbackSpec.supportsAdvancedChildFeedbacks ? 'Conditions' : null}
+									heading={
+										feedbackSpec.supportsAdvancedChildFeedbacks ? (
+											<>
+												Conditions&nbsp;
+												<FontAwesomeIcon
+													icon={faQuestionCircle}
+													title="This feedback will only execute when all of the conditions are true"
+												/>
+											</>
+										) : null
+									}
 									feedbacks={feedback.children ?? []}
 									entityType="condition"
 									onlyType={'boolean'}
@@ -521,10 +532,18 @@ const FeedbackEditor = observer(function FeedbackEditor({
 
 							{feedbackSpec.supportsAdvancedChildFeedbacks && (
 								<>
-									<CForm onSubmit={PreventDefaultHandler}>
+									<CForm onSubmit={PreventDefaultHandler} className="mt-2">
 										<InlineFeedbacksEditor
 											controlId={controlId}
-											heading={'Feedbacks'}
+											heading={
+												<>
+													Feedbacks&nbsp;
+													<FontAwesomeIcon
+														icon={faQuestionCircle}
+														title="These feedbacks will only be shown if the conditions above are met"
+													/>
+												</>
+											}
 											feedbacks={feedback.advancedChildren ?? []}
 											entityType="feedback"
 											onlyType={'advanced'}

--- a/webui/src/Services/Controls/ControlFeedbacksService.ts
+++ b/webui/src/Services/Controls/ControlFeedbacksService.ts
@@ -1,11 +1,11 @@
 import { useContext, useMemo, useRef } from 'react'
 import { SocketContext, socketEmitPromise } from '../../util.js'
-import { FeedbackInstance } from '@companion-app/shared/Model/FeedbackModel.js'
+import { FeedbackInstance, FeedbackOwner } from '@companion-app/shared/Model/FeedbackModel.js'
 import { GenericConfirmModalRef } from '../../Components/GenericConfirmModal.js'
 
 export interface IFeedbackEditorService {
-	addFeedback: (feedbackType: string, parentId: string | null) => void
-	moveCard: (dragId: string, hoverParentId: string | null, hoverIndex: number) => void
+	addFeedback: (feedbackType: string, ownerId: FeedbackOwner | null) => void
+	moveCard: (dragId: string, hoverOwnerId: FeedbackOwner | null, hoverIndex: number) => void
 
 	setValue: (feedbackId: string, feedback: FeedbackInstance | undefined, key: string, value: any) => void
 	setConnection: (feedbackId: string, connectionId: string | number) => void
@@ -41,22 +41,19 @@ export function useControlFeedbacksEditorService(
 
 	return useMemo(
 		() => ({
-			addFeedback: (feedbackType: string, parentId: string | null) => {
+			addFeedback: (feedbackType: string, ownerId: FeedbackOwner | null) => {
 				const [connectionId, feedbackId] = feedbackType.split(':', 2)
-				socketEmitPromise(socket, 'controls:feedback:add', [
-					controlId,
-					parentId ? { parentFeedbackId: parentId, childGroup: 'children' } : null,
-					connectionId,
-					feedbackId,
-				]).catch((e) => {
-					console.error('Failed to add control feedback', e)
-				})
+				socketEmitPromise(socket, 'controls:feedback:add', [controlId, ownerId, connectionId, feedbackId]).catch(
+					(e) => {
+						console.error('Failed to add control feedback', e)
+					}
+				)
 			},
-			moveCard: (dragFeedbackId: string, hoverParentId: string | null, hoverIndex: number) => {
+			moveCard: (dragFeedbackId: string, hoverOwnerId: FeedbackOwner | null, hoverIndex: number) => {
 				socketEmitPromise(socket, 'controls:feedback:move', [
 					controlId,
 					dragFeedbackId,
-					hoverParentId ? { parentFeedbackId: hoverParentId, childGroup: 'children' } : null,
+					hoverOwnerId,
 					hoverIndex,
 				]).catch((e) => {
 					console.error(`Move failed: ${e}`)

--- a/webui/src/Services/Controls/ControlFeedbacksService.ts
+++ b/webui/src/Services/Controls/ControlFeedbacksService.ts
@@ -43,17 +43,20 @@ export function useControlFeedbacksEditorService(
 		() => ({
 			addFeedback: (feedbackType: string, parentId: string | null) => {
 				const [connectionId, feedbackId] = feedbackType.split(':', 2)
-				socketEmitPromise(socket, 'controls:feedback:add', [controlId, parentId, connectionId, feedbackId]).catch(
-					(e) => {
-						console.error('Failed to add control feedback', e)
-					}
-				)
+				socketEmitPromise(socket, 'controls:feedback:add', [
+					controlId,
+					parentId ? { parentFeedbackId: parentId, childGroup: 'children' } : null,
+					connectionId,
+					feedbackId,
+				]).catch((e) => {
+					console.error('Failed to add control feedback', e)
+				})
 			},
 			moveCard: (dragFeedbackId: string, hoverParentId: string | null, hoverIndex: number) => {
 				socketEmitPromise(socket, 'controls:feedback:move', [
 					controlId,
 					dragFeedbackId,
-					hoverParentId,
+					hoverParentId ? { parentFeedbackId: hoverParentId, childGroup: 'children' } : null,
 					hoverIndex,
 				]).catch((e) => {
 					console.error(`Move failed: ${e}`)

--- a/webui/src/Triggers/EditPanel.tsx
+++ b/webui/src/Triggers/EditPanel.tsx
@@ -152,7 +152,7 @@ export function EditTriggerPanel({ controlId }: EditTriggerPanelProps) {
 									entityType="condition"
 									controlId={controlId}
 									feedbacks={config.condition}
-									booleanOnly={true}
+									onlyType={'boolean'}
 									location={undefined}
 									addPlaceholder="+ Add condition"
 								/>


### PR DESCRIPTION
Extends the work from #2947 so that it can be used in combination with 'advanced' feedbacks from modules.

Resolves #2800 

![image](https://github.com/user-attachments/assets/0fd1511a-50a0-4a73-aa28-14ae9e7ab192)

This is a semi hardcoded to there being 'children' and 'advancedChildren' for internal feedbacks, with other parts of the implementation being generic. I don't feel like this is worth unifying into a truely generic implementation at this time, most of the effort in doing so is the execution (which has to be specific to this feedback) and fixing up existing configs (as that would require changing the structure of the 'children' property added in #2947)
