### PR TITLE
fix: Also escape backslashes in the Content-Disposition legacy filename parameter

### DIFF
--- a/companion/lib/ImportExport/Controller.ts
+++ b/companion/lib/ImportExport/Controller.ts
@@ -109,7 +109,7 @@ function attachmentWithFilename(filename: string): string {
 			'"' +
 			[...s.normalize('NFKD')]
 				.filter((c) => '\x20' <= c && c <= '\x7e')
-				.map((c) => (c === '"' ? '\\"' : c))
+				.map((c) => (c === '"' || c === '\\' ? '\\' : '') + c)
 				.join('') +
 			'"'
 		)


### PR DESCRIPTION
I was rereading the landed commit and noticed I wasn't escaping backslashes.  :neutral_face:  The effect of not doing so seems to be fairly minimal -- this is a "trusted" input from the user so they could only mess with themselves -- but still, worth getting it right.