### PR TITLE
feat!: remove support for legacy xkeys layouts

### DIFF
--- a/companion/lib/Data/UserConfig.ts
+++ b/companion/lib/Data/UserConfig.ts
@@ -38,7 +38,6 @@ export class DataUserConfig extends CoreBase {
 		remove_topbar: false,
 
 		xkeys_enable: true,
-		xkeys_legacy_layout: false,
 		elgato_plugin_enable: false, // Also disables local streamdeck
 		usb_hotplug: true,
 		loupedeck_enable: false,

--- a/companion/lib/Surface/Controller.ts
+++ b/companion/lib/Surface/Controller.ts
@@ -907,14 +907,7 @@ export class SurfaceController extends EventEmitter<SurfaceControllerEvents> {
 										}
 									} else if (deviceInfo.vendorId === 1523 && deviceInfo.interface === 0) {
 										if (this.#handlerDependencies.userconfig.getKey('xkeys_enable')) {
-											await this.#addDevice(
-												deviceInfo.path,
-												{
-													useLegacyLayout: !!this.#handlerDependencies.userconfig.getKey('xkeys_legacy_layout'),
-												},
-												'xkeys',
-												SurfaceUSBXKeys
-											)
+											await this.#addDevice(deviceInfo.path, {}, 'xkeys', SurfaceUSBXKeys)
 										}
 									} else if (
 										deviceInfo.vendorId === shuttleControlUSB.vids.CONTOUR &&

--- a/companion/lib/Surface/Types.ts
+++ b/companion/lib/Surface/Types.ts
@@ -19,7 +19,6 @@ export type SurfacePanelFactory = {
 
 export interface LocalUSBDeviceOptions {
 	executeExpression: SurfaceExecuteExpressionFn
-	useLegacyLayout?: boolean
 }
 
 export type SurfaceExecuteExpressionFn = (
@@ -44,7 +43,6 @@ export interface SurfacePanel extends EventEmitter<SurfacePanelEvents> {
 	clearDeck(): void
 	draw(x: number, y: number, render: ImageResult): void
 	drawMany?: (entries: DrawButtonItem[]) => void
-	drawColor?: (pageOffset: number, x: number, y: number, color: number) => void
 	setConfig(config: any, force?: boolean): void
 	getDefaultConfig?: () => any
 	onVariablesChanged?: (allChangedVariables: Set<string>) => void
@@ -62,15 +60,12 @@ export interface SurfacePanelEvents {
 	error: [error: Error]
 
 	click: [x: number, y: number, pressed: boolean, pageOffset?: number]
-	rotate: [x: number, y: number, direction: boolean]
+	rotate: [x: number, y: number, direction: boolean, pageOffset?: number]
 
 	setVariable: [variableId: string, value: CompanionVariableValue]
 	setCustomVariable: [variableId: string, value: CompanionVariableValue]
 
 	resized: []
-
-	/** @deprecated */
-	'xkeys-subscribePage': [pageCount: number]
 }
 
 export interface SurfaceHandlerDependencies {

--- a/shared-lib/lib/Model/UserConfigModel.ts
+++ b/shared-lib/lib/Model/UserConfigModel.ts
@@ -6,7 +6,6 @@ export interface UserConfigModel {
 	remove_topbar: boolean
 
 	xkeys_enable: boolean
-	xkeys_legacy_layout: boolean
 	elgato_plugin_enable: boolean // Also disables local streamdeck
 	usb_hotplug: boolean
 	loupedeck_enable: boolean

--- a/webui/src/UserConfig/Sections/SurfacesConfig.tsx
+++ b/webui/src/UserConfig/Sections/SurfacesConfig.tsx
@@ -38,12 +38,6 @@ export const SurfacesConfig = observer(function SurfacesConfig(props: UserConfig
 			<UserConfigSwitchRow userConfig={props} label="Enable connected X-keys" requiresRestart field="xkeys_enable" />
 			<UserConfigSwitchRow
 				userConfig={props}
-				label="Use old layout for X-keys"
-				requiresRestart
-				field="xkeys_legacy_layout"
-			/>
-			<UserConfigSwitchRow
-				userConfig={props}
 				label="Enable connected Loupedeck and Razer Stream Controller devices"
 				requiresRestart
 				field="loupedeck_enable"


### PR DESCRIPTION
This is a breaking change, removing support for the old xkeys compatibility layouts.

The new 'accurate' layouts have been the default since 3.2, so hopefully this won't impact many users

TBD whether this will happen soon or be put off until it becomes necessary