### PR TITLE
feat: Improve set variable performance

### DIFF
--- a/companion/lib/Instance/Wrapper.ts
+++ b/companion/lib/Instance/Wrapper.ts
@@ -698,9 +698,14 @@ export class SocketEventsHandler {
 	async #handleSetVariableValues(msg: SetVariableValuesMessage): Promise<void> {
 		if (!this.#label) throw new Error(`Got call to handleSetVariableValues before init was called`)
 
-		const variables: Record<string, CompanionVariableValue | undefined> = {}
-		for (const variable of msg.newValues) {
-			variables[variable.id] = variable.value
+		let variables: Record<string, CompanionVariableValue | undefined> = {}
+
+		if (msg.newValues instanceof Array) {
+			for (const variable of msg.newValues) {
+				variables[variable.id] = variable.value
+			}
+		} else {
+			variables = msg.newValues
 		}
 
 		this.#deps.variables.values.setVariableValues(this.#label, variables)


### PR DESCRIPTION
Part of a set of changes (the other being to companion-module-base) to improve the performance of modules setting variables.

Currently, modules set variable values as an Object of key/value pairs, such as `{ someVariableId: 'variableValue' }`, but the companion-module-base transforms this into an array such as `[{ variableId: 'someVariableId, value: 'variableValue' }]`, and then after being sent from the child process to Companion it has to be transformed into `{ someVariableId: 'variableValue' }` again. This iteration over the variables adds avoidable overhead.

A simple test I set up to generate an arrays of set amounts of variables took this long to transform to an object:
1,000 variables: 0.2ms
10,000 variables: 1.8344ms
100,00 variables: 23.3069ms
1,000,000 variables: 148.7271ms

Compared to if the object sent by the instance was already an object
1,000 variables: 0.0024ms
10,000 variables: 0.0006ms
100,000 variables: 0.0006ms
1,000,000 variables: 0.0014ms

This PR should be fully backwards compatible, so all existing modules would continue to send arrays of variables and need to be transformed, but any module that updates their companion module base (with a PR that will be coming shortly), it would be sending an object and bypass the transforming completely.