### PR TITLE
feat: Allow custom variables' descriptions to be edited

### DIFF
--- a/companion/lib/Variables/CustomVariable.ts
+++ b/companion/lib/Variables/CustomVariable.ts
@@ -68,8 +68,25 @@ export class VariablesCustomVariable {
 		client.onPromise('custom-variables:delete', this.deleteVariable.bind(this))
 		client.onPromise('custom-variables:set-default', this.setVariableDefaultValue.bind(this))
 		client.onPromise('custom-variables:set-current', this.setValue.bind(this))
+		client.onPromise('custom-variables:set-description', this.setVariableDescription.bind(this))
 		client.onPromise('custom-variables:set-persistence', this.setPersistence.bind(this))
 		client.onPromise('custom-variables:set-order', this.setOrder.bind(this))
+	}
+
+	/**
+	 * Emit to any room members an update of the named variable
+	 * @param name
+	 */
+	#emitUpdateOneVariable(name: string): void {
+		if (this.#io.countRoomMembers(CustomVariablesRoom) > 0) {
+			this.#io.emitToRoom(CustomVariablesRoom, 'custom-variables:update', [
+				{
+					type: 'update',
+					itemId: name,
+					info: this.#custom_variables[name],
+				},
+			])
+		}
 	}
 
 	/**
@@ -102,15 +119,7 @@ export class VariablesCustomVariable {
 
 		this.#doSave()
 
-		if (this.#io.countRoomMembers(CustomVariablesRoom) > 0) {
-			this.#io.emitToRoom(CustomVariablesRoom, 'custom-variables:update', [
-				{
-					type: 'update',
-					itemId: name,
-					info: this.#custom_variables[name],
-				},
-			])
-		}
+		this.#emitUpdateOneVariable(name)
 
 		this.#setValueInner(name, defaultVal)
 
@@ -264,15 +273,7 @@ export class VariablesCustomVariable {
 
 		this.#doSave()
 
-		if (this.#io.countRoomMembers(CustomVariablesRoom) > 0) {
-			this.#io.emitToRoom(CustomVariablesRoom, 'custom-variables:update', [
-				{
-					type: 'update',
-					itemId: name,
-					info: this.#custom_variables[name],
-				},
-			])
-		}
+		this.#emitUpdateOneVariable(name)
 
 		return null
 	}
@@ -365,6 +366,26 @@ export class VariablesCustomVariable {
 	}
 
 	/**
+	 * Set the description of a custom variable
+	 * @param name
+	 * @param description
+	 * @returns Failure reason, if any
+	 */
+	setVariableDescription(name: string, description: string): string | null {
+		if (!this.#custom_variables[name]) {
+			return 'Unknown name'
+		}
+
+		this.#custom_variables[name].description = description
+
+		this.#doSave()
+
+		this.#emitUpdateOneVariable(name)
+
+		return null
+	}
+
+	/**
 	 * Reset a custom variable to the default value
 	 */
 	resetValueToDefault(name: string): void {
@@ -386,15 +407,7 @@ export class VariablesCustomVariable {
 
 			this.#doSave()
 
-			if (this.#io.countRoomMembers(CustomVariablesRoom) > 0) {
-				this.#io.emitToRoom(CustomVariablesRoom, 'custom-variables:update', [
-					{
-						type: 'update',
-						itemId: name,
-						info: this.#custom_variables[name],
-					},
-				])
-			}
+			this.#emitUpdateOneVariable(name)
 		}
 	}
 
@@ -413,15 +426,7 @@ export class VariablesCustomVariable {
 
 		this.#doSave()
 
-		if (this.#io.countRoomMembers(CustomVariablesRoom) > 0) {
-			this.#io.emitToRoom(CustomVariablesRoom, 'custom-variables:update', [
-				{
-					type: 'update',
-					itemId: name,
-					info: this.#custom_variables[name],
-				},
-			])
-		}
+		this.#emitUpdateOneVariable(name)
 
 		return null
 	}
@@ -435,15 +440,7 @@ export class VariablesCustomVariable {
 
 			this.#doSave()
 
-			if (this.#io.countRoomMembers(CustomVariablesRoom) > 0) {
-				this.#io.emitToRoom(CustomVariablesRoom, 'custom-variables:update', [
-					{
-						type: 'update',
-						itemId: name,
-						info: this.#custom_variables[name],
-					},
-				])
-			}
+			this.#emitUpdateOneVariable(name)
 		}
 	}
 }

--- a/shared-lib/lib/SocketIO.ts
+++ b/shared-lib/lib/SocketIO.ts
@@ -74,6 +74,7 @@ export interface ClientToBackendEventsMap {
 	'custom-variables:create': (name: string, value: string) => string | null
 	'custom-variables:set-default': (name: string, value: string) => string | null
 	'custom-variables:set-current': (name: string, value: string) => string | null
+	'custom-variables:set-description': (name: string, description: string) => string | null
 	'custom-variables:set-persistence': (name: string, value: boolean) => string | null
 	'custom-variables:delete': (name: string) => void
 	'custom-variables:set-order': (newNames: string[]) => void

--- a/webui/src/Variables/CustomVariablesList.tsx
+++ b/webui/src/Variables/CustomVariablesList.tsx
@@ -117,6 +117,15 @@ export const CustomVariablesListPage = observer(function CustomVariablesList() {
 		[socket]
 	)
 
+	const setDescription = useCallback(
+		(name: string, description: string) => {
+			socket.emitPromise('custom-variables:set-description', [name, description]).catch(() => {
+				console.error('Failed to update variable description')
+			})
+		},
+		[socket]
+	)
+
 	const confirmRef = useRef<GenericConfirmModalRef>(null)
 	const doDelete = useCallback(
 		(name: string) => {
@@ -261,10 +270,12 @@ export const CustomVariablesListPage = observer(function CustomVariablesList() {
 									key={info.name}
 									index={index}
 									name={info.name}
+									description={info.description}
 									value={variableValues[info.name]}
 									info={info}
 									onCopied={onCopied}
 									doDelete={doDelete}
+									setDescription={setDescription}
 									setStartupValue={setStartupValue}
 									setCurrentValue={setCurrentValue}
 									setPersistenceValue={setPersistenceValue}
@@ -316,10 +327,12 @@ interface CustomVariableDragStatus {
 interface CustomVariableRowProps {
 	index: number
 	name: string
+	description: string
 	value: any
 	info: CustomVariableDefinitionExt
 	onCopied: () => void
 	doDelete: (name: string) => void
+	setDescription: (name: string, value: string) => void
 	setStartupValue: (name: string, value: any) => void
 	setCurrentValue: (name: string, value: any) => void
 	setPersistenceValue: (name: string, persisted: boolean) => void
@@ -330,10 +343,12 @@ interface CustomVariableRowProps {
 function CustomVariableRow({
 	index,
 	name,
+	description,
 	value,
 	info,
 	onCopied,
 	doDelete,
+	setDescription,
 	setStartupValue,
 	setCurrentValue,
 	setPersistenceValue,
@@ -450,7 +465,11 @@ function CustomVariableRow({
 							</CButtonGroup>
 						</div>
 					</div>
-					{!isCollapsed && (
+					{isCollapsed ? (
+						<>
+							<div className="variable-description">{description}</div>
+						</>
+					) : (
 						<>
 							<CForm onSubmit={PreventDefaultHandler} className="cell-fields">
 								<div>
@@ -463,6 +482,17 @@ function CustomVariableRow({
 									/>
 								</div>
 								<CRow>
+									<CFormLabel htmlFor="colFormDescription" className="col-sm-3 align-right">
+										Description:
+									</CFormLabel>
+									<CCol sm={9}>
+										<TextInputField
+											value={description}
+											setValue={(description) => setDescription(name, description)}
+											style={{ marginBottom: '0.5rem' }}
+										/>
+									</CCol>
+
 									<CFormLabel htmlFor="colFormCurrentValue" className="col-sm-3 align-right">
 										Current value:
 									</CFormLabel>

--- a/webui/src/scss/_instances.scss
+++ b/webui/src/scss/_instances.scss
@@ -116,6 +116,10 @@
 		opacity: 0.5;
 	}
 
+	.variable-description {
+		padding: 1px 3px 1px;
+	}
+
 	.editor-grid {
 		.cell-header {
 			grid-column: 1/4;


### PR DESCRIPTION
For the most part this was driven by finding the UI that needed changing, then following the TypeScript breadcrumbs.  I mostly stomped around here.  :slightly_smiling_face:

My webdev knowledge is dated enough to not include CSS Grid beyond starting an MDN read , so I largely worked around it by shunting the collapsed description to its own line (`.variable-description` exists to sync with `.variable-style` in [`App.scss`](https://github.com/bitfocus/companion/blob/25912fab53986a5305e450507ce09f89776cad92/webui/src/App.scss#L133)), rather than trying to wedge it somewhere into the top line.  One could _argue_ for doing the table the way it's done for module variables which uses a table.  But I was trying to do the relatively least change I could to get something half-suitable.  (Honestly, freed of resource constraints I'd argue for unifying the variables table and custom variables list UI code to get shared structure/styling, but that shouldn't be done in a feature.)

I note in passing that:

* The `htmlFor` attribute I used is copied (with appropriate change) from the adjacent entry lines.  And it is equally as dangling as those are.  (Given it's supposed to refer to a unique `id` attribute, I don't know how React handles referring to and generating `id` values.  The other alternative is placing the `TextInputField` _inside_ the `CFormLabel`, but that won't play with grid use.)
* The `grow` class on the collapsed variable value `<div>` is meaningless because it's a grid item, not a flex item.