### PR TITLE
Fix: entityType being passed to add entity modal

### DIFF
--- a/webui/src/Controls/Components/AddEntityPanel.tsx
+++ b/webui/src/Controls/Components/AddEntityPanel.tsx
@@ -50,7 +50,7 @@ export function AddEntityPanel({
 				<AddEntitiesModal
 					ref={addEntitiesRef}
 					addEntity={addEntity}
-					entityType={EntityModelType.Feedback}
+					entityType={entityType}
 					onlyFeedbackType={onlyFeedbackType}
 					entityTypeLabel={entityTypeLabel}
 				/>


### PR DESCRIPTION
Currently the `entityType` being passed to the model is static, and set to use the Feedback entityType, as a result when trying to add an Action (in any place that utilizes the modal, such as adding to a button or a trigger) it would only show the list of Feedbacks, which when clicked do nothing as the Feedback ID isn't an Action ID.

https://github.com/bitfocus/companion/blob/a94441784d6b3fe6b073a73eb44f504d8e921354/webui/src/Controls/Components/AddEntityPanel.tsx#L50-L56

This commit resolves this by just changing the `entityType` to the variable passed from the parent.
