### PR TITLE
feat: support nodejs permissions model

### DIFF
--- a/companion/lib/Instance/ApiVersions.ts
+++ b/companion/lib/Instance/ApiVersions.ts
@@ -1,0 +1,12 @@
+import semver, { SemVer } from 'semver'
+
+const range1_2_0OrLater = new semver.Range('>=1.2.0-0', { includePrerelease: true })
+const range1_12_0OrLater = new semver.Range('>=1.12.0-0', { includePrerelease: true })
+
+export function doesModuleExpectLabelUpdates(apiVersion: SemVer): boolean {
+	return range1_2_0OrLater.test(apiVersion)
+}
+
+export function doesModuleSupportPermissionsModel(apiVersion: string): boolean {
+	return range1_12_0OrLater.test(apiVersion)
+}

--- a/companion/lib/Instance/Host.ts
+++ b/companion/lib/Instance/Host.ts
@@ -6,7 +6,7 @@ import { InstanceModuleWrapperDependencies, SocketEventsHandler } from './Wrappe
 import fs from 'fs-extra'
 import ejson from 'ejson'
 import os from 'os'
-import { getNodeJsPath } from './NodePath.js'
+import { getNodeJsPath, getNodeJsPermissionArguments } from './NodePath.js'
 import { RespawnMonitor } from '@companion-app/shared/Respawn.js'
 import type { ConnectionConfig } from '@companion-app/shared/Model/Connections.js'
 import type { InstanceModules } from './Modules.js'
@@ -16,6 +16,9 @@ import type { ModuleVersionInfo } from './Types.js'
 import type { SomeEntityModel } from '@companion-app/shared/Model/EntityModel.js'
 import { CompanionOptionValues } from '@companion-module/base'
 import { Serializable } from 'child_process'
+import { createRequire } from 'module'
+
+const require = createRequire(import.meta.url)
 
 /**
  * A backoff sleep strategy
@@ -374,10 +377,24 @@ export class ModuleHost {
 							return
 						}
 
-						if (moduleInfo.isPackaged && !isModuleApiVersionCompatible(moduleInfo.manifest.runtime.apiVersion)) {
-							this.#logger.error(
-								`Module Api version is too new/old: "${connectionId}" ${moduleInfo.manifest.runtime.apiVersion}`
-							)
+						// Determine the module api version
+						let moduleApiVersion = moduleInfo.manifest.runtime.apiVersion
+						if (!moduleInfo.isPackaged) {
+							// When not packaged, lookup the version from the library itself
+							try {
+								const moduleLibPackagePath = require.resolve('@companion-module/base/package.json', {
+									paths: [moduleInfo.basePath],
+								})
+								const moduleLibPackage = require(moduleLibPackagePath)
+								moduleApiVersion = moduleLibPackage.version
+							} catch (e) {
+								this.#logger.error(`Failed to get module api version: "${connectionId}" ${e}`)
+								return
+							}
+						}
+
+						if (!isModuleApiVersionCompatible(moduleApiVersion)) {
+							this.#logger.error(`Module Api version is too new/old: "${connectionId}" ${moduleApiVersion}`)
 							return
 						}
 
@@ -412,6 +429,7 @@ export class ModuleHost {
 
 						const cmd: string[] = [
 							nodePath,
+							...getNodeJsPermissionArguments(moduleInfo.manifest, moduleApiVersion, moduleInfo.basePath),
 							inspectPort !== undefined ? `--inspect=${inspectPort}` : undefined,
 							jsPath,
 						].filter((v): v is string => !!v)
@@ -423,11 +441,6 @@ export class ModuleHost {
 								CONNECTION_ID: connectionId,
 								VERIFICATION_TOKEN: child.authToken,
 								MODULE_MANIFEST: 'companion/manifest.json',
-
-								// Provide sentry details
-								// SENTRY_DSN:
-								// SENTRY_USERID:
-								// SENTRY_COMPANION_VERSION:
 							},
 							maxRestarts: -1,
 							kill: 5000,

--- a/companion/lib/Instance/Wrapper.ts
+++ b/companion/lib/Instance/Wrapper.ts
@@ -54,8 +54,7 @@ import {
 import type { ClientEntityDefinition } from '@companion-app/shared/Model/EntityDefinitionModel.js'
 import type { Complete } from '@companion-module/base/dist/util.js'
 import type { RespawnMonitor } from '@companion-app/shared/Respawn.js'
-
-const range1_2_0OrLater = new semver.Range('>=1.2.0-0', { includePrerelease: true })
+import { doesModuleExpectLabelUpdates } from './ApiVersions.js'
 
 export interface InstanceModuleWrapperDependencies {
 	readonly controls: ControlsController
@@ -111,7 +110,7 @@ export class SocketEventsHandler {
 
 		this.connectionId = connectionId
 		this.#label = connectionId // Give a default label until init is called
-		this.#expectsLabelUpdates = range1_2_0OrLater.test(apiVersion)
+		this.#expectsLabelUpdates = doesModuleExpectLabelUpdates(apiVersion)
 
 		const funcs: IpcEventHandlers<ModuleToHostEventsV0> = {
 			'log-message': this.#handleLogMessage.bind(this),

--- a/companion/package.json
+++ b/companion/package.json
@@ -49,7 +49,7 @@
 	"dependencies": {
 		"@blackmagic-controller/node": "^0.1.1",
 		"@companion-app/shared": "*",
-		"@companion-module/base": "^1.12.0-0",
+		"@companion-module/base": "^1.12.0-2",
 		"@elgato-stream-deck/node": "^7.1.2",
 		"@elgato-stream-deck/tcp": "^7.1.2",
 		"@julusian/bonjour-service": "^1.3.0-2",

--- a/shared-lib/lib/ModuleApiVersionCheck.ts
+++ b/shared-lib/lib/ModuleApiVersionCheck.ts
@@ -1,6 +1,6 @@
 import semver from 'semver'
 
-const MODULE_BASE_VERSION = '1.12.0-0'
+const MODULE_BASE_VERSION = '1.12.0-2'
 
 const moduleVersion = semver.parse(MODULE_BASE_VERSION)
 if (!moduleVersion) throw new Error(`Failed to parse version as semver: ${MODULE_BASE_VERSION}`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1350,20 +1350,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@companion-module/base@npm:^1.12.0-0":
-  version: 1.12.0-0
-  resolution: "@companion-module/base@npm:1.12.0-0"
+"@companion-module/base@npm:^1.12.0-2":
+  version: 1.12.0-2
+  resolution: "@companion-module/base@npm:1.12.0-2"
   dependencies:
     ajv: "npm:^8.17.1"
     colord: "npm:^2.9.3"
     ejson: "npm:^2.2.3"
     eventemitter3: "npm:^5.0.1"
     mimic-fn: "npm:^3.1.0"
-    nanoid: "npm:^3.3.8"
+    nanoid: "npm:^3.3.11"
     p-queue: "npm:^6.6.2"
     p-timeout: "npm:^4.1.0"
     tslib: "npm:^2.8.1"
-  checksum: 10c0/fd4ddf657ba5cb41adbac4457476bf7b16e7df94fd72bf1f7b4c2fcf35bdce1da8b3fb0a72e4b2754ea7485c05b9629807aff62e4b88c2e17d9b1717330afa9b
+  checksum: 10c0/d0db97124ea182677ff9db215484eccc12be5f3667fb9a39b74b40d06a3d610c388b527fd1efff0400de13d4b59a884955bf324bdee7500e3dd28a2fe6b07112
   languageName: node
   linkType: hard
 
@@ -7037,7 +7037,7 @@ asn1@evs-broadcast/node-asn1:
   dependencies:
     "@blackmagic-controller/node": "npm:^0.1.1"
     "@companion-app/shared": "npm:*"
-    "@companion-module/base": "npm:^1.12.0-0"
+    "@companion-module/base": "npm:^1.12.0-2"
     "@elgato-stream-deck/node": "npm:^7.1.2"
     "@elgato-stream-deck/tcp": "npm:^7.1.2"
     "@julusian/bonjour-service": "npm:^1.3.0-2"
@@ -11680,12 +11680,12 @@ asn1@evs-broadcast/node-asn1:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.8":
-  version: 3.3.8
-  resolution: "nanoid@npm:3.3.8"
+"nanoid@npm:^3.3.11, nanoid@npm:^3.3.8":
+  version: 3.3.11
+  resolution: "nanoid@npm:3.3.11"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/4b1bb29f6cfebf3be3bc4ad1f1296fb0a10a3043a79f34fbffe75d1621b4318319211cd420549459018ea3592f0d2f159247a6f874911d6d26eaaadda2478120
+  checksum: 10c0/40e7f70b3d15f725ca072dfc4f74e81fcf1fbb02e491cf58ac0c79093adc9b0a73b152bcde57df4b79cd097e13023d7504acb38404a4da7bc1cd8e887b82fe0b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #3207

This enables the permissions model for modules running the module-api v1.12.0 and node22.
As such it is 'opt-in' per module, and so I do not think we need to class as a breaking change (although it may become 2.0.0, due to other changes coming soon to the api)

I have verified that these checks are also applied correctly when developing a module, so there shouldnt be any surprises when releasing a module.

Ideally we should also report these modules in the UI somewhere, but that can come later