### PR TITLE
feat: support new upgrade execution for modules

### DIFF
--- a/companion/lib/Controls/ActionRecorder.ts
+++ b/companion/lib/Controls/ActionRecorder.ts
@@ -346,6 +346,7 @@ export class ActionRecorder extends EventEmitter<ActionRecorderEvents> {
 					options: options,
 
 					uniquenessId,
+					upgradeIndex: undefined,
 				}
 				const delayAction: RecordActionEntityModel = {
 					type: EntityModelType.Action,
@@ -356,6 +357,7 @@ export class ActionRecorder extends EventEmitter<ActionRecorderEvents> {
 						time: delay,
 					},
 					uniquenessId: undefined,
+					upgradeIndex: undefined,
 				}
 
 				// Replace existing action with matching uniquenessId, or push to end of the list

--- a/companion/lib/Controls/ActionRecorder.ts
+++ b/companion/lib/Controls/ActionRecorder.ts
@@ -338,6 +338,8 @@ export class ActionRecorder extends EventEmitter<ActionRecorderEvents> {
 			const session = this.#currentSession
 
 			if (session.connectionIds.includes(connectionId)) {
+				const currentUpgradeIndex = this.#registry.instance.getInstanceConfig(connectionId)?.lastUpgradeIndex
+
 				const newAction: RecordActionEntityModel = {
 					type: EntityModelType.Action,
 					id: nanoid(),
@@ -346,7 +348,7 @@ export class ActionRecorder extends EventEmitter<ActionRecorderEvents> {
 					options: options,
 
 					uniquenessId,
-					upgradeIndex: undefined,
+					upgradeIndex: currentUpgradeIndex,
 				}
 				const delayAction: RecordActionEntityModel = {
 					type: EntityModelType.Action,

--- a/companion/lib/Controls/Entities/EntityInstance.ts
+++ b/companion/lib/Controls/Entities/EntityInstance.ts
@@ -568,6 +568,7 @@ export class ControlEntityInstance {
 	replaceProps(newProps: SomeReplaceableEntityModel, skipNotifyModule = false): void {
 		this.#data.definitionId = newProps.definitionId
 		this.#data.options = newProps.options
+		this.#data.upgradeIndex = newProps.upgradeIndex
 
 		if (this.#data.type === EntityModelType.Feedback) {
 			const feedbackData = this.#data as FeedbackEntityModel
@@ -575,8 +576,6 @@ export class ControlEntityInstance {
 			feedbackData.isInverted = !!newPropsData.isInverted
 			feedbackData.style = Object.keys(feedbackData.style || {}).length > 0 ? feedbackData.style : newPropsData.style
 		}
-
-		delete this.#data.upgradeIndex
 
 		if (!skipNotifyModule) {
 			this.subscribe(false)

--- a/companion/lib/Controls/Entities/EntityInstance.ts
+++ b/companion/lib/Controls/Entities/EntityInstance.ts
@@ -60,6 +60,10 @@ export class ControlEntityInstance {
 		return this.#data.type
 	}
 
+	get upgradeIndex(): number | undefined {
+		return this.#data.upgradeIndex
+	}
+
 	/**
 	 * Get the id of the connection this action belongs to
 	 */
@@ -213,7 +217,7 @@ export class ControlEntityInstance {
 			if (this.#data.connectionId === 'internal') {
 				this.#internalModule.entityUpdate(this.asEntityModel(), this.#controlId)
 			} else {
-				this.#moduleHost.connectionEntityUpdate(this.asEntityModel(), this.#controlId).catch((e) => {
+				this.#moduleHost.connectionEntityUpdate(this, this.#controlId).catch((e) => {
 					this.#logger.silly(`entityUpdate to connection "${this.connectionId}" failed: ${e.message} ${e.stack}`)
 				})
 			}
@@ -294,6 +298,16 @@ export class ControlEntityInstance {
 
 		// Inform relevant module
 		this.subscribe(false)
+	}
+
+	/**
+	 * Set the upgradeIndex for this entity or throw an error if it is already set
+	 */
+	setMissingUpgradeIndex(upgradeIndex: number): void {
+		if (this.#data.upgradeIndex !== undefined)
+			throw new Error(`Entity ${this.#data.id} already has an upgrade index set`)
+
+		this.#data.upgradeIndex = upgradeIndex
 	}
 
 	/**

--- a/companion/lib/Controls/Entities/EntityInstance.ts
+++ b/companion/lib/Controls/Entities/EntityInstance.ts
@@ -60,6 +60,13 @@ export class ControlEntityInstance {
 		return this.#data.type
 	}
 
+	/**
+	 * Get the upgrade index of this entity.
+	 * This _should_ always be defined now, but it may be msising for older entities
+	 *
+	 * Prior to 4.0, this was only stored for entities which were awaiting an upgrade.
+	 * Since 4.0, this should always be set.
+	 */
 	get upgradeIndex(): number | undefined {
 		return this.#data.upgradeIndex
 	}

--- a/companion/lib/Controls/Entities/EntityListPoolBase.ts
+++ b/companion/lib/Controls/Entities/EntityListPoolBase.ts
@@ -92,6 +92,12 @@ export abstract class ControlEntityListPoolBase {
 	protected abstract getEntityList(listId: SomeSocketEntityLocation): ControlEntityList | undefined
 	protected abstract getAllEntityLists(): ControlEntityList[]
 
+	/**
+	 * Find an entity by its id
+	 * This will search all entity lists and through all child
+	 * @param id the id of the entity to find
+	 * @returns The entity instance if found, or undefined
+	 */
 	findEntityById(id: string): ControlEntityInstance | undefined {
 		for (const list of this.getAllEntityLists()) {
 			const entity = list.findById(id)

--- a/companion/lib/Controls/Entities/EntityListPoolBase.ts
+++ b/companion/lib/Controls/Entities/EntityListPoolBase.ts
@@ -92,6 +92,14 @@ export abstract class ControlEntityListPoolBase {
 	protected abstract getEntityList(listId: SomeSocketEntityLocation): ControlEntityList | undefined
 	protected abstract getAllEntityLists(): ControlEntityList[]
 
+	findEntityById(id: string): ControlEntityInstance | undefined {
+		for (const list of this.getAllEntityLists()) {
+			const entity = list.findById(id)
+			if (entity) return entity
+		}
+		return undefined
+	}
+
 	/**
 	 * Recursively get all the entities
 	 */

--- a/companion/lib/Instance/ApiVersions.ts
+++ b/companion/lib/Instance/ApiVersions.ts
@@ -2,11 +2,16 @@ import semver, { SemVer } from 'semver'
 
 const range1_2_0OrLater = new semver.Range('>=1.2.0-0', { includePrerelease: true })
 const range1_12_0OrLater = new semver.Range('>=1.12.0-0', { includePrerelease: true })
+const range1_12_5OrLater = new semver.Range('>=1.12.0-5', { includePrerelease: true })
 
-export function doesModuleExpectLabelUpdates(apiVersion: SemVer): boolean {
+export function doesModuleExpectLabelUpdates(apiVersion: SemVer | string): boolean {
 	return range1_2_0OrLater.test(apiVersion)
 }
 
-export function doesModuleSupportPermissionsModel(apiVersion: string): boolean {
+export function doesModuleSupportPermissionsModel(apiVersion: SemVer | string): boolean {
 	return range1_12_0OrLater.test(apiVersion)
+}
+
+export function doesModuleUseSeparateUpgradeMethod(apiVersion: SemVer | string): boolean {
+	return range1_12_5OrLater.test(apiVersion)
 }

--- a/companion/lib/Instance/Controller.ts
+++ b/companion/lib/Instance/Controller.ts
@@ -102,7 +102,7 @@ export class InstanceController extends EventEmitter<InstanceControllerEvents> {
 		this.#configStore = new ConnectionConfigStore(db, this.broadcastChanges.bind(this))
 
 		this.sharedUdpManager = new InstanceSharedUdpManager()
-		this.definitions = new InstanceDefinitions(io, controls, graphics, variables.values)
+		this.definitions = new InstanceDefinitions(io, controls, graphics, variables.values, this.#configStore)
 		this.status = new InstanceStatus(io, controls)
 		this.modules = new InstanceModules(io, this, apiRouter, appInfo.modulesDir)
 		this.moduleHost = new ModuleHost(

--- a/companion/lib/Instance/Definitions.ts
+++ b/companion/lib/Instance/Definitions.ts
@@ -194,6 +194,7 @@ export class InstanceDefinitions {
 			definitionId: definitionId,
 			connectionId: connectionId,
 			options: {},
+			upgradeIndex: undefined,
 		}
 
 		if (definition.options !== undefined && definition.options.length > 0) {
@@ -360,6 +361,7 @@ export class InstanceDefinitions {
 				isInverted: feedback.isInverted,
 				style: cloneDeep(feedback.style),
 				headline: feedback.headline,
+				upgradeIndex: undefined,
 			}))
 		}
 
@@ -600,6 +602,7 @@ function toActionInstance(action: PresetActionInstance, connectionId: string): A
 		definitionId: action.action,
 		options: cloneDeep(action.options ?? {}),
 		headline: action.headline,
+		upgradeIndex: undefined,
 	}
 }
 
@@ -672,6 +675,7 @@ function wrapActionsInGroup(actions: ActionEntityModel[]): ActionEntityModel {
 		children: {
 			default: actions,
 		},
+		upgradeIndex: undefined,
 	}
 }
 function createWaitAction(delay: number): ActionEntityModel {
@@ -683,5 +687,6 @@ function createWaitAction(delay: number): ActionEntityModel {
 		options: {
 			time: delay,
 		},
+		upgradeIndex: undefined,
 	}
 }

--- a/companion/lib/Instance/EntityManager.ts
+++ b/companion/lib/Instance/EntityManager.ts
@@ -1,0 +1,325 @@
+import debounceFn from 'debounce-fn'
+import type { ControlEntityInstance } from '../Controls/Entities/EntityInstance.js'
+import type {
+	HostToModuleEventsV0,
+	ModuleToHostEventsV0,
+	UpdateActionInstancesMessage,
+	UpdateFeedbackInstancesMessage,
+	UpgradeActionAndFeedbackInstancesMessage,
+} from '@companion-module/base/dist/host-api/api.js'
+import { assertNever } from '@companion-app/shared/Util.js'
+import { EntityModelType } from '@companion-app/shared/Model/EntityModel.js'
+import type { IpcWrapper } from '@companion-module/base/dist/host-api/ipc-wrapper.js'
+import { nanoid } from 'nanoid'
+
+enum EntityState {
+	UNLOADED = 'UNLOADED',
+	UPGRADING = 'UPGRADING',
+	UPGRADING_INVALIDATED = 'UPGRADING_INVALIDATED',
+	READY = 'READY',
+	PENDING_DELETE = 'PENDING_DELETE',
+}
+
+interface EntityWrapper {
+	/** A unqiue id for this wrapper, so that we know if the entity was replaced/deleted */
+	readonly wrapperId: string
+	readonly entity: ControlEntityInstance // TODO - should this be a weak ref?
+	readonly controlId: string
+
+	state: EntityState
+}
+
+export class InstanceEntityManager {
+	readonly #entities = new Map<string, EntityWrapper>()
+	readonly #ipcWrapper: IpcWrapper<HostToModuleEventsV0, ModuleToHostEventsV0>
+
+	// Before the connection is ready, we need to not send any updates
+	#ready = false
+	#currentUpgradeIndex = 0
+
+	constructor(ipcWrapper: IpcWrapper<HostToModuleEventsV0, ModuleToHostEventsV0>) {
+		this.#ipcWrapper = ipcWrapper
+	}
+
+	readonly #debounceProcessPending = debounceFn(
+		() => {
+			if (!this.#ready) return
+
+			// TODO - each entity needs to trcak its upgradeIndex now, otherwise we stand no chance of tracking it correctly.
+			// Or perhaps more importantly, if it doesn't, then how do we know at this point whether to run it through them
+
+			const entityIdsInThisBatch = new Map<string, string>()
+			const upgradePayload: UpgradeActionAndFeedbackInstancesMessage = {
+				actions: [],
+				feedbacks: [],
+				defaultUpgradeIndex: 0, // TODO - remove this!
+			}
+			const updateActionsPayload: UpdateActionInstancesMessage = {
+				actions: {},
+			}
+			const updateFeedbacksPayload: UpdateFeedbackInstancesMessage = {
+				feedbacks: {},
+			}
+
+			const pushEntityToUpgrade = (wrapper: EntityWrapper) => {
+				entityIdsInThisBatch.set(wrapper.entity.id, wrapper.wrapperId)
+				const entityModel = wrapper.entity.asEntityModel(false)
+				switch (entityModel.type) {
+					case EntityModelType.Action:
+						upgradePayload.actions.push({
+							id: entityModel.id,
+							controlId: wrapper.controlId,
+							actionId: entityModel.definitionId,
+							options: entityModel.options,
+
+							upgradeIndex: entityModel.upgradeIndex ?? null,
+							disabled: !!entityModel.disabled,
+						})
+						break
+					case EntityModelType.Feedback:
+						upgradePayload.feedbacks.push({
+							id: entityModel.id,
+							controlId: wrapper.controlId,
+							feedbackId: entityModel.definitionId,
+							options: entityModel.options,
+
+							isInverted: !!entityModel.isInverted,
+
+							upgradeIndex: entityModel.upgradeIndex ?? null,
+							disabled: !!entityModel.disabled,
+						})
+						break
+					default:
+						assertNever(entityModel)
+						console.log('Unknown entity type', wrapper.entity.type)
+				}
+			}
+
+			// First, look over all the entiites and figure out what needs to be done to each
+			for (const [entityId, wrapper] of this.#entities) {
+				switch (wrapper.state) {
+					case EntityState.UNLOADED:
+						// The entity is unloaded, it either needs to be upgraded or loaded
+						if (wrapper.entity.upgradeIndex === this.#currentUpgradeIndex) {
+							wrapper.state = EntityState.READY
+
+							const entityModel = wrapper.entity.asEntityModel(false)
+							switch (entityModel.type) {
+								case EntityModelType.Action:
+									updateActionsPayload.actions[entityId] = {
+										id: entityModel.id,
+										controlId: wrapper.controlId,
+										actionId: entityModel.definitionId,
+										options: entityModel.options,
+
+										upgradeIndex: entityModel.upgradeIndex ?? null,
+										disabled: !!entityModel.disabled,
+									}
+									break
+								case EntityModelType.Feedback:
+									updateFeedbacksPayload.feedbacks[entityId] = {
+										id: entityModel.id,
+										controlId: wrapper.controlId,
+										feedbackId: entityModel.definitionId,
+										options: entityModel.options,
+
+										image: undefined, // TODO
+
+										isInverted: !!entityModel.isInverted,
+
+										upgradeIndex: entityModel.upgradeIndex ?? null,
+										disabled: !!entityModel.disabled,
+									}
+									break
+								default:
+									assertNever(entityModel)
+									console.log('Unknown entity type', wrapper.entity.type)
+							}
+						} else {
+							wrapper.state = EntityState.UPGRADING
+							pushEntityToUpgrade(wrapper)
+						}
+						break
+					case EntityState.UPGRADING:
+					case EntityState.UPGRADING_INVALIDATED:
+						// In progress, ignore
+						break
+					case EntityState.READY:
+						// Already processed, ignore
+						break
+					case EntityState.PENDING_DELETE:
+						// Plan for deletion
+						this.#entities.delete(entityId)
+
+						switch (wrapper.entity.type) {
+							case EntityModelType.Action:
+								updateActionsPayload.actions[entityId] = null
+								break
+							case EntityModelType.Feedback:
+								updateFeedbacksPayload.feedbacks[entityId] = null
+								break
+							default:
+								assertNever(wrapper.entity.type)
+								console.log('Unknown entity type', wrapper.entity.type)
+						}
+						break
+
+					default:
+						assertNever(wrapper.state)
+				}
+			}
+
+			// Start by sending the simple payloads
+			if (Object.keys(updateActionsPayload.actions).length > 0) {
+				this.#ipcWrapper.sendWithCb('updateActions', updateActionsPayload).catch((e) => {
+					console.error('Error sending updateActions', e)
+				})
+			}
+			if (Object.keys(updateFeedbacksPayload.feedbacks).length > 0) {
+				this.#ipcWrapper.sendWithCb('updateFeedbacks', updateFeedbacksPayload).catch((e) => {
+					console.error('Error sending updateFeedbacks', e)
+				})
+			}
+
+			// Now we need to send the upgrades
+			if (upgradePayload.actions.length > 0 || upgradePayload.feedbacks.length > 0) {
+				this.#ipcWrapper
+					.sendWithCb('upgradeActionsAndFeedbacks', upgradePayload)
+					.then((upgraded) => {
+						if (!this.#ready) return
+
+						// We have the upgraded entities, lets patch the tracked entities
+
+						const upgradedActions = new Map(upgraded.updatedActions.map((act) => [act.id, act]))
+						const upgradedFeedbacks = new Map(upgraded.updatedFeedbacks.map((fb) => [fb.id, fb]))
+
+						// Loop through what we sent, as we don't get a response for all of them
+						for (const [entityId, wrapperId] of entityIdsInThisBatch) {
+							const wrapper = this.#entities.get(entityId)
+							// Entity may have been deleted or recreated, if so we can ignore it
+							if (!wrapper || wrapper.wrapperId !== wrapperId) continue
+
+							switch (wrapper.state) {
+								case EntityState.UPGRADING_INVALIDATED:
+									// It has been invalidated, it needs to be re-run
+									wrapper.state = EntityState.UNLOADED
+									break
+								case EntityState.UPGRADING:
+									// It has been upgraded, so we can update the entity
+									// TODO
+
+									switch (wrapper.entity.type) {
+										case EntityModelType.Action: {
+											const action = upgradedActions.get(wrapper.entity.id)
+											if (action) {
+												wrapper.entity.replaceProps({
+													id: action.id,
+													type: EntityModelType.Action,
+													definitionId: action.actionId,
+													options: action.options,
+													upgradeIndex: action.upgradeIndex ?? this.#currentUpgradeIndex,
+												})
+											}
+											break
+										}
+										case EntityModelType.Feedback: {
+											const feedback = upgradedFeedbacks.get(wrapper.entity.id)
+											if (feedback) {
+												wrapper.entity.replaceProps({
+													id: feedback.id,
+													type: EntityModelType.Feedback,
+													definitionId: feedback.feedbackId,
+													options: feedback.options,
+													style: feedback.style,
+													isInverted: feedback.isInverted,
+													upgradeIndex: feedback.upgradeIndex ?? this.#currentUpgradeIndex,
+												})
+											}
+											break
+										}
+										default:
+											assertNever(wrapper.entity.type)
+											break
+									}
+
+									break
+								case EntityState.READY:
+								case EntityState.UNLOADED:
+									// Shouldn't happen, lets pretend it didnt
+									break
+								case EntityState.PENDING_DELETE:
+									// About to be deleted, so we can ignore it
+									break
+
+								default:
+									assertNever(wrapper.state)
+									break
+							}
+						}
+
+						this.#debounceProcessPending()
+					})
+					.catch((e) => {
+						console.error('Error sending upgradeActionsAndFeedbacks', e)
+
+						// There isn't much we can do to retry the upgrad, the best we can do is pretend it was fine and progress the entities through the process
+						for (const [entityId, wrapperId] of entityIdsInThisBatch) {
+							const wrapper = this.#entities.get(entityId)
+							if (!wrapper || wrapper.wrapperId !== wrapperId) continue
+							if (wrapper.state === EntityState.UPGRADING) {
+								// Pretend it was fine
+								wrapper.state = EntityState.READY
+							} else if (wrapper.state === EntityState.UPGRADING_INVALIDATED) {
+								// This can be retried
+								wrapper.state = EntityState.UNLOADED
+							}
+						}
+
+						// Make sure anything pending is processed
+						this.#debounceProcessPending()
+					})
+			}
+		},
+		{
+			before: false,
+			after: true,
+			maxWait: 50,
+			wait: 10,
+		}
+	)
+
+	start(currentUpgradeIndex: number): void {
+		this.#ready = true
+		this.#currentUpgradeIndex = currentUpgradeIndex
+
+		this.#debounceProcessPending()
+	}
+
+	destroy() {
+		this.#debounceProcessPending.cancel()
+		this.#entities.clear()
+		this.#ready = false
+	}
+
+	trackEntity(entity: ControlEntityInstance, controlId: string): void {
+		// This may replace an existing entity, if so it needs to follow the usual process
+		this.#entities.set(entity.id, {
+			wrapperId: nanoid(),
+			entity,
+			controlId: controlId,
+			state: EntityState.UNLOADED,
+		})
+
+		this.#debounceProcessPending()
+	}
+
+	forgetEntity(entityId: string): void {
+		const wrapper = this.#entities.get(entityId)
+		if (!wrapper) return
+
+		// mark as pending deletion
+		wrapper.state = EntityState.PENDING_DELETE
+
+		this.#debounceProcessPending()
+	}
+}

--- a/companion/lib/Instance/Host.ts
+++ b/companion/lib/Instance/Host.ts
@@ -17,6 +17,7 @@ import type { SomeEntityModel } from '@companion-app/shared/Model/EntityModel.js
 import { CompanionOptionValues } from '@companion-module/base'
 import { Serializable } from 'child_process'
 import { createRequire } from 'module'
+import type { ControlEntityInstance } from '../Controls/Entities/EntityInstance.js'
 
 const require = createRequire(import.meta.url)
 
@@ -529,11 +530,11 @@ export class ModuleHost {
 		})
 	}
 
-	async connectionEntityUpdate(entityModel: SomeEntityModel, controlId: string): Promise<boolean> {
-		const connection = this.getChild(entityModel.connectionId, true)
+	async connectionEntityUpdate(entity: ControlEntityInstance, controlId: string): Promise<boolean> {
+		const connection = this.getChild(entity.connectionId, true)
 		if (!connection) return false
 
-		await connection.entityUpdate(entityModel, controlId)
+		await connection.entityUpdate(entity, controlId)
 
 		return true
 	}

--- a/companion/lib/Instance/Host.ts
+++ b/companion/lib/Instance/Host.ts
@@ -249,7 +249,7 @@ export class ModuleHost {
 
 		for (const child of this.#children.values()) {
 			if (child.handler && child.isReady) {
-				child.handler.sendVariablesChanged(changedVariableIds).catch((e) => {
+				child.handler.sendVariablesChanged(all_changed_variables_set, changedVariableIds).catch((e) => {
 					this.#logger.warn(`sendVariablesChanged failed for "${child.connectionId}": ${e}`)
 				})
 			}

--- a/companion/lib/Instance/Wrapper.ts
+++ b/companion/lib/Instance/Wrapper.ts
@@ -955,18 +955,30 @@ function translateOptionsIsVisible(
 	options?: EncodeIsVisible<SomeCompanionActionInputField>[]
 ): (InternalActionInputField | InternalFeedbackInputField)[] {
 	// @companion-module-base exposes these through a mapping that loses the differentiation between types
-	return (options || []).map((o) => ({
-		...(o as any),
-		isVisibleFn: undefined,
-		isVisibleData: undefined,
-		isVisibleUi: o.isVisibleFn
-			? ({
-					type: 'function',
-					fn: o.isVisibleFn,
-					data: o.isVisibleData,
-				} satisfies InternalActionInputField['isVisibleUi'])
-			: undefined,
-	}))
+	return (options || []).map((o) => {
+		let isVisibleUi: InternalFeedbackInputField['isVisibleUi'] | undefined = undefined
+		if (o.isVisibleFn && o.isVisibleFnType === 'expression') {
+			isVisibleUi = {
+				type: 'expression',
+				fn: o.isVisibleFn,
+				data: undefined,
+			}
+		} else if (o.isVisibleFn) {
+			// Either type: 'function' or undefined (backwards compat)
+			isVisibleUi = {
+				type: 'function',
+				fn: o.isVisibleFn,
+				data: o.isVisibleData,
+			}
+		}
+
+		return {
+			...(o as any),
+			isVisibleFn: undefined,
+			isVisibleData: undefined,
+			isVisibleUi,
+		}
+	})
 }
 
 export interface RunActionExtras {

--- a/companion/lib/Instance/Wrapper.ts
+++ b/companion/lib/Instance/Wrapper.ts
@@ -296,7 +296,7 @@ export class SocketEventsHandler {
 	 */
 	async sendAllFeedbackInstances(): Promise<void> {
 		if (this.#entityManager) {
-			// TODO - trigger this
+			this.#entityManager.resendFeedbacks()
 			return
 		}
 

--- a/companion/lib/Instance/Wrapper.ts
+++ b/companion/lib/Instance/Wrapper.ts
@@ -154,7 +154,9 @@ export class SocketEventsHandler {
 			5000
 		)
 
-		this.#entityManager = this.#usesNewUpgradeFlow ? new InstanceEntityManager(this.#ipcWrapper) : null
+		this.#entityManager = this.#usesNewUpgradeFlow
+			? new InstanceEntityManager(this.#ipcWrapper, this.#deps.controls)
+			: null
 
 		const messageHandler = (msg: any) => {
 			this.#ipcWrapper.receivedMessage(msg)
@@ -178,7 +180,7 @@ export class SocketEventsHandler {
 
 		// Ensure each entity knows its upgradeIndex
 		const allControls = this.#deps.controls.getAllControls()
-		for (const control of allControls.values()) {
+		for (const [controlId, control] of allControls.entries()) {
 			if (!control.supportsEntities) continue
 
 			for (const entity of control.entities.getAllEntities()) {
@@ -187,6 +189,8 @@ export class SocketEventsHandler {
 				if (entity.upgradeIndex === undefined) {
 					entity.setMissingUpgradeIndex(config.lastUpgradeIndex)
 				}
+
+				this.#entityManager?.trackEntity(entity, controlId)
 			}
 		}
 

--- a/companion/lib/Instance/Wrapper.ts
+++ b/companion/lib/Instance/Wrapper.ts
@@ -92,6 +92,8 @@ export class SocketEventsHandler {
 
 	readonly #entityManager: InstanceEntityManager | null
 
+	#currentUpgradeIndex: number | null = null
+
 	/**
 	 * Current label of the connection
 	 */
@@ -211,7 +213,7 @@ export class SocketEventsHandler {
 		// Save the resulting values
 		this.#hasHttpHandler = !!msg.hasHttpHandler
 		this.hasRecordActionsHandler = !!msg.hasRecordActionsHandler
-		config.lastUpgradeIndex = msg.newUpgradeIndex
+		this.#currentUpgradeIndex = config.lastUpgradeIndex = msg.newUpgradeIndex
 		this.#deps.setConnectionConfig(this.connectionId, msg.updatedConfig)
 
 		this.#entityManager?.start(config.lastUpgradeIndex)
@@ -909,7 +911,7 @@ export class SocketEventsHandler {
 								options: feedback.options,
 								style: feedback.style,
 								isInverted: feedback.isInverted,
-								upgradeIndex: feedback.upgradeIndex ?? undefined,
+								upgradeIndex: feedback.upgradeIndex ?? this.#currentUpgradeIndex ?? undefined,
 							},
 							true
 						)
@@ -930,7 +932,7 @@ export class SocketEventsHandler {
 								id: action.id,
 								definitionId: action.actionId,
 								options: action.options,
-								upgradeIndex: action.upgradeIndex ?? undefined,
+								upgradeIndex: action.upgradeIndex ?? this.#currentUpgradeIndex ?? undefined,
 							},
 							true
 						)

--- a/companion/lib/Internal/Controls.ts
+++ b/companion/lib/Internal/Controls.ts
@@ -753,6 +753,7 @@ export class InternalControls extends EventEmitter<InternalModuleFragmentEvents>
 				options: {
 					...action.options,
 				},
+				upgradeIndex: undefined,
 			}
 			delete newChildAction.options.expression
 
@@ -764,6 +765,7 @@ export class InternalControls extends EventEmitter<InternalModuleFragmentEvents>
 				options: {
 					expression: action.options.expression,
 				},
+				upgradeIndex: undefined,
 			}
 
 			return {
@@ -777,6 +779,7 @@ export class InternalControls extends EventEmitter<InternalModuleFragmentEvents>
 					actions: [newChildAction],
 					else_actions: [],
 				},
+				upgradeIndex: undefined,
 			} satisfies ActionEntityModel
 		} else if (
 			action.definitionId === 'button_pressrelease_condition' ||
@@ -792,6 +795,7 @@ export class InternalControls extends EventEmitter<InternalModuleFragmentEvents>
 				options: {
 					...action.options,
 				},
+				upgradeIndex: undefined,
 			}
 			delete newChildAction.options.variable
 			delete newChildAction.options.op
@@ -807,6 +811,7 @@ export class InternalControls extends EventEmitter<InternalModuleFragmentEvents>
 					op: action.options.op,
 					value: action.options.value,
 				},
+				upgradeIndex: undefined,
 			}
 
 			return {
@@ -820,6 +825,7 @@ export class InternalControls extends EventEmitter<InternalModuleFragmentEvents>
 					actions: [newChildAction],
 					else_actions: [],
 				},
+				upgradeIndex: undefined,
 			} satisfies ActionEntityModel
 		}
 

--- a/companion/package.json
+++ b/companion/package.json
@@ -49,7 +49,7 @@
 	"dependencies": {
 		"@blackmagic-controller/node": "^0.1.1",
 		"@companion-app/shared": "*",
-		"@companion-module/base": "^1.12.0-4",
+		"@companion-module/base": "^1.12.0-5",
 		"@elgato-stream-deck/node": "^7.1.2",
 		"@elgato-stream-deck/tcp": "^7.1.2",
 		"@julusian/bonjour-service": "^1.3.0-2",

--- a/companion/test/Controls/Entities/EntityList.test.ts
+++ b/companion/test/Controls/Entities/EntityList.test.ts
@@ -65,6 +65,7 @@ function createList(controlId: string, ownerId?: EntityOwner | null, listId?: Co
 		connectionId: 'internal',
 		definitionId: 'def01',
 		options: {},
+		upgradeIndex: undefined,
 	}
 	const newAction = new ControlEntityInstance(
 		instanceDefinitions,
@@ -437,6 +438,7 @@ describe('addEntity', () => {
 			options: {
 				test: 123,
 			},
+			upgradeIndex: undefined,
 		}
 
 		const newInstance = list.addEntity(cloneDeep(newAction))
@@ -455,6 +457,7 @@ describe('addEntity', () => {
 			options: {
 				test: 123,
 			},
+			upgradeIndex: undefined,
 		}
 
 		expect(() => list.addEntity(cloneDeep(newAction))).toThrowError('EntityList cannot accept this type of entity')
@@ -472,6 +475,7 @@ describe('addEntity', () => {
 			options: {
 				test: 123,
 			},
+			upgradeIndex: undefined,
 		}
 
 		expect(() => list.addEntity(cloneDeep(newFeedback))).toThrowError('EntityList cannot accept this type of entity')
@@ -489,6 +493,7 @@ describe('addEntity', () => {
 			options: {
 				test: 123,
 			},
+			upgradeIndex: undefined,
 		}
 
 		const newInstance = list.addEntity(cloneDeep(newFeedback))
@@ -507,6 +512,7 @@ describe('addEntity', () => {
 			options: {
 				test: 123,
 			},
+			upgradeIndex: undefined,
 		}
 
 		expect(() => list.addEntity(cloneDeep(newFeedback))).toThrowError('EntityList cannot accept this type of entity')
@@ -532,6 +538,7 @@ describe('addEntity', () => {
 			options: {
 				test: 123,
 			},
+			upgradeIndex: undefined,
 		}
 
 		expect(() => list.addEntity(cloneDeep(newFeedback))).toThrowError('EntityList cannot accept this type of entity')
@@ -555,6 +562,7 @@ describe('addEntity', () => {
 			options: {
 				test: 123,
 			},
+			upgradeIndex: undefined,
 		}
 
 		getEntityDefinition.mockReturnValueOnce({
@@ -583,6 +591,7 @@ describe('addEntity', () => {
 			options: {
 				test: 123,
 			},
+			upgradeIndex: undefined,
 			children: {
 				group1: [
 					{
@@ -593,6 +602,7 @@ describe('addEntity', () => {
 						options: {
 							test: 123,
 						},
+						upgradeIndex: undefined,
 					},
 				],
 			},
@@ -633,6 +643,7 @@ describe('addEntity', () => {
 			options: {
 				test: 123,
 			},
+			upgradeIndex: undefined,
 			children: {
 				group1: [
 					{
@@ -643,6 +654,7 @@ describe('addEntity', () => {
 						options: {
 							test: 99,
 						},
+						upgradeIndex: undefined,
 					},
 				],
 				group2: [
@@ -654,6 +666,7 @@ describe('addEntity', () => {
 						options: {
 							test: 45,
 						},
+						upgradeIndex: undefined,
 					},
 				],
 			},
@@ -687,6 +700,7 @@ describe('addEntity', () => {
 			options: {
 				test: 123,
 			},
+			upgradeIndex: undefined,
 		}
 
 		const newInstance = list.addEntity(cloneDeep(newFeedback), true)
@@ -723,6 +737,7 @@ describe('addEntity', () => {
 			options: {
 				test: 123,
 			},
+			upgradeIndex: undefined,
 			children: {
 				group1: [
 					{
@@ -733,6 +748,7 @@ describe('addEntity', () => {
 						options: {
 							test: 99,
 						},
+						upgradeIndex: undefined,
 					},
 				],
 			},

--- a/companion/test/Controls/Entities/EntityList.test.ts
+++ b/companion/test/Controls/Entities/EntityList.test.ts
@@ -1057,7 +1057,7 @@ describe('duplicateEntity', () => {
 		expect(afterIds[2]).toBe(newEntity!.id)
 
 		expect(connectionEntityUpdate).toHaveBeenCalledTimes(1)
-		expect(connectionEntityUpdate).toHaveBeenCalledWith(newEntity!.asEntityModel(), 'test01')
+		expect(connectionEntityUpdate).toHaveBeenCalledWith(newEntity, 'test01')
 		expect(internalEntityUpdate).toHaveBeenCalledTimes(0)
 	})
 
@@ -1085,7 +1085,7 @@ describe('duplicateEntity', () => {
 		expect(afterIds[6]).toBe(newEntityChild!.id)
 
 		expect(connectionEntityUpdate).toHaveBeenCalledTimes(1)
-		expect(connectionEntityUpdate).toHaveBeenCalledWith(newEntityChild!.asEntityModel(), 'test01')
+		expect(connectionEntityUpdate).toHaveBeenCalledWith(newEntityChild, 'test01')
 		expect(internalEntityUpdate).toHaveBeenCalledTimes(1)
 		expect(internalEntityUpdate).toHaveBeenCalledWith(newEntity!.asEntityModel(), 'test01')
 	})

--- a/companion/tsconfig.json
+++ b/companion/tsconfig.json
@@ -10,7 +10,7 @@
 		"module": "Node16",
 		"moduleResolution": "Node16",
 
-		"target": "es2022",
+		"target": "es2024",
 		"noImplicitAny": true,
 		"sourceMap": true,
 		"declaration": false,
@@ -18,7 +18,7 @@
 		"listFiles": false,
 		"traceResolution": false,
 		"pretty": true,
-		"lib": ["es2024"],
+		"lib": ["es2024", "ESNext.Collection"],
 		"types": ["node"],
 		"strict": true,
 		"alwaysStrict": false,

--- a/shared-lib/lib/Model/EntityModel.ts
+++ b/shared-lib/lib/Model/EntityModel.ts
@@ -3,8 +3,8 @@ import type { ButtonStyleProperties } from './StyleModel.js'
 
 export type SomeEntityModel = ActionEntityModel | FeedbackEntityModel
 export type SomeReplaceableEntityModel =
-	| Pick<ActionEntityModel, 'id' | 'type' | 'definitionId' | 'options'>
-	| Pick<FeedbackEntityModel, 'id' | 'type' | 'definitionId' | 'style' | 'options' | 'isInverted'>
+	| Pick<ActionEntityModel, 'id' | 'type' | 'definitionId' | 'options' | 'upgradeIndex'>
+	| Pick<FeedbackEntityModel, 'id' | 'type' | 'definitionId' | 'style' | 'options' | 'isInverted' | 'upgradeIndex'>
 
 export enum EntityModelType {
 	Action = 'action',
@@ -31,7 +31,7 @@ export interface EntityModelBase {
 	headline?: string
 	options: Record<string, any>
 	disabled?: boolean
-	upgradeIndex?: number
+	upgradeIndex: number | undefined
 
 	/**
 	 * Some internal entities can have children, one or more set of them

--- a/shared-lib/lib/ModuleApiVersionCheck.ts
+++ b/shared-lib/lib/ModuleApiVersionCheck.ts
@@ -1,6 +1,6 @@
 import semver from 'semver'
 
-const MODULE_BASE_VERSION = '1.12.0-4'
+const MODULE_BASE_VERSION = '1.12.0-5'
 
 const moduleVersion = semver.parse(MODULE_BASE_VERSION)
 if (!moduleVersion) throw new Error(`Failed to parse version as semver: ${MODULE_BASE_VERSION}`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1347,9 +1347,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@companion-module/base@npm:^1.12.0-4":
-  version: 1.12.0-4
-  resolution: "@companion-module/base@npm:1.12.0-4"
+"@companion-module/base@npm:^1.12.0-5":
+  version: 1.12.0-5
+  resolution: "@companion-module/base@npm:1.12.0-5"
   dependencies:
     ajv: "npm:^8.17.1"
     colord: "npm:^2.9.3"
@@ -1360,7 +1360,7 @@ __metadata:
     p-queue: "npm:^6.6.2"
     p-timeout: "npm:^4.1.0"
     tslib: "npm:^2.8.1"
-  checksum: 10c0/96d1e223436c57186c6f324528a4135382baa7da1abf0874ad08652e19c288c4c3e7c87e0e880092deafaf79c80e11b2f3f3231e4fb0a5e05f418a3a55d1990b
+  checksum: 10c0/d102b7e376a45a0f6cfb1adc8277d54be2ffd79a568f738970832a1338b25f9ce4471063dd55c0789425f29df221f49eafbb0229ae13e2fe24a51994b5339ee5
   languageName: node
   linkType: hard
 
@@ -6364,7 +6364,7 @@ asn1@evs-broadcast/node-asn1:
   dependencies:
     "@blackmagic-controller/node": "npm:^0.1.1"
     "@companion-app/shared": "npm:*"
-    "@companion-module/base": "npm:^1.12.0-4"
+    "@companion-module/base": "npm:^1.12.0-5"
     "@elgato-stream-deck/node": "npm:^7.1.2"
     "@elgato-stream-deck/tcp": "npm:^7.1.2"
     "@julusian/bonjour-service": "npm:^1.3.0-2"


### PR DESCRIPTION
Implements https://github.com/bitfocus/companion-module-base/pull/118

This has turned out to be a more complex state machine than I initially expected, so I am wondering if this should be held back for 4.1 (it could still be reverted in the module lib, so that the other changes can be released)

This api change is done so that how the options are stored can be different from how they are used, without needing modules to be the ones doing the parsing. 

This is a precursor to #2345, which I expect will build on this by further by changing the structure of the options object that companion and upgrade scripts use, but not for action/feedback execution or subscribe/unsubscribe calls.
At this stage, that means we can pre-parse variables in textinput fields (only those with the `useVariables` flag set for now) before passing the objects off to the modules. 

This should be non-breaking for modules, and only those using the updated base lib will hit the new flows, so any bugs found will have limited impact.

TODO
- [ ] try it with a module
- [ ] thoroughly test it with a module
- [ ] write some unit tests?
