### PR TITLE
feat: allow filtering bonjour queries by port

### DIFF
--- a/companion/lib/Service/BonjourDiscovery.ts
+++ b/companion/lib/Service/BonjourDiscovery.ts
@@ -126,7 +126,7 @@ export class ServiceBonjourDiscovery extends ServiceBase {
 		const filters: BonjourBrowserFilter[] = []
 
 		for (const query of bonjourQueries) {
-			const filter = {
+			const filter: BonjourBrowserFilter = {
 				type: query.type,
 				protocol: query.protocol,
 				port: query.port,


### PR DESCRIPTION
Requires https://github.com/bitfocus/companion-module-base/pull/133 as well.

This allows modules to filter by port number, for devices / software that have static communication ports.