### PR TITLE
fix: emberplus api close/init

### DIFF
--- a/companion/lib/Service/EmberPlus.ts
+++ b/companion/lib/Service/EmberPlus.ts
@@ -345,11 +345,7 @@ export class ServiceEmberPlus extends ServiceBase {
 						),
 					}),
 					1: new EmberModel.NumberedTreeNodeImpl(1, new EmberModel.EmberNodeImpl('pages'), this.#getPagesTree()),
-					2: new EmberModel.NumberedTreeNodeImpl(
-						2,
-						new EmberModel.EmberNodeImpl('location'),
-						this.#getLocationTree()
-					),
+					2: new EmberModel.NumberedTreeNodeImpl(2, new EmberModel.EmberNodeImpl('location'), this.#getLocationTree()),
 				}),
 			}
 


### PR DESCRIPTION
Allows the emberplus api to be correctly disabled and reinitialized. Previously the `if (this.#server === undefined)` check during `listen` would return `false` after the first call of the method, leaving the connection disabled until Companion was restarted. Now during `close` `this.#server` is set to `undefined` and if `this.#server` is truthy during `listen` `close` is called before it proceeds.

Fixes the easy part of #3419, in that new pages or a resized button matrix will populate the ember tree on reinitialization.
What it doesn't address is (a) dynamically changing the tree, or (b) prompting the user that a re-init is necessary ~~or (c) auto re-init on page count change~~.