### PR TITLE
 feat(graphics-overhaul): support 'old feedbacks'

### DIFF
--- a/companion/lib/Controls/Controller.ts
+++ b/companion/lib/Controls/Controller.ts
@@ -503,10 +503,15 @@ export class ControlsController {
 			const control = this.getControl(controlId)
 			if (!control) return false
 
-			if (!control.supportsEntities || !control.supportsStyle)
+			if (!control.supportsEntities || (!control.supportsStyle && !control.supportsLayeredStyle))
 				throw new Error(`Control "${controlId}" does not support entities or styles`)
 
-			return control.entities.entitySetStyleSelection(entityLocation, control.baseStyle, id, selected)
+			return control.entities.entitySetStyleSelection(
+				entityLocation,
+				control.supportsStyle ? control.baseStyle : ControlButtonNormal.DefaultStyle,
+				id,
+				selected
+			)
 		})
 		client.onPromise('controls:entity:set-style-value', (controlId, entityLocation, id, key, value) => {
 			const control = this.getControl(controlId)

--- a/companion/lib/Controls/Entities/EntityListPoolButton.ts
+++ b/companion/lib/Controls/Entities/EntityListPoolButton.ts
@@ -178,11 +178,15 @@ export class ControlEntityListPoolButton extends ControlEntityListPoolBase imple
 		return entityLists
 	}
 
+	get hasFeedbacks(): boolean {
+		return this.#feedbacks.getDirectEntities().length > 0
+	}
+
 	/**
 	 * Get the unparsed style for the feedbacks
 	 * Note: Does not clone the style
 	 */
-	getUnparsedFeedbackStyle(baseStyle: ButtonStyleProperties): UnparsedButtonStyle {
+	getUnparsedFeedbackStyle(baseStyle: Partial<ButtonStyleProperties>): UnparsedButtonStyle {
 		const styleBuilder = new FeedbackStyleBuilder(baseStyle)
 		this.#feedbacks.buildFeedbackStyle(styleBuilder)
 		return styleBuilder.style

--- a/companion/lib/Controls/Entities/FeedbackStyleBuilder.ts
+++ b/companion/lib/Controls/Entities/FeedbackStyleBuilder.ts
@@ -10,7 +10,7 @@ export class FeedbackStyleBuilder {
 		return this.#combinedStyle
 	}
 
-	constructor(baseStyle: ButtonStyleProperties) {
+	constructor(baseStyle: Partial<ButtonStyleProperties>) {
 		this.#combinedStyle = {
 			...baseStyle,
 			imageBuffers: [],

--- a/companion/lib/Graphics/LayeredProcessedStyleGenerator.ts
+++ b/companion/lib/Graphics/LayeredProcessedStyleGenerator.ts
@@ -1,37 +1,15 @@
-import {
-	ButtonGraphicsTextDrawElement,
-	ButtonGraphicsElementUsage,
-	ButtonGraphicsBoxDrawElement,
-	ButtonGraphicsDrawBase,
-	SomeButtonGraphicsDrawElement,
-	ButtonGraphicsImageDrawElement,
-} from '@companion-app/shared/Model/StyleLayersModel.js'
 import type { DrawStyleLayeredButtonModel } from '@companion-app/shared/Model/StyleModel.js'
 import type { Complete } from '@companion-module/base/dist/util.js'
 import { ImageResultProcessedStyle } from './ImageResult.js'
+import { GraphicsLayeredElementUsageMatcher } from '@companion-app/shared/Graphics/LayeredElementUsageMatcher.js'
 
 export class GraphicsLayeredProcessedStyleGenerator {
 	static Generate(drawStyle: DrawStyleLayeredButtonModel): ImageResultProcessedStyle {
-		const canvasLayer = drawStyle.elements.find((e) => e.type === 'canvas')
-		const textLayer = GraphicsLayeredProcessedStyleGenerator.SelectLayerForUsage<ButtonGraphicsTextDrawElement>(
-			drawStyle.elements,
-			ButtonGraphicsElementUsage.Text,
-			'text'
-		)
-		const boxLayer = GraphicsLayeredProcessedStyleGenerator.SelectLayerForUsage<ButtonGraphicsBoxDrawElement>(
-			drawStyle.elements,
-			ButtonGraphicsElementUsage.Color,
-			'box'
-		)
-		const imageLayer = GraphicsLayeredProcessedStyleGenerator.SelectLayerForUsage<ButtonGraphicsImageDrawElement>(
-			drawStyle.elements,
-			ButtonGraphicsElementUsage.Image,
-			'image'
-		)
+		const selectedElements = GraphicsLayeredElementUsageMatcher.SelectBasicLayers(drawStyle.elements)
 
 		let showTopBar: boolean | 'default' = 'default'
-		if (canvasLayer) {
-			switch (canvasLayer.decoration) {
+		if (selectedElements.canvas) {
+			switch (selectedElements.canvas.decoration) {
 				case 'topbar':
 					showTopBar = true
 					break
@@ -46,21 +24,21 @@ export class GraphicsLayeredProcessedStyleGenerator {
 
 		const processedStyle: Complete<ImageResultProcessedStyle> = {
 			type: 'button',
-			color: boxLayer ? { color: boxLayer.color } : undefined,
-			text: textLayer
+			color: selectedElements.box ? { color: selectedElements.box.color } : undefined,
+			text: selectedElements.text
 				? {
-						text: textLayer.text,
-						color: textLayer.color,
-						size: Number(textLayer.fontsize) || 'auto', // TODO - scale value?
-						halign: textLayer.halign,
-						valign: textLayer.valign,
+						text: selectedElements.text.text,
+						color: selectedElements.text.color,
+						size: Number(selectedElements.text.fontsize) || 'auto', // TODO - scale value?
+						halign: selectedElements.text.halign,
+						valign: selectedElements.text.valign,
 					}
 				: undefined,
-			png64: imageLayer?.base64Image
+			png64: selectedElements.image?.base64Image
 				? {
-						dataUrl: imageLayer.base64Image,
-						halign: imageLayer.halign,
-						valign: imageLayer.valign,
+						dataUrl: selectedElements.image.base64Image,
+						halign: selectedElements.image.halign,
+						valign: selectedElements.image.valign,
 					}
 				: undefined,
 			state: {
@@ -71,56 +49,5 @@ export class GraphicsLayeredProcessedStyleGenerator {
 		}
 
 		return processedStyle
-	}
-
-	private static SelectLayerForUsage<TElement extends ButtonGraphicsDrawBase & { type: string }>(
-		elements: SomeButtonGraphicsDrawElement[],
-		usage: ButtonGraphicsElementUsage,
-		layerType: TElement['type']
-	): TElement | undefined {
-		return (
-			GraphicsLayeredProcessedStyleGenerator.SelectFirstLayerWithUsage<TElement>(elements, usage, layerType) ||
-			GraphicsLayeredProcessedStyleGenerator.SelectFirstLayerOfType<TElement>(elements, layerType)
-		)
-	}
-
-	private static SelectFirstLayerWithUsage<TElement extends ButtonGraphicsDrawBase & { type: string }>(
-		elements: SomeButtonGraphicsDrawElement[],
-		usage: ButtonGraphicsElementUsage,
-		layerType: TElement['type']
-	): TElement | undefined {
-		for (const element of elements) {
-			if (element.type === 'group') {
-				const match = GraphicsLayeredProcessedStyleGenerator.SelectFirstLayerWithUsage<TElement>(
-					element.children,
-					usage,
-					layerType
-				)
-				if (match) return match
-			} else if (element.type === layerType && element.usage === usage) {
-				return element as unknown as TElement
-			}
-		}
-
-		return undefined
-	}
-
-	private static SelectFirstLayerOfType<TElement extends ButtonGraphicsDrawBase & { type: string }>(
-		elements: SomeButtonGraphicsDrawElement[],
-		layerType: TElement['type']
-	): TElement | undefined {
-		for (const element of elements) {
-			if (element.type === 'group') {
-				const match = GraphicsLayeredProcessedStyleGenerator.SelectFirstLayerOfType<TElement>(
-					element.children,
-					layerType
-				)
-				if (match) return match
-			} else if (element.type === layerType && element.usage === ButtonGraphicsElementUsage.Automatic) {
-				return element as unknown as TElement
-			}
-		}
-
-		return undefined
 	}
 }

--- a/companion/lib/Variables/Util.ts
+++ b/companion/lib/Variables/Util.ts
@@ -29,7 +29,7 @@ export type VariableValueData = Record<string, Record<string, CompanionVariableV
 export type VariablesCache = Map<string, CompanionVariableValue | undefined>
 export interface ParseVariablesResult {
 	text: string
-	variableIds: Set<string>
+	variableIds: ReadonlySet<string>
 }
 
 export function parseVariablesInString(

--- a/companion/tsconfig.json
+++ b/companion/tsconfig.json
@@ -20,7 +20,7 @@
 		"listFiles": false,
 		"traceResolution": false,
 		"pretty": true,
-		"lib": ["es2024"],
+		"lib": ["es2024", "ESNext.Collection"],
 		"types": ["node"],
 		"strict": true,
 		"alwaysStrict": false,

--- a/shared-lib/lib/Graphics/LayeredElementUsageMatcher.ts
+++ b/shared-lib/lib/Graphics/LayeredElementUsageMatcher.ts
@@ -1,0 +1,92 @@
+import {
+	type ButtonGraphicsBoxDrawElement,
+	ButtonGraphicsElementUsage,
+	type ButtonGraphicsImageDrawElement,
+	type ButtonGraphicsTextDrawElement,
+	type ButtonGraphicsDrawBase,
+	type SomeButtonGraphicsDrawElement,
+	type ButtonGraphicsCanvasDrawElement,
+} from '../Model/StyleLayersModel.js'
+
+export interface MatchedElements {
+	canvas: ButtonGraphicsCanvasDrawElement | undefined
+	text: ButtonGraphicsTextDrawElement | undefined
+	box: ButtonGraphicsBoxDrawElement | undefined
+	image: ButtonGraphicsImageDrawElement | undefined
+}
+
+export class GraphicsLayeredElementUsageMatcher {
+	public static SelectBasicLayers(elements: SomeButtonGraphicsDrawElement[]): MatchedElements {
+		const canvas = elements.find((e) => e.type === 'canvas')
+		const text = GraphicsLayeredElementUsageMatcher.SelectLayerForUsage<ButtonGraphicsTextDrawElement>(
+			elements,
+			ButtonGraphicsElementUsage.Text,
+			'text'
+		)
+		const box = GraphicsLayeredElementUsageMatcher.SelectLayerForUsage<ButtonGraphicsBoxDrawElement>(
+			elements,
+			ButtonGraphicsElementUsage.Color,
+			'box'
+		)
+		const image = GraphicsLayeredElementUsageMatcher.SelectLayerForUsage<ButtonGraphicsImageDrawElement>(
+			elements,
+			ButtonGraphicsElementUsage.Image,
+			'image'
+		)
+
+		return {
+			canvas,
+			text,
+			box,
+			image,
+		}
+	}
+
+	public static SelectLayerForUsage<TElement extends ButtonGraphicsDrawBase & { type: string }>(
+		elements: SomeButtonGraphicsDrawElement[],
+		usage: ButtonGraphicsElementUsage,
+		layerType: TElement['type']
+	): TElement | undefined {
+		return (
+			GraphicsLayeredElementUsageMatcher.SelectFirstLayerWithUsage<TElement>(elements, usage, layerType) ||
+			GraphicsLayeredElementUsageMatcher.SelectFirstLayerOfType<TElement>(elements, layerType)
+		)
+	}
+
+	private static SelectFirstLayerWithUsage<TElement extends ButtonGraphicsDrawBase & { type: string }>(
+		elements: SomeButtonGraphicsDrawElement[],
+		usage: ButtonGraphicsElementUsage,
+		layerType: TElement['type']
+	): TElement | undefined {
+		for (const element of elements) {
+			if (element.type === 'group') {
+				const match = GraphicsLayeredElementUsageMatcher.SelectFirstLayerWithUsage<TElement>(
+					element.children,
+					usage,
+					layerType
+				)
+				if (match) return match
+			} else if (element.type === layerType && element.usage === usage) {
+				return element as unknown as TElement
+			}
+		}
+
+		return undefined
+	}
+
+	private static SelectFirstLayerOfType<TElement extends ButtonGraphicsDrawBase & { type: string }>(
+		elements: SomeButtonGraphicsDrawElement[],
+		layerType: TElement['type']
+	): TElement | undefined {
+		for (const element of elements) {
+			if (element.type === 'group') {
+				const match = GraphicsLayeredElementUsageMatcher.SelectFirstLayerOfType<TElement>(element.children, layerType)
+				if (match) return match
+			} else if (element.type === layerType && element.usage === ButtonGraphicsElementUsage.Automatic) {
+				return element as unknown as TElement
+			}
+		}
+
+		return undefined
+	}
+}

--- a/shared-lib/lib/Model/StyleModel.ts
+++ b/shared-lib/lib/Model/StyleModel.ts
@@ -44,7 +44,7 @@ export interface DrawImageBuffer {
 	pixelFormat: 'RGB' | 'RGBA' | 'ARGB' | undefined
 }
 
-export interface UnparsedButtonStyle extends ButtonStyleProperties {
+export interface UnparsedButtonStyle extends Partial<ButtonStyleProperties> {
 	imageBuffers: DrawImageBuffer[]
 }
 

--- a/webui/src/Buttons/EditButton/LayeredButtonEditor/ElementCommonProperties.tsx
+++ b/webui/src/Buttons/EditButton/LayeredButtonEditor/ElementCommonProperties.tsx
@@ -38,7 +38,7 @@ export const ElementCommonProperties = observer(function ElementCommonProperties
 			{elementProps.type !== 'canvas' && elementProps.type !== 'group' && (
 				<>
 					<CFormLabel htmlFor="inputUsage" className="col-sm-4 col-form-label col-form-label-sm">
-						<InlineHelp help="Some surfaces do not have full rgb displays and so require specific elements for providing feedback in alternate ways. You can override the automatic selection of layers for these purposes by selecting the appropriate usage for this element.">
+						<InlineHelp help="Some surfaces do not have full rgb displays and require specific values for providing feedback in alternate ways. You can override the automatic selection of elements for these purposes by selecting the appropriate usage.">
 							Usage
 						</InlineHelp>
 					</CFormLabel>

--- a/webui/src/Buttons/EditButton/LayeredButtonEditor/LayeredButtonEditor.tsx
+++ b/webui/src/Buttons/EditButton/LayeredButtonEditor/LayeredButtonEditor.tsx
@@ -13,10 +13,12 @@ import { faLayerGroup } from '@fortawesome/free-solid-svg-icons'
 import { LayeredButtonPreviewRenderer } from './Preview/LayeredButtonPreviewRenderer.js'
 import { LocalVariablesEditor } from '../LocalVariablesEditor.js'
 import { LocalVariablesStore, useLocalVariablesStore } from '../../../Controls/LocalVariablesStore.js'
+import { OldFeedbacksEditor } from '../OldFeedbacksEditor.js'
 
 const LayeredButtonExtraTabs: ButtonEditorExtraTabs[] = [
 	{ id: 'style', name: 'Style', position: 'start' },
 	{ id: 'variables', name: 'Local Variables', position: 'end' },
+	{ id: 'old-feedbacks', name: 'Old Feedbacks', position: 'end' },
 	{ id: 'options', name: 'Options', position: 'end' },
 ]
 
@@ -84,6 +86,21 @@ export const LayeredButtonEditor = observer(function LayeredButtonEditor({
 												controlId={controlId}
 												location={location}
 												variables={config.localVariables}
+												localVariablesStore={localVariablesStore}
+											/>
+										</MyErrorBoundary>
+									</div>
+								)
+							}
+
+							if (currentTab === 'old-feedbacks') {
+								return (
+									<div className="mt-10">
+										<MyErrorBoundary>
+											<OldFeedbacksEditor
+												controlId={controlId}
+												location={location}
+												feedbacks={config.feedbacks}
 												localVariablesStore={localVariablesStore}
 											/>
 										</MyErrorBoundary>

--- a/webui/src/Buttons/EditButton/LocalVariablesEditor.tsx
+++ b/webui/src/Buttons/EditButton/LocalVariablesEditor.tsx
@@ -18,22 +18,22 @@ export function LocalVariablesEditor({
 	localVariablesStore,
 }: LocalVariablesEditorProps): React.JSX.Element {
 	return (
-		<>
-			<CAlert color="info" className="mb-2">
-				This is a work in progress. Local variables are not supported in actions or feedbacks yet.
-			</CAlert>
-			<ControlEntitiesEditor
-				heading="Local Variables"
-				controlId={controlId}
-				entities={variables}
-				location={location}
-				listId="local-variables"
-				entityType={EntityModelType.Feedback}
-				entityTypeLabel="variable"
-				feedbackListType={FeedbackEntitySubType.Value}
-				localVariablesStore={localVariablesStore}
-				isLocalVariablesList={true}
-			/>
-		</>
+		<ControlEntitiesEditor
+			heading="Local Variables"
+			headingSummary={
+				<CAlert color="info" className="mb-2">
+					This is a work in progress. Local variables are not supported in actions or feedbacks yet.
+				</CAlert>
+			}
+			controlId={controlId}
+			entities={variables}
+			location={location}
+			listId="local-variables"
+			entityType={EntityModelType.Feedback}
+			entityTypeLabel="variable"
+			feedbackListType={FeedbackEntitySubType.Value}
+			localVariablesStore={localVariablesStore}
+			isLocalVariablesList={true}
+		/>
 	)
 }

--- a/webui/src/Buttons/EditButton/OldFeedbacksEditor.tsx
+++ b/webui/src/Buttons/EditButton/OldFeedbacksEditor.tsx
@@ -18,26 +18,26 @@ export function OldFeedbacksEditor({
 	localVariablesStore,
 }: OldFeedbacksEditorProps): React.JSX.Element {
 	return (
-		<>
-			<CAlert color="warning" className="mb-2">
-				Using feedbacks like this is deprecated and is no longer recommended.
-				<br />
-				Since Companion 4.x, feedbacks should be defined through 'Local Variables', and bound to elements through
-				expressions. This old approach has been kept with older buttons and modules that have not updated their
-				feedbacks.
-			</CAlert>
-			<ControlEntitiesEditor
-				heading="Old Feedbacks"
-				controlId={controlId}
-				entities={feedbacks}
-				location={location}
-				listId="feedbacks"
-				entityType={EntityModelType.Feedback}
-				entityTypeLabel="feedback"
-				feedbackListType={FeedbackEntitySubType.Advanced}
-				localVariablesStore={localVariablesStore}
-				isLocalVariablesList={false}
-			/>
-		</>
+		<ControlEntitiesEditor
+			heading="Old Feedbacks"
+			headingSummary={
+				<CAlert color="warning" className="mb-2 ">
+					Using feedbacks like this is deprecated and is no longer recommended.
+					<br />
+					Since Companion 4.x, feedbacks should be defined through 'Local Variables', and bound to elements through
+					expressions. This old approach has been kept for compatibility with older buttons and modules that have not
+					updated their feedbacks.
+				</CAlert>
+			}
+			controlId={controlId}
+			entities={feedbacks}
+			location={location}
+			listId="feedbacks"
+			entityType={EntityModelType.Feedback}
+			entityTypeLabel="feedback"
+			feedbackListType={FeedbackEntitySubType.Advanced}
+			localVariablesStore={localVariablesStore}
+			isLocalVariablesList={false}
+		/>
 	)
 }

--- a/webui/src/Buttons/EditButton/OldFeedbacksEditor.tsx
+++ b/webui/src/Buttons/EditButton/OldFeedbacksEditor.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
 import { ControlEntitiesEditor } from '../../Controls/EntitiesEditor.js'
-import { EntityModelType, FeedbackEntitySubType, SomeEntityModel } from '@companion-app/shared/Model/EntityModel.js'
+import { EntityModelType, SomeEntityModel } from '@companion-app/shared/Model/EntityModel.js'
 import { CAlert } from '@coreui/react'
 import { LocalVariablesStore } from '../../Controls/LocalVariablesStore.js'
 
@@ -35,7 +35,7 @@ export function OldFeedbacksEditor({
 			listId="feedbacks"
 			entityType={EntityModelType.Feedback}
 			entityTypeLabel="feedback"
-			feedbackListType={FeedbackEntitySubType.Advanced}
+			feedbackListType={null}
 			localVariablesStore={localVariablesStore}
 			isLocalVariablesList={false}
 		/>

--- a/webui/src/Buttons/EditButton/OldFeedbacksEditor.tsx
+++ b/webui/src/Buttons/EditButton/OldFeedbacksEditor.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
+import { ControlEntitiesEditor } from '../../Controls/EntitiesEditor.js'
+import { EntityModelType, FeedbackEntitySubType, SomeEntityModel } from '@companion-app/shared/Model/EntityModel.js'
+import { CAlert } from '@coreui/react'
+import { LocalVariablesStore } from '../../Controls/LocalVariablesStore.js'
+
+interface OldFeedbacksEditorProps {
+	controlId: string
+	location: ControlLocation | undefined
+	feedbacks: SomeEntityModel[]
+	localVariablesStore: LocalVariablesStore
+}
+export function OldFeedbacksEditor({
+	controlId,
+	location,
+	feedbacks,
+	localVariablesStore,
+}: OldFeedbacksEditorProps): React.JSX.Element {
+	return (
+		<>
+			<CAlert color="warning" className="mb-2">
+				Using feedbacks like this is deprecated and is no longer recommended.
+				<br />
+				Since Companion 4.x, feedbacks should be defined through 'Local Variables', and bound to elements through
+				expressions. This old approach has been kept with older buttons and modules that have not updated their
+				feedbacks.
+			</CAlert>
+			<ControlEntitiesEditor
+				heading="Old Feedbacks"
+				controlId={controlId}
+				entities={feedbacks}
+				location={location}
+				listId="feedbacks"
+				entityType={EntityModelType.Feedback}
+				entityTypeLabel="feedback"
+				feedbackListType={FeedbackEntitySubType.Advanced}
+				localVariablesStore={localVariablesStore}
+				isLocalVariablesList={false}
+			/>
+		</>
+	)
+}

--- a/webui/src/Controls/Components/EntityEditorHeadingProps.tsx
+++ b/webui/src/Controls/Components/EntityEditorHeadingProps.tsx
@@ -9,6 +9,7 @@ import { observer } from 'mobx-react-lite'
 
 interface EntityEditorHeadingProps {
 	heading: JSX.Element | string | null
+	headingSummary: JSX.Element | null
 	ownerId: EntityOwner | null
 	childEntityIds: string[]
 	headingActions?: JSX.Element[]
@@ -16,6 +17,7 @@ interface EntityEditorHeadingProps {
 
 export const EntityEditorHeading = observer(function EntityEditorHeading({
 	heading,
+	headingSummary,
 	ownerId,
 	childEntityIds,
 	headingActions,
@@ -25,32 +27,35 @@ export const EntityEditorHeading = observer(function EntityEditorHeading({
 	const ownerIdString = stringifyEntityOwnerId(ownerId)
 
 	return (
-		<h5>
-			{heading}
+		<>
+			<h5>
+				{heading}
 
-			<CButtonGroup className="right">
-				{childEntityIds.length >= 1 && panelCollapseHelper.canExpandAll(ownerIdString, childEntityIds) && (
-					<CButton
-						color="white"
-						size="sm"
-						onClick={() => panelCollapseHelper.setAllExpanded(ownerIdString, childEntityIds)}
-						title="Expand all"
-					>
-						<FontAwesomeIcon icon={faExpandArrowsAlt} />
-					</CButton>
-				)}
-				{childEntityIds.length >= 1 && panelCollapseHelper.canCollapseAll(ownerIdString, childEntityIds) && (
-					<CButton
-						color="white"
-						size="sm"
-						onClick={() => panelCollapseHelper.setAllCollapsed(ownerIdString, childEntityIds)}
-						title="Collapse all"
-					>
-						<FontAwesomeIcon icon={faCompressArrowsAlt} />
-					</CButton>
-				)}
-				{headingActions || ''}
-			</CButtonGroup>
-		</h5>
+				<CButtonGroup className="right">
+					{childEntityIds.length >= 1 && panelCollapseHelper.canExpandAll(ownerIdString, childEntityIds) && (
+						<CButton
+							color="white"
+							size="sm"
+							onClick={() => panelCollapseHelper.setAllExpanded(ownerIdString, childEntityIds)}
+							title="Expand all"
+						>
+							<FontAwesomeIcon icon={faExpandArrowsAlt} />
+						</CButton>
+					)}
+					{childEntityIds.length >= 1 && panelCollapseHelper.canCollapseAll(ownerIdString, childEntityIds) && (
+						<CButton
+							color="white"
+							size="sm"
+							onClick={() => panelCollapseHelper.setAllCollapsed(ownerIdString, childEntityIds)}
+							title="Collapse all"
+						>
+							<FontAwesomeIcon icon={faCompressArrowsAlt} />
+						</CButton>
+					)}
+					{headingActions || ''}
+				</CButtonGroup>
+			</h5>
+			{headingSummary}
+		</>
 	)
 })

--- a/webui/src/Controls/Components/EntityList.tsx
+++ b/webui/src/Controls/Components/EntityList.tsx
@@ -14,6 +14,7 @@ import { LocalVariablesStore } from '../LocalVariablesStore.js'
 interface EditableEntityListProps {
 	controlId: string
 	heading: JSX.Element | string | null
+	headingSummary?: JSX.Element
 	headingActions?: JSX.Element[]
 	entities: SomeEntityModel[] | undefined
 	location: ControlLocation | undefined
@@ -29,6 +30,7 @@ interface EditableEntityListProps {
 export const EditableEntityList = observer(function EditableEntityList({
 	controlId,
 	heading,
+	headingSummary,
 	headingActions,
 	entities,
 	location,
@@ -50,6 +52,7 @@ export const EditableEntityList = observer(function EditableEntityList({
 		<>
 			<EntityEditorHeading
 				heading={heading}
+				headingSummary={headingSummary ?? null}
 				ownerId={ownerId}
 				childEntityIds={entities?.map((f) => f.id) ?? []}
 				headingActions={headingActions}

--- a/webui/src/Controls/EntitiesEditor.tsx
+++ b/webui/src/Controls/EntitiesEditor.tsx
@@ -24,6 +24,7 @@ interface ControlEntitiesEditorProps {
 	feedbackListType: ClientEntityDefinition['feedbackType']
 	entities: SomeEntityModel[] | undefined
 	heading: JSX.Element | string
+	headingSummary?: JSX.Element
 	headingActions?: JSX.Element[]
 	localVariablesStore: LocalVariablesStore | null
 	isLocalVariablesList: boolean
@@ -38,6 +39,7 @@ export const ControlEntitiesEditor = observer(function ControlEntitiesEditor({
 	feedbackListType,
 	entities,
 	heading,
+	headingSummary,
 	headingActions,
 	localVariablesStore,
 	isLocalVariablesList,
@@ -59,6 +61,7 @@ export const ControlEntitiesEditor = observer(function ControlEntitiesEditor({
 				<EditableEntityList
 					controlId={controlId}
 					heading={heading}
+					headingSummary={headingSummary}
 					headingActions={headingActions}
 					entities={entities}
 					location={location}


### PR DESCRIPTION
See a full explanation of the plan and reasoning in https://github.com/bitfocus/companion/discussions/3293#discussioncomment-13333908

This is my pitch on how to handle 'old feedbacks' (primarily advanced feedbacks) that don't fit into the new element based flow.  
I see this as a medium term solution, until we can drop support for versions of the module-api that support advanced feedbacks.
The hope here is to make it so that existing configs could be auto-converted across without affecting how buttons are drawn (for the simple square button case). This theory is not implemented, and needs testing to verify if it will work well enough.

![image](https://github.com/user-attachments/assets/ed0d2079-8f0c-48b0-92b4-c164f538d620)

TODO:
- [ ] Hook up to ui preview drawing