### PR TITLE
Confirm mapping for ContourShuttlePro V1

### DIFF
--- a/companion/lib/Surface/USB/ContourShuttle.ts
+++ b/companion/lib/Surface/USB/ContourShuttle.ts
@@ -52,7 +52,6 @@ const contourShuttleProV1Info: ShuttleModelInfo = {
 	totalCols: 5,
 	totalRows: 4,
 
-	// TODO(Someone with hardware): This mapping is guesswork and hasn't been tested
 	jog: [1, 2],
 	shuttle: [2, 2],
 	buttons: [


### PR DESCRIPTION
The button mappings work correctly on my ContourShuttlePro V1, so deleting the TODO:
~~~
	// TODO(Someone with hardware): This mapping is guesswork and hasn't been tested
~~~

P.S. Please let me know if you'd prefer I report this in other ways than a PR!
