### PR TITLE
feat: move version number into sidebar

### DIFF
--- a/webui/src/Layout/Header.tsx
+++ b/webui/src/Layout/Header.tsx
@@ -1,14 +1,5 @@
 import React, { useContext } from 'react'
-import {
-	CHeader,
-	CHeaderBrand,
-	CHeaderNav,
-	CNavItem,
-	CNavLink,
-	CHeaderToggler,
-	CContainer,
-	CSpinner,
-} from '@coreui/react'
+import { CHeader, CHeaderBrand, CHeaderNav, CNavItem, CNavLink, CHeaderToggler, CContainer } from '@coreui/react'
 import { faBars, faLock, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { RootAppStoreContext } from '~/Stores/RootAppStore.js'
@@ -16,7 +7,6 @@ import { observer } from 'mobx-react-lite'
 import { useSidebarState } from './Sidebar.js'
 import { trpc } from '../TRPC.js'
 import { useSubscription } from '@trpc/tanstack-react-query'
-import { useQuery } from '@tanstack/react-query'
 
 interface MyHeaderProps {
 	canLock: boolean
@@ -47,8 +37,6 @@ export const MyHeader = observer(function MyHeader({ canLock, setLocked }: MyHea
 						<CNavItem className="install-name">{userConfig.properties?.installName}</CNavItem>
 					)}
 
-					<HeaderVersion />
-
 					{updateData.data ? (
 						<CNavItem className="header-update-warn">
 							<CNavLink target="_blank" href={updateData.data.link || 'https://bitfocus.io/companion/'}>
@@ -74,25 +62,3 @@ export const MyHeader = observer(function MyHeader({ canLock, setLocked }: MyHea
 		</CHeader>
 	)
 })
-
-function HeaderVersion() {
-	const versionInfo = useQuery(trpc.appInfo.version.queryOptions())
-
-	const versionString = versionInfo.data
-		? versionInfo.data.appBuild.includes('stable')
-			? `v${versionInfo.data.appVersion}`
-			: `v${versionInfo.data.appBuild}`
-		: ''
-	const buildString = versionInfo.data ? `Build ${versionInfo.data.appBuild}` : ''
-
-	return (
-		<CNavItem>
-			{versionInfo.isLoading ? <CSpinner color="white" /> : null}
-			{versionInfo.data ? (
-				<CNavLink target="_blank" title={buildString} href="https://bitfocus.io/companion/">
-					{versionString}
-				</CNavLink>
-			) : null}
-		</CNavItem>
-	)
-}

--- a/webui/src/Layout/Sidebar.tsx
+++ b/webui/src/Layout/Sidebar.tsx
@@ -10,15 +10,7 @@ import React, {
 	useRef,
 	useState,
 } from 'react'
-import {
-	CSidebarNav,
-	CNavItem,
-	CNavLink,
-	CSidebarBrand,
-	CSidebarToggler,
-	CSidebarHeader,
-	CBackdrop,
-} from '@coreui/react'
+import { CSidebarNav, CNavItem, CNavLink, CSidebarBrand, CSidebarHeader, CBackdrop } from '@coreui/react'
 import {
 	faFileImport,
 	faCog,
@@ -52,6 +44,8 @@ import { observer } from 'mobx-react-lite'
 import { RootAppStoreContext } from '~/Stores/RootAppStore.js'
 import { useSortedConnectionsThatHaveVariables } from '~/Stores/Util.js'
 import { makeAbsolutePath } from '~/util.js'
+import { trpc } from '~/TRPC'
+import { useQuery } from '@tanstack/react-query'
 
 export interface SidebarStateProps {
 	showToggle: boolean
@@ -88,18 +82,21 @@ export function SidebarStateProvider({ children }: React.PropsWithChildren): Rea
 interface SidebarMenuItemProps {
 	name: string
 	subheading?: string
-	icon: IconDefinition | null
+	icon: IconDefinition | null | 'empty'
 	notifications?: React.ComponentType<Record<string, never>>
 	path?: string
 	onClick?: () => void
 	target?: string
+	title?: string
 }
 
 function SidebarMenuItemLabel(item: SidebarMenuItemProps) {
 	return (
 		<>
 			<span className="nav-icon-wrapper">
-				{item.icon ? (
+				{item.icon === 'empty' ? (
+					''
+				) : item.icon ? (
 					<FontAwesomeIcon className="nav-icon" icon={item.icon} />
 				) : (
 					<span className="nav-icon">
@@ -108,7 +105,7 @@ function SidebarMenuItemLabel(item: SidebarMenuItemProps) {
 				)}
 			</span>
 
-			<span className="flex-fill">
+			<span className="flex-fill text-truncate">
 				<span>{item.name}</span>
 				{!!item.subheading && (
 					<>
@@ -118,7 +115,7 @@ function SidebarMenuItemLabel(item: SidebarMenuItemProps) {
 				)}
 			</span>
 
-			{item.target === '_new' && <FontAwesomeIcon icon={faExternalLinkSquare} />}
+			{item.target === '_blank' && <FontAwesomeIcon icon={faExternalLinkSquare} className="ms-1" />}
 			{!!item.notifications && <item.notifications />}
 		</>
 	)
@@ -133,11 +130,11 @@ function SidebarMenuItem(item: SidebarMenuItemProps) {
 	return (
 		<CNavItem idx={item.path ?? item.name}>
 			{item.path ? (
-				<CNavLink to={item.path} target={item.target} as={Link} onClick={onClick2}>
+				<CNavLink to={item.path} target={item.target} as={Link} onClick={onClick2} title={item.title}>
 					<SidebarMenuItemLabel {...item} />
 				</CNavLink>
 			) : (
-				<CNavLink onClick={onClick2} style={{ cursor: 'pointer' }}>
+				<CNavLink onClick={onClick2} style={{ cursor: 'pointer' }} title={item.title}>
 					<SidebarMenuItemLabel {...item} />
 				</CNavLink>
 			)}
@@ -160,6 +157,8 @@ function SidebarMenuItemGroup(item: SidebarMenuItemGroupProps) {
 export const MySidebar = memo(function MySidebar() {
 	const { whatsNewModal, showWizard } = useContext(RootAppStoreContext)
 	const [unfoldable, setUnfoldable] = useLocalStorage('sidebar-foldable', false)
+
+	const doToggle = useCallback(() => setUnfoldable((val) => !val), [setUnfoldable])
 
 	const whatsNewOpen = useCallback(() => whatsNewModal.current?.show(), [whatsNewModal])
 
@@ -225,7 +224,7 @@ export const MySidebar = memo(function MySidebar() {
 				</SidebarMenuItemGroup>
 			</CSidebarNav>
 			<CSidebarHeader className="border-top d-none d-lg-flex sidebar-header-toggler">
-				<CSidebarToggler onClick={() => setUnfoldable((val) => !val)} />
+				<SidebarTogglerAndVersion doToggle={doToggle} />
 			</CSidebarHeader>
 		</CSidebar>
 	)
@@ -248,6 +247,42 @@ const SidebarVariablesGroups = observer(function SidebarVariablesGroups() {
 				/>
 			))}
 		</>
+	)
+})
+
+const SidebarTogglerAndVersion = observer(function SidebarTogglerAndVersion({ doToggle }: { doToggle: () => void }) {
+	const versionInfo = useQuery(trpc.appInfo.version.queryOptions())
+
+	let versionString = ''
+	let versionSubheading = ''
+
+	if (versionInfo.data) {
+		if (versionInfo.data.appBuild.includes('-stable-')) {
+			versionString = `v${versionInfo.data.appVersion}`
+		} else {
+			// split appBuild into parts.
+			const splitPoint = versionInfo.data.appBuild.indexOf('-')
+			if (splitPoint === -1) {
+				versionString = `v${versionInfo.data.appBuild}`
+			} else {
+				versionString = `v${versionInfo.data.appBuild.substring(0, splitPoint)}`
+				versionSubheading = versionInfo.data.appBuild.substring(splitPoint + 1)
+			}
+		}
+	}
+
+	return (
+		<div className="nav-link sidebar-header-toggler2">
+			<span className="nav-icon-wrapper" onClick={doToggle}>
+				<span className="nav-icon sidebar-toggler"></span>
+			</span>
+
+			<span className="flex-fill text-truncate">
+				<span className="version">{versionString || 'Unknown'}</span>
+				{/* <br /> */}
+				<span className="version-sub">{versionSubheading}</span>
+			</span>
+		</div>
 	)
 })
 

--- a/webui/src/scss/_layout.scss
+++ b/webui/src/scss/_layout.scss
@@ -304,7 +304,51 @@ form.row > * {
 
 	.sidebar-header.sidebar-header-toggler {
 		justify-content: left;
-		padding-left: 1.5rem;
+		padding: 0.5rem 1rem;
+	}
+
+	.sidebar-header-toggler2 {
+		display: flex;
+		overflow: hidden;
+
+		background: none !important;
+		border: none !important;
+
+		&:hover {
+			background: none !important;
+			border: none !important;
+		}
+
+		.nav-icon-wrapper {
+			cursor: pointer;
+
+			display: flex;
+			align-items: center;
+
+			.sidebar-toggler {
+				display: block;
+				width: 100%;
+			}
+		}
+
+		.version,
+		.version-sub {
+			display: block;
+
+			overflow: hidden;
+			white-space: nowrap;
+			text-overflow: ellipsis;
+		}
+
+		.version {
+			font-size: 0.95em;
+			color: #aaa;
+			display: block;
+		}
+		.version-sub {
+			font-size: 0.85em;
+			color: #888;
+		}
 	}
 
 	.sidebar-header.brand {


### PR DESCRIPTION
~~I am not 100% certain on this, so throwing it here for any feedback.~~

Its always felt a bit weird/messy to have the version number so prominent on the top header bar. This moves it to the bottom of the sidebar:

![image](https://github.com/user-attachments/assets/70d7d6dd-b882-45e7-b2c6-fb744050afcc)

For a stable build:
![image](https://github.com/user-attachments/assets/3ecddcad-9fab-48f7-b352-6c6c1bee302e)
