### PR TITLE
Add a udev file for developing/running Companion on WSL

### DIFF
--- a/assets/linux/50-companion-WSL.rules
+++ b/assets/linux/50-companion-WSL.rules
@@ -1,0 +1,2 @@
+SUBSYSTEM=="usb", GROUP="plugdev", MODE:="0666"
+SUBSYSTEM=="hidraw", GROUP="plugdev", MODE:="0666"

--- a/assets/linux/README
+++ b/assets/linux/README
@@ -24,10 +24,13 @@
 
    If you are running headless, run as root:
    $ cp 50-companion-headless.rules /etc/udev/rules.d/50-companion.rules
-   Or for desktop Companion, run as root:
+   Or for desktop Companion (except WSL), run as root:
    $ cp 50-companion-desktop.rules /etc/udev/rules.d/50-companion.rules
-
-   Apply the new rules:
+   Or for desktop Companion on WSL, (run as root):
+   $ sudo cp 50-companion-WSL.rules /etc/udev/rules.d/
+     (if this is your first time running on WSL, please see the instruction for using USB devices at https://github.com/bitfocus/companion/wiki/Setting-up-Developer-Environment)
+     
+   Apply the new rules (run as root):
    $ udevadm control --reload-rules
    And replugging any usb devices that Companion should be able to use.
 

--- a/assets/linux/README
+++ b/assets/linux/README
@@ -28,8 +28,8 @@
    $ cp 50-companion-desktop.rules /etc/udev/rules.d/50-companion.rules
    Or for desktop Companion on WSL, (run as root):
    $ sudo cp 50-companion-WSL.rules /etc/udev/rules.d/
-     (if this is your first time running on WSL, please see the instruction for using USB devices at https://github.com/bitfocus/companion/wiki/Setting-up-Developer-Environment)
-     
+   (if this is your first time running on WSL, please see the instruction for using USB devices at https://github.com/bitfocus/companion/wiki/Setting-up-Developer-Environment)
+
    Apply the new rules (run as root):
    $ udevadm control --reload-rules
    And replugging any usb devices that Companion should be able to use.


### PR DESCRIPTION
Add a udev file for developing/running Companion on WSL (Windows Subsystem for Linux).

In order to access surfaces in WSL, the user needs to open up both USB and HID devices. This rules file shows the simplest way to do it.

This PR is related to suggestion I have made for the Wiki page: [Setting up Developer Environment](https://github.com/bitfocus/companion/wiki/Setting-up-Developer-Environment)

Since I couldn't find a way to do a PR on wiki pages, I copied and edited it in Google Docs [here](https://docs.google.com/document/d/1jYic5nYimB9Jvv0Omv-IPfrx_tZpnKVZt-jvUOgVfag/edit?usp=sharing), as per Dorian's request to send him suggestions directly and he would check it in.  Here is the result of the edits (i.e. accepting all of my suggestions) in markdown: https://github.com/arikorn/companion-wiki/blob/main/README.md )

Note: the file _README_ should be renamed _README.md_ so formatting shows up in GitHub. I left the filename alone in order to make the diff usable.