### PR TITLE
feat: improved backups control #2961

### DIFF
--- a/companion/lib/Data/StoreBase.ts
+++ b/companion/lib/Data/StoreBase.ts
@@ -40,9 +40,9 @@ export abstract class DataStoreBase<TDefaultTableContent extends Record<string, 
 	 */
 	private backupCycle: NodeJS.Timeout | undefined
 	/**
-	 * The interval to fire a backup to disk when dirty
+	 * The interval to slowly write a backup to disk to minimise risk of corruption
 	 */
-	private readonly backupInterval: number = 60000
+	private readonly backupInterval: number = 10 * 60 * 1000
 	/**
 	 * The full backup file path
 	 */

--- a/companion/lib/ImportExport/Backups.ts
+++ b/companion/lib/ImportExport/Backups.ts
@@ -1,0 +1,717 @@
+/*
+ * This file is part of the Companion project
+ * Copyright (c) 2018 Bitfocus AS
+ * Authors: Julian Waller <companion@julusian.co.uk>
+ *
+ * This program is free software.
+ * You should have received a copy of the MIT licence as well as the Bitfocus
+ * Individual Contributor License Agreement for companion along with
+ * this program.
+ *
+ */
+
+import LogController from '../Log/Controller.js'
+import path from 'path'
+import fs from 'fs/promises'
+import nodeCron from 'node-cron'
+import { nanoid } from 'nanoid'
+import type { BackupRulesConfig, PreviousBackupInfo } from '@companion-app/shared/Model/UserConfigModel.js'
+import type { AppInfo } from '../Registry.js'
+import type { VariablesValues } from '../Variables/Values.js'
+import type winston from 'winston'
+import { stringifyExport } from './Util.js'
+import { Logger } from 'winston'
+import type { ExportFormat } from '@companion-app/shared/Model/ExportFormat.js'
+import type { ExportController } from './Export.js'
+import type { DataDatabase } from '../Data/Database.js'
+import type { DataUserConfig } from '../Data/UserConfig.js'
+import { publicProcedure, router } from '../UI/TRPC.js'
+import z from 'zod'
+
+/**
+ * BackupController handles scheduled backups of companion app data.
+ */
+export class BackupController {
+	readonly #logger = LogController.createLogger('ImportExport/BackupController')
+
+	readonly #db: DataDatabase
+	readonly #userConfig: DataUserConfig
+	readonly #variableValuesController: VariablesValues
+	readonly #defaultBackupDir: string
+	readonly #cronJobs: Map<string, nodeCron.ScheduledTask> = new Map()
+	readonly #exportController: ExportController
+	#backupRules: BackupRulesConfig[] = []
+
+	/**
+	 * Create a new backup controller
+	 * @param appInfo Application information
+	 * @param db Database instance (for raw backups)
+	 * @param userConfig User configuration controller
+	 * @param variableValuesController Variable values controller
+	 * @param exportController Export controller
+	 */
+	constructor(
+		appInfo: AppInfo,
+		db: DataDatabase,
+		userConfig: DataUserConfig,
+		variableValuesController: VariablesValues,
+		exportController: ExportController
+	) {
+		this.#db = db
+		this.#userConfig = userConfig
+		this.#variableValuesController = variableValuesController
+		this.#defaultBackupDir = path.join(appInfo.configDir, 'backups')
+		this.#exportController = exportController
+
+		// Listen for config changes
+		this.#userConfig.on('keyChanged', (key, value) => {
+			if (key === 'backups') {
+				this.#backupRules = value as BackupRulesConfig[]
+				this.#scheduleBackups()
+			}
+		})
+	}
+
+	createTrpcRouter() {
+		return router({
+			runBackupNow: publicProcedure
+				.input(
+					z.object({
+						ruleId: z.string(),
+					})
+				)
+				.mutation(async ({ input }) => {
+					return this.runBackupNow(input.ruleId)
+				}),
+
+			deleteBackupFile: publicProcedure
+				.input(
+					z.object({
+						ruleId: z.string(),
+						filePath: z.string(),
+					})
+				)
+				.mutation(async ({ input }) => {
+					return this.deleteBackup(input.ruleId, input.filePath)
+				}),
+
+			updateRuleField: publicProcedure
+				.input(
+					z.object({
+						ruleId: z.string(),
+						field: z.string(),
+						value: z.unknown(),
+					})
+				)
+				.mutation(async ({ input }) => {
+					return this.updateRuleField(input.ruleId, input.field, input.value)
+				}),
+
+			createRule: publicProcedure
+				.input(
+					z.object({
+						name: z.string(),
+					})
+				)
+				.mutation(async ({ input }) => {
+					return this.createRule(input.name)
+				}),
+			deleteRule: publicProcedure
+				.input(
+					z.object({
+						ruleId: z.string(),
+					})
+				)
+				.mutation(async ({ input }) => {
+					return this.deleteRule(input.ruleId)
+				}),
+			reorderRules: publicProcedure
+				.input(
+					z.object({
+						ruleId: z.string(),
+						targetId: z.string(),
+					})
+				)
+				.mutation(async ({ input }) => {
+					return this.reorderRules(input.ruleId, input.targetId)
+				}),
+		})
+	}
+
+	/**
+	 * Run a specific backup rule immediately
+	 * @param ruleId ID of the backup rule to run
+	 */
+	private async runBackupNow(ruleId: string): Promise<void> {
+		const rule = this.#backupRules.find((r) => r.id === ruleId)
+		if (!rule) {
+			this.#logger.error(`Cannot run backup - rule with ID ${ruleId} not found`)
+			throw new Error('Backup rule not found')
+		}
+
+		const logger = LogController.createLogger(`ImportExport/BackupController/${rule.name}`)
+
+		logger.info(`Starting backup to: ${rule.backupPath || this.#defaultBackupDir}`)
+		const backupInfo = await this.#createBackup(logger, rule)
+		if (backupInfo) {
+			// Update the last ran timestamp
+			this.#updateLastRanTimestamp(rule.id, backupInfo)
+			logger.info(`Manual backup created successfully: ${backupInfo.filePath} (${backupInfo.fileSize} bytes)`)
+		} else {
+			logger.error('Failed to create manual backup')
+			throw new Error('No backup created')
+		}
+	}
+
+	/**
+	 * Update the last ran timestamp for a backup rule
+	 * @param ruleId ID of the backup rule to update
+	 */
+	#updateLastRanTimestamp(ruleId: string, newBackupInfo: PreviousBackupInfo): void {
+		const newBackupRules = [...this.#backupRules]
+		const ruleIndex = newBackupRules.findIndex((r) => r.id === ruleId)
+
+		if (ruleIndex !== -1) {
+			const updatedRule: BackupRulesConfig = {
+				...newBackupRules[ruleIndex],
+				lastRan: Date.now(),
+				previousBackups: [...newBackupRules[ruleIndex].previousBackups, newBackupInfo],
+			}
+			newBackupRules[ruleIndex] = updatedRule
+
+			this.#userConfig.setKeyUnchecked('backups', newBackupRules)
+
+			this.cleanupOldBackups(updatedRule).catch((err) => {
+				this.#logger.error(`Failed to clean up old backups for rule ${ruleId}: ${err}`)
+			})
+		}
+	}
+
+	/**
+	 * Initialize backup scheduler with user configuration
+	 * @param backupRules Backup rules configuration object
+	 */
+	initializeWithConfig(backupRules: BackupRulesConfig[]): void {
+		this.#ensureBackupDirExists().catch((err) => {
+			this.#logger.error(`Failed to ensure backup directory exists: ${err}`)
+		})
+
+		this.#backupRules = backupRules
+		this.#scheduleBackups()
+	}
+
+	/**
+	 * Schedule all backup rules from configuration
+	 */
+	#scheduleBackups(): void {
+		this.#clearScheduledJobs()
+
+		// Create new jobs from current config
+		for (const rule of this.#backupRules) {
+			if (rule.enabled) {
+				this.#scheduleBackup(rule)
+			}
+		}
+	}
+
+	/**
+	 * Clear all scheduled backup jobs
+	 */
+	#clearScheduledJobs(): void {
+		for (const [id, job] of this.#cronJobs.entries()) {
+			Promise.resolve(job.stop()).catch((err) => {
+				this.#logger.error(`Failed to stop cron job ${id}: ${err}`)
+			})
+			this.#cronJobs.delete(id)
+		}
+	}
+
+	/**
+	 * Schedule a single backup rule
+	 * @param rule Backup rule configuration
+	 */
+	#scheduleBackup(rule: BackupRulesConfig): void {
+		try {
+			// Stop existing job if it exists
+			const existingJob = this.#cronJobs.get(rule.id)
+			if (existingJob) {
+				Promise.resolve(existingJob.stop()).catch((err) => {
+					this.#logger.error(`Failed to stop cron job ${rule.id}: ${err}`)
+				})
+				this.#cronJobs.delete(rule.id)
+			}
+
+			if (!nodeCron.validate(rule.cron)) {
+				this.#logger.error(`Invalid cron expression for rule "${rule.name}": ${rule.cron}`)
+				return
+			}
+
+			// Create new job
+			const job = nodeCron.schedule(
+				rule.cron,
+				async () => {
+					const logger = LogController.createLogger(`ImportExport/BackupController/${rule.name}`)
+					try {
+						logger.info(`Running scheduled backup for rule`)
+						const backupInfo = await this.#createBackup(logger, rule)
+						if (backupInfo) {
+							this.#updateLastRanTimestamp(rule.id, backupInfo)
+							logger.info(
+								`Scheduled backup created successfully: ${backupInfo.filePath} (${backupInfo.fileSize} bytes)`
+							)
+						} else {
+							logger.error(`Failed to create scheduled backup for rule`)
+						}
+					} catch (err) {
+						logger.error(`Error in scheduled backup: ${err}`)
+					}
+				},
+				{
+					noOverlap: true,
+				}
+			)
+
+			// Store the job
+			this.#cronJobs.set(rule.id, job)
+			this.#logger.info(`Scheduled backup rule: ${rule.name} with cron: ${rule.cron}`)
+		} catch (err) {
+			this.#logger.error(`Failed to schedule backup rule ${rule.name}: ${err}`)
+		}
+	}
+
+	/**
+	 * Clean up old backups based on keep count
+	 * @param rule Backup rule configuration
+	 */
+	private async cleanupOldBackups(rule: BackupRulesConfig): Promise<void> {
+		try {
+			if (rule.keep <= 0 || !rule.previousBackups || rule.previousBackups.length <= rule.keep) {
+				// No cleanup needed
+				return
+			}
+
+			// Sort backups by creation time (newest first)
+			const sortedBackups = [...rule.previousBackups].sort((a, b) => b.createdAt - a.createdAt)
+
+			// Identify backups to delete (keep only the newest 'keep' count)
+			const backupsToDelete = sortedBackups.slice(rule.keep)
+			if (backupsToDelete.length === 0) return
+
+			this.#logger.info(`Cleaning up ${backupsToDelete.length} old backups for rule ${rule.name}`)
+
+			// Delete the old backup files
+			const deletionPromises = backupsToDelete.map(async (backup) => {
+				try {
+					await fs.unlink(backup.filePath)
+					this.#logger.info(`Deleted old backup: ${backup.filePath}`)
+					return backup
+				} catch (err) {
+					this.#logger.warn(`Failed to delete backup file ${backup.filePath}: ${err}`)
+					// Return null to indicate this backup wasn't deleted
+					return null
+				}
+			})
+
+			const deletionResults = await Promise.all(deletionPromises)
+
+			// Update the rule's previousBackups list to remove successfully deleted backups
+			// Note: this needs to lookup the list again, as the original array may have been modified during the delete
+			const updatedPreviousBackups = rule.previousBackups.filter(
+				(backup) => !deletionResults.some((deleted) => deleted && deleted.filePath === backup.filePath)
+			)
+
+			// Update the rule in the configuration if any backups were deleted
+			if (updatedPreviousBackups.length !== rule.previousBackups.length) {
+				const updatedBackupRules = [...this.#backupRules]
+				const ruleIndex = updatedBackupRules.findIndex((r) => r.id === rule.id)
+
+				if (ruleIndex !== -1) {
+					updatedBackupRules[ruleIndex] = {
+						...updatedBackupRules[ruleIndex],
+						previousBackups: updatedPreviousBackups,
+					}
+
+					// Update the userConfig
+					this.#userConfig.setKeyUnchecked('backups', updatedBackupRules)
+					this.#backupRules = updatedBackupRules
+				}
+			}
+		} catch (err) {
+			this.#logger.error(`Failed to clean up old backups for rule ${rule.name}: ${err}`)
+		}
+	}
+
+	/**
+	 * Ensure backup directory exists
+	 */
+	async #ensureBackupDirExists(): Promise<void> {
+		try {
+			await fs.mkdir(this.#defaultBackupDir, { recursive: true })
+		} catch (e) {
+			this.#logger.error('Failed to create backup directory', e)
+		}
+	}
+
+	/**
+	 * Check if a file already exists and throw an error if it does
+	 * @param filePath Path to check for existence
+	 * @throws Error if file already exists or if there's an access error other than ENOENT
+	 */
+	async #ensureFileDoesNotExist(filePath: string): Promise<void> {
+		try {
+			await fs.access(filePath)
+			// File exists, this is an error
+			throw new Error(`Backup file already exists: ${filePath}`)
+		} catch (err) {
+			// File doesn't exist (ENOENT error), which is what we want
+			if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+				// Some other error occurred
+				throw err
+			}
+		}
+	}
+
+	/**
+	 * Create a backup of the current configuration
+	 * @param rule Configuration for the backup
+	 * @returns Promise resolving to the backup filename or null if failed
+	 */
+	async #createBackup(logger: winston.Logger, rule: BackupRulesConfig): Promise<PreviousBackupInfo | null> {
+		try {
+			await this.#ensureBackupDirExists()
+
+			// Determine backup directory - use rule path if specified, otherwise default
+			const backupDir = rule.backupPath ? rule.backupPath : this.#defaultBackupDir
+			await fs.mkdir(backupDir, { recursive: true })
+
+			// Generate backup filename
+			const backupName = this.#variableValuesController.parseVariables(rule.backupNamePattern, null)
+			if (!backupName) {
+				logger.info('No backup name generated, skipping backup')
+				return null
+			}
+
+			// Create the backup based on type
+			switch (rule.backupType) {
+				case 'db': {
+					const filePath = path.join(backupDir, `${backupName.text}.companiondb`)
+
+					// Check if file already exists
+					await this.#ensureFileDoesNotExist(filePath)
+
+					logger.info(`Creating database backup at ${filePath}`)
+
+					const fileSize = await this.#db.createBackup(filePath)
+
+					return {
+						filePath,
+						fileSize,
+						createdAt: Date.now(),
+					}
+				}
+
+				case 'export-gz':
+					return this.#generateExportBackup(logger, backupDir, backupName.text, 'json-gz')
+				case 'export-json':
+					return this.#generateExportBackup(logger, backupDir, backupName.text, 'json')
+				case 'export-yaml':
+					return this.#generateExportBackup(logger, backupDir, backupName.text, 'yaml')
+
+				default:
+					throw new Error(`Unsupported backup type: ${rule.backupType}`)
+			}
+		} catch (err: any) {
+			logger.error(`Failed to create backup: ${err}`)
+			throw new Error(`Failed to create backup: ${err.message || err}`)
+		}
+	}
+
+	async #generateExportBackup(
+		logger: Logger,
+		backupDir: string,
+		filename: string,
+		format: ExportFormat
+	): Promise<PreviousBackupInfo> {
+		const data = this.#exportController.generateCustomExport(null)
+		const exportData = await stringifyExport(logger, data, `${filename}.companionconfig`, format)
+		if (!exportData) throw new Error('Failed to stringify export data')
+
+		const filePath = path.join(backupDir, exportData.utf8Filename)
+
+		await this.#ensureFileDoesNotExist(filePath)
+
+		logger.info(`Exporting to ${filePath}`)
+
+		await fs.writeFile(filePath, exportData.data)
+
+		return {
+			filePath,
+			fileSize: exportData.data.length,
+			createdAt: Date.now(),
+		}
+	}
+
+	/**
+	 * Delete a backup file
+	 * @param ruleId ID of the backup rule that owns this backup
+	 * @param filePath Path to the backup file to delete
+	 * @returns Promise resolving to true if deletion was successful
+	 */
+	async deleteBackup(ruleId: string, filePath: string): Promise<boolean> {
+		try {
+			// Find the rule and verify the backup exists in its previousBackups list
+			const rule = this.#backupRules.find((r) => r.id === ruleId)
+			if (!rule) {
+				this.#logger.warn(`Backup rule not found: ${ruleId}`)
+				return false
+			}
+
+			const backupIndex = rule.previousBackups.findIndex((backup) => backup.filePath === filePath)
+			if (backupIndex === -1) {
+				this.#logger.warn(`Backup file not found in rule ${ruleId}: ${filePath}`)
+				return false
+			}
+
+			// Delete the file if it exists
+			try {
+				await fs.unlink(filePath)
+				this.#logger.info(`Deleted backup file: ${filePath}`)
+			} catch (err) {
+				this.#logger.warn(`Failed to delete backup file ${filePath}, but will remove from rule: ${err}`)
+			}
+
+			// Update backup rules to remove this backup from the specific rule
+			const updatedBackupRules = [...this.#backupRules]
+			const updatedRule = updatedBackupRules.find((r) => r.id === ruleId)
+			if (updatedRule) {
+				updatedRule.previousBackups.splice(backupIndex, 1)
+
+				// Update the userConfig through the database
+				this.#userConfig.setKeyUnchecked('backups', updatedBackupRules)
+				this.#backupRules = updatedBackupRules
+			}
+
+			return true
+		} catch (e) {
+			this.#logger.error(`Failed to delete backup file ${filePath}:`, e)
+			return false
+		}
+	}
+
+	/**
+	 * Validate a field update for a backup rule
+	 * @param field The field name to update
+	 * @param value The value to set
+	 * @returns Validation result with success status and error message
+	 */
+	#validateFieldUpdate(field: string, value: unknown): { valid: boolean; error?: string } {
+		// Type validation for each field
+		switch (field) {
+			case 'name':
+			case 'backupPath':
+			case 'backupNamePattern':
+				if (typeof value !== 'string') {
+					return { valid: false, error: `Field '${field}' must be a string, got ${typeof value}` }
+				}
+				if (field === 'name' && value.trim().length === 0) {
+					return { valid: false, error: 'Name cannot be empty' }
+				}
+				break
+
+			case 'cron':
+				if (typeof value !== 'string') {
+					return { valid: false, error: `Field '${field}' must be a string, got ${typeof value}` }
+				}
+				if (!nodeCron.validate(value)) {
+					return { valid: false, error: `Field '${field}' must be a valid cron expression, got '${value}'` }
+				}
+				break
+
+			case 'enabled':
+				if (typeof value !== 'boolean') {
+					return { valid: false, error: `Field '${field}' must be a boolean, got ${typeof value}` }
+				}
+				break
+
+			case 'keep':
+				if (!Number.isInteger(value) || (value as number) < 0) {
+					return { valid: false, error: `Field '${field}' must be a non-negative integer, got ${value}` }
+				}
+				if ((value as number) > 1000) {
+					return { valid: false, error: `Field '${field}' cannot exceed 1000 backups, got ${value}` }
+				}
+				break
+
+			case 'backupType': {
+				const validBackupTypes = ['db', 'export-gz', 'export-json', 'export-yaml']
+				if (typeof value !== 'string' || !validBackupTypes.includes(value)) {
+					return {
+						valid: false,
+						error: `Field '${field}' must be one of: ${validBackupTypes.join(', ')}, got ${value}`,
+					}
+				}
+				break
+			}
+
+			default:
+				return { valid: false, error: `Unknown field: ${field}` }
+		}
+
+		return { valid: true }
+	}
+
+	/**
+	 * Update a specific field in a backup rule
+	 * @param ruleId ID of the rule to update
+	 * @param field Field name to update
+	 * @param value New value for the field
+	 * @returns Promise resolving to true if update was successful
+	 */
+	async updateRuleField(ruleId: string, field: string, value: unknown): Promise<boolean> {
+		try {
+			const updatedBackupRules = [...this.#backupRules]
+			const ruleIndex = updatedBackupRules.findIndex((r) => r.id === ruleId)
+
+			if (ruleIndex === -1) {
+				this.#logger.warn(`Backup rule not found for update: ${ruleId}`)
+				return false
+			}
+
+			// Validate the field name and value type
+			const validationResult = this.#validateFieldUpdate(field, value)
+			if (!validationResult.valid) {
+				this.#logger.warn(`Invalid field update for backup rule: ${validationResult.error}`)
+				return false
+			}
+
+			// Update the field
+			updatedBackupRules[ruleIndex] = {
+				...updatedBackupRules[ruleIndex],
+				[field]: value,
+			}
+
+			// Update the userConfig through the UserConfig controller
+			this.#userConfig.setKeyUnchecked('backups', updatedBackupRules)
+			this.#backupRules = updatedBackupRules
+
+			// Reschedule if the rule was updated
+			this.#scheduleBackups()
+
+			this.#logger.info(`Updated backup rule ${ruleId} field ${field}`)
+			return true
+		} catch (e) {
+			this.#logger.error(`Failed to update backup rule ${ruleId} field ${field}:`, e)
+			return false
+		}
+	}
+
+	/**
+	 * Create a new backup rule
+	 * @param name Name for the new backup rule
+	 * @returns Promise resolving to the new rule ID if creation was successful
+	 */
+	async createRule(name: string): Promise<string> {
+		try {
+			const newRuleId = nanoid()
+			const newRule: BackupRulesConfig = {
+				id: newRuleId,
+				name: name || 'New Backup Rule',
+				cron: '0 0 * * *', // Daily at midnight
+				enabled: true,
+				keep: 5,
+				backupType: 'db',
+				backupPath: '', // Default to empty, will use default backup directory
+				backupNamePattern: 'backup-$(internal:hostname)_$(internal:date_iso)-$(internal:time_h)$(internal:time_m)',
+				lastRan: 0,
+				previousBackups: [],
+			}
+
+			const updatedBackupRules = [...this.#backupRules, newRule]
+
+			// Update the userConfig through the UserConfig controller
+			this.#userConfig.setKeyUnchecked('backups', updatedBackupRules)
+			this.#backupRules = updatedBackupRules
+
+			// Reschedule backups
+			this.#scheduleBackups()
+
+			this.#logger.info(`Created backup rule: ${newRule.name} (${newRuleId})`)
+			return newRuleId
+		} catch (e) {
+			this.#logger.error(`Failed to create backup rule:`, e)
+			throw new Error('Failed to create backup rule')
+		}
+	}
+
+	/**
+	 * Delete a backup rule
+	 * @param ruleId ID of the rule to delete
+	 * @returns Promise resolving to true if deletion was successful
+	 */
+	async deleteRule(ruleId: string): Promise<boolean> {
+		try {
+			const ruleIndex = this.#backupRules.findIndex((r) => r.id === ruleId)
+
+			if (ruleIndex === -1) {
+				this.#logger.warn(`Backup rule not found for deletion: ${ruleId}`)
+				return false
+			}
+
+			const updatedBackupRules = [...this.#backupRules]
+			const deletedRule = updatedBackupRules.splice(ruleIndex, 1)[0]
+
+			// Update the userConfig through the UserConfig controller
+			this.#userConfig.setKeyUnchecked('backups', updatedBackupRules)
+			this.#backupRules = updatedBackupRules
+
+			// Remove any scheduled job for this rule
+			const job = this.#cronJobs.get(ruleId)
+			if (job) {
+				Promise.resolve(job.stop()).catch((err) => {
+					this.#logger.error(`Failed to stop cron job ${ruleId}: ${err}`)
+				})
+				this.#cronJobs.delete(ruleId)
+			}
+
+			this.#logger.info(`Deleted backup rule: ${deletedRule.name} (${ruleId})`)
+			return true
+		} catch (e) {
+			this.#logger.error(`Failed to delete backup rule ${ruleId}:`, e)
+			return false
+		}
+	}
+
+	/**
+	 * Reorder backup rules by moving one rule to another position
+	 * @param ruleId ID of the rule to move
+	 * @param targetId ID of the rule to move next to
+	 * @returns Promise<boolean> Success status
+	 */
+	async reorderRules(ruleId: string, targetId: string): Promise<boolean> {
+		try {
+			const rules = [...this.#backupRules]
+			const itemIndex = rules.findIndex((rule) => rule.id === ruleId)
+			const targetIndex = rules.findIndex((rule) => rule.id === targetId)
+
+			if (itemIndex === -1 || targetIndex === -1) {
+				this.#logger.warn(`Cannot reorder: rule not found. itemId=${ruleId}, targetId=${targetId}`)
+				return false
+			}
+
+			// Remove the item
+			const [movedItem] = rules.splice(itemIndex, 1)
+			// Insert at the target position
+			rules.splice(targetIndex, 0, movedItem)
+
+			// Update the userConfig through the UserConfig controller
+			this.#userConfig.setKeyUnchecked('backups', rules)
+			this.#backupRules = rules
+
+			this.#logger.info(`Reordered backup rules: moved ${ruleId} to position near ${targetId}`)
+			return true
+		} catch (e) {
+			this.#logger.error(`Failed to reorder backup rules: ${ruleId} -> ${targetId}:`, e)
+			return false
+		}
+	}
+}

--- a/companion/lib/ImportExport/Export.ts
+++ b/companion/lib/ImportExport/Export.ts
@@ -15,8 +15,6 @@ import { ParseControlId } from '@companion-app/shared/ControlId.js'
 import archiver from 'archiver'
 import path from 'path'
 import fs from 'fs'
-import yaml from 'yaml'
-import zlib from 'node:zlib'
 import { stringify as csvStringify } from 'csv-stringify/sync'
 import LogController, { Logger } from '../Log/Controller.js'
 import type express from 'express'
@@ -46,6 +44,7 @@ import type { RequestHandler } from 'express'
 import { FILE_VERSION } from './Constants.js'
 import type { TriggerCollection } from '@companion-app/shared/Model/TriggerModel.js'
 import type { CollectionBase } from '@companion-app/shared/Model/Collections.js'
+import { formatAttachmentFilename, StringifiedExportData, stringifyExport } from './Util.js'
 
 export class ExportController {
 	readonly #logger = LogController.createLogger('ImportExport/Controller')
@@ -92,7 +91,7 @@ export class ExportController {
 
 		const filename = this.#generateFilename(String(req.query.filename as any), 'trigger_list', 'companionconfig')
 
-		downloadBlob(this.#logger, res, next, exp, filename, parseDownloadFormat(req.query.format))
+		downloadBlob(this.#logger, res, next, exp, filename, String(req.query.format as any))
 	}
 
 	#exportTriggerSingleHandler: RequestHandler = (req, res, next) => {
@@ -107,7 +106,7 @@ export class ExportController {
 				'companionconfig'
 			)
 
-			downloadBlob(this.#logger, res, next, exp, filename, parseDownloadFormat(req.query.format))
+			downloadBlob(this.#logger, res, next, exp, filename, String(req.query.format as any))
 		} else {
 			next()
 		}
@@ -150,20 +149,20 @@ export class ExportController {
 
 			const filename = this.#generateFilename(String(req.query.filename as any), `page${page}`, 'companionconfig')
 
-			downloadBlob(this.#logger, res, next, exp, filename, parseDownloadFormat(req.query.format))
+			downloadBlob(this.#logger, res, next, exp, filename, String(req.query.format as any))
 		}
 	}
 
 	#exportCustomHandler: RequestHandler = (req, res, next) => {
-		const exp = this.#generateCustomExport(req.query as any)
+		const exp = this.generateCustomExport(req.query as any)
 
 		const filename = this.#generateFilename(String(req.query.filename as any), '', 'companionconfig')
 
-		downloadBlob(this.#logger, res, next, exp, filename, parseDownloadFormat(req.query.format))
+		downloadBlob(this.#logger, res, next, exp, filename, String(req.query.format as any))
 	}
 
 	#exportFullHandler: RequestHandler = (req, res, next) => {
-		const exp = this.#generateCustomExport(null)
+		const exp = this.generateCustomExport(null)
 
 		const filename = this.#generateFilename(
 			String(this.#userConfigController.getKey('default_export_filename')),
@@ -171,7 +170,7 @@ export class ExportController {
 			'companionconfig'
 		)
 
-		downloadBlob(this.#logger, res, next, exp, filename, parseDownloadFormat(req.query.format))
+		downloadBlob(this.#logger, res, next, exp, filename, String(req.query.format as any))
 	}
 
 	#exportLogHandler: RequestHandler = (_req, res, _next) => {
@@ -183,18 +182,16 @@ export class ExportController {
 			'csv'
 		)
 
-		res.status(200)
-		res.set({
-			'Content-Type': 'text/csv',
-			'Content-Disposition': attachmentWithFilename(filename),
-		})
-
 		const csvOut = csvStringify([
 			['Date', 'Module', 'Type', 'Log'],
 			...logs.map((line) => [new Date(line.time).toISOString(), line.source, line.level, line.message]),
 		])
 
-		res.end(csvOut)
+		sendExportData(res, {
+			data: csvOut,
+			contentType: 'text/csv',
+			...formatAttachmentFilename(filename),
+		})
 	}
 
 	#exportSupportBundleHandler: RequestHandler = async (_req, res, _next) => {
@@ -417,7 +414,7 @@ export class ExportController {
 		return pageExport
 	}
 
-	#generateCustomExport(config: ClientExportSelection | null): ExportFullv6 {
+	generateCustomExport(config: ClientExportSelection | null): ExportFullv6 {
 		// Export file protocol version
 		const exp: ExportFullv6 = {
 			version: FILE_VERSION,
@@ -507,50 +504,13 @@ function parseDownloadFormat(raw: ParsedQs[0]): ExportFormat | undefined {
 	return undefined
 }
 
-/**
- * Replacer that splits "png64" values into multiple lines.
- *
- * These are base64 encoded PNGs and can get very long. A length of 60 characters is used to allow
- * for indentation in the YAML.
- *
- * @param key - The key of the value being processed.
- * @param value - The value to be processed.
- * @returns The modified value or the original value if the conditions are not met.
- */
-function splitLongPng64Values(key: string, value: string): string {
-	if (key === 'png64' && typeof value === 'string' && value.length > 60) {
-		return btoa(atob(value)).replace(/(.{60})/g, '$1\n') + '\n'
-	}
-	return value
-}
-
-/**
- * Compute a Content-Disposition header specifying an attachment with the
- * given filename.
- */
-function attachmentWithFilename(filename: string): string {
-	function quotedAscii(s: string): string {
-		// Boil away combining characters and non-ASCII code points and escape
-		// quotes.  Modern browsers don't use this, so don't bother going all-out.
-		// Don't percent-encode anything, because browsers don't agree on whether
-		// quoted filenames should be percent-decoded (Firefox and Chrome yes,
-		// Safari no).
-		return (
-			'"' +
-			[...s.normalize('NFKD')]
-				.filter((c) => '\x20' <= c && c <= '\x7e')
-				.map((c) => (c === '"' || c === '\\' ? '\\' : '') + c)
-				.join('') +
-			'"'
-		)
-	}
-
-	// The filename parameter is used primarily by legacy browsers.  Strangely, it
-	// must be present for at least some versions of Safari to use the modern
-	// filename* parameter.
-	const quotedFallbackAsciiFilename = quotedAscii(filename)
-	const modernUnicodeFilename = encodeURIComponent(filename)
-	return `attachment; filename=${quotedFallbackAsciiFilename}; filename*=UTF-8''${modernUnicodeFilename}`
+function sendExportData(res: express.Response, data: StringifiedExportData) {
+	res.status(200)
+	res.set({
+		'Content-Type': data.contentType,
+		'Content-Disposition': `attachment; filename=${data.asciiFilename}; filename*=UTF-8''${data.utf8Filename}`,
+	})
+	res.end(data.data)
 }
 
 function downloadBlob(
@@ -559,37 +519,18 @@ function downloadBlob(
 	next: express.NextFunction,
 	data: SomeExportv6,
 	filename: string,
-	format: ExportFormat | undefined
+	formatStr: string
 ): void {
-	if (!format || format === 'json-gz') {
-		zlib.gzip(JSON.stringify(data), (err, result) => {
-			if (err) {
-				logger.warn(`Failed to gzip data, retrying uncompressed: ${err}`)
-				downloadBlob(logger, res, next, data, filename, 'json')
+	stringifyExport(logger, data, filename, parseDownloadFormat(formatStr))
+		.then((data) => {
+			if (data) {
+				sendExportData(res, data)
 			} else {
-				res.status(200)
-				res.set({
-					'Content-Type': 'application/gzip',
-					'Content-Disposition': attachmentWithFilename(filename),
-				})
-				res.end(result)
+				next(new Error(`Unknown format: ${formatStr}`))
 			}
 		})
-	} else if (format === 'json') {
-		res.status(200)
-		res.set({
-			'Content-Type': 'application/json',
-			'Content-Disposition': attachmentWithFilename(filename),
+		.catch((err) => {
+			logger.error(`Failed to stringify export data: ${err}`)
+			next(err)
 		})
-		res.end(JSON.stringify(data, undefined, '\t'))
-	} else if (format === 'yaml') {
-		res.status(200)
-		res.set({
-			'Content-Type': 'application/yaml',
-			'Content-Disposition': attachmentWithFilename(filename),
-		})
-		res.end(yaml.stringify(data, splitLongPng64Values))
-	} else {
-		next(new Error(`Unknown format: ${format}`))
-	}
 }

--- a/companion/lib/ImportExport/Util.ts
+++ b/companion/lib/ImportExport/Util.ts
@@ -1,0 +1,104 @@
+import zlib from 'node:zlib'
+import yaml from 'yaml'
+import type { ExportFormat } from '@companion-app/shared/Model/ExportFormat.js'
+import type { SomeExportv6 } from '@companion-app/shared/Model/ExportModel.js'
+import type { Logger } from 'winston'
+import { promisify } from 'node:util'
+
+const gzipAsync = promisify(zlib.gzip)
+
+export interface StringifiedExportData {
+	data: string | Buffer
+	contentType: string
+	asciiFilename: string
+	utf8Filename: string
+}
+
+export async function stringifyExport(
+	logger: Logger,
+	data: SomeExportv6,
+	filename: string,
+	format: ExportFormat | undefined
+): Promise<StringifiedExportData | null> {
+	if (!format || format === 'json-gz') {
+		try {
+			const dataGz = await gzipAsync(JSON.stringify(data))
+			return {
+				data: dataGz,
+				contentType: 'application/json',
+				...formatAttachmentFilename(filename),
+			}
+		} catch (err) {
+			logger.warn(`Failed to gzip data, retrying uncompressed: ${err}`)
+			return stringifyExport(logger, data, filename, 'json')
+		}
+	} else if (format === 'json') {
+		return {
+			data: JSON.stringify(data, undefined, '\t'),
+			contentType: 'application/json',
+			...formatAttachmentFilename(filename),
+		}
+	} else if (format === 'yaml') {
+		return {
+			data: yaml.stringify(data, splitLongPng64Values),
+			contentType: 'application/yaml',
+			...formatAttachmentFilename(filename),
+		}
+	} else {
+		return null
+	}
+}
+
+/**
+ * Replacer that splits "png64" values into multiple lines.
+ *
+ * These are base64 encoded PNGs and can get very long. A length of 60 characters is used to allow
+ * for indentation in the YAML.
+ *
+ * @param key - The key of the value being processed.
+ * @param value - The value to be processed.
+ * @returns The modified value or the original value if the conditions are not met.
+ */
+function splitLongPng64Values(key: string, value: string): string {
+	if (key === 'png64' && typeof value === 'string' && value.length > 60) {
+		return btoa(atob(value)).replace(/(.{60})/g, '$1\n') + '\n'
+	}
+	return value
+}
+
+/**
+ * Compute a Content-Disposition header specifying an attachment with the
+ * given filename.
+ */
+export function formatAttachmentFilename(filename: string): {
+	asciiFilename: string
+	utf8Filename: string
+} {
+	function quotedAscii(s: string): string {
+		// Boil away combining characters and non-ASCII code points and escape
+		// quotes.  Modern browsers don't use this, so don't bother going all-out.
+		// Don't percent-encode anything, because browsers don't agree on whether
+		// quoted filenames should be percent-decoded (Firefox and Chrome yes,
+		// Safari no).
+		return (
+			'"' +
+			[...s.normalize('NFKD')]
+				.filter((c) => '\x20' <= c && c <= '\x7e')
+				.map((c) => (c === '"' || c === '\\' ? '\\' : '') + c)
+				.join('') +
+			'"'
+		)
+	}
+
+	// The filename parameter is used primarily by legacy browsers.  Strangely, it
+	// must be present for at least some versions of Safari to use the modern
+	// filename* parameter.
+	const quotedFallbackAsciiFilename = quotedAscii(filename)
+	const modernUnicodeFilename = encodeURIComponent(filename)
+	// return `attachment; filename=${quotedFallbackAsciiFilename}; filename*=UTF-8''${modernUnicodeFilename}`
+
+	return {
+		asciiFilename: quotedFallbackAsciiFilename,
+		utf8Filename: modernUnicodeFilename,
+	}
+}

--- a/companion/lib/Registry.ts
+++ b/companion/lib/Registry.ts
@@ -242,6 +242,7 @@ export class Registry {
 			this.importExport = new ImportExportController(
 				this.#appInfo,
 				this.#internalApiRouter,
+				this.db,
 				this.controls,
 				this.graphics,
 				this.instance,

--- a/companion/package.json
+++ b/companion/package.json
@@ -83,6 +83,7 @@
     "lodash-es": "^4.17.21",
     "lru-cache": "^11.1.0",
     "nanoid": "^5.1.5",
+    "node-cron": "^4.2.1",
     "node-machine-id": "^1.1.12",
     "openapi-fetch": "^0.14.0",
     "osc": "2.4.5",

--- a/shared-lib/lib/Model/UserConfigModel.ts
+++ b/shared-lib/lib/Model/UserConfigModel.ts
@@ -74,6 +74,8 @@ export interface UserConfigModel {
 
 	/** Whether to run the mdns  */
 	discoveryEnabled: boolean
+
+	backups: BackupRulesConfig[]
 }
 
 export interface UserConfigGridSize {
@@ -81,6 +83,27 @@ export interface UserConfigGridSize {
 	maxColumn: number
 	minRow: number
 	maxRow: number
+}
+
+export interface BackupRulesConfig {
+	id: string
+	name: string
+	cron: string
+	enabled: boolean
+	keep: number
+	backupType: 'db' | 'export-gz' | 'export-json' | 'export-yaml'
+	backupPath: string
+	backupNamePattern: string
+
+	lastRan: number
+
+	previousBackups: PreviousBackupInfo[]
+}
+
+export interface PreviousBackupInfo {
+	filePath: string
+	fileSize: number
+	createdAt: number
 }
 
 export type UserConfigUpdate = UserConfigUpdateInit | UserConfigUpdateKey

--- a/webui/src/Layout/Sidebar.tsx
+++ b/webui/src/Layout/Sidebar.tsx
@@ -197,8 +197,8 @@ export const MySidebar = memo(function MySidebar() {
 					<SidebarMenuItem name="Buttons" icon={null} path="/settings/buttons" />
 					<SidebarMenuItem name="Surfaces" icon={null} path="/settings/surfaces" />
 					<SidebarMenuItem name="Protocols" icon={null} path="/settings/protocols" />
+					<SidebarMenuItem name="Backups" icon={null} path="/settings/backups" />
 					<SidebarMenuItem name="Advanced" icon={null} path="/settings/advanced" />
-					<></>
 				</SidebarMenuItemGroup>
 				<SidebarMenuItem name="Import / Export" icon={faFileImport} path="/import-export" />
 				<SidebarMenuItem name="Log" icon={faClipboardList} path="/log" />

--- a/webui/src/UserConfig/BackupConstants.ts
+++ b/webui/src/UserConfig/BackupConstants.ts
@@ -1,0 +1,6 @@
+export const backupTypes = [
+	{ label: 'Raw Database', value: 'db' },
+	{ label: 'Compressed (Default)', value: 'export-gz' },
+	{ label: 'JSON (Standard)', value: 'export-json' },
+	{ label: 'YAML (More human readable)', value: 'export-yaml' },
+] as const

--- a/webui/src/UserConfig/BackupRuleEditor.tsx
+++ b/webui/src/UserConfig/BackupRuleEditor.tsx
@@ -1,0 +1,206 @@
+import React, { useCallback, useContext, useMemo } from 'react'
+import { CAlert, CButton, CForm, CFormSelect, CInputGroup } from '@coreui/react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faTrash } from '@fortawesome/free-solid-svg-icons'
+import { RootAppStoreContext } from '../Stores/RootAppStore.js'
+import { observer } from 'mobx-react-lite'
+import type { BackupRulesConfig, PreviousBackupInfo } from '@companion-app/shared/Model/UserConfigModel.js'
+import { TextInputField } from '../Components/TextInputField.js'
+import { NumberInputField } from '../Components/NumberInputField.js'
+import { backupTypes } from './BackupConstants.js'
+import { trpc, useMutationExt } from '~/TRPC.js'
+
+interface PreviousBackupRowProps {
+	backup: PreviousBackupInfo
+	ruleId: string
+}
+
+const PreviousBackupRow = observer(function PreviousBackupRow({ backup, ruleId }: PreviousBackupRowProps) {
+	const { notifier } = useContext(RootAppStoreContext)
+
+	const deleteBackupFileMutation = useMutationExt(trpc.importExport.backupRules.deleteBackupFile.mutationOptions())
+
+	const deleteBackup = useCallback(() => {
+		if (confirm('Are you sure you want to delete this backup file?')) {
+			deleteBackupFileMutation.mutateAsync({ ruleId, filePath: backup.filePath }).catch((err) => {
+				console.error('Error deleting backup:', err)
+				notifier.current?.show('Error', `Failed to delete backup file: ${err.message || err}`, 5000)
+			})
+		}
+	}, [deleteBackupFileMutation, notifier, ruleId, backup.filePath])
+
+	const formatFileSize = (bytes: number): string => {
+		if (bytes === 0) return '0 Bytes'
+		const k = 1024
+		const sizes = ['Bytes', 'KB', 'MB', 'GB']
+		const i = Math.floor(Math.log(bytes) / Math.log(k))
+		return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i]
+	}
+
+	const getFileName = (filePath: string): string => {
+		return filePath.split('/').pop() || filePath
+	}
+
+	return (
+		<tr>
+			<td>
+				<span
+					title={getFileName(backup.filePath)}
+					style={{
+						overflow: 'hidden',
+						textOverflow: 'ellipsis',
+						whiteSpace: 'nowrap',
+						fontWeight: 500,
+					}}
+				>
+					{getFileName(backup.filePath)}
+				</span>
+				<br />
+				<small>
+					{new Date(backup.createdAt).toLocaleString()} • {formatFileSize(backup.fileSize)}
+				</small>
+			</td>
+			<td className="no-wrap" style={{ verticalAlign: 'middle' }}>
+				<CButton color="danger" size="sm" onClick={deleteBackup} title="Delete backup">
+					<FontAwesomeIcon icon={faTrash} />
+				</CButton>
+			</td>
+		</tr>
+	)
+})
+
+interface BackupRuleEditorProps {
+	ruleId: string
+}
+
+export const BackupRuleEditor = observer(function BackupRuleEditor({ ruleId }: BackupRuleEditorProps) {
+	const { userConfig, notifier } = useContext(RootAppStoreContext)
+
+	const updateRuleFieldMutation = useMutationExt(trpc.importExport.backupRules.updateRuleField.mutationOptions())
+	const runBackupNowMutation = useMutationExt(trpc.importExport.backupRules.runBackupNow.mutationOptions())
+
+	// Find the rule in the config
+	const rule = useMemo(() => {
+		return userConfig.properties?.backups?.find((r) => r.id === ruleId)
+	}, [userConfig.properties?.backups, ruleId])
+
+	// Function to update a specific field in the rule
+	const updateField = useCallback(
+		<K extends keyof BackupRulesConfig>(field: K, value: BackupRulesConfig[K]) => {
+			updateRuleFieldMutation.mutateAsync({ ruleId, field, value }).catch((err) => {
+				console.error('Error updating backup rule field:', err)
+			})
+		},
+		[updateRuleFieldMutation, ruleId]
+	)
+
+	// Function to run the backup rule immediately
+	const runNow = useCallback(() => {
+		runBackupNowMutation
+			.mutateAsync({ ruleId })
+			.then(() => {
+				notifier.current?.show('Success', 'Backup created successfully', 3000)
+			})
+			.catch((err) => {
+				console.error('Error running backup now:', err)
+				notifier.current?.show('Error', `${err.message || err || 'Failed to create backup'}`, 5000)
+			})
+	}, [runBackupNowMutation, notifier, ruleId])
+
+	// If no rule found, show message
+	if (!rule) {
+		return <CAlert color="warning">Backup rule not found</CAlert>
+	}
+
+	const previousBackups = [...(rule.previousBackups || [])].sort((a, b) => b.createdAt - a.createdAt)
+
+	return (
+		<CForm className="p-3">
+			<div className="mb-3">
+				<label className="form-label">Rule Name</label>
+				<CInputGroup>
+					<TextInputField value={rule.name} setValue={(value) => updateField('name', value)} />
+					<CButton color="warning" onClick={runNow}>
+						Run Now
+					</CButton>
+				</CInputGroup>
+			</div>
+
+			<div className="mb-3">
+				<label className="form-label">Cron Schedule</label>
+				<TextInputField value={rule.cron} setValue={(value) => updateField('cron', value)} />
+				<small className="form-text text-muted">
+					Use cron syntax (e.g., "0 0 * * *" for daily at midnight). You can use{' '}
+					<a href="https://crontab.guru" target="_blank" rel="noopener noreferrer">
+						crontab guru
+					</a>{' '}
+					to help you generate the correct syntax.
+				</small>
+			</div>
+
+			<div className="mb-3">
+				<label className="form-label">Backup Type</label>
+				<CFormSelect
+					value={rule.backupType}
+					onChange={(e) => updateField('backupType', e.target.value as BackupRulesConfig['backupType'])}
+				>
+					{backupTypes.map((type) => (
+						<option key={type.value} value={type.value}>
+							{type.label}
+						</option>
+					))}
+				</CFormSelect>
+				{rule.backupType === 'db' && (
+					<CAlert color="warning" className="mt-2">
+						Raw backups are a direct copy of the database file. They cannot be restored through the web interface, but
+						contain more data than the default exports.
+					</CAlert>
+				)}
+			</div>
+
+			<div className="mb-3">
+				<label className="form-label">Backup Path</label>
+				<TextInputField value={rule.backupPath} setValue={(value) => updateField('backupPath', value)} />
+				<small className="form-text text-muted">
+					Directory path where backups will be saved. Leave empty for default location.
+				</small>
+			</div>
+
+			<div className="mb-3">
+				<label className="form-label">Backup Name Pattern</label>
+				<TextInputField
+					value={rule.backupNamePattern}
+					setValue={(value) => updateField('backupNamePattern', value)}
+					useVariables
+				/>
+			</div>
+
+			<div className="mb-3">
+				<label className="form-label">Number of Backups to Keep</label>
+				<NumberInputField value={rule.keep} min={1} setValue={(value) => updateField('keep', value)} />
+				<small className="form-text text-muted">How many backup files to retain before deleting the oldest ones</small>
+			</div>
+
+			<div className="mb-3">
+				<label className="form-label">Previous Backups</label>
+				{rule.previousBackups && rule.previousBackups.length > 0 && (
+					<div className="table-responsive">
+						<table className="table table-sm table-striped">
+							<tbody>
+								{previousBackups.map((backup) => (
+									<PreviousBackupRow key={`${backup.filePath}-${backup.createdAt}`} backup={backup} ruleId={ruleId} />
+								))}
+							</tbody>
+						</table>
+					</div>
+				)}
+
+				{(!rule.previousBackups || rule.previousBackups.length === 0) && (
+					<div className="text-muted">
+						<small>No backup files found. Backups may have been manually deleted or moved.</small>
+					</div>
+				)}
+			</div>
+		</CForm>
+	)
+})

--- a/webui/src/UserConfig/backups.tsx
+++ b/webui/src/UserConfig/backups.tsx
@@ -1,0 +1,235 @@
+import React, { useCallback, useContext, useRef } from 'react'
+import { CButton, CButtonGroup, CCol, CFormSwitch, CRow } from '@coreui/react'
+import { RootAppStoreContext } from '../Stores/RootAppStore.js'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faAdd, faSort, faTrash } from '@fortawesome/free-solid-svg-icons'
+import classNames from 'classnames'
+import dayjs from 'dayjs'
+import { useDrag, useDrop } from 'react-dnd'
+import { GenericConfirmModal, GenericConfirmModalRef } from '../Components/GenericConfirmModal.js'
+import type { BackupRulesConfig } from '@companion-app/shared/Model/UserConfigModel.js'
+import { observer } from 'mobx-react-lite'
+import { NonIdealState } from '../Components/NonIdealState.js'
+import { Outlet, useMatchRoute, useNavigate } from '@tanstack/react-router'
+import { backupTypes } from './BackupConstants.js'
+import { checkDragState, DragState } from '~/util.js'
+import { trpc, useMutationExt } from '~/TRPC.js'
+
+export const SettingsBackupsPage = observer(function UserConfig() {
+	const navigate = useNavigate({ from: '/settings/backups' })
+
+	const doEditRule = useCallback(
+		(ruleId: string) => {
+			void navigate({ to: `/settings/backups/${ruleId}` })
+		},
+		[navigate]
+	)
+
+	const createRuleMutation = useMutationExt(trpc.importExport.backupRules.createRule.mutationOptions())
+
+	const doAddNew = useCallback(() => {
+		// Create the new rule using the dedicated endpoint
+		createRuleMutation
+			.mutateAsync({ name: 'New Backup Rule' })
+			.then((ruleId) => {
+				// Navigate to the new rule for editing
+				doEditRule(ruleId)
+			})
+			.catch((err) => {
+				console.error('Error creating backup rule:', err)
+			})
+	}, [createRuleMutation, doEditRule])
+
+	return (
+		<CRow className="split-panels">
+			<CCol xl={6} className="primary-panel">
+				<div className="d-flex justify-content-between">
+					<div>
+						<h4>Settings - Backups</h4>
+						<p>Scheduled backups of your Companion configuration. Settings apply instantaneously!</p>
+					</div>
+				</div>
+
+				<div className="mb-2">
+					<CButtonGroup>
+						<CButton color="primary" onClick={doAddNew} size="sm">
+							<FontAwesomeIcon icon={faAdd} /> Add Backup Rule
+						</CButton>
+					</CButtonGroup>
+				</div>
+
+				<BackupsTable editRule={doEditRule} />
+			</CCol>
+
+			<CCol xs={12} xl={6} className="secondary-panel">
+				<div className="secondary-panel-inner">
+					<Outlet />
+				</div>
+			</CCol>
+		</CRow>
+	)
+})
+
+interface BackupsTableProps {
+	editRule: (ruleId: string) => void
+}
+
+const BackupsTable = observer(function BackupsTable({ editRule }: BackupsTableProps) {
+	const { userConfig } = useContext(RootAppStoreContext)
+
+	const reorderRulesMutation = useMutationExt(trpc.importExport.backupRules.reorderRules.mutationOptions())
+
+	const backupRules = userConfig.properties?.backups || []
+
+	const moveRule = useCallback(
+		(ruleId: string, targetId: string) => {
+			reorderRulesMutation.mutateAsync({ ruleId, targetId }).catch((err) => {
+				console.error('Error reordering backup rules:', err)
+			})
+		},
+		[reorderRulesMutation]
+	)
+
+	return (
+		<table className="table-tight table-responsive-sm" style={{ marginBottom: 10 }}>
+			<tbody>
+				{backupRules.length > 0 ? (
+					backupRules.map((rule) => (
+						<BackupsTableRow key={rule.id} rule={rule} editRule={editRule} moveRule={moveRule} />
+					))
+				) : (
+					<tr>
+						<td colSpan={4} className="currentlyNone">
+							<NonIdealState icon={faAdd} text="No backup rules configured. Add one to get started!" />
+						</td>
+					</tr>
+				)}
+			</tbody>
+		</table>
+	)
+})
+
+interface BackupsTableRowDragData {
+	id: string
+
+	dragState: DragState | null
+}
+interface BackupsTableRowDragStatus {
+	isDragging: boolean
+}
+
+interface BackupsTableRowProps {
+	rule: BackupRulesConfig
+	editRule: (ruleId: string) => void
+	moveRule: (itemId: string, targetId: string) => void
+}
+
+function BackupsTableRow({ rule, editRule, moveRule }: BackupsTableRowProps) {
+	const confirmRef = useRef<GenericConfirmModalRef>(null)
+
+	const updateRuleFieldMutation = useMutationExt(trpc.importExport.backupRules.updateRuleField.mutationOptions())
+	const deleteRuleMutation = useMutationExt(trpc.importExport.backupRules.deleteRule.mutationOptions())
+
+	const doEnableDisable = useCallback(() => {
+		// Toggle the enabled state using the dedicated endpoint
+		updateRuleFieldMutation.mutateAsync({ ruleId: rule.id, field: 'enabled', value: !rule.enabled }).catch((err) => {
+			console.error('Error updating backup rule enabled state:', err)
+		})
+	}, [updateRuleFieldMutation, rule.id, rule.enabled])
+
+	const doDelete = useCallback(() => {
+		confirmRef.current?.show(
+			'Delete backup rule',
+			'Are you sure you wish to delete this backup rule?',
+			'Delete',
+			() => {
+				deleteRuleMutation.mutateAsync({ ruleId: rule.id }).catch((err) => {
+					console.error('Error deleting backup rule:', err)
+				})
+			}
+		)
+	}, [deleteRuleMutation, rule.id])
+
+	const doEdit = useCallback(() => editRule(rule.id), [editRule, rule.id])
+
+	const ref = useRef(null)
+	const [, drop] = useDrop<BackupsTableRowDragData>({
+		accept: 'backup-rule',
+		hover(hoverItem, monitor) {
+			if (!ref.current) {
+				return
+			}
+			// Don't replace items with themselves
+			if (hoverItem.id === rule.id) {
+				return
+			}
+
+			if (!checkDragState(hoverItem, monitor, rule.id)) return
+
+			// Time to actually perform the action
+			moveRule(hoverItem.id, rule.id)
+		},
+	})
+
+	const [{ isDragging }, drag, preview] = useDrag<BackupsTableRowDragData, unknown, BackupsTableRowDragStatus>({
+		type: 'backup-rule',
+		item: {
+			id: rule.id,
+			dragState: null,
+		},
+		collect: (monitor) => ({
+			isDragging: monitor.isDragging(),
+		}),
+	})
+	preview(drop(ref))
+
+	const matchRoute = useMatchRoute()
+	const routeMatch = matchRoute({ to: '/settings/backups/$ruleId' })
+	const isSelected = routeMatch && routeMatch.ruleId === rule.id
+
+	const backupTypeLabel =
+		backupTypes.find((type: { label: string; value: string }) => type.value === rule.backupType)?.label ||
+		rule.backupType
+
+	return (
+		<tr
+			ref={ref}
+			className={classNames({
+				'connectionlist-dragging': isDragging,
+				'connectionlist-notdragging': !isDragging,
+				'connectionlist-selected': isSelected,
+			})}
+		>
+			<td ref={drag} className="td-reorder">
+				<FontAwesomeIcon icon={faSort} />
+				<GenericConfirmModal ref={confirmRef} />
+			</td>
+			<td onClick={doEdit} className="hand">
+				<b>{rule.name}</b>
+				<br />
+				<small>Format: {backupTypeLabel}</small>
+			</td>
+			<td onClick={doEdit} className="hand">
+				<small>Cron: {rule.cron}</small>
+				<br />
+				{rule.lastRan ? <small>Last run: {dayjs(rule.lastRan).format('MM/DD HH:mm:ss')}</small> : ''}
+			</td>
+			<td className="action-buttons">
+				<CButtonGroup>
+					<CFormSwitch
+						className="connection-enabled-switch ms-2"
+						color="success"
+						checked={rule.enabled}
+						onChange={doEnableDisable}
+						title={rule.enabled ? 'Disable rule' : 'Enable rule'}
+						size="xl"
+					/>
+
+					<CButton color="gray" onClick={doDelete} title="Delete">
+						<FontAwesomeIcon icon={faTrash} />
+					</CButton>
+				</CButtonGroup>
+			</td>
+		</tr>
+	)
+}

--- a/webui/src/UserConfig/index.tsx
+++ b/webui/src/UserConfig/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Link, RegisteredRouter, ToPathOption } from '@tanstack/react-router'
 import { CCard, CCol, CRow } from '@coreui/react'
-import { faCog, faGamepad, faNetworkWired, faTh, faWarning } from '@fortawesome/free-solid-svg-icons'
+import { faCog, faFloppyDisk, faGamepad, faNetworkWired, faTh, faWarning } from '@fortawesome/free-solid-svg-icons'
 import { NonIdealState } from '~/Components/NonIdealState.js'
 import { IconProp } from '@fortawesome/fontawesome-svg-core'
 
@@ -20,7 +20,8 @@ export function SettingsSelectPage(): React.JSX.Element {
 						<SettingsLinkCard label="Buttons" to="/settings/buttons" icon={faTh} />
 						<SettingsLinkCard label="Surfaces" to="/settings/surfaces" icon={faGamepad} />
 						<SettingsLinkCard label="Protocols" to="/settings/protocols" icon={faNetworkWired} />
-						<SettingsLinkCard label="Advanced" to="/settings/advanced" icon={faWarning} center />
+						<SettingsLinkCard label="Backups" to="/settings/backups" icon={faFloppyDisk} />
+						<SettingsLinkCard label="Advanced" to="/settings/advanced" icon={faWarning} />
 					</CRow>
 				</div>
 			</CCol>

--- a/webui/src/routeTree.gen.ts
+++ b/webui/src/routeTree.gen.ts
@@ -48,12 +48,15 @@ import { Route as SettingsSurfacesRouteImport } from './routes/app/settings/surf
 import { Route as SettingsProtocolsRouteImport } from './routes/app/settings/protocols.tsx'
 import { Route as SettingsGeneralRouteImport } from './routes/app/settings/general.tsx'
 import { Route as SettingsButtonsRouteImport } from './routes/app/settings/buttons.tsx'
+import { Route as SettingsBackupsRouteImport } from './routes/app/settings/backups.tsx'
 import { Route as SettingsAdvancedRouteImport } from './routes/app/settings/advanced.tsx'
 import { Route as ModulesModuleIdRouteImport } from './routes/app/modules/$moduleId.tsx'
 import { Route as ConnectionsConnectionIdRouteImport } from './routes/app/connections/$connectionId.tsx'
 import { Route as ButtonsPageRouteImport } from './routes/app/buttons/$page.tsx'
 import { Route as SurfacesConfiguredIndexRouteImport } from './routes/app/surfaces/configured/index.tsx'
+import { Route as SettingsBackupsIndexRouteImport } from './routes/app/settings/backups/index.tsx'
 import { Route as SurfacesConfiguredItemIdRouteImport } from './routes/app/surfaces/configured/$itemId.tsx'
+import { Route as SettingsBackupsRuleIdRouteImport } from './routes/app/settings/backups/$ruleId.tsx'
 
 const TabletDotlazyRouteImport = createFileRoute('/tablet')()
 const GettingStartedDotlazyRouteImport = createFileRoute('/getting-started')()
@@ -272,6 +275,11 @@ const SettingsButtonsRoute = SettingsButtonsRouteImport.update({
   path: '/settings/buttons',
   getParentRoute: () => appRoute,
 } as any)
+const SettingsBackupsRoute = SettingsBackupsRouteImport.update({
+  id: '/settings/backups',
+  path: '/settings/backups',
+  getParentRoute: () => appRoute,
+} as any)
 const SettingsAdvancedRoute = SettingsAdvancedRouteImport.update({
   id: '/settings/advanced',
   path: '/settings/advanced',
@@ -297,12 +305,22 @@ const SurfacesConfiguredIndexRoute = SurfacesConfiguredIndexRouteImport.update({
   path: '/',
   getParentRoute: () => SurfacesConfiguredRoute,
 } as any)
+const SettingsBackupsIndexRoute = SettingsBackupsIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => SettingsBackupsRoute,
+} as any)
 const SurfacesConfiguredItemIdRoute =
   SurfacesConfiguredItemIdRouteImport.update({
     id: '/$itemId',
     path: '/$itemId',
     getParentRoute: () => SurfacesConfiguredRoute,
   } as any)
+const SettingsBackupsRuleIdRoute = SettingsBackupsRuleIdRouteImport.update({
+  id: '/$ruleId',
+  path: '/$ruleId',
+  getParentRoute: () => SettingsBackupsRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/emulator': typeof EmulatorRouteWithChildren
@@ -332,6 +350,7 @@ export interface FileRoutesByFullPath {
   '/connections/$connectionId': typeof ConnectionsConnectionIdRoute
   '/modules/$moduleId': typeof ModulesModuleIdRoute
   '/settings/advanced': typeof SettingsAdvancedRoute
+  '/settings/backups': typeof SettingsBackupsRouteWithChildren
   '/settings/buttons': typeof SettingsButtonsRoute
   '/settings/general': typeof SettingsGeneralRoute
   '/settings/protocols': typeof SettingsProtocolsRoute
@@ -348,7 +367,9 @@ export interface FileRoutesByFullPath {
   '/settings': typeof SettingsIndexRoute
   '/triggers/': typeof TriggersIndexRoute
   '/variables': typeof VariablesIndexRoute
+  '/settings/backups/$ruleId': typeof SettingsBackupsRuleIdRoute
   '/surfaces/configured/$itemId': typeof SurfacesConfiguredItemIdRoute
+  '/settings/backups/': typeof SettingsBackupsIndexRoute
   '/surfaces/configured/': typeof SurfacesConfiguredIndexRoute
 }
 export interface FileRoutesByTo {
@@ -390,7 +411,9 @@ export interface FileRoutesByTo {
   '/settings': typeof SettingsIndexRoute
   '/triggers': typeof TriggersIndexRoute
   '/variables': typeof VariablesIndexRoute
+  '/settings/backups/$ruleId': typeof SettingsBackupsRuleIdRoute
   '/surfaces/configured/$itemId': typeof SurfacesConfiguredItemIdRoute
+  '/settings/backups': typeof SettingsBackupsIndexRoute
   '/surfaces/configured': typeof SurfacesConfiguredIndexRoute
 }
 export interface FileRoutesById {
@@ -423,6 +446,7 @@ export interface FileRoutesById {
   '/_app/connections/$connectionId': typeof ConnectionsConnectionIdRoute
   '/_app/modules/$moduleId': typeof ModulesModuleIdRoute
   '/_app/settings/advanced': typeof SettingsAdvancedRoute
+  '/_app/settings/backups': typeof SettingsBackupsRouteWithChildren
   '/_app/settings/buttons': typeof SettingsButtonsRoute
   '/_app/settings/general': typeof SettingsGeneralRoute
   '/_app/settings/protocols': typeof SettingsProtocolsRoute
@@ -439,7 +463,9 @@ export interface FileRoutesById {
   '/_app/settings/': typeof SettingsIndexRoute
   '/_app/triggers/': typeof TriggersIndexRoute
   '/_app/variables/': typeof VariablesIndexRoute
+  '/_app/settings/backups/$ruleId': typeof SettingsBackupsRuleIdRoute
   '/_app/surfaces/configured/$itemId': typeof SurfacesConfiguredItemIdRoute
+  '/_app/settings/backups/': typeof SettingsBackupsIndexRoute
   '/_app/surfaces/configured/': typeof SurfacesConfiguredIndexRoute
 }
 export interface FileRouteTypes {
@@ -472,6 +498,7 @@ export interface FileRouteTypes {
     | '/connections/$connectionId'
     | '/modules/$moduleId'
     | '/settings/advanced'
+    | '/settings/backups'
     | '/settings/buttons'
     | '/settings/general'
     | '/settings/protocols'
@@ -488,7 +515,9 @@ export interface FileRouteTypes {
     | '/settings'
     | '/triggers/'
     | '/variables'
+    | '/settings/backups/$ruleId'
     | '/surfaces/configured/$itemId'
+    | '/settings/backups/'
     | '/surfaces/configured/'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -530,7 +559,9 @@ export interface FileRouteTypes {
     | '/settings'
     | '/triggers'
     | '/variables'
+    | '/settings/backups/$ruleId'
     | '/surfaces/configured/$itemId'
+    | '/settings/backups'
     | '/surfaces/configured'
   id:
     | '__root__'
@@ -562,6 +593,7 @@ export interface FileRouteTypes {
     | '/_app/connections/$connectionId'
     | '/_app/modules/$moduleId'
     | '/_app/settings/advanced'
+    | '/_app/settings/backups'
     | '/_app/settings/buttons'
     | '/_app/settings/general'
     | '/_app/settings/protocols'
@@ -578,7 +610,9 @@ export interface FileRouteTypes {
     | '/_app/settings/'
     | '/_app/triggers/'
     | '/_app/variables/'
+    | '/_app/settings/backups/$ruleId'
     | '/_app/surfaces/configured/$itemId'
+    | '/_app/settings/backups/'
     | '/_app/surfaces/configured/'
   fileRoutesById: FileRoutesById
 }
@@ -880,6 +914,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SettingsButtonsRouteImport
       parentRoute: typeof appRoute
     }
+    '/_app/settings/backups': {
+      id: '/_app/settings/backups'
+      path: '/settings/backups'
+      fullPath: '/settings/backups'
+      preLoaderRoute: typeof SettingsBackupsRouteImport
+      parentRoute: typeof appRoute
+    }
     '/_app/settings/advanced': {
       id: '/_app/settings/advanced'
       path: '/settings/advanced'
@@ -915,12 +956,26 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SurfacesConfiguredIndexRouteImport
       parentRoute: typeof SurfacesConfiguredRoute
     }
+    '/_app/settings/backups/': {
+      id: '/_app/settings/backups/'
+      path: '/'
+      fullPath: '/settings/backups/'
+      preLoaderRoute: typeof SettingsBackupsIndexRouteImport
+      parentRoute: typeof SettingsBackupsRoute
+    }
     '/_app/surfaces/configured/$itemId': {
       id: '/_app/surfaces/configured/$itemId'
       path: '/$itemId'
       fullPath: '/surfaces/configured/$itemId'
       preLoaderRoute: typeof SurfacesConfiguredItemIdRouteImport
       parentRoute: typeof SurfacesConfiguredRoute
+    }
+    '/_app/settings/backups/$ruleId': {
+      id: '/_app/settings/backups/$ruleId'
+      path: '/$ruleId'
+      fullPath: '/settings/backups/$ruleId'
+      preLoaderRoute: typeof SettingsBackupsRuleIdRouteImport
+      parentRoute: typeof SettingsBackupsRoute
     }
   }
 }
@@ -977,6 +1032,20 @@ const TriggersRouteWithChildren = TriggersRoute._addFileChildren(
   TriggersRouteChildren,
 )
 
+interface SettingsBackupsRouteChildren {
+  SettingsBackupsRuleIdRoute: typeof SettingsBackupsRuleIdRoute
+  SettingsBackupsIndexRoute: typeof SettingsBackupsIndexRoute
+}
+
+const SettingsBackupsRouteChildren: SettingsBackupsRouteChildren = {
+  SettingsBackupsRuleIdRoute: SettingsBackupsRuleIdRoute,
+  SettingsBackupsIndexRoute: SettingsBackupsIndexRoute,
+}
+
+const SettingsBackupsRouteWithChildren = SettingsBackupsRoute._addFileChildren(
+  SettingsBackupsRouteChildren,
+)
+
 interface SurfacesConfiguredRouteChildren {
   SurfacesConfiguredItemIdRoute: typeof SurfacesConfiguredItemIdRoute
   SurfacesConfiguredIndexRoute: typeof SurfacesConfiguredIndexRoute
@@ -1001,6 +1070,7 @@ interface appRouteChildren {
   TriggersRoute: typeof TriggersRouteWithChildren
   IndexRoute: typeof IndexRoute
   SettingsAdvancedRoute: typeof SettingsAdvancedRoute
+  SettingsBackupsRoute: typeof SettingsBackupsRouteWithChildren
   SettingsButtonsRoute: typeof SettingsButtonsRoute
   SettingsGeneralRoute: typeof SettingsGeneralRoute
   SettingsProtocolsRoute: typeof SettingsProtocolsRoute
@@ -1026,6 +1096,7 @@ const appRouteChildren: appRouteChildren = {
   TriggersRoute: TriggersRouteWithChildren,
   IndexRoute: IndexRoute,
   SettingsAdvancedRoute: SettingsAdvancedRoute,
+  SettingsBackupsRoute: SettingsBackupsRouteWithChildren,
   SettingsButtonsRoute: SettingsButtonsRoute,
   SettingsGeneralRoute: SettingsGeneralRoute,
   SettingsProtocolsRoute: SettingsProtocolsRoute,

--- a/webui/src/routes/app/settings/backups.tsx
+++ b/webui/src/routes/app/settings/backups.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { SettingsBackupsPage } from '../../../UserConfig/backups.js'
+
+export const Route = createFileRoute('/_app/settings/backups')({
+	component: SettingsBackupsPage,
+})

--- a/webui/src/routes/app/settings/backups/$ruleId.tsx
+++ b/webui/src/routes/app/settings/backups/$ruleId.tsx
@@ -1,0 +1,42 @@
+import { CNav, CNavItem, CNavLink, CTabContent, CTabPane } from '@coreui/react'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import React, { useContext } from 'react'
+import { BackupRuleEditor } from '../../../../UserConfig/BackupRuleEditor.js'
+import { RootAppStoreContext } from '../../../../Stores/RootAppStore.js'
+import { useComputed } from '../../../../util.js'
+import { observer } from 'mobx-react-lite'
+
+const RouteComponent = observer(function RouteComponent() {
+	const { userConfig } = useContext(RootAppStoreContext)
+	const { ruleId } = Route.useParams()
+
+	const navigate = useNavigate({ from: '/settings/backups/$ruleId' })
+
+	// Find the matching rule in the user config
+	const backupRule = userConfig.properties?.backups?.find((rule) => rule.id === ruleId)
+
+	useComputed(() => {
+		if (ruleId && !backupRule) {
+			void navigate({ to: `/settings/backups` })
+		}
+	}, [navigate, ruleId, backupRule])
+
+	return (
+		<>
+			<CNav variant="tabs" role="tablist">
+				<CNavItem>
+					<CNavLink active>{backupRule?.name || 'Edit Backup Rule'}</CNavLink>
+				</CNavItem>
+			</CNav>
+			<CTabContent>
+				<CTabPane data-tab="editor" visible>
+					<BackupRuleEditor ruleId={ruleId} />
+				</CTabPane>
+			</CTabContent>
+		</>
+	)
+})
+
+export const Route = createFileRoute('/_app/settings/backups/$ruleId')({
+	component: RouteComponent,
+})

--- a/webui/src/routes/app/settings/backups/index.tsx
+++ b/webui/src/routes/app/settings/backups/index.tsx
@@ -1,0 +1,26 @@
+import { CNav, CNavItem, CNavLink, CTabContent, CTabPane } from '@coreui/react'
+import { faCalendarAlt } from '@fortawesome/free-solid-svg-icons'
+import { createFileRoute } from '@tanstack/react-router'
+import React from 'react'
+import { NonIdealState } from '../../../../Components/NonIdealState.js'
+
+export const Route = createFileRoute('/_app/settings/backups/')({
+	component: RouteComponent,
+})
+
+function RouteComponent() {
+	return (
+		<>
+			<CNav variant="tabs" role="tablist">
+				<CNavItem>
+					<CNavLink active>Select a backup rule</CNavLink>
+				</CNavItem>
+			</CNav>
+			<CTabContent>
+				<CTabPane data-tab="placeholder" visible>
+					<NonIdealState text="Select a backup rule to edit" icon={faCalendarAlt} />
+				</CTabPane>
+			</CTabContent>
+		</>
+	)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7165,6 +7165,7 @@ asn1@evs-broadcast/node-asn1:
     lodash-es: "npm:^4.17.21"
     lru-cache: "npm:^11.1.0"
     nanoid: "npm:^5.1.5"
+    node-cron: "npm:^4.2.1"
     node-machine-id: "npm:^1.1.12"
     openapi-fetch: "npm:^0.14.0"
     osc: "npm:2.4.5"
@@ -12497,6 +12498,13 @@ asn1@evs-broadcast/node-asn1:
   dependencies:
     semver: "npm:^7.3.5"
   checksum: 10c0/a5bdc7559237d2acebadc9ac0f29dd1279726e4226a8b3256ea605f6ad4a5c48528a2b6684d09237d33f0b714a95573d7f14a2a628642d31e05c79395e2c7873
+  languageName: node
+  linkType: hard
+
+"node-cron@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "node-cron@npm:4.2.1"
+  checksum: 10c0/804df01df230e96fd2f8ffcde004f4d5af953bccdf3ccf993dc450526dd65f553a2f2ad4bc0faf55c90c38cbc99c9ddbb88ee16cba3fc6bc74e606da6efb249e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
closes #2961

This allows the user to define some auto-backup on interval
![image](https://github.com/user-attachments/assets/b41454ef-bc73-4798-983e-df744b67963a)

The idea is that the user can define different rules, into different paths on different intervals.  
One could be a daily one into dropbox keeping 90 days worth, another could be hourly elsewhere keeping the last 2.

This supports the usual export formats, and the 'raw database' format, which is a full sqlite db. For now that is the default, but if we get to a point where a normal export contains 'everything', then we could change the default format.