### PR TITLE
Modernize sass code

### DIFF
--- a/webui/src/App.scss
+++ b/webui/src/App.scss
@@ -1,72 +1,37 @@
-@use 'sass:color';
+// IMPORTANT: 'scss/variables' MUST be the first @use rule: it overrides the defaults in @coreui
+//  See Sass @use documentation: "A module will keep the same configuration ... even if it’s loaded multiple times"
 @use 'scss/variables'; // local definitions not related to @coreui definitions
 
-$local-header-bg: #d50215; // needed for both $header-bg and the adjust() call, below.
+// let coreui (with the overrides defined in _variables.scss) be the default source of variables.
+@use '@coreui/coreui/scss/coreui' as *;
 
-// pass all remaining local definitions that are meant to override @coreui defaults:
-// note that Sass will issue a strange error message if a variable specified here is not already in coreui. (As of Sass 1.89)
-@use '@coreui/coreui/scss/coreui' as * with (
-	$primary: #d50215,
-	$secondary: #ccc,
-	$body-bg: #333,
-	$light: #e9e9e9,
+// note: if a variable is defined in the following imports, they will need to be reference below by module name.
+@use 'scss/react-time-picker';
+@use 'scss/react-date-picker';
 
-	$header-bg: $local-header-bg,
-	//$header-border: ( // can't do: causes @use "redifined" error (because it's not defined in coreui, apparently)
-	$header-color: #fff,
-	$header-brand-color: #fff,
-	$header-brand-hover-color: #fff,
-	$sidebar-bg: #111,
-	$sidebar-brand-bg: color.adjust($local-header-bg, $lightness: -10%),
-	$form-switch-color: #fff,
-	$form-switch-checked-color: #fff,
-	$form-switch-focus-color: #fff,
-	$form-switch-widths: (
-		xl: (
-			width: 2.75em,
-			height: 1.5em,
-		),
-	),
+@use 'scss/layout';
+@use 'scss/common';
+@use 'scss/tablet';
+@use 'scss/emulator';
+@use 'scss/modules-manage';
 
-	$btn-font-size-sm: 12px,
-	$btn-font-size: 0.9rem,
+@use 'scss/action-recorder';
+@use 'scss/button-control';
+@use 'scss/button-edit';
+@use 'scss/button-grid';
+@use 'scss/page-list';
+@use 'scss/cloud';
+@use 'scss/controls';
+@use 'scss/instances';
+@use 'scss/loading';
+@use 'scss/log';
+@use 'scss/presets';
+@use 'scss/settings';
+@use 'scss/wizard';
+@use 'scss/import-export';
+@use 'scss/collections-nesting-table';
 
-	$modal-content-bg: #fff,
-	$table-bg: #fff,
-	$dropdown-bg: #fff,
-
-	$card-bg: #f7f7f7,
-
-	$sidebar-nav-link-padding-x: 0.5rem
-	// $variable-padding: 1px 3px 0px // can't do; not in coreui
-);
-
-// note: the following could be imported without the ""as *" as long as they don't define new variables
-//  but there's no harm in doing it this way, and it could avoid headaches down the line.
-@use 'scss/react-time-picker' as *;
-@use 'scss/react-date-picker' as *;
-
-@use 'scss/layout' as *;
-@use 'scss/common' as *;
-@use 'scss/tablet' as *;
-@use 'scss/emulator' as *;
-@use 'scss/modules-manage' as *;
-
-@use 'scss/action-recorder' as *;
-@use 'scss/button-control' as *;
-@use 'scss/button-edit' as *;
-@use 'scss/button-grid' as *;
-@use 'scss/page-list' as *;
-@use 'scss/cloud' as *;
-@use 'scss/controls' as *;
-@use 'scss/instances' as *;
-@use 'scss/loading' as *;
-@use 'scss/log' as *;
-@use 'scss/presets' as *;
-@use 'scss/settings' as *;
-@use 'scss/wizard' as *;
-@use 'scss/import-export' as *;
-@use 'scss/collections-nesting-table' as *;
+//@debug "$primary = #{$primary}"; // should be red (#d50215), not the coreui default blue (#5856d6).
 
 body {
 	overflow: hidden;

--- a/webui/src/App.scss
+++ b/webui/src/App.scss
@@ -1,30 +1,72 @@
-@import 'scss/variables';
+@use 'sass:color';
+@use 'scss/variables'; // local definitions not related to @coreui definitions
 
-@import '@coreui/coreui/scss/coreui';
-@import 'scss/react-time-picker';
-@import 'scss/react-date-picker';
+$local-header-bg: #d50215; // needed for both $header-bg and the adjust() call, below.
 
-@import 'scss/layout';
-@import 'scss/common';
-@import 'scss/tablet';
-@import 'scss/emulator';
-@import 'scss/modules-manage';
+// pass all remaining local definitions that are meant to override @coreui defaults:
+// note that Sass will issue a strange error message if a variable specified here is not already in coreui. (As of Sass 1.89)
+@use '@coreui/coreui/scss/coreui' as * with (
+	$primary: #d50215,
+	$secondary: #ccc,
+	$body-bg: #333,
+	$light: #e9e9e9,
 
-@import 'scss/action-recorder';
-@import 'scss/button-control';
-@import 'scss/button-edit';
-@import 'scss/button-grid';
-@import 'scss/page-list';
-@import 'scss/cloud';
-@import 'scss/controls';
-@import 'scss/instances';
-@import 'scss/loading';
-@import 'scss/log';
-@import 'scss/presets';
-@import 'scss/settings';
-@import 'scss/wizard';
-@import 'scss/import-export';
-@import 'scss/collections-nesting-table';
+	$header-bg: $local-header-bg,
+	//$header-border: ( // can't do: causes @use "redifined" error (because it's not defined in coreui, apparently)
+	$header-color: #fff,
+	$header-brand-color: #fff,
+	$header-brand-hover-color: #fff,
+	$sidebar-bg: #111,
+	$sidebar-brand-bg: color.adjust($local-header-bg, $lightness: -10%),
+	$form-switch-color: #fff,
+	$form-switch-checked-color: #fff,
+	$form-switch-focus-color: #fff,
+	$form-switch-widths: (
+		xl: (
+			width: 2.75em,
+			height: 1.5em,
+		),
+	),
+
+	$btn-font-size-sm: 12px,
+	$btn-font-size: 0.9rem,
+
+	$modal-content-bg: #fff,
+	$table-bg: #fff,
+	$dropdown-bg: #fff,
+
+	$card-bg: #f7f7f7,
+
+	$sidebar-nav-link-padding-x: 0.5rem
+	// $variable-padding: 1px 3px 0px // can't do; not in coreui
+);
+
+// note: the following could be imported without the ""as *" as long as they don't define new variables
+//  but there's no harm in doing it this way, and it could avoid headaches down the line.
+@use 'scss/react-time-picker' as *;
+@use 'scss/react-date-picker' as *;
+
+@use 'scss/layout' as *;
+@use 'scss/common' as *;
+@use 'scss/tablet' as *;
+@use 'scss/emulator' as *;
+@use 'scss/modules-manage' as *;
+
+@use 'scss/action-recorder' as *;
+@use 'scss/button-control' as *;
+@use 'scss/button-edit' as *;
+@use 'scss/button-grid' as *;
+@use 'scss/page-list' as *;
+@use 'scss/cloud' as *;
+@use 'scss/controls' as *;
+@use 'scss/instances' as *;
+@use 'scss/loading' as *;
+@use 'scss/log' as *;
+@use 'scss/presets' as *;
+@use 'scss/settings' as *;
+@use 'scss/wizard' as *;
+@use 'scss/import-export' as *;
+@use 'scss/collections-nesting-table' as *;
 
 body {
 	overflow: hidden;
@@ -134,7 +176,7 @@ body {
 
 .variable-style {
 	font-family: monospace;
-	padding: $variable-padding;
+	padding: variables.$variable-padding;
 	color: $primary;
 	font-weight: 600;
 	font-size: 16px;

--- a/webui/src/scss/_button-edit.scss
+++ b/webui/src/scss/_button-edit.scss
@@ -1,3 +1,5 @@
+@use '@coreui/coreui/scss/coreui' as *;
+
 .edit-button-panel {
 	margin-right: -0.5rem;
 	h4 {

--- a/webui/src/scss/_button-grid.scss
+++ b/webui/src/scss/_button-grid.scss
@@ -1,3 +1,5 @@
+@use '@coreui/coreui/scss/coreui' as *;
+
 .button-grid-header {
 	display: grid;
 	grid-template-columns: 1fr auto;

--- a/webui/src/scss/_cloud.scss
+++ b/webui/src/scss/_cloud.scss
@@ -1,3 +1,5 @@
+@use '@coreui/coreui/scss/coreui' as *;
+
 .cloud-auth-form {
 	.row > div {
 		margin-bottom: 1rem;

--- a/webui/src/scss/_common.scss
+++ b/webui/src/scss/_common.scss
@@ -1,4 +1,5 @@
 @use 'sass:color';
+@use '@coreui/coreui/scss/coreui' as *;
 
 h4 {
 	font-weight: bold;
@@ -158,12 +159,7 @@ code {
 .c-app {
 	color: #222;
 }
-.form-control {
-	color: #333;
-}
-.form-control:focus {
-	color: #111;
-}
+
 .form-control[type='text']:read-only {
 	background-color: #eeeeee;
 }

--- a/webui/src/scss/_controls.scss
+++ b/webui/src/scss/_controls.scss
@@ -1,6 +1,7 @@
 .form-check:not(.form-switch) {
 	input[type='checkbox'] {
 		-webkit-appearance: none;
+		appearance: none;
 		width: 22px;
 		height: 22px;
 		background: white;

--- a/webui/src/scss/_instances.scss
+++ b/webui/src/scss/_instances.scss
@@ -1,3 +1,6 @@
+@use '@coreui/coreui/scss/coreui' as *;
+@use 'variables';
+
 .float_right {
 	float: right;
 }
@@ -109,7 +112,7 @@
 
 	.variable-description {
 		word-break: normal;
-		padding: $variable-padding;
+		padding: variables.$variable-padding;
 	}
 
 	.editor-grid {

--- a/webui/src/scss/_layout.scss
+++ b/webui/src/scss/_layout.scss
@@ -1,3 +1,5 @@
+@use '@coreui/coreui/scss/coreui' as *;
+
 body {
 	-webkit-text-size-adjust: 100%;
 	-moz-tab-size: 4;

--- a/webui/src/scss/_react-date-picker.scss
+++ b/webui/src/scss/_react-date-picker.scss
@@ -1,3 +1,6 @@
+@use '@coreui/coreui/scss/coreui' as *;
+@use 'common'; // updates .form-control background-color (rearranging the @use lines in App.scss doesn't work)
+
 @import 'react-date-picker/dist/DatePicker.css';
 @import 'react-calendar/dist/Calendar.css';
 

--- a/webui/src/scss/_react-time-picker.scss
+++ b/webui/src/scss/_react-time-picker.scss
@@ -1,3 +1,6 @@
+@use '@coreui/coreui/scss/coreui' as *;
+@use 'common'; // updates .form-control background-color (rearranging the @use lines in App.scss doesn't work)
+
 @import 'react-time-picker/dist/TimePicker.css';
 
 .react-time-picker {

--- a/webui/src/scss/_variables.scss
+++ b/webui/src/scss/_variables.scss
@@ -1,5 +1,47 @@
-// Define variables that are *not* defined in @coreui
-// For variables meant to override @coreui, see App.scss
+@use 'sass:color';
+// NOTE: files other than App.scss should load this file ONLY if they need the non-@coreui variables defined in part 2, below.
+//   Otherwise they should load @coreui, which will use the values shown here.
+
+// PART 1:
+// Define variables that should override @coreui defaults:
+// note that Sass will issue a strange error message if a variable specified here is not already in coreui. (As of Sass 1.89)
+$_private-header-bg: #d50215; // needed for both $header-bg and the adjust() call, below.
+@use '@coreui/coreui/scss/coreui' with (
+	$primary: #d50215,
+	$secondary: #ccc,
+	$body-bg: #333,
+	$light: #e9e9e9,
+
+	$header-bg: $_private-header-bg,
+	$header-color: #fff,
+	$header-brand-color: #fff,
+	$header-brand-hover-color: #fff,
+	$sidebar-bg: #111,
+	$sidebar-brand-bg: color.adjust($_private-header-bg, $lightness: -10%),
+	$form-switch-color: #fff,
+	$form-switch-checked-color: #fff,
+	$form-switch-focus-color: #fff,
+	$form-switch-widths: (
+		xl: (
+			width: 2.75em,
+			height: 1.5em,
+		),
+	),
+
+	$btn-font-size-sm: 12px,
+	$btn-font-size: 0.9rem,
+
+	$modal-content-bg: #fff,
+	$table-bg: #fff,
+	$dropdown-bg: #fff,
+
+	$card-bg: #f7f7f7,
+
+	$sidebar-nav-link-padding-x: 0.5rem
+);
+
+// PART 2:
+// Define variables that do *not* have defaults in @coreui
 
 // note $header-border appears to be defined but never used
 $header-border: (

--- a/webui/src/scss/_variables.scss
+++ b/webui/src/scss/_variables.scss
@@ -1,39 +1,9 @@
-@use 'sass:color';
+// Define variables that are *not* defined in @coreui
+// For variables meant to override @coreui, see App.scss
 
-$primary: #d50215;
-$secondary: #ccc;
-$body-bg: #333;
-$light: #e9e9e9;
-
-$header-bg: #d50215;
+// note $header-border appears to be defined but never used
 $header-border: (
 	bottom: none,
 );
-$header-color: #fff;
-$header-brand-color: #fff;
-$header-brand-hover-color: #fff;
-$sidebar-bg: #111;
-$sidebar-brand-bg: color.adjust($header-bg, $lightness: -10%);
-
-$form-switch-color: #fff;
-$form-switch-checked-color: #fff;
-$form-switch-focus-color: #fff;
-$form-switch-widths: (
-	xl: (
-		width: 2.75em,
-		height: 1.5em,
-	),
-) !default;
-
-$btn-font-size-sm: 12px;
-$btn-font-size: 0.9rem;
-
-$modal-content-bg: #fff;
-$table-bg: #fff;
-$dropdown-bg: #fff;
-
-$card-bg: #f7f7f7;
-
-$sidebar-nav-link-padding-x: 0.5rem;
 
 $variable-padding: 1px 3px 0px;


### PR DESCRIPTION
Remove deprecated `@import` code, as recommended by Sass; completes issue #3522. This PR consists of two commits. **Main changes are in support of replacing `@import` with `@use.`** In the final commit:

1. `@coreui` is loaded in the file *scss/variables.scss* so the Companion variables can override @coreui defaults; Consequently, *scss/variables.scss* **must be** the very first file loaded in *Apps.css*, so that the overrides work. (See the notes, below.)
2. Certain files have `@use` added to the beginning of the file. (See the notes.)
3. (additional cleanup: removed extraneous `.form-control` clauses from _common.scss)
4. (additional cleanup: added `appearance: none;` to `.form-check:not()` for compatibility.)

(Item 1 is the main difference between this and the first commit in the PR: in the first commit local variable definitions are moved from *_variables.scss* to *App.scss*. While I think this first version is a bit clearer for subsequent development, this current commit is more consistent with the existing file architecture.)

Notes:
To minimize changes I’ve opted to import coreui into the global environment: any variables referenced w/o a package identifier are from coreui. (See below.)
The `@use` directive differs subtly from `@import` Here is a detailed explanation:
1.	By default, `@use` establishes a separate namespace for the imported variables (note: css rules appear to load into the global namespace). This can be largely circumvented by writing `@use 'file' as *` with important caveats:
2.	 Two imported files cannot define the same variable into global space. For example, the files *`_variables`* and *`@coreui`* cannot both define `$primary-color` if both are imported using `as *` As a result it is not possible to override default variables in a module such as `@coreui` by simply loading the overrides into global space. Instead:
3.	To override default values in an external module (such as `coreui`), the `@use` line must send the variables using `@use 'module' with ($var1: 'a', $var2: 'b', …)` However if `$var2` does not exist in the module, Sass generates a very misleading error about multiple definitions. On the good-news side,
4.	A module will keep the same configuration (or lack of configuration) even if it’s loaded multiple times. Because of this, `@use ... with` can only be used once per module, the first time that module is loaded. (Quoted from Sass docs):  so submodules don’t need to use the `with` clause.
5.	Unlike `@import` which acts like a `#include`, code in files imported with @use is not “aware” of the file into which they are being inserted. This means that if the sub-file references other variables, css rules, `@extend` or `@include` clauses it will need to import the relevant modules/files with `@use`. (note: `as *` does not appear to be needed to reference imported css rules.)
5a.	`@use` uses the file's location as its current directory, so whereas the path in *Apps.scss* is `scss/subfile`, the path in other subfiles is just `subfile`
6. Note: two warnings are unrelated to Sass: the warnings about `alert-variant()` and `avatar()` appear to be generated by `@coreui` regardless of if they're being used.
