### PR TITLE
Improve new `@use` workflow

### DIFF
--- a/webui/src/App.scss
+++ b/webui/src/App.scss
@@ -1,9 +1,7 @@
-// IMPORTANT: 'scss/variables' MUST be the first @use rule: it overrides the defaults in @coreui
+// IMPORTANT: 'scss/variables' MUST be the first @use rule: it loads and overrides the defaults in @coreui
 //  See Sass @use documentation: "A module will keep the same configuration ... even if it’s loaded multiple times"
-@use 'scss/variables'; // local definitions not related to @coreui definitions
-
-// let coreui (with the overrides defined in _variables.scss) be the default source of variables.
-@use '@coreui/coreui/scss/coreui' as *;
+@use 'scss/variables' as *; // local definitions not related to @coreui definitions
+@use '@coreui/coreui/scss/coreui';  // note this is not strictly necessary, since it's forwarded by _variables, above.
 
 // note: if a variable is defined in the following imports, they will need to be reference below by module name.
 @use 'scss/react-time-picker';
@@ -141,7 +139,7 @@ body {
 
 .variable-style {
 	font-family: monospace;
-	padding: variables.$variable-padding;
+	padding: $variable-padding;
 	color: $primary;
 	font-weight: 600;
 	font-size: 16px;

--- a/webui/src/scss/_button-edit.scss
+++ b/webui/src/scss/_button-edit.scss
@@ -1,4 +1,4 @@
-@use '@coreui/coreui/scss/coreui' as *;
+@use 'variables' as *;
 
 .edit-button-panel {
 	margin-right: -0.5rem;

--- a/webui/src/scss/_button-grid.scss
+++ b/webui/src/scss/_button-grid.scss
@@ -1,4 +1,4 @@
-@use '@coreui/coreui/scss/coreui' as *;
+@use 'variables' as *;
 
 .button-grid-header {
 	display: grid;

--- a/webui/src/scss/_cloud.scss
+++ b/webui/src/scss/_cloud.scss
@@ -1,4 +1,4 @@
-@use '@coreui/coreui/scss/coreui' as *;
+@use 'variables' as *;
 
 .cloud-auth-form {
 	.row > div {

--- a/webui/src/scss/_common.scss
+++ b/webui/src/scss/_common.scss
@@ -1,5 +1,5 @@
 @use 'sass:color';
-@use '@coreui/coreui/scss/coreui' as *;
+@use 'variables' as *;
 
 h4 {
 	font-weight: bold;

--- a/webui/src/scss/_instances.scss
+++ b/webui/src/scss/_instances.scss
@@ -1,5 +1,5 @@
-@use '@coreui/coreui/scss/coreui' as *;
-@use 'variables';
+@use 'variables' as *;
+@use '@coreui/coreui/scss/coreui';  // not strictly necessary, but it allows us to clarify the origin of mixins
 
 .float_right {
 	float: right;
@@ -112,7 +112,7 @@
 
 	.variable-description {
 		word-break: normal;
-		padding: variables.$variable-padding;
+		padding: $variable-padding;
 	}
 
 	.editor-grid {
@@ -133,13 +133,13 @@
 			display: grid;
 			grid-template-columns: 0.25fr 1fr;
 
-			@include media-breakpoint-up(sm) {
+			@include coreui.media-breakpoint-up(sm) {
 				.align-right {
 					text-align: right;
 					align-self: center;
 				}
 			}
-			@include media-breakpoint-down(sm) {
+			@include coreui.media-breakpoint-down(sm) {
 				.align-right {
 					margin-bottom: 0;
 				}

--- a/webui/src/scss/_layout.scss
+++ b/webui/src/scss/_layout.scss
@@ -1,4 +1,5 @@
-@use '@coreui/coreui/scss/coreui' as *;
+@use 'variables' as *;
+@use '@coreui/coreui/scss/coreui';  // not strictly necessary, but it allows us to clarify the origin of mixins
 
 body {
 	-webkit-text-size-adjust: 100%;
@@ -31,7 +32,7 @@ body {
 	height: 100vh;
 	overflow-y: hidden;
 
-	@include ltr-rtl('padding-left', var(--cui-sidebar-occupy-start, 0));
+	@include coreui.ltr-rtl('padding-left', var(--cui-sidebar-occupy-start, 0));
 }
 
 .body {
@@ -181,7 +182,7 @@ form.row > * {
 			color: rgba(0, 0, 0, 0.3);
 		}
 
-		@include media-breakpoint-down('lg') {
+		@include coreui.media-breakpoint-down('lg') {
 			padding: 10px;
 			border-radius: 0px;
 			padding: 5px 10px;
@@ -432,7 +433,7 @@ form.row > * {
 }
 
 // scroll if side-by-side
-@include media-breakpoint-up('xl') {
+@include coreui.media-breakpoint-up('xl') {
 	.split-panels {
 		height: 100%;
 

--- a/webui/src/scss/_react-date-picker.scss
+++ b/webui/src/scss/_react-date-picker.scss
@@ -1,4 +1,4 @@
-@use '@coreui/coreui/scss/coreui' as *;
+@use 'variables' as *;
 @use 'common'; // updates .form-control background-color (rearranging the @use lines in App.scss doesn't work)
 
 @import 'react-date-picker/dist/DatePicker.css';

--- a/webui/src/scss/_react-time-picker.scss
+++ b/webui/src/scss/_react-time-picker.scss
@@ -1,4 +1,4 @@
-@use '@coreui/coreui/scss/coreui' as *;
+@use 'variables' as *;
 @use 'common'; // updates .form-control background-color (rearranging the @use lines in App.scss doesn't work)
 
 @import 'react-time-picker/dist/TimePicker.css';

--- a/webui/src/scss/_variables.scss
+++ b/webui/src/scss/_variables.scss
@@ -6,7 +6,7 @@
 // Define variables that should override @coreui defaults:
 // note that Sass will issue a strange error message if a variable specified here is not already in coreui. (As of Sass 1.89)
 $_private-header-bg: #d50215; // needed for both $header-bg and the adjust() call, below.
-@use '@coreui/coreui/scss/coreui' with (
+@forward '@coreui/coreui/scss/coreui' with (
 	$primary: #d50215,
 	$secondary: #ccc,
 	$body-bg: #333,
@@ -26,7 +26,7 @@ $_private-header-bg: #d50215; // needed for both $header-bg and the adjust() cal
 			width: 2.75em,
 			height: 1.5em,
 		),
-	),
+	) !default,
 
 	$btn-font-size-sm: 12px,
 	$btn-font-size: 0.9rem,


### PR DESCRIPTION
This adjusts the code from PR #3523 to improve the workflow and clarity, and to add back a minor feature that had been removed as a consequence of that PR.

- Change the `@use...with` in *_variables.scss* to `@forward...with`

-- This allows all variables to be loaded with: `@use 'variables' as *` in the other subfiles, making the origin of the variable-values clearer. (As opposed to needing to load `@coreui` even though the overrides were defined in *_variables.scss*. )

-- It also allows reinstating `!default` as it was used in the original _variables.scss.

- Change remaining `@use '@coreui'` rules to `@use 'variables'`

note: I left an `@use '@coreui'` in *App.scss* for clarity only. It doesn't actually do anything -- good or bad. Likewise, adding `@use '@coreui'` in subfiles to allow identifying mixins that originate in coreui. These statements can be considered comments: they have no actual external effect.