### PR TITLE
Improve "visibility" of groups in the new surfaces page

### DIFF
--- a/webui/src/Surfaces/KnownSurfacesTable.tsx
+++ b/webui/src/Surfaces/KnownSurfacesTable.tsx
@@ -239,7 +239,7 @@ const SurfaceRow = observer(function SurfaceRow({
 			onClick={handleSurfaceClick}
 		>
 			<div className="grid-cell">{index !== undefined ? `#${index}` : ''}</div>
-			<div className="grid-cell" style={{ paddingLeft: index === undefined ? '2em' : 'default' }}>
+			<div className={classNames('grid-cell', { 'ps-4': index === undefined })}>
 				<b>{surface.name ? `${surface.name} - (${surface.type})` : surface.type}</b>
 				{!!surface.hasFirmwareUpdates && (
 					<>

--- a/webui/src/Surfaces/KnownSurfacesTable.tsx
+++ b/webui/src/Surfaces/KnownSurfacesTable.tsx
@@ -239,7 +239,7 @@ const SurfaceRow = observer(function SurfaceRow({
 			onClick={handleSurfaceClick}
 		>
 			<div className="grid-cell">{index !== undefined ? `#${index}` : ''}</div>
-			<div className="grid-cell">
+			<div className="grid-cell" style={{ paddingLeft: index === undefined ? '2em' : 'default' }}>
 				<b>{surface.name ? `${surface.name} - (${surface.type})` : surface.type}</b>
 				{!!surface.hasFirmwareUpdates && (
 					<>


### PR DESCRIPTION
(This idea could be applied to the current stable version too.)

Now that I've had a chance to play with the new Surfaces page, I believe that indentation would really help: Even though the "NO" column indicates groups, that column is easy to overlook. This PR indents members of a group under the group heading to make group membership clearer (especially for single-member groups).

<img width="587" height="422" alt="image" src="https://github.com/user-attachments/assets/be5a76b6-f080-4f23-b9f5-e173041bf569" />
