### PR TITLE
fix: checkbox option jumping in safari

### DIFF
--- a/webui/src/Components/CheckboxInputField.tsx
+++ b/webui/src/Components/CheckboxInputField.tsx
@@ -54,13 +54,14 @@ export function CheckboxInputField({
 				style={
 					inline
 						? {
-								display: 'inline-block',
+								display: 'inline-flex',
+								alignItems: 'center',
 								verticalAlign: 'middle',
 								marginLeft: '1em',
 								paddingBottom: '.5em',
 								paddingTop: '.3em',
 							}
-						: {}
+						: { display: 'flex', alignItems: 'center' }
 				}
 			>
 				<CFormCheck


### PR DESCRIPTION
This is a workaround to fix an issue in Safari with the checkbox UI.

This is before, if the label text was multiline it would cause the checkbox to jump and be difficult to select: 

https://github.com/user-attachments/assets/6660180e-a9ef-4f2d-90e4-4f4834a5e592

After:

https://github.com/user-attachments/assets/4a1a9ff8-755e-456f-97e0-605f0567cd37

