### PR TITLE
feat: clearer beta icon, add icon to connection list

### DIFF
--- a/webui/src/Connections/ConnectionList/ConnectionsTableRow.tsx
+++ b/webui/src/Connections/ConnectionList/ConnectionsTableRow.tsx
@@ -7,6 +7,7 @@ import {
 	faTerminal,
 	faTrash,
 	faEllipsisV,
+	faFlask,
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
@@ -108,6 +109,11 @@ export const ConnectionsTableRow = observer(function ConnectionsTableRow({
 							color="#f80"
 							title="This module has not been updated for Companion 3.0, and may not work fully"
 						/>{' '}
+					</>
+				)}
+				{moduleVersion?.isBeta && (
+					<>
+						<FontAwesomeIcon icon={faFlask} title="Beta" />{' '}
 					</>
 				)}
 				{moduleVersion?.displayName ?? connection.moduleVersionId}

--- a/webui/src/Modules/ModuleVersionsTable.tsx
+++ b/webui/src/Modules/ModuleVersionsTable.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useContext, useState } from 'react'
 import { CButton, CButtonGroup } from '@coreui/react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
-	faAsterisk,
 	faEyeSlash,
 	faPlus,
 	faQuestionCircle,
@@ -10,6 +9,7 @@ import {
 	faCircleMinus,
 	faTrash,
 	faWarning,
+	faFlask,
 } from '@fortawesome/free-solid-svg-icons'
 import { RootAppStoreContext } from '~/Stores/RootAppStore.js'
 import { observer } from 'mobx-react-lite'
@@ -184,9 +184,7 @@ const ModuleVersionRow = observer(function ModuleVersionRow({
 			</td>
 			<td>
 				{versionId}
-				{storeInfo?.releaseChannel === 'beta' && (
-					<FontAwesomeIcon className="pad-left" icon={faAsterisk} title="Beta" />
-				)}
+				{storeInfo?.releaseChannel === 'beta' && <FontAwesomeIcon className="pad-left" icon={faFlask} title="Beta" />}
 				{storeInfo?.deprecationReason && <FontAwesomeIcon className="pad-left" icon={faWarning} title="Deprecated" />}
 			</td>
 			<td>


### PR DESCRIPTION
This makes the "beta" icon in the module store clearer, matching what is displayed in the developer portal:
<img width="477" height="238" alt="Screenshot 2025-07-14 at 11 48 09 AM" src="https://github.com/user-attachments/assets/5b334b8b-77ed-43a9-9d09-6cc78077c972" />

This also displays the icon in the connection list as an additional warning, for modules that have the preRelease tag.
<img width="677" height="84" alt="Screenshot 2025-07-14 at 11 48 37 AM" src="https://github.com/user-attachments/assets/64447d93-babf-4a80-ad1e-4587491a70d1" />
