### PR TITLE
Ability to import components without a full reset

### DIFF
--- a/companion/lib/ImportExport/Controller.ts
+++ b/companion/lib/ImportExport/Controller.ts
@@ -470,7 +470,7 @@ export class ImportExportController {
 				}),
 
 			importFull: publicProcedure
-				.input(z.object({ choices: zodClientImportSelection, fullReset: z.boolean() }))
+				.input(z.object({ choices: zodClientImportSelection.nullable(), fullReset: z.boolean() }))
 				.mutation(async (opts) => {
 					// the following minimizes the changes below, by preserving the meaning of `input`
 					const ctx = opts.ctx
@@ -483,7 +483,7 @@ export class ImportExportController {
 
 						if (data.type !== 'full') throw new Error('Invalid import object')
 
-						const resetArg = fullReset ? undefined : { ...input, connections: true, userconfig: false }
+						const resetArg = fullReset || !input ? null : { ...input, connections: true, userconfig: false }
 
 						// Destroy old stuff
 						await this.#reset(resetArg, !input || input.buttons)
@@ -621,7 +621,7 @@ export class ImportExportController {
 		}
 	}
 
-	async #reset(config: ClientResetSelection | undefined, skipNavButtons = false): Promise<'ok'> {
+	async #reset(config: ClientResetSelection | null, skipNavButtons = false): Promise<'ok'> {
 		const controls = this.#controlsController.getAllControls()
 
 		if (!config || config.buttons) {

--- a/companion/lib/ImportExport/Controller.ts
+++ b/companion/lib/ImportExport/Controller.ts
@@ -477,7 +477,7 @@ export class ImportExportController {
 					if (data.type !== 'full') throw new Error('Invalid import object')
 
 					// Destroy old stuff
-					await this.#reset(undefined, !input || input.buttons)
+					await this.#reset({ ...input, connections: true, userconfig: false }, !input || input.buttons)
 
 					// import custom variables
 					if (!input || input.customVariables) {

--- a/companion/lib/ImportExport/Controller.ts
+++ b/companion/lib/ImportExport/Controller.ts
@@ -471,10 +471,7 @@ export class ImportExportController {
 
 			importFull: publicProcedure
 				.input(z.object({ config: zodClientImportSelection.nullable(), fullReset: z.boolean() }))
-				.mutation(async ({ input, ctx }) => {
-					// the following minimizes the changes below, by preserving the meaning of `input`
-					const { config, fullReset } = input
-
+				.mutation(async ({ input: { config, fullReset }, ctx }) => {
 					return this.#checkOrRunImportTask('import', async () => {
 						const data = ctx.pendingImport?.object
 						if (!data) throw new Error('No in-progress import object')

--- a/docs/3_config/import-export/import.md
+++ b/docs/3_config/import-export/import.md
@@ -2,7 +2,7 @@ Here you can import a `.companionconfig` file. Various options will be disabled 
 
 ![Import](images/import.png?raw=true 'Import')
 
-On the **Full import** tab, you can specify which categories you want to import. Clicking the "Reset and Import" button will reset the selected categories and then import those parts of the configuration.
+On the **Full import** tab, you can specify which categories you want to import. Clicking the button: "Import, Preserving unselected components" allows you to import without performing a full reset (your selected components will still be reset and then repopulated from the import file). The "Full Reset then Import" button will reset all components and then import only the selected configuration categories.
 
 Make sure to take an export of your current configuration first, in case you make a mistake.
 

--- a/docs/3_config/import-export/import.md
+++ b/docs/3_config/import-export/import.md
@@ -2,7 +2,7 @@ Here you can import a `.companionconfig` file. Various options will be disabled 
 
 ![Import](images/import.png?raw=true 'Import')
 
-On the **Full import** tab, you can specify what you want to import and then import it while performing a full reset of the configuration.
+On the **Full import** tab, you can specify which categories you want to import. Clicking the "Reset and Import" button will reset the selected categories and then import those parts of the configuration.
 
 Make sure to take an export of your current configuration first, in case you make a mistake.
 

--- a/webui/src/ImportExport/Import/Full.tsx
+++ b/webui/src/ImportExport/Import/Full.tsx
@@ -171,10 +171,10 @@ function FullImportTab({ snapshot }: FullImportTabProps) {
 	const importFullMutation = useMutationExt(trpc.importExport.importFull.mutationOptions())
 	const doImport = useCallback(
 		(e: React.MouseEvent<HTMLElement>) => {
-			const fullReset = e.currentTarget.getAttribute('full-reset') === 'true'
+			const fullReset = e.currentTarget.getAttribute('data-fullreset') === 'true'
 
 			importFullMutation // TODO: 60s timeout?
-				.mutateAsync({ choices: config, fullReset: fullReset })
+				.mutateAsync({ config: config, fullReset: fullReset })
 				.then(() => {
 					// notifier.current.show(`Import successful`, `Page was imported successfully`, 10000)
 					window.location.reload()
@@ -247,11 +247,11 @@ function FullImportTab({ snapshot }: FullImportTabProps) {
 			</CAlert>
 
 			<CButtonGroup>
-				<CButton color="success" full-reset="false" onClick={doImport} disabled={validConfigKeys.length === 0}>
+				<CButton color="success" data-fullreset={false} onClick={doImport} disabled={validConfigKeys.length === 0}>
 					<FontAwesomeIcon icon={faFileImport} /> Import, Preserving unselected components
 				</CButton>
 
-				<CButton color="primary" full-reset="true" onClick={doImport} disabled={validConfigKeys.length === 0}>
+				<CButton color="primary" data-fullreset={true} onClick={doImport} disabled={validConfigKeys.length === 0}>
 					<FontAwesomeIcon icon={faFileImport} /> Full Reset then Import
 				</CButton>
 			</CButtonGroup>

--- a/webui/src/ImportExport/Import/Full.tsx
+++ b/webui/src/ImportExport/Import/Full.tsx
@@ -187,7 +187,7 @@ function FullImportTab({ snapshot }: FullImportTabProps) {
 
 			<p>&nbsp;</p>
 
-			<p>Perform a full reset, and import the selected components:</p>
+			<p>Reset and import the selected components:</p>
 
 			{/* <InputCheckbox
 				config={config}


### PR DESCRIPTION
This commit/PR implements the feature described in #3348

Note that although there may be some interdependencies between the import categories, it seems to me that resetting all is certain to break them when importing only a subset of all the categories, whereas leaving the unimported sections alone makes it likely that things won't break...  (The same argument goes for userconfig: since it currently isn't saved, it shouldn't be reset.)