### PR TITLE
fix: `yarn dist:webui` running out of heap space

### DIFF
--- a/webui/package.json
+++ b/webui/package.json
@@ -85,7 +85,7 @@
   "scripts": {
     "start": "vite",
     "dev": "run start",
-    "build": "vite build --base=/ROOT_URL_HERE",
+    "build": "NODE_OPTIONS=--max-old-space-size=4096 vite build --base=/ROOT_URL_HERE",
     "serve": "vite preview"
   },
   "devDependencies": {


### PR DESCRIPTION
On WSL, at least, `vite build` runs out of heap space. Other tasks/scripts are fine, so I fixed it only for the build script.

> <--- Last few GCs --->
> 
> [2441:0x2c3b3000]    48720 ms: Scavenge (interleaved) 2039.3 (2086.7) -> 2038.3 (2087.4) MB, pooled: 0 MB, 10.73 / 0.00 ms  (average mu = 0.286, current mu = 0.113) allocation failure;
> [2441:0x2c3b3000]    49950 ms: Mark-Compact 2040.4 (2087.8) -> 2039.2 (2098.6) MB, pooled: 0 MB, 1222.37 / 0.00 ms  (average mu = 0.165, current mu = 0.055) allocation failure; scavenge might not succeed
> 
> <--- JS stacktrace --->
> 
> FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
> 