### PR TITLE
Replace "copy" icon with "clone" icon for duplication

### DIFF
--- a/webui/src/Buttons/EditButton/ButtonEditorTabs.tsx
+++ b/webui/src/Buttons/EditButton/ButtonEditorTabs.tsx
@@ -3,7 +3,7 @@ import { ActionStepOptions } from '@companion-app/shared/Model/ActionModel.js'
 import { NormalButtonSteps } from '@companion-app/shared/Model/ButtonModel.js'
 import { ControlLocation } from '@companion-app/shared/Model/Common.js'
 import { CNav, CNavItem, CNavLink, CButton } from '@coreui/react'
-import { faPlus, faCopy } from '@fortawesome/free-solid-svg-icons'
+import { faPlus, faClone } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import React, { useRef, useMemo, useState, useEffect, useCallback } from 'react'
 import { GenericConfirmModalRef, GenericConfirmModal } from '~/Components/GenericConfirmModal.js'
@@ -124,7 +124,7 @@ export function ButtonEditorTabs({
 								<FontAwesomeIcon icon={faPlus} />
 							</CButton>
 							<CButton title="Duplicate step" size="sm" onClick={() => service.duplicateStep(stepKeys[0])}>
-								<FontAwesomeIcon icon={faCopy} />
+								<FontAwesomeIcon icon={faClone} />
 							</CButton>
 						</div>
 					)}

--- a/webui/src/Buttons/EditButton/ControlActionStepTab.tsx
+++ b/webui/src/Buttons/EditButton/ControlActionStepTab.tsx
@@ -2,7 +2,7 @@ import { NormalButtonSteps } from '@companion-app/shared/Model/ButtonModel.js'
 import { ControlLocation } from '@companion-app/shared/Model/Common.js'
 import { EntityModelType } from '@companion-app/shared/Model/EntityModel.js'
 import { CButtonGroup, CButton } from '@coreui/react'
-import { faChevronLeft, faChevronRight, faPlus, faCopy, faTrash } from '@fortawesome/free-solid-svg-icons'
+import { faChevronLeft, faChevronRight, faPlus, faClone, faTrash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import React from 'react'
 import { ControlEntitiesEditor } from '~/Controls/EntitiesEditor.js'
@@ -83,7 +83,7 @@ export function ControlActionStepTab({
 					title="Duplicate step"
 					onClick={() => service.duplicateStep(selectedKey)}
 				>
-					<FontAwesomeIcon icon={faCopy} />
+					<FontAwesomeIcon icon={faClone} />
 				</CButton>
 				<CButton
 					style={{ backgroundColor: '#f0f0f0' }}

--- a/webui/src/Controls/Components/EntityCellControls.tsx
+++ b/webui/src/Controls/Components/EntityCellControls.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react'
 import { CButtonGroup, CButton, CFormSwitch } from '@coreui/react'
-import { faPencil, faExpandArrowsAlt, faCompressArrowsAlt, faCopy, faTrash } from '@fortawesome/free-solid-svg-icons'
+import { faPencil, faExpandArrowsAlt, faCompressArrowsAlt, faClone, faTrash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import type { IEntityEditorActionService } from '~/Services/Controls/ControlEntitiesService.js'
 import { EntityModelType, EntityOwner, SomeEntityModel } from '@companion-app/shared/Model/EntityModel.js'
@@ -88,7 +88,7 @@ export const EntityRowHeader = observer(function EntityRowHeader({
 						onClick={service.performDuplicate}
 						title={`Duplicate ${entityTypeLabel}`}
 					>
-						<FontAwesomeIcon icon={faCopy} />
+						<FontAwesomeIcon icon={faClone} />
 					</CButton>
 					<CButton size="sm" disabled={readonly} onClick={service.performDelete} title={`Remove ${entityTypeLabel}`}>
 						<FontAwesomeIcon icon={faTrash} />

--- a/webui/src/Triggers/EventEditor.tsx
+++ b/webui/src/Triggers/EventEditor.tsx
@@ -4,7 +4,7 @@ import {
 	faTrash,
 	faCompressArrowsAlt,
 	faExpandArrowsAlt,
-	faCopy,
+	faClone,
 	faPencil,
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -254,7 +254,7 @@ const EventEditor = observer(function EventEditor({ event, service, panelCollaps
 							</CButton>
 						)}
 						<CButton size="sm" onClick={service.performDuplicate} title="Duplicate event">
-							<FontAwesomeIcon icon={faCopy} />
+							<FontAwesomeIcon icon={faClone} />
 						</CButton>
 						<CButton size="sm" onClick={service.performDelete} title="Remove event">
 							<FontAwesomeIcon icon={faTrash} />


### PR DESCRIPTION
This could be considered a "fix" or a "feat"...

 Although the difference is subtle, the change could be considered a first baby step to adding cut/copy/paste functionality to those items.

 (Note, I might have preferred the unfilled icon, to make the difference more distinct, but that would involve loading the "regular" font, which we currently don't use.)

Current: (steps, actions, action containers, trigger events)
<img width="65" height="81" alt="image" src="https://github.com/user-attachments/assets/12d41084-5b0b-46a7-abf0-8b20f8d3bea5" />

This PR:
<img width="57" height="101" alt="image" src="https://github.com/user-attachments/assets/b3169b97-7e3a-4440-b2c7-5d51c4638c39" />

Maybe better, but requires installing additional font:
<img width="61" height="87" alt="image" src="https://github.com/user-attachments/assets/18cca306-df6d-44a8-9b04-6c9a06cfb77e" />
