### PR TITLE
fix: Edit-Button Load-PNG not loading updated files

### DIFF
--- a/webui/src/Components/PNGInputField.tsx
+++ b/webui/src/Components/PNGInputField.tsx
@@ -48,56 +48,61 @@ export function PNGInputField({ min, max, onSelect, onError }: PNGInputFieldProp
 	}
 
 	const onClick = useCallback(() => {
-		const fileForm = inputRef.current // "file" type of input form
-		onError(null)
-		if (fileForm) {
-			// ensure that the file is reloaded even if it has the same name as the current one:
-			fileForm.value = ''
-			fileForm.files = new DataTransfer().files // you can't create a FileList object directly (even though compiler doesn't complain)
-			fileForm.click()
-		}
-	}, [onError])
-	const onChange = useCallback(() => {
-		const newFiles = inputRef.current?.files
-		console.log('change', newFiles)
-
-		//check whether browser fully supports all File API
-		if (apiIsSupported) {
-			if (!newFiles || !newFiles.length || newFiles[0].type !== 'image/png') {
-				onError('Sorry. Only proper PNG files are supported.')
-				return
+			const fileForm = inputRef.current // "file" type of input form
+			onError(null)
+			if (fileForm) {
+				// ensure that the file is reloaded even if it has the same name as the current one:
+				fileForm.value = ''
+				fileForm.files = new DataTransfer().files // you can't create a FileList object directly (even though compiler doesn't complain)
+				fileForm.click()
 			}
+		},
+		[onError]
+	)
+	const onChange = useCallback(
+		(e: React.ChangeEvent<HTMLInputElement>) => {
+			const newFiles = e.currentTarget.files
+			console.log('change', newFiles)
 
-			Promise.resolve()
-				.then(async () => {
-					const imageSourceStr = await blobToDataURL(newFiles[0])
+			//check whether browser fully supports all File API
+			if (apiIsSupported) {
+				if (!newFiles || !newFiles.length || newFiles[0].type !== 'image/png') {
+					onError('Sorry. Only proper PNG files are supported.')
+					return
+				}
 
-					// file is loaded
-					const img = new Image()
+				Promise.resolve()
+					.then(async () => {
+						const imageSourceStr = await blobToDataURL(newFiles[0])
 
-					img.onload = () => {
-						// image is loaded; sizes are available
-						if (max && (img.height > max.height || img.width > max.width)) {
-							onError(null)
-							onSelect(imageResize(img, max.width, max.height), newFiles[0].name)
-						} else if (min && (img.width < min.width || img.height < min.height)) {
-							onError(`Image dimensions must be at least ${min.width}x${min.height}`)
-						} else {
-							onError(null)
-							onSelect(imageSourceStr, newFiles[0].name)
+						// file is loaded
+						const img = new Image()
+
+						img.onload = () => {
+							// image is loaded; sizes are available
+							if (max && (img.height > max.height || img.width > max.width)) {
+								onError(null)
+								onSelect(imageResize(img, max.width, max.height), newFiles[0].name)
+							} else if (min && (img.width < min.width || img.height < min.height)) {
+								onError(`Image dimensions must be at least ${min.width}x${min.height}`)
+							} else {
+								onError(null)
+								onSelect(imageSourceStr, newFiles[0].name)
+							}
 						}
-					}
 
-					img.src = imageSourceStr
-				})
-				.catch((err) => {
-					onError(`Error reading file: ${err}`)
-					console.error('Error reading file:', err)
-				})
-		} else {
-			onError('Companion requires a newer browser')
-		}
-	}, [min, max, apiIsSupported, onSelect, onError])
+						img.src = imageSourceStr
+					})
+					.catch((err) => {
+						onError(`Error reading file: ${err}`)
+						console.error('Error reading file:', err)
+					})
+			} else {
+				onError('Companion requires a newer browser')
+			}
+		},
+		[min, max, apiIsSupported, onSelect, onError]
+	)
 
 	return (
 		<CButton

--- a/webui/src/Components/PNGInputField.tsx
+++ b/webui/src/Components/PNGInputField.tsx
@@ -48,17 +48,15 @@ export function PNGInputField({ min, max, onSelect, onError }: PNGInputFieldProp
 	}
 
 	const onClick = useCallback(() => {
-			const fileForm = inputRef.current // "file" type of input form
-			onError(null)
-			if (fileForm) {
-				// ensure that the file is reloaded even if it has the same name as the current one:
-				fileForm.value = ''
-				fileForm.files = new DataTransfer().files // you can't create a FileList object directly (even though compiler doesn't complain)
-				fileForm.click()
-			}
-		},
-		[onError]
-	)
+		const fileForm = inputRef.current // "file" type of input form
+		onError(null)
+		if (fileForm) {
+			// ensure that the file is reloaded even if it has the same name as the current one:
+			fileForm.value = ''
+			fileForm.files = new DataTransfer().files // you can't create a FileList object directly (even though compiler doesn't complain)
+			fileForm.click()
+		}
+	}, [onError])
 	const onChange = useCallback(
 		(e: React.ChangeEvent<HTMLInputElement>) => {
 			const newFiles = e.currentTarget.files

--- a/webui/src/Components/PNGInputField.tsx
+++ b/webui/src/Components/PNGInputField.tsx
@@ -51,6 +51,7 @@ export function PNGInputField({ min, max, onSelect, onError }: PNGInputFieldProp
 		const fileForm = inputRef.current // "file" type of input form
 		onError(null)
 		if (fileForm) {
+			// ensure that the file is reloaded even if it has the same name as the current one:
 			fileForm.value = ''
 			fileForm.files = new DataTransfer().files // you can't create a FileList object directly (even though compiler doesn't complain)
 			fileForm.click()

--- a/webui/src/Components/PNGInputField.tsx
+++ b/webui/src/Components/PNGInputField.tsx
@@ -47,16 +47,19 @@ export function PNGInputField({ min, max, onSelect, onError }: PNGInputFieldProp
 		return canvas.toDataURL()
 	}
 
-	const onClick = useCallback(() => {
+	const onClick = useCallback((e: React.MouseEvent) => {
 		onError(null)
 		if (inputRef.current) {
+			//const newFiles = e.currentTarget.files
+			const form = e.currentTarget.getElementsByClassName("form-control")[0] as HTMLInputElement
+			form.value = '' //files = null didn't work
 			inputRef.current.click()
 		}
 	}, [onError])
 	const onChange = useCallback(
 		(e: React.ChangeEvent<HTMLInputElement>) => {
 			const newFiles = e.currentTarget.files
-			e.currentTarget.files = null
+			e.currentTarget.files = null  // note: this doesn't do anything (files is unaffected)
 			console.log('change', newFiles)
 
 			//check whether browser fully supports all File API

--- a/webui/src/Components/PNGInputField.tsx
+++ b/webui/src/Components/PNGInputField.tsx
@@ -47,19 +47,21 @@ export function PNGInputField({ min, max, onSelect, onError }: PNGInputFieldProp
 		return canvas.toDataURL()
 	}
 
-	const onClick = useCallback((e: React.MouseEvent) => {
-		onError(null)
-		if (inputRef.current) {
-			//const newFiles = e.currentTarget.files
-			const form = e.currentTarget.getElementsByClassName("form-control")[0] as HTMLInputElement
-			form.value = '' //files = null didn't work
-			inputRef.current.click()
-		}
-	}, [onError])
+	const onClick = useCallback(
+		(e: React.MouseEvent) => {
+			onError(null)
+			if (inputRef.current) {
+				const form = e.currentTarget.getElementsByClassName('form-control')[0] as HTMLInputElement
+				form.value = '' //files = null didn't work
+				inputRef.current.click()
+			}
+		},
+		[onError]
+	)
 	const onChange = useCallback(
 		(e: React.ChangeEvent<HTMLInputElement>) => {
 			const newFiles = e.currentTarget.files
-			e.currentTarget.files = null  // note: this doesn't do anything (files is unaffected)
+			e.currentTarget.files = null // note: this doesn't do anything (files is unaffected)
 			console.log('change', newFiles)
 
 			//check whether browser fully supports all File API


### PR DESCRIPTION
(Note: I can post an issue if you prefer, or do so in the future -- this one just removes a minor though persistent annoyance so it didn't seem worth it.)

When the contents of a PNG file is updated, replacing the button image from the file of the same name doesn't always work, when using the PNG "folder" button:
    <img width="107" height="77" alt="image" src="https://github.com/user-attachments/assets/42de0e6e-4aee-4d88-a503-1130ea4829bb" />

Specifically,
1. Load a PNG file using the PNG "folder" button.
2. Stay on the Buttons page
3. Modify the PNG file. (Switching apps doesn't matter, just as long as "Bitfocus Companion - Admin" remains on the same page)
4. Try to update the button-image  using the PNG "folder" button and selecting the updated file (same name as before).

Moving to a different buttons page doesn't help, though moving to a different URL or restarting will solve the problem.

This commit fixes the issue, so one can do rapid "protoyping" of the PNG image without leaving the "Buttons" page.

This PR works by erasing the form's `value` property. While in theory, one should test for when to erase the existing value, doing it all the time doesn't appear to harm anything in this case, even if the user cancels the file dialog.