### PR TITLE
feat: Rework connection config layout #3559

### DIFF
--- a/companion/lib/Instance/ApiVersions.ts
+++ b/companion/lib/Instance/ApiVersions.ts
@@ -3,6 +3,7 @@ import semver, { type SemVer } from 'semver'
 const range1_2_0OrLater = new semver.Range('>=1.2.0-0', { includePrerelease: true })
 const range1_12_0OrLater = new semver.Range('>=1.12.0-0', { includePrerelease: true })
 const range1_13_0OrLater = new semver.Range('>=1.13.0-3', { includePrerelease: true })
+const range1_14_0OrLater = new semver.Range('>=1.14.0-0', { includePrerelease: true })
 
 export function doesModuleExpectLabelUpdates(apiVersion: SemVer | string): boolean {
 	return range1_2_0OrLater.test(apiVersion)
@@ -14,4 +15,8 @@ export function doesModuleSupportPermissionsModel(apiVersion: SemVer | string): 
 
 export function doesModuleUseSeparateUpgradeMethod(apiVersion: SemVer | string): boolean {
 	return range1_13_0OrLater.test(apiVersion)
+}
+
+export function doesModuleUseNewConfigLayout(apiVersion: SemVer | string): boolean {
+	return range1_14_0OrLater.test(apiVersion)
 }

--- a/companion/lib/Instance/Connection/ChildHandler.ts
+++ b/companion/lib/Instance/Connection/ChildHandler.ts
@@ -53,7 +53,11 @@ import {
 import type { ClientEntityDefinition } from '@companion-app/shared/Model/EntityDefinitionModel.js'
 import type { Complete } from '@companion-module/base/dist/util.js'
 import type { RespawnMonitor } from '@companion-app/shared/Respawn.js'
-import { doesModuleExpectLabelUpdates, doesModuleUseSeparateUpgradeMethod } from '../ApiVersions.js'
+import {
+	doesModuleExpectLabelUpdates,
+	doesModuleUseSeparateUpgradeMethod,
+	doesModuleUseNewConfigLayout,
+} from '../ApiVersions.js'
 import { ConnectionEntityManager } from './EntityManager.js'
 import type { ControlEntityInstance } from '../../Controls/Entities/EntityInstance.js'
 import { translateEntityInputFields } from '../ConfigFields.js'
@@ -95,6 +99,7 @@ export class ConnectionChildHandler implements ChildProcessHandlerBase {
 	#hasHttpHandler = false
 
 	hasRecordActionsHandler: boolean = false
+	usesNewConfigLayout: boolean = false
 
 	#expectsLabelUpdates: boolean = false
 
@@ -166,6 +171,8 @@ export class ConnectionChildHandler implements ChildProcessHandlerBase {
 			5000
 		)
 
+		this.usesNewConfigLayout = doesModuleUseNewConfigLayout(apiVersion0)
+
 		this.#entityManager = doesModuleUseSeparateUpgradeMethod(apiVersion)
 			? new ConnectionEntityManager(this.#ipcWrapper, this.#deps.controls, this.connectionId)
 			: null
@@ -224,6 +231,7 @@ export class ConnectionChildHandler implements ChildProcessHandlerBase {
 		// Save the resulting values
 		this.#hasHttpHandler = !!msg.hasHttpHandler
 		this.hasRecordActionsHandler = !!msg.hasRecordActionsHandler
+		this.usesNewConfigLayout = this.usesNewConfigLayout && !msg.disableNewConfigLayout
 		this.#currentUpgradeIndex = config.lastUpgradeIndex = msg.newUpgradeIndex
 		this.#deps.setInstanceConfig(this.connectionId, msg.updatedConfig, msg.updatedSecrets, msg.newUpgradeIndex)
 

--- a/companion/lib/Instance/Connection/TrpcRouter.ts
+++ b/companion/lib/Instance/Connection/TrpcRouter.ts
@@ -106,6 +106,7 @@ export function createConnectionsTrpcRouter(
 
 					const result: ClientEditInstanceConfig = {
 						fields: translateConnectionConfigFields(fields),
+						useNewLayout: instance.usesNewConfigLayout,
 						config: instanceConf.config,
 						secrets: instanceConf.secrets || {},
 					}

--- a/companion/package.json
+++ b/companion/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@blackmagic-controller/node": "^1.0.2",
     "@companion-app/shared": "*",
-    "@companion-module/base": "^1.13.4",
+    "@companion-module/base": "1.14.0-0-nightly-main-20251113-203236-30c5c0c",
     "@elgato-stream-deck/node": "^7.3.4",
     "@elgato-stream-deck/tcp": "^7.3.4",
     "@julusian/bonjour-service": "^1.4.2",

--- a/shared-lib/lib/Model/Common.ts
+++ b/shared-lib/lib/Model/Common.ts
@@ -71,6 +71,7 @@ export interface WrappedImage {
 
 export interface ClientEditInstanceConfig {
 	fields: Array<SomeCompanionInputField>
+	useNewLayout: boolean
 	config: unknown
 	secrets: unknown
 }

--- a/shared-lib/lib/ModuleApiVersionCheck.ts
+++ b/shared-lib/lib/ModuleApiVersionCheck.ts
@@ -2,7 +2,7 @@ import semver from 'semver'
 import { ModuleInstanceType } from './Model/Instance.js'
 import { assertNever } from './Util.js'
 
-export const MODULE_BASE_VERSION = '1.13.1'
+export const MODULE_BASE_VERSION = '1.14.0-0-nightly-main-20251113-203236-30c5c0c'
 
 const moduleVersion = semver.parse(MODULE_BASE_VERSION)
 if (!moduleVersion) throw new Error(`Failed to parse version as semver: ${MODULE_BASE_VERSION}`)

--- a/webui/src/Instances/InstanceEdit/InstanceEditField.tsx
+++ b/webui/src/Instances/InstanceEdit/InstanceEditField.tsx
@@ -98,7 +98,6 @@ export function InstanceEditField({
 					presetColors={definition.presetColors}
 				/>
 			)
-			break
 		}
 		case 'bonjour-device':
 			return moduleType === ModuleInstanceType.Connection ? (

--- a/webui/src/Instances/InstanceEdit/InstanceEditPanel.tsx
+++ b/webui/src/Instances/InstanceEdit/InstanceEditPanel.tsx
@@ -281,15 +281,18 @@ const InstanceConfigFields = observer(function InstanceConfigFields<TConfig exte
 
 				const isSecret = isConfigFieldSecret(fieldInfo)
 				return (
-					<InstanceFormRow fieldInfo={fieldInfo} isVisible={isVisible} useNewLayout={configData.useNewLayout}>
+					<InstanceFormRow
+						key={fieldInfo.id}
+						fieldInfo={fieldInfo}
+						isVisible={isVisible}
+						useNewLayout={configData.useNewLayout}
+					>
 						{isSecret ? (
-							<>
-								<InstanceSecretField
-									definition={fieldInfo}
-									value={configData.secrets[fieldInfo.id]}
-									setValue={(value) => panelStore.setConfigValue(fieldInfo.id, value)}
-								/>
-							</>
+							<InstanceSecretField
+								definition={fieldInfo}
+								value={configData.secrets[fieldInfo.id]}
+								setValue={(value) => panelStore.setConfigValue(fieldInfo.id, value)}
+							/>
 						) : (
 							<InstanceEditField
 								definition={fieldInfo}
@@ -366,7 +369,6 @@ const InstanceFormRow = observer(function InstanceFormRow({
 	children,
 }: React.PropsWithChildren<InstanceFormRowProps>): React.JSX.Element | null {
 	if (useNewLayout) {
-		fieldInfo.width = 12
 		if (fieldInfo.type === 'static-text') {
 			if (!fieldInfo.label && !fieldInfo.value) return null // Skip rendering the fields used to force alignment
 
@@ -377,7 +379,7 @@ const InstanceFormRow = observer(function InstanceFormRow({
 				return (
 					<CCol sm={12}>
 						{fieldInfo.label ? <CFormLabel>{fieldInfo.label}</CFormLabel> : ''}
-						{<StaticTextFieldText {...fieldInfo} allowImages />}
+						<StaticTextFieldText {...fieldInfo} allowImages />
 					</CCol>
 				)
 			}

--- a/webui/src/Instances/InstanceEdit/InstanceEditPanel.tsx
+++ b/webui/src/Instances/InstanceEdit/InstanceEditPanel.tsx
@@ -21,6 +21,7 @@ import { InlineHelp } from '~/Components/InlineHelp.js'
 import { getModuleVersionInfo } from '~/Instances/Util.js'
 import type { InstanceEditPanelService } from '~/Instances/InstanceEdit/InstanceEditPanelService.js'
 import { capitalize } from 'lodash-es'
+import { StaticTextFieldText } from '~/Controls/StaticTextField.js'
 
 interface InstanceGenericEditPanelProps<TConfig extends ClientInstanceConfigBase> {
 	instanceInfo: TConfig
@@ -279,37 +280,17 @@ const InstanceConfigFields = observer(function InstanceConfigFields<TConfig exte
 				if (!isVisible) return null
 
 				const isSecret = isConfigFieldSecret(fieldInfo)
-				if (isSecret) {
-					return (
-						<CCol
-							className={`fieldtype-${fieldInfo.type}`}
-							sm={fieldInfo.width}
-							style={{ display: !isVisible ? 'none' : undefined }}
-						>
-							<CFormLabel>
-								<InstanceFieldLabel fieldInfo={fieldInfo} />
-							</CFormLabel>
-							<InstanceSecretField
-								definition={fieldInfo}
-								value={configData.secrets[fieldInfo.id]}
-								setValue={(value) => panelStore.setConfigValue(fieldInfo.id, value)}
-							/>
-							{fieldInfo.description && <div className="form-text">{fieldInfo.description}</div>}
-						</CCol>
-					)
-				} else {
-					// Hide certain fields when in 'xs' column size, to avoid unexpected padding
-					const hideInXs = fieldInfo.type === 'static-text' && !fieldInfo.label && !fieldInfo.value
-
-					return (
-						<CCol
-							className={classNames(`fieldtype-${fieldInfo.type}`, { 'd-none': hideInXs, 'd-sm-block': hideInXs })}
-							sm={fieldInfo.width}
-							style={{ display: !isVisible ? 'none' : undefined }}
-						>
-							<CFormLabel>
-								<InstanceFieldLabel fieldInfo={fieldInfo} />
-							</CFormLabel>
+				return (
+					<InstanceFormRow fieldInfo={fieldInfo} isVisible={isVisible} useNewLayout={configData.useNewLayout}>
+						{isSecret ? (
+							<>
+								<InstanceSecretField
+									definition={fieldInfo}
+									value={configData.secrets[fieldInfo.id]}
+									setValue={(value) => panelStore.setConfigValue(fieldInfo.id, value)}
+								/>
+							</>
+						) : (
 							<InstanceEditField
 								definition={fieldInfo}
 								value={configData.config[fieldInfo.id]}
@@ -317,10 +298,10 @@ const InstanceConfigFields = observer(function InstanceConfigFields<TConfig exte
 								moduleType={panelStore.instanceInfo.moduleType}
 								instanceId={panelStore.service.instanceId}
 							/>
-							{fieldInfo.description && <div className="form-text">{fieldInfo.description}</div>}
-						</CCol>
-					)
-				}
+						)}
+						{fieldInfo.description && <div className="form-text">{fieldInfo.description}</div>}
+					</InstanceFormRow>
+				)
 			})}
 		</>
 	)
@@ -370,4 +351,67 @@ const InstanceFormButtons = observer(function InstanceFormButtons<TConfig extend
 			</CCol>
 		</div>
 	)
+})
+
+interface InstanceFormRowProps {
+	fieldInfo: SomeCompanionInputField
+	isVisible: boolean
+	useNewLayout: boolean
+}
+
+const InstanceFormRow = observer(function InstanceFormRow({
+	fieldInfo,
+	isVisible,
+	useNewLayout,
+	children,
+}: React.PropsWithChildren<InstanceFormRowProps>): React.JSX.Element | null {
+	if (useNewLayout) {
+		fieldInfo.width = 12
+		if (fieldInfo.type === 'static-text') {
+			if (!fieldInfo.label && !fieldInfo.value) return null // Skip rendering the fields used to force alignment
+
+			const fieldValueStr = fieldInfo.value?.toString() ?? ''
+			const isLong = fieldValueStr.includes('\n') || fieldValueStr.length > 100 // Arbitrary length to consider text "long"
+
+			if (isLong && (!fieldInfo.width || fieldInfo.width > 6)) {
+				return (
+					<CCol sm={12}>
+						{fieldInfo.label ? <CFormLabel>{fieldInfo.label}</CFormLabel> : ''}
+						{<StaticTextFieldText {...fieldInfo} allowImages />}
+					</CCol>
+				)
+			}
+		}
+
+		return (
+			<React.Fragment>
+				<CFormLabel
+					className="col-sm-4 col-form-label col-form-label-sm"
+					style={{ display: !isVisible ? 'none' : undefined }}
+				>
+					<InstanceFieldLabel fieldInfo={fieldInfo} />
+				</CFormLabel>
+				<CCol sm={8} style={{ display: !isVisible ? 'none' : undefined }}>
+					{children}
+				</CCol>
+			</React.Fragment>
+		)
+	} else {
+		// Hide certain fields when in 'xs' column size, to avoid unexpected padding
+		const hideInXs = fieldInfo.type === 'static-text' && !fieldInfo.label && !fieldInfo.value
+
+		return (
+			<CCol
+				className={classNames(`fieldtype-${fieldInfo.type}`, { 'd-none': hideInXs, 'd-sm-block': hideInXs })}
+				sm={fieldInfo.width}
+				style={{ display: !isVisible ? 'none' : undefined }}
+			>
+				<CFormLabel>
+					<InstanceFieldLabel fieldInfo={fieldInfo} />
+				</CFormLabel>
+
+				{children}
+			</CCol>
+		)
+	}
 })

--- a/webui/src/Instances/InstanceEdit/InstanceEditPanelStore.tsx
+++ b/webui/src/Instances/InstanceEdit/InstanceEditPanelStore.tsx
@@ -102,7 +102,7 @@ export class InstanceEditPanelStore<TConfig extends ClientInstanceConfigBase> {
 						this.#configAndSecrets.set({
 							fields: data.fields,
 
-							useNewLayout: true, // nocommit me!
+							useNewLayout: data.useNewLayout,
 
 							config: data.config as CompanionOptionValues,
 							configDirty: false,

--- a/webui/src/Instances/InstanceEdit/InstanceEditPanelStore.tsx
+++ b/webui/src/Instances/InstanceEdit/InstanceEditPanelStore.tsx
@@ -18,6 +18,8 @@ export interface InstanceBasicInfoChanges {
 export interface InstanceConfigAndSecrets {
 	fields: Array<SomeCompanionInputField>
 
+	useNewLayout: boolean
+
 	config: CompanionOptionValues
 	configDirty: boolean
 	secrets: CompanionOptionValues
@@ -99,6 +101,8 @@ export class InstanceEditPanelStore<TConfig extends ClientInstanceConfigBase> {
 						this.#isLoading.set(null)
 						this.#configAndSecrets.set({
 							fields: data.fields,
+
+							useNewLayout: true, // nocommit me!
 
 							config: data.config as CompanionOptionValues,
 							configDirty: false,

--- a/webui/src/scss/_controls.scss
+++ b/webui/src/scss/_controls.scss
@@ -153,7 +153,7 @@ label.disabled {
 }
 
 .static-text-content {
-	:last-child {
+	& > :last-child {
 		margin-bottom: 0;
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1889,9 +1889,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@companion-module/base@npm:^1.13.4":
-  version: 1.13.4
-  resolution: "@companion-module/base@npm:1.13.4"
+"@companion-module/base@npm:1.14.0-0-nightly-main-20251113-203236-30c5c0c":
+  version: 1.14.0-0-nightly-main-20251113-203236-30c5c0c
+  resolution: "@companion-module/base@npm:1.14.0-0-nightly-main-20251113-203236-30c5c0c"
   dependencies:
     ajv: "npm:^8.17.1"
     colord: "npm:^2.9.3"
@@ -1902,7 +1902,7 @@ __metadata:
     p-queue: "npm:^6.6.2"
     p-timeout: "npm:^4.1.0"
     tslib: "npm:^2.8.1"
-  checksum: 10c0/1d57fc67d10cef7cda1d627daac8c79b03be1059a18ff5476f0427a35909fa8d53cd29c1bb0c8d37a65c59e15b0ee561b8faeb318f2511efae6974e4c3d9a9e5
+  checksum: 10c0/fc4a4f614be5ba9b0acd0edf80d26e7dbd35ae7d88ca029c438105ad76d97e8cce91bee4fdf0b6d17a999846be1e1607546d43ec320d55b86500202fd248ed7a
   languageName: node
   linkType: hard
 
@@ -10970,7 +10970,7 @@ asn1@evs-broadcast/node-asn1:
   dependencies:
     "@blackmagic-controller/node": "npm:^1.0.2"
     "@companion-app/shared": "npm:*"
-    "@companion-module/base": "npm:^1.13.4"
+    "@companion-module/base": "npm:1.14.0-0-nightly-main-20251113-203236-30c5c0c"
     "@elgato-stream-deck/node": "npm:^7.3.4"
     "@elgato-stream-deck/tcp": "npm:^7.3.4"
     "@julusian/bonjour-service": "npm:^1.4.2"


### PR DESCRIPTION
closes #3559 

I still need some input on whether this is something we want to do, but it was quick enough to do so having a screenshot might help.

Atem module (which is a basic 6/6 layout):

<img width="1020" height="1175" alt="Screenshot From 2025-07-22 00-04-31" src="https://github.com/user-attachments/assets/c31e1d66-ef3a-4f91-b43d-a2bd05990a9e" />

<img width="1020" height="1175" alt="Screenshot From 2025-07-22 00-04-26" src="https://github.com/user-attachments/assets/e0e14d7a-f4dc-4f0e-873d-fe18c83ded53" />

The 'detected module' static-text doesnt look great. I think that in general we want to keep static-text spanning the full width, as they are commonly long blocks of text.  
Which means some might end up odd like this. But that can be mitigated by adding a new `singleLine?: boolean` property to the field type (and maybe guessing this value if a width value is defined and not 12)

Maybe a 'lineAbove' property would be useful too for some modules, to be better able to breakup the list a bit (ie a `<hr />`)