### PR TITLE
Feature: create/delete custom-variable from API

### DIFF
--- a/companion/lib/Service/HttpApi.ts
+++ b/companion/lib/Service/HttpApi.ts
@@ -318,6 +318,9 @@ export class ServiceHttpApi {
 		// Add create endpoint for custom variables
 		this.#apiRouter.post('/custom-variable/:name/create', this.#customVariableCreate)
 
+		// Add delete endpoint for custom variables
+		this.#apiRouter.delete('/custom-variable/:name', this.#customVariableDelete)
+
 		// Module variables
 		this.#apiRouter.route('/variable/:label/:name/value').get(this.#moduleVariableGetValue)
 
@@ -644,6 +647,20 @@ export class ServiceHttpApi {
 		} else {
 			res.status(201).send('ok')
 		}
+	}
+
+	/**
+	 * Delete a custom variable
+	 */
+	#customVariableDelete = (req: express.Request, res: express.Response): void => {
+		const variableName = req.params.name
+		// Check if variable exists
+		if (!this.#serviceApi.getCustomVariableValue(variableName)) {
+			res.status(404).send('Not found')
+			return
+		}
+		this.#serviceApi.deleteCustomVariable(variableName)
+		res.status(204).send()
 	}
 
 	/**

--- a/companion/lib/Service/HttpApi.ts
+++ b/companion/lib/Service/HttpApi.ts
@@ -315,6 +315,9 @@ export class ServiceHttpApi {
 			.post(this.#customVariableSetValue)
 			.get(this.#customVariableGetValue)
 
+		// Add create endpoint for custom variables
+		this.#apiRouter.post('/custom-variable/:name/create', this.#customVariableCreate)
+
 		// Module variables
 		this.#apiRouter.route('/variable/:label/:name/value').get(this.#moduleVariableGetValue)
 
@@ -622,6 +625,27 @@ export class ServiceHttpApi {
 			}
 		}
 	}
+
+	/**
+	 * Create a new custom variable
+	 */
+	#customVariableCreate = (req: express.Request, res: express.Response): void => {
+		const variableName = req.params.name
+		const defaultValue = req.body?.default
+
+		if (typeof defaultValue !== 'string') {
+			res.status(400).send('Missing or invalid default value')
+			return
+		}
+
+		const result = this.#serviceApi.createCustomVariable(variableName, defaultValue)
+		if (result) {
+			res.status(400).send(result)
+		} else {
+			res.status(201).send('ok')
+		}
+	}
+
 	/**
 	 * Retrieve any module variable value
 	 */

--- a/companion/lib/Service/HttpApi.ts
+++ b/companion/lib/Service/HttpApi.ts
@@ -316,7 +316,7 @@ export class ServiceHttpApi {
 			.get(this.#customVariableGetValue)
 
 		// Add create endpoint for custom variables
-		this.#apiRouter.post('/custom-variable/:name/create', this.#customVariableCreate)
+		this.#apiRouter.post('/custom-variable/:name', this.#customVariableCreate)
 
 		// Add delete endpoint for custom variables
 		this.#apiRouter.delete('/custom-variable/:name', this.#customVariableDelete)

--- a/companion/lib/Service/ServiceApi.ts
+++ b/companion/lib/Service/ServiceApi.ts
@@ -115,6 +115,14 @@ export class ServiceApi extends EventEmitter<ServiceApiEvents> {
 	}
 
 	/**
+	 * Delete a custom variable
+	 * @param name
+	 */
+	deleteCustomVariable(name: string): void {
+		this.#variablesController.custom.deleteVariable(name)
+	}
+
+	/**
 	 * Get the value of a connection variable
 	 * @param connectionLabel
 	 * @param variableName

--- a/companion/lib/Service/ServiceApi.ts
+++ b/companion/lib/Service/ServiceApi.ts
@@ -105,6 +105,16 @@ export class ServiceApi extends EventEmitter<ServiceApiEvents> {
 	}
 
 	/**
+	 * Create a new custom variable
+	 * @param name
+	 * @param defaultVal
+	 * @returns Failure reason, if any
+	 */
+	createCustomVariable(name: string, defaultVal: string): string | null {
+		return this.#variablesController.custom.createVariable(name, defaultVal)
+	}
+
+	/**
 	 * Get the value of a connection variable
 	 * @param connectionLabel
 	 * @param variableName

--- a/companion/test/Service/HttpApi.test.ts
+++ b/companion/test/Service/HttpApi.test.ts
@@ -201,7 +201,7 @@ describe('HttpApi', () => {
 				mockFn.mockReturnValue(null)
 
 				const res = await supertest(app)
-					.post('/api/custom-variable/my-new-var/create')
+					.post('/api/custom-variable/my-new-var')
 					.send({ default: 'init' })
 				expect(res.status).toBe(201)
 				expect(res.text).toBe('ok')
@@ -215,7 +215,7 @@ describe('HttpApi', () => {
 				mockFn.mockReturnValue(null)
 
 				const res = await supertest(app)
-					.post('/api/custom-variable/my-new-var/create')
+					.post('/api/custom-variable/my-new-var')
 					.send({})
 				expect(res.status).toBe(400)
 				expect(res.text).toBe('Missing or invalid default value')
@@ -229,7 +229,7 @@ describe('HttpApi', () => {
 				mockFn.mockReturnValue('Variable "my-new-var" already exists')
 
 				const res = await supertest(app)
-					.post('/api/custom-variable/my-new-var/create')
+					.post('/api/custom-variable/my-new-var')
 					.send({ default: 'init' })
 				expect(res.status).toBe(400)
 				expect(res.text).toBe('Variable "my-new-var" already exists')

--- a/docs/5_remote_control/http_remote_control.md
+++ b/docs/5_remote_control/http_remote_control.md
@@ -55,8 +55,6 @@ This API tries to follow REST principles, and the convention that a `POST` reque
 - Get custom variable value  
   Method: GET  
   Path: `/api/custom-variable/<name>/value`
-
-**Custom Variable Management**
 - Create a new custom variable  
   Method: POST  
   Path: `/api/custom-variable/<name>/create`  
@@ -66,6 +64,7 @@ This API tries to follow REST principles, and the convention that a `POST` reque
   Method: DELETE  
   Path: `/api/custom-variable/<name>`
   - Returns 204 on success, 404 if the variable does not exist.
+
 - Get Module variable value  
   Method: GET  
   Path: `/api/variable/<Connection Label>/<name>/value`

--- a/docs/5_remote_control/http_remote_control.md
+++ b/docs/5_remote_control/http_remote_control.md
@@ -55,6 +55,17 @@ This API tries to follow REST principles, and the convention that a `POST` reque
 - Get custom variable value  
   Method: GET  
   Path: `/api/custom-variable/<name>/value`
+
+**Custom Variable Management**
+- Create a new custom variable  
+  Method: POST  
+  Path: `/api/custom-variable/<name>/create`  
+  Body: `{ "default": "<default_value>" }` (Content-Type: application/json)
+  - Returns 201 on success, 400 if the variable already exists or the default value is missing/invalid.
+- Delete a custom variable  
+  Method: DELETE  
+  Path: `/api/custom-variable/<name>`
+  - Returns 204 on success, 404 if the variable does not exist.
 - Get Module variable value  
   Method: GET  
   Path: `/api/variable/<Connection Label>/<name>/value`
@@ -91,6 +102,16 @@ POST `/api/custom-variable/data/value`
 Content-Type `application/json`  
 Body: `{"name":"Douglas", "answer":42}` - Body needs to be a valid JSON.  
 The object will be stored in the variable value and will not be converted to a string. You can also use the data types boolean, number, array or null. JSON does not support sending undefined as a value, but we interpret an empty body as undefined, properties of an object can of course be undefined.
+
+**Examples**
+
+Create a new custom variable "myvar" with default value "hello":
+POST `/api/custom-variable/myvar/create`
+Content-Type: application/json
+Body: `{ "default": "hello" }`
+
+Delete a custom variable "myvar":
+DELETE `/api/custom-variable/myvar`
 
 **Deprecated Commands**
 

--- a/docs/5_remote_control/http_remote_control.md
+++ b/docs/5_remote_control/http_remote_control.md
@@ -57,7 +57,7 @@ This API tries to follow REST principles, and the convention that a `POST` reque
   Path: `/api/custom-variable/<name>/value`
 - Create a new custom variable  
   Method: POST  
-  Path: `/api/custom-variable/<name>/create`  
+  Path: `/api/custom-variable/<name>`  
   Body: `{ "default": "<default_value>" }` (Content-Type: application/json)
   - Returns 201 on success, 400 if the variable already exists or the default value is missing/invalid.
 - Delete a custom variable  
@@ -105,7 +105,7 @@ The object will be stored in the variable value and will not be converted to a s
 **Examples**
 
 Create a new custom variable "myvar" with default value "hello":
-POST `/api/custom-variable/myvar/create`
+POST `/api/custom-variable/myvar`
 Content-Type: application/json
 Body: `{ "default": "hello" }`
 


### PR DESCRIPTION
I was missing an endpoint to create/delete a custom-variable programmatically, this should add it.