### PR TITLE
Add support for the MiraBox HSV293S.

### DIFF
--- a/companion/lib/Surface/Controller.ts
+++ b/companion/lib/Surface/Controller.ts
@@ -1138,6 +1138,7 @@ export class SurfaceController extends EventEmitter<SurfaceControllerEvents> {
 										(deviceInfo.productId === 0x1001 ||
 											deviceInfo.productId === 0x1007 ||
 											deviceInfo.productId === 0x1005 ||
+											deviceInfo.productId === 0x1014 || // Stream Dock HSV 293S
 											deviceInfo.productId === 0x1006) && // Stream Dock N4 or 293V3
 										deviceInfo.interface === 0
 									) {

--- a/companion/lib/Surface/USB/MiraboxStreamDock.ts
+++ b/companion/lib/Surface/USB/MiraboxStreamDock.ts
@@ -110,7 +110,7 @@ export class SurfaceUSBMiraboxStreamDock extends EventEmitter<SurfacePanelEvents
 					try {
 						newbuffer = await transformButtonImage(
 							render,
-							offsetRotation(this.config.rotation, 180),
+							offsetRotation(this.config.rotation, this.#streamDock.iconRotation), // was set to 180
 							output.resolutionx,
 							output.resolutiony,
 							imageRs.PixelFormat.Rgb
@@ -260,6 +260,7 @@ export class SurfaceUSBMiraboxStreamDock extends EventEmitter<SurfacePanelEvents
 
 interface StreamDockModelDefinition {
 	productName: string
+	iconRotation: number
 	inputs: any[]
 	outputs: any[]
 }
@@ -273,6 +274,7 @@ class StreamDock extends EventEmitter {
 		'293V3': {
 			productName: 'Stream Dock 293V3',
 			pid: 0x1001,
+			iconRotation: 180,
 
 			inputs: [
 				{
@@ -522,6 +524,7 @@ class StreamDock extends EventEmitter {
 		'N4-1234': {
 			productName: 'Stream Dock N4',
 			pid: 0x1002,
+			iconRotation: 180,
 			inputs: [
 				{
 					type: 'button',
@@ -852,6 +855,7 @@ class StreamDock extends EventEmitter {
 		'N4-1245': {
 			productName: 'Stream Dock N4',
 			pid: 0x1002,
+			iconRotation: 180,
 			inputs: [
 				{
 					type: 'button',
@@ -1179,6 +1183,305 @@ class StreamDock extends EventEmitter {
 				},
 			],
 		},
+		'HSV 293S': {
+			productName: 'Stream Dock HSV 293S',
+			iconRotation: 90,
+			pid: 0x1014,
+
+			inputs: [
+				{
+					type: 'button',
+					id: 0x0d,
+					row: 0,
+					column: 0,
+					name: 'Button 1',
+				},
+				{
+					type: 'button',
+					id: 0x0a,
+					row: 0,
+					column: 1,
+					name: 'Button 2',
+				},
+				{
+					type: 'button',
+					id: 0x07,
+					row: 0,
+					column: 2,
+					name: 'Button 3',
+				},
+				{
+					type: 'button',
+					id: 0x04,
+					row: 0,
+					column: 3,
+					name: 'Button 4',
+				},
+				{
+					type: 'button',
+					id: 0x01,
+					row: 0,
+					column: 4,
+					name: 'Button 5',
+				},
+				{
+					type: 'button',
+					id: 0x0e,
+					row: 1,
+					column: 0,
+					name: 'Button 6',
+				},
+				{
+					type: 'button',
+					id: 0x0b,
+					row: 1,
+					column: 1,
+					name: 'Button 7',
+				},
+				{
+					type: 'button',
+					id: 0x08,
+					row: 1,
+					column: 2,
+					name: 'Button 8',
+				},
+				{
+					type: 'button',
+					id: 0x05,
+					row: 1,
+					column: 3,
+					name: 'Button 9',
+				},
+				{
+					type: 'button',
+					id: 0x02,
+					row: 1,
+					column: 4,
+					name: 'Button 10',
+				},
+				{
+					type: 'button',
+					id: 0x0f,
+					row: 2,
+					column: 0,
+					name: 'Button 11',
+				},
+				{
+					type: 'button',
+					id: 0x0c,
+					row: 2,
+					column: 1,
+					name: 'Button 12',
+				},
+				{
+					type: 'button',
+					id: 0x09,
+					row: 2,
+					column: 2,
+					name: 'Button 13',
+				},
+				{
+					type: 'button',
+					id: 0x06,
+					row: 2,
+					column: 3,
+					name: 'Button 14',
+				},
+				{
+					type: 'button',
+					id: 0x03,
+					row: 2,
+					column: 4,
+					name: 'Button 15',
+				},
+				{
+					type: 'push',
+					id: 0x10,
+					row: 0,
+					column: 5,
+					name: 'Softbutton 1',
+				},
+				{
+					type: 'push',
+					id: 0x11,
+					row: 1,
+					column: 5,
+					name: 'Softbutton 2',
+				},
+				{
+					type: 'push',
+					id: 0x12,
+					row: 2,
+					column: 5,
+					name: 'Softbutton 3',
+				},
+			],
+			outputs: [
+				{
+					type: 'lcd',
+					id: 0x0d,
+					row: 0,
+					column: 0,
+					name: 'LCD 1',
+					resolutionx: 100,
+					resolutiony: 100,
+				},
+				{
+					type: 'lcd',
+					id: 0x0a,
+					row: 0,
+					column: 1,
+					name: 'LCD 2',
+					resolutionx: 100,
+					resolutiony: 100,
+				},
+				{
+					type: 'lcd',
+					id: 0x07,
+					row: 0,
+					column: 2,
+					name: 'LCD 3',
+					resolutionx: 100,
+					resolutiony: 100,
+				},
+				{
+					type: 'lcd',
+					id: 0x04,
+					row: 0,
+					column: 3,
+					name: 'LCD 4',
+					resolutionx: 100,
+					resolutiony: 100,
+				},
+				{
+					type: 'lcd',
+					id: 0x01,
+					row: 0,
+					column: 4,
+					name: 'LCD 5',
+					resolutionx: 100,
+					resolutiony: 100,
+				},
+				{
+					type: 'lcd',
+					id: 0x0e,
+					row: 1,
+					column: 0,
+					name: 'LCD 6',
+					resolutionx: 100,
+					resolutiony: 100,
+				},
+				{
+					type: 'lcd',
+					id: 0x0b,
+					row: 1,
+					column: 1,
+					name: 'LCD 7',
+					resolutionx: 100,
+					resolutiony: 100,
+				},
+				{
+					type: 'lcd',
+					id: 0x08,
+					row: 1,
+					column: 2,
+					name: 'LCD 8',
+					resolutionx: 100,
+					resolutiony: 100,
+				},
+				{
+					type: 'lcd',
+					id: 0x05,
+					row: 1,
+					column: 3,
+					name: 'LCD 9',
+					resolutionx: 100,
+					resolutiony: 100,
+				},
+				{
+					type: 'lcd',
+					id: 0x02,
+					row: 1,
+					column: 4,
+					name: 'LCD 10',
+					resolutionx: 100,
+					resolutiony: 100,
+				},
+				{
+					type: 'lcd',
+					id: 0x0f,
+					row: 2,
+					column: 0,
+					name: 'LCD 11',
+					resolutionx: 100,
+					resolutiony: 100,
+				},
+				{
+					type: 'lcd',
+					id: 0x0c,
+					row: 2,
+					column: 1,
+					name: 'LCD 12',
+					resolutionx: 100,
+					resolutiony: 100,
+				},
+				{
+					type: 'lcd',
+					id: 0x09,
+					row: 2,
+					column: 2,
+					name: 'LCD 13',
+					resolutionx: 100,
+					resolutiony: 100,
+				},
+				{
+					type: 'lcd',
+					id: 0x06,
+					row: 2,
+					column: 3,
+					name: 'LCD 14',
+					resolutionx: 100,
+					resolutiony: 100,
+				},
+				{
+					type: 'lcd',
+					id: 0x03,
+					row: 2,
+					column: 4,
+					name: 'LCD 15',
+					resolutionx: 100,
+					resolutiony: 100,
+				},
+
+				{
+					type: 'lcd',
+					id: 0x10,
+					row: 0,
+					column: 5,
+					name: 'Strip 1',
+					resolutionx: 80,
+					resolutiony: 80,
+				},
+				{
+					type: 'lcd',
+					id: 0x11,
+					row: 1,
+					column: 5,
+					name: 'Strip 2',
+					resolutionx: 80,
+					resolutiony: 80,
+				},
+				{
+					type: 'lcd',
+					id: 0x12,
+					row: 2,
+					column: 5,
+					name: 'Strip 3',
+					resolutionx: 80,
+					resolutiony: 80,
+				},
+			],
+		},
 	}
 
 	private static cmdPrefix = [0x43, 0x52, 0x54, 0, 0]
@@ -1186,7 +1489,7 @@ class StreamDock extends EventEmitter {
 
 	private info: Device
 	private device: HIDAsync
-	private model: StreamDockModelDefinition = { productName: 'Unknown Stream Dock', inputs: [], outputs: [] }
+	private model: StreamDockModelDefinition = { productName: 'Unknown Stream Dock', iconRotation: 180, inputs: [], outputs: [] }
 
 	constructor(deviceInfo: Device, device: HIDAsync) {
 		super()
@@ -1205,6 +1508,8 @@ class StreamDock extends EventEmitter {
 		} else if (this.info.productId === 0x1001 || this.info.productId === 0x1007) {
 			// modelType = 'N4'
 			this.model = StreamDock.models['N4-1234']
+		} else if (this.info.productId === 0x1014 ) {
+			this.model = StreamDock.models["HSV 293S"]
 		} else {
 			// this.modelType = 'Unknown'
 			this.emit('remove')
@@ -1364,6 +1669,10 @@ class StreamDock extends EventEmitter {
 
 	get outputs() {
 		return this.model.outputs
+	}
+
+	get iconRotation() {
+		return this.model.iconRotation
 	}
 
 	async writeRaw(data: Buffer | Array<number>): Promise<void> {


### PR DESCRIPTION
This contribution adds support for the MiraBox HSV293S.

Code taken from @andrzejl (https://github.com/bitfocus/companion-module-requests/issues/1494#issuecomment-3133545643), and modified to fit with the implementation on main. Modify the model for a StreamBox such that it exposes an iconRotation property. Modify offsetRotation() call to use this new property.