### PR TITLE
feat: configure syslog from launcher

### DIFF
--- a/companion/lib/main.ts
+++ b/companion/lib/main.ts
@@ -80,7 +80,11 @@ program.command('start', { isDefault: true, hidden: true }).action(() => {
 			if (!Number.isNaN(port) && port > 100 && port <= 65535) opt.port = port
 		}
 		if (options.syslogTcp) opt.protocol = 'tcp4'
-		opt.localhost = options.syslogLocalhost?.trim() || os.hostname()
+		const localhost: string = options.syslogLocalhost
+			?.replaceAll(/[^a-zA-Z0-9-_. ]/gm, '')
+			.substring(0, 254)
+			.trim()
+		opt.localhost = localhost || os.hostname()
 		logger.addSyslogHost(opt)
 	}
 

--- a/companion/lib/main.ts
+++ b/companion/lib/main.ts
@@ -20,25 +20,7 @@ import { nanoid } from 'nanoid'
 import logger from './Log/Controller.js'
 import { ConfigReleaseDirs } from '@companion-app/shared/Paths.js'
 import { type SyslogTransportOptions } from 'winston-syslog'
-
-const isValidIPv4 = (ip: string): boolean => {
-	const parts = ip.split('.')
-	if (parts.length !== 4) {
-		return false
-	}
-	for (const part of parts) {
-		const num = Number(part)
-		// Check if it's a valid number and within range [0, 255]
-		if (Number.isNaN(num) || num < 0 || num > 255) {
-			return false
-		}
-		// Disallow leading zeros for numbers other than '0' itself
-		if (part.length > 1 && part[0] === '0' && num !== 0) {
-			return false
-		}
-	}
-	return true
-}
+import net from 'net'
 
 const program = new Command()
 
@@ -92,7 +74,7 @@ program.command('start', { isDefault: true, hidden: true }).action(() => {
 
 	if (options.syslogEnable) {
 		const opt: SyslogTransportOptions = {}
-		if (isValidIPv4(options.syslogHost)) opt.host = options.syslogHost
+		if (net.isIPv4(options.syslogHost)) opt.host = options.syslogHost
 		if (options.syslogPort) {
 			const port = Number.parseInt(options.syslogPort)
 			if (!Number.isNaN(port) && port > 100 && port <= 65535) opt.port = port

--- a/companion/lib/main.ts
+++ b/companion/lib/main.ts
@@ -98,7 +98,7 @@ program.command('start', { isDefault: true, hidden: true }).action(() => {
 			if (!Number.isNaN(port) && port > 100 && port <= 65535) opt.port = port
 		}
 		if (options.syslogTcp) opt.protocol = 'tcp4'
-		opt.localhost = options.syslogLocalhost ? options.syslogLocalhost : os.hostname()
+		opt.localhost = options.syslogLocalhost?.trim() || os.hostname()
 		logger.addSyslogHost(opt)
 	}
 

--- a/launcher-ui/src/Sections.tsx
+++ b/launcher-ui/src/Sections.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { DeveloperSection } from './sections/Developer'
 import { GeneralSection } from './sections/General'
+import { SyslogSection } from './sections/Syslog'
 
 export interface SectionDefinition {
 	title: string
@@ -18,5 +19,10 @@ export const SectionDefinitions: SectionDefinition[] = [
 		title: 'Developer',
 		id: 'developer',
 		component: DeveloperSection,
+	},
+	{
+		title: 'Syslog',
+		id: 'syslog',
+		component: SyslogSection,
 	},
 ]

--- a/launcher-ui/src/contexts/ConfigContext.tsx
+++ b/launcher-ui/src/contexts/ConfigContext.tsx
@@ -116,11 +116,17 @@ export function ConfigProvider({ children }: ConfigProviderProps): JSX.Element {
 
 	useEffect(() => {
 		// Set up IPC listeners
-		const handleConfigResponse = (config: ConfigData['config'], appInfo: ConfigData['appInfo'], platform: string) => {
+		const handleConfigResponse = (
+			config: ConfigData['config'],
+			appInfo: ConfigData['appInfo'],
+			platform: string,
+			hostname: string
+		) => {
 			const configData: ConfigData = {
 				config,
 				appInfo,
 				platform,
+				hostname,
 			}
 			dispatch({ type: 'SUCCESS', payload: configData })
 			// Update original config when data is loaded

--- a/launcher-ui/src/sections/Syslog.tsx
+++ b/launcher-ui/src/sections/Syslog.tsx
@@ -132,7 +132,7 @@ export function SyslogSection(): JSX.Element {
 								/>
 							</div>
 							<p className="text-sm text-muted-foreground mt-1">
-								Change the hostname this companion instance will report
+								Change the hostname this companion instance will report. If not set the system hostname will be used
 							</p>
 						</div>
 					</div>

--- a/launcher-ui/src/sections/Syslog.tsx
+++ b/launcher-ui/src/sections/Syslog.tsx
@@ -1,0 +1,148 @@
+import React, { useState, useEffect } from 'react'
+import { useConfig } from '~/hooks/useConfig'
+import { Input } from '~/components/ui/input'
+import { Label } from '~/components/ui/label'
+/* import { Button } from '~/components/ui/button'
+import { Alert, AlertDescription } from '~/components/ui/alert'
+import { Info } from 'lucide-react' */
+
+export function SyslogSection(): JSX.Element {
+	const { state, updateConfig } = useConfig()
+
+	// Assume data is available since loading/error states are handled elsewhere
+	const { config } = state.data!
+
+	// Local state for form inputs
+	const [enableSyslog, setEnableSyslog] = useState(config.enable_syslog)
+	const [syslogHost, setSyslogHost] = useState(config.syslog_host || '127.0.0.1')
+	const [syslogPort, setSyslogPort] = useState(config.syslog_port || 514)
+	const [syslogTcp, setSyslogTcp] = useState(config.syslog_use_tcp)
+	const [syslogLocalHost, setSyslogLocalHost] = useState(config.syslog_local_hostname || '')
+
+	// Update local state when config changes
+	useEffect(() => {
+		setEnableSyslog(config.enable_syslog)
+		setSyslogHost(config.syslog_host || '127.0.0.1')
+		setSyslogPort(config.syslog_port || 514)
+		setSyslogTcp(config.syslog_use_tcp)
+		setSyslogLocalHost(config.syslog_local_hostname || '')
+	}, [
+		config.enable_syslog,
+		config.syslog_host,
+		config.syslog_port,
+		config.syslog_use_tcp,
+		config.syslog_local_hostname,
+	])
+
+	// Handle changes and update config
+	const handleEnableSyslog = (checked: boolean) => {
+		setEnableSyslog(checked)
+		updateConfig({ enable_syslog: checked })
+	}
+
+	const handleSyslogHostChange = (value: string) => {
+		setSyslogHost(value)
+		updateConfig({ syslog_host: value })
+	}
+	const handleSyslogPortChange = (value: string) => {
+		let port = Number.parseInt(value)
+		port = Number.isNaN(port) ? 514 : port
+		port = port < 20 ? 20 : port
+		port = port > 65535 ? 65535 : port
+		setSyslogPort(port)
+		updateConfig({ syslog_port: port })
+	}
+
+	const handleSyslogTcpChange = (checked: boolean) => {
+		setSyslogTcp(checked)
+		updateConfig({ syslog_use_tcp: checked })
+	}
+
+	const handleSyslogLocalHostChange = (value: string) => {
+		setSyslogLocalHost(value)
+		updateConfig({ syslog_local_hostname: value })
+	}
+
+	return (
+		<div className="space-y-6">
+			<div>
+				<p className="text-muted-foreground mb-4 text-sm">Configure Companion syslog client</p>
+				<div className="space-y-4">
+					<div className="grid grid-cols-4 gap-4 items-center">
+						<Label htmlFor="enable-syslog">Enable</Label>
+						<div className="flex items-center col-span-3 ">
+							<input
+								type="checkbox"
+								id="enable_syslog"
+								checked={enableSyslog}
+								onChange={(e) => handleEnableSyslog(e.target.checked)}
+								className="rounded"
+							/>
+						</div>
+					</div>
+					<div className="grid grid-cols-4 gap-4 items-center">
+						<Label htmlFor="syslog-host">Syslog Server</Label>
+						<div className="col-span-3">
+							<div className="flex">
+								<Input
+									id="syslog_host"
+									type="text"
+									value={syslogHost}
+									onChange={(e) => handleSyslogHostChange(e.target.value)}
+									placeholder=""
+									className="flex-1 rounded-r-none"
+								/>
+							</div>
+							<p className="text-sm text-muted-foreground mt-1">Hostname or IP of Syslog Server</p>
+						</div>
+					</div>
+					<div className="grid grid-cols-4 gap-4 items-center">
+						<Label htmlFor="syslog-port">Port</Label>
+						<div className="col-span-3">
+							<div className="flex">
+								<Input
+									id="syslog_port"
+									type="number"
+									value={syslogPort}
+									onChange={(e) => handleSyslogPortChange(e.target.value)}
+									placeholder=""
+									className="flex-1 rounded-r-none"
+								/>
+							</div>
+						</div>
+					</div>
+					<div className="grid grid-cols-4 gap-4 items-center">
+						<Label htmlFor="syslog-tcp">Use TCP</Label>
+						<div className="flex items-center col-span-3 ">
+							<input
+								type="checkbox"
+								id="syslog_use_tcp"
+								checked={syslogTcp}
+								onChange={(e) => handleSyslogTcpChange(e.target.checked)}
+								className="rounded"
+							/>
+						</div>
+					</div>
+					<div className="grid grid-cols-4 gap-4 items-center">
+						<Label htmlFor="syslog-local-host">Local Hostname</Label>
+						<div className="col-span-3">
+							<div className="flex">
+								<Input
+									id="syslog_local_hostname"
+									type="text"
+									value={syslogLocalHost}
+									onChange={(e) => handleSyslogLocalHostChange(e.target.value)}
+									placeholder=""
+									className="flex-1 rounded-r-none"
+								/>
+							</div>
+							<p className="text-sm text-muted-foreground mt-1">
+								Change the hostname this companion instance will report
+							</p>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	)
+}

--- a/launcher-ui/src/sections/Syslog.tsx
+++ b/launcher-ui/src/sections/Syslog.tsx
@@ -2,9 +2,6 @@ import React, { useState, useEffect } from 'react'
 import { useConfig } from '~/hooks/useConfig'
 import { Input } from '~/components/ui/input'
 import { Label } from '~/components/ui/label'
-/* import { Button } from '~/components/ui/button'
-import { Alert, AlertDescription } from '~/components/ui/alert'
-import { Info } from 'lucide-react' */
 
 export function SyslogSection(): JSX.Element {
 	const { state, updateConfig } = useConfig()
@@ -47,7 +44,7 @@ export function SyslogSection(): JSX.Element {
 	const handleSyslogPortChange = (value: string) => {
 		let port = Number.parseInt(value)
 		port = Number.isNaN(port) ? 514 : port
-		port = port < 20 ? 20 : port
+		port = port < 100 ? 100 : port
 		port = port > 65535 ? 65535 : port
 		setSyslogPort(port)
 		updateConfig({ syslog_port: port })
@@ -93,7 +90,7 @@ export function SyslogSection(): JSX.Element {
 									className="flex-1 rounded-r-none"
 								/>
 							</div>
-							<p className="text-sm text-muted-foreground mt-1">Hostname or IP of Syslog Server</p>
+							<p className="text-sm text-muted-foreground mt-1">IP of Syslog Server</p>
 						</div>
 					</div>
 					<div className="grid grid-cols-4 gap-4 items-center">
@@ -105,7 +102,6 @@ export function SyslogSection(): JSX.Element {
 									type="number"
 									value={syslogPort}
 									onChange={(e) => handleSyslogPortChange(e.target.value)}
-									placeholder=""
 									className="flex-1 rounded-r-none"
 								/>
 							</div>
@@ -132,7 +128,6 @@ export function SyslogSection(): JSX.Element {
 									type="text"
 									value={syslogLocalHost}
 									onChange={(e) => handleSyslogLocalHostChange(e.target.value)}
-									placeholder=""
 									className="flex-1 rounded-r-none"
 								/>
 							</div>

--- a/launcher-ui/src/sections/Syslog.tsx
+++ b/launcher-ui/src/sections/Syslog.tsx
@@ -103,6 +103,8 @@ export function SyslogSection(): JSX.Element {
 									value={syslogPort}
 									onChange={(e) => handleSyslogPortChange(e.target.value)}
 									className="flex-1 rounded-r-none"
+									min={101}
+									max={65535}
 								/>
 							</div>
 						</div>

--- a/launcher-ui/src/sections/Syslog.tsx
+++ b/launcher-ui/src/sections/Syslog.tsx
@@ -131,6 +131,7 @@ export function SyslogSection(): JSX.Element {
 									value={syslogLocalHost}
 									onChange={(e) => handleSyslogLocalHostChange(e.target.value)}
 									className="flex-1 rounded-r-none"
+									placeholder={state.data?.hostname}
 								/>
 							</div>
 							<p className="text-sm text-muted-foreground mt-1">

--- a/launcher-ui/src/types/config.ts
+++ b/launcher-ui/src/types/config.ts
@@ -6,6 +6,11 @@ export interface LauncherConfig {
 	enable_developer: boolean
 	dev_modules_path: string
 	log_level: string
+	enable_syslog: boolean
+	syslog_host: string
+	syslog_port: number
+	syslog_use_tcp: boolean
+	syslog_local_hostname: string
 }
 
 export interface AppInfo {

--- a/launcher-ui/src/types/config.ts
+++ b/launcher-ui/src/types/config.ts
@@ -24,4 +24,5 @@ export interface ConfigData {
 	config: LauncherConfig
 	appInfo: AppInfo
 	platform: string
+	hostname: string
 }

--- a/launcher/main.js
+++ b/launcher/main.js
@@ -121,7 +121,7 @@ if (!lock) {
 		syslog_host: '127.0.0.1',
 		syslog_port: 514,
 		syslog_use_tcp: false,
-		syslog_local_hostname: os.hostname(),
+		syslog_local_hostname: '',
 	}
 
 	try {

--- a/launcher/main.js
+++ b/launcher/main.js
@@ -116,6 +116,12 @@ if (!lock) {
 		enable_developer: false,
 		dev_modules_path: '',
 		log_level: 'info',
+
+		enable_syslog: false,
+		syslog_host: '127.0.0.1',
+		syslog_port: 514,
+		syslog_use_tcp: false,
+		syslog_local_hostname: '',
 	}
 
 	try {
@@ -552,6 +558,31 @@ if (!lock) {
 					doRestartApp = true
 				}
 
+				if (configData.enable_syslog !== undefined) {
+					uiConfig.set('enable_syslog', configData.enable_syslog)
+					doRestartApp = true
+				}
+
+				if (configData.syslog_host !== undefined) {
+					uiConfig.set('syslog_host', configData.syslog_host)
+					if (uiConfig.get('enable_syslog')) doRestartApp = true
+				}
+
+				if (configData.syslog_port !== undefined) {
+					uiConfig.set('syslog_port', configData.syslog_port)
+					if (uiConfig.get('enable_syslog')) doRestartApp = true
+				}
+
+				if (configData.syslog_use_tcp !== undefined) {
+					uiConfig.set('syslog_use_tcp', configData.syslog_use_tcp)
+					if (uiConfig.get('enable_syslog')) doRestartApp = true
+				}
+
+				if (configData.syslog_local_hostname !== undefined) {
+					uiConfig.set('syslog_local_hostname', configData.syslog_local_hostname)
+					if (uiConfig.get('enable_syslog')) doRestartApp = true
+				}
+
 				// Refresh config info to all windows
 				sendAppInfo()
 
@@ -893,6 +924,13 @@ if (!lock) {
 						`--log-level=${uiConfig.get('log_level')}`,
 						uiConfig.get('enable_developer') ? `--extra-module-path=${uiConfig.get('dev_modules_path')}` : undefined,
 						disableAdminPassword || process.env.DISABLE_ADMIN_PASSWORD ? `--disable-admin-password` : undefined,
+						uiConfig.get('enable_syslog') ? '--syslog-enable' : undefined,
+						uiConfig.get('enable_syslog') ? `--syslog-host=${uiConfig.get('syslog_host')}` : undefined,
+						uiConfig.get('enable_syslog') ? `--syslog-port=${uiConfig.get('syslog_port')}` : undefined,
+						uiConfig.get('enable_syslog') && uiConfig.get('syslog_use_tcp') ? `--syslog-tcp` : undefined,
+						uiConfig.get('enable_syslog') && uiConfig.get('syslog_local_hostname')
+							? `--syslog-localhost=${uiConfig.get('syslog_local_hostname')}`
+							: undefined,
 					].filter((v) => !!v),
 				{
 					name: `Companion process`,

--- a/launcher/main.js
+++ b/launcher/main.js
@@ -223,7 +223,7 @@ if (!lock) {
 		// Send to settings window
 		const settingsWindow = getSettingsWindow()
 		if (settingsWindow) {
-			settingsWindow.webContents.send('info', configData, appInfo, process.platform)
+			settingsWindow.webContents.send('info', configData, appInfo, process.platform, os.hostname())
 		}
 	}
 

--- a/launcher/main.js
+++ b/launcher/main.js
@@ -121,7 +121,7 @@ if (!lock) {
 		syslog_host: '127.0.0.1',
 		syslog_port: 514,
 		syslog_use_tcp: false,
-		syslog_local_hostname: '',
+		syslog_local_hostname: os.hostname(),
 	}
 
 	try {
@@ -256,7 +256,7 @@ if (!lock) {
 			child?.stop(() => child?.start())
 		},
 		{
-			wait: 500,
+			wait: 1000,
 			before: false,
 			after: true,
 		}

--- a/launcher/main.js
+++ b/launcher/main.js
@@ -929,7 +929,7 @@ if (!lock) {
 						uiConfig.get('enable_syslog') ? `--syslog-port=${uiConfig.get('syslog_port')}` : undefined,
 						uiConfig.get('enable_syslog') && uiConfig.get('syslog_use_tcp') ? `--syslog-tcp` : undefined,
 						uiConfig.get('enable_syslog') && uiConfig.get('syslog_local_hostname')
-							? `--syslog-localhost=${uiConfig.get('syslog_local_hostname')}`
+							? `--syslog-localhost="${uiConfig.get('syslog_local_hostname')}"`
 							: undefined,
 					].filter((v) => !!v),
 				{


### PR DESCRIPTION
Add syslog configuration to the new launcher `Advanced Settings` window.

I would prefer to allow specifying the syslog server via hostname as well as IP; however when an invalid hostname is supplied, companion will crash when trying to write to the logs, and this is not caught by the `try/catch` block that sets up the syslog transport for winston.

When the `Local Hostname` field is empty, the system defaults to `os.hostname()`

Trigger restart debounce duration extended slightly to make it more tolerant of typing in the text fields.

<img width="2538" height="1430" alt="image" src="https://github.com/user-attachments/assets/28774a01-01db-4d3d-a9e6-89d22cd0975c" />


 