### PR TITLE
feat: support expressions for all internal action fields #2345

### DIFF
--- a/companion/lib/Instance/ConfigFields.ts
+++ b/companion/lib/Instance/ConfigFields.ts
@@ -249,13 +249,17 @@ function translateCustomVariableField(
 
 function translateCommonFields(
 	field: EncodeIsVisible<CompanionInputFieldBase>
-): Pick<Complete<CompanionInputFieldBaseExtended>, 'id' | 'label' | 'tooltip' | 'description' | 'isVisibleUi'> {
+): Pick<
+	Complete<CompanionInputFieldBaseExtended>,
+	'id' | 'label' | 'tooltip' | 'description' | 'isVisibleUi' | 'disableAutoExpression'
+> {
 	return {
 		id: field.id,
 		label: field.label,
 		tooltip: field.tooltip,
 		description: field.description,
 		isVisibleUi: translateIsVisibleFn(field),
+		disableAutoExpression: true, // Temporary until #2345
 	}
 }
 

--- a/companion/lib/Instance/ConfigFields.ts
+++ b/companion/lib/Instance/ConfigFields.ts
@@ -143,9 +143,11 @@ function translateTextInputField(
 	usesInternalVariableParsing: boolean
 ): Complete<CompanionInputFieldTextInputExtended> {
 	let useVariables: CompanionFieldVariablesSupport | undefined
-	if (field.useVariables) {
+	if (usesInternalVariableParsing) {
+		useVariables = { local: true }
+	} else if (field.useVariables) {
 		useVariables = {
-			local: usesInternalVariableParsing || (typeof field.useVariables === 'object' && field.useVariables.local),
+			local: typeof field.useVariables === 'object' && field.useVariables.local,
 		}
 	}
 

--- a/companion/lib/Instance/Definitions.ts
+++ b/companion/lib/Instance/Definitions.ts
@@ -42,6 +42,7 @@ import { publicProcedure, router, toIterable } from '../UI/TRPC.js'
 import { EventEmitter } from 'node:events'
 import { ConnectionConfigStore } from './ConnectionConfigStore.js'
 import { ButtonStyleProperties } from '@companion-app/shared/Model/StyleModel.js'
+import { ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
 
 type InstanceDefinitionsEvents = {
 	readonly updatePresets: [connectionId: string]
@@ -169,7 +170,15 @@ export class InstanceDefinitions extends EventEmitter<InstanceDefinitionsEvents>
 
 		if (definition.options !== undefined && definition.options.length > 0) {
 			for (const opt of definition.options) {
-				entity.options[opt.id] = cloneDeep((opt as any).default)
+				const defaultValue = cloneDeep((opt as any).default)
+				if (definition.internalUsesAutoParser) {
+					entity.options[opt.id] = {
+						isExpression: false,
+						value: defaultValue,
+					} satisfies ExpressionOrValue<any>
+				} else {
+					entity.options[opt.id] = defaultValue
+				}
 			}
 		}
 

--- a/companion/lib/Instance/Definitions.ts
+++ b/companion/lib/Instance/Definitions.ts
@@ -171,7 +171,7 @@ export class InstanceDefinitions extends EventEmitter<InstanceDefinitionsEvents>
 		if (definition.options !== undefined && definition.options.length > 0) {
 			for (const opt of definition.options) {
 				const defaultValue = cloneDeep((opt as any).default)
-				if (definition.internalUsesAutoParser) {
+				if (definition.internalUsesAutoParser && !opt.disableAutoExpression) {
 					entity.options[opt.id] = {
 						isExpression: false,
 						value: defaultValue,

--- a/companion/lib/Instance/EntityManager/EntityManager.ts
+++ b/companion/lib/Instance/EntityManager/EntityManager.ts
@@ -385,32 +385,8 @@ export class EntityManager {
 			// If we don't know what fields need parsing, we can't do anything
 			return { parsedOptions: options, referencedVariableIds: new Set() }
 
-		const parsedOptions: OptionsObject = {}
-		const referencedVariableIds = new Set<string>()
-
 		const parser = this.#controlsController.createVariablesAndExpressionParser(controlId, null)
-
-		for (const field of entityDefinition.options) {
-			if (field.type !== 'textinput' || !field.useVariables) {
-				// Field doesn't support variables, pass unchanged
-				parsedOptions[field.id] = options[field.id]
-				continue
-			}
-
-			// Field needs parsing
-			// Note - we don't need to care about the granularity given in `useVariables`,
-			const parseResult = parser.parseVariables(String(options[field.id]))
-			parsedOptions[field.id] = parseResult.text
-
-			// Track the variables referenced in this field
-			if (!entityDefinition.optionsToIgnoreForSubscribe.includes(field.id)) {
-				for (const variable of parseResult.variableIds) {
-					referencedVariableIds.add(variable)
-				}
-			}
-		}
-
-		return { parsedOptions, referencedVariableIds }
+		return parser.parseEntityOptions(entityDefinition, options)
 	}
 
 	/**

--- a/companion/lib/Instance/EntityManager/EntityManager.ts
+++ b/companion/lib/Instance/EntityManager/EntityManager.ts
@@ -1,21 +1,16 @@
 import debounceFn from 'debounce-fn'
-import type { ControlEntityInstance } from '../Controls/Entities/EntityInstance.js'
-import type {
-	FeedbackInstance as ModuleFeedbackInstance,
-	HostToModuleEventsV0,
-	ModuleToHostEventsV0,
-	UpdateActionInstancesMessage,
-	UpdateFeedbackInstancesMessage,
-	UpgradeActionAndFeedbackInstancesMessage,
-} from '@companion-module/base/dist/host-api/api.js'
+import { ControlEntityInstance } from '../../Controls/Entities/EntityInstance.js'
 import { assertNever } from '@companion-app/shared/Util.js'
-import { EntityModelType } from '@companion-app/shared/Model/EntityModel.js'
-import type { IpcWrapper } from '@companion-module/base/dist/host-api/ipc-wrapper.js'
+import {
+	EntityModelType,
+	SomeEntityModel,
+	SomeReplaceableEntityModel,
+} from '@companion-app/shared/Model/EntityModel.js'
 import { nanoid } from 'nanoid'
-import type { ControlsController } from '../Controls/Controller.js'
+import type { ControlsController } from '../../Controls/Controller.js'
 import type { ClientEntityDefinition } from '@companion-app/shared/Model/EntityDefinitionModel.js'
 import type { OptionsObject } from '@companion-module/base/dist/util.js'
-import LogController, { Logger } from '../Log/Controller.js'
+import LogController, { Logger } from '../../Log/Controller.js'
 
 enum EntityState {
 	UNLOADED = 'UNLOADED',
@@ -35,15 +30,41 @@ interface EntityWrapper {
 	lastReferencedVariableIds?: ReadonlySet<string>
 }
 
+export interface EntityManagerMethods {
+	updateEntities(entities: EntityForUpdate[]): Promise<void>
+	upgradeEntities(entities: EntityForUpgrade[], currentUpgradeIndex: number): Promise<SomeReplaceableEntityModel[]>
+}
+
+export interface EntityForUpgrade {
+	controlId: string
+	entityModel: SomeEntityModel
+}
+
+export type EntityForUpdate =
+	| {
+			controlId: string
+			type: 'update'
+			entityId: string
+			entityModel: SomeEntityModel
+
+			parsedOptions: OptionsObject
+	  }
+	| {
+			controlId: string
+			type: 'delete'
+			entityId: string
+			entityType: EntityModelType
+	  }
+
 /**
  * This class is responsible for managing the entities that are tracked by the module
  * With this, it will ensure that the entities are run through the upgrade scripts as needed, and also
  * have the options parsed (by as much as companion supports) before being sent to the module for subscription callbacks
  */
-export class InstanceEntityManager {
+export class EntityManager {
 	readonly #logger: Logger
 
-	readonly #ipcWrapper: IpcWrapper<HostToModuleEventsV0, ModuleToHostEventsV0>
+	readonly #managerMethods: EntityManagerMethods
 	readonly #controlsController: ControlsController
 
 	readonly #entities = new Map<string, EntityWrapper>()
@@ -52,13 +73,9 @@ export class InstanceEntityManager {
 	#ready = false
 	#currentUpgradeIndex = 0
 
-	constructor(
-		ipcWrapper: IpcWrapper<HostToModuleEventsV0, ModuleToHostEventsV0>,
-		controlsController: ControlsController,
-		connectionId: string
-	) {
+	constructor(managerMethods: EntityManagerMethods, controlsController: ControlsController, connectionId: string) {
 		this.#logger = LogController.createLogger(`Instance/EntityManager/${connectionId}`)
-		this.#ipcWrapper = ipcWrapper
+		this.#managerMethods = managerMethods
 		this.#controlsController = controlsController
 	}
 
@@ -67,17 +84,8 @@ export class InstanceEntityManager {
 			if (!this.#ready) return
 
 			const entityIdsInThisBatch = new Map<string, string>()
-			const upgradePayload: UpgradeActionAndFeedbackInstancesMessage = {
-				actions: [],
-				feedbacks: [],
-				defaultUpgradeIndex: 0, // TODO - remove this!
-			}
-			const updateActionsPayload: UpdateActionInstancesMessage = {
-				actions: {},
-			}
-			const updateFeedbacksPayload: UpdateFeedbackInstancesMessage = {
-				feedbacks: {},
-			}
+			const upgradeEntities: EntityForUpgrade[] = []
+			const updatedEntities: EntityForUpdate[] = []
 
 			const pushEntityToUpgrade = (wrapper: EntityWrapper, entity: ControlEntityInstance) => {
 				this.#logger.silly(
@@ -85,39 +93,11 @@ export class InstanceEntityManager {
 				)
 
 				entityIdsInThisBatch.set(entity.id, wrapper.wrapperId)
-				const entityModel = entity.asEntityModel(false)
-				switch (entityModel.type) {
-					case EntityModelType.Action:
-						upgradePayload.actions.push({
-							id: entityModel.id,
-							controlId: wrapper.controlId,
-							actionId: entityModel.definitionId,
-							options: entityModel.options,
-
-							upgradeIndex: entityModel.upgradeIndex ?? null,
-							disabled: !!entityModel.disabled,
-						})
-						break
-					case EntityModelType.Feedback:
-						upgradePayload.feedbacks.push({
-							id: entityModel.id,
-							controlId: wrapper.controlId,
-							feedbackId: entityModel.definitionId,
-							options: entityModel.options,
-
-							isInverted: !!entityModel.isInverted,
-
-							upgradeIndex: entityModel.upgradeIndex ?? null,
-							disabled: !!entityModel.disabled,
-						})
-						break
-					default:
-						assertNever(entityModel)
-						this.#logger.warn('Unknown entity type', entity.type)
-				}
+				upgradeEntities.push({
+					controlId: wrapper.controlId,
+					entityModel: entity.asEntityModel(false),
+				})
 			}
-
-			const controlImageSizeCache = new Map<string, ModuleFeedbackInstance['image']>()
 
 			// First, look over all the entiites and figure out what needs to be done to each
 			for (const [entityId, wrapper] of this.#entities) {
@@ -150,47 +130,14 @@ export class InstanceEntityManager {
 							)
 							wrapper.lastReferencedVariableIds = referencedVariableIds
 
-							switch (entityModel.type) {
-								case EntityModelType.Action:
-									updateActionsPayload.actions[entityId] = {
-										id: entityModel.id,
-										controlId: wrapper.controlId,
-										actionId: entityModel.definitionId,
-										options: parsedOptions,
+							updatedEntities.push({
+								controlId: wrapper.controlId,
+								type: 'update',
+								entityId: entityModel.id,
+								entityModel: entityModel,
 
-										upgradeIndex: entityModel.upgradeIndex ?? null,
-										disabled: !!entityModel.disabled,
-									}
-									break
-								case EntityModelType.Feedback: {
-									let imageSize: ModuleFeedbackInstance['image'] | undefined
-									if (controlImageSizeCache.has(wrapper.controlId)) {
-										imageSize = controlImageSizeCache.get(wrapper.controlId)
-									} else {
-										const control = this.#controlsController.getControl(wrapper.controlId)
-										imageSize = control?.getBitmapSize() ?? undefined
-										controlImageSizeCache.set(wrapper.controlId, imageSize)
-									}
-
-									updateFeedbacksPayload.feedbacks[entityId] = {
-										id: entityModel.id,
-										controlId: wrapper.controlId,
-										feedbackId: entityModel.definitionId,
-										options: parsedOptions,
-
-										image: imageSize,
-
-										isInverted: !!entityModel.isInverted,
-
-										upgradeIndex: entityModel.upgradeIndex ?? null,
-										disabled: !!entityModel.disabled,
-									}
-									break
-								}
-								default:
-									assertNever(entityModel)
-									this.#logger.warn('Unknown entity type', entity.type)
-							}
+								parsedOptions: parsedOptions,
+							})
 						} else {
 							wrapper.state = EntityState.UPGRADING
 							pushEntityToUpgrade(wrapper, entity)
@@ -211,17 +158,12 @@ export class InstanceEntityManager {
 						const entity = wrapper.entity.deref()
 
 						if (entity) {
-							switch (entity.type) {
-								case EntityModelType.Action:
-									updateActionsPayload.actions[entityId] = null
-									break
-								case EntityModelType.Feedback:
-									updateFeedbacksPayload.feedbacks[entityId] = null
-									break
-								default:
-									assertNever(entity.type)
-									this.#logger.warn('Unknown entity type', entity.type)
-							}
+							updatedEntities.push({
+								type: 'delete',
+								controlId: wrapper.controlId,
+								entityId: entity.id,
+								entityType: entity.type,
+							})
 						}
 						break
 					}
@@ -232,28 +174,22 @@ export class InstanceEntityManager {
 			}
 
 			// Start by sending the simple payloads
-			if (Object.keys(updateActionsPayload.actions).length > 0) {
-				this.#ipcWrapper.sendWithCb('updateActions', updateActionsPayload).catch((e) => {
-					this.#logger.error('Error sending updateActions', e)
-				})
-			}
-			if (Object.keys(updateFeedbacksPayload.feedbacks).length > 0) {
-				this.#ipcWrapper.sendWithCb('updateFeedbacks', updateFeedbacksPayload).catch((e) => {
-					this.#logger.error('Error sending updateFeedbacks', e)
+			if (Object.keys(updatedEntities).length > 0) {
+				this.#managerMethods.updateEntities(updatedEntities).catch((e) => {
+					this.#logger.error('Error sending updated entities', e)
 				})
 			}
 
 			// Now we need to send the upgrades
-			if (upgradePayload.actions.length > 0 || upgradePayload.feedbacks.length > 0) {
-				this.#ipcWrapper
-					.sendWithCb('upgradeActionsAndFeedbacks', upgradePayload)
+			if (upgradeEntities.length > 0) {
+				this.#managerMethods
+					.upgradeEntities(upgradeEntities, this.#currentUpgradeIndex)
 					.then((upgraded) => {
 						if (!this.#ready) return
 
 						// We have the upgraded entities, lets patch the tracked entities
 
-						const upgradedActions = new Map(upgraded.updatedActions.map((act) => [act.id, act]))
-						const upgradedFeedbacks = new Map(upgraded.updatedFeedbacks.map((fb) => [fb.id, fb]))
+						const upgradedEntities = new Map(upgraded.map((act) => [act.id, act]))
 
 						// Loop through what we sent, as we don't get a response for all of them
 						for (const [entityId, wrapperId] of entityIdsInThisBatch) {
@@ -288,38 +224,9 @@ export class InstanceEntityManager {
 									}
 
 									try {
-										switch (entity.type) {
-											case EntityModelType.Action: {
-												const action = upgradedActions.get(entity.id)
-												if (action) {
-													control.entities.entityReplace({
-														id: action.id,
-														type: EntityModelType.Action,
-														definitionId: action.actionId,
-														options: action.options,
-														upgradeIndex: this.#currentUpgradeIndex,
-													})
-												}
-												break
-											}
-											case EntityModelType.Feedback: {
-												const feedback = upgradedFeedbacks.get(entity.id)
-												if (feedback) {
-													control.entities.entityReplace({
-														id: feedback.id,
-														type: EntityModelType.Feedback,
-														definitionId: feedback.feedbackId,
-														options: feedback.options,
-														style: feedback.style,
-														isInverted: feedback.isInverted,
-														upgradeIndex: this.#currentUpgradeIndex,
-													})
-												}
-												break
-											}
-											default:
-												assertNever(entity.type)
-												break
+										const newEntityProps = upgradedEntities.get(entity.id)
+										if (newEntityProps) {
+											control.entities.entityReplace(newEntityProps)
 										}
 									} catch (e) {
 										this.#logger.error(`Error replacing entity ${entity.id} in control ${wrapper.controlId}`, e)

--- a/companion/lib/Instance/EntityManager/InstanceEntityManager.ts
+++ b/companion/lib/Instance/EntityManager/InstanceEntityManager.ts
@@ -1,0 +1,181 @@
+import type {
+	FeedbackInstance as ModuleFeedbackInstance,
+	HostToModuleEventsV0,
+	ModuleToHostEventsV0,
+	UpdateActionInstancesMessage,
+	UpdateFeedbackInstancesMessage,
+	UpgradeActionAndFeedbackInstancesMessage,
+} from '@companion-module/base/dist/host-api/api.js'
+import { assertNever } from '@companion-app/shared/Util.js'
+import { EntityModelType, SomeReplaceableEntityModel } from '@companion-app/shared/Model/EntityModel.js'
+import type { IpcWrapper } from '@companion-module/base/dist/host-api/ipc-wrapper.js'
+import type { ControlsController } from '../../Controls/Controller.js'
+import LogController from '../../Log/Controller.js'
+
+import { EntityManager, EntityManagerMethods } from './EntityManager.js'
+
+export function createInstanceEntityManager(
+	ipcWrapper: IpcWrapper<HostToModuleEventsV0, ModuleToHostEventsV0>,
+	controlsController: ControlsController,
+	connectionId: string
+): EntityManager {
+	const logger = LogController.createLogger(`Instance/EntityManager/${connectionId}`)
+
+	const instanceMethods: EntityManagerMethods = {
+		async updateEntities(entities) {
+			const updateActionsPayload: UpdateActionInstancesMessage = {
+				actions: {},
+			}
+			const updateFeedbacksPayload: UpdateFeedbackInstancesMessage = {
+				feedbacks: {},
+			}
+
+			const controlImageSizeCache = new Map<string, ModuleFeedbackInstance['image']>()
+
+			for (const entityInfo of entities) {
+				if (entityInfo.type === 'delete') {
+					// Deletion
+					switch (entityInfo.entityType) {
+						case EntityModelType.Action:
+							updateActionsPayload.actions[entityInfo.entityId] = null
+							break
+						case EntityModelType.Feedback:
+							updateFeedbacksPayload.feedbacks[entityInfo.entityId] = null
+							break
+						default:
+							assertNever(entityInfo.entityType)
+							logger.warn('Unknown entity type: ' + entityInfo.entityType)
+					}
+				} else if (entityInfo.type === 'update') {
+					const { controlId, entityId, entityModel, parsedOptions } = entityInfo
+
+					const entityType = entityModel.type
+					switch (entityModel.type) {
+						case EntityModelType.Action:
+							updateActionsPayload.actions[entityId] = {
+								id: entityModel.id,
+								controlId: controlId,
+								actionId: entityModel.definitionId,
+								options: parsedOptions,
+
+								upgradeIndex: entityModel.upgradeIndex ?? null,
+								disabled: !!entityModel.disabled,
+							}
+							break
+						case EntityModelType.Feedback: {
+							let imageSize: ModuleFeedbackInstance['image'] | undefined
+							if (controlImageSizeCache.has(controlId)) {
+								imageSize = controlImageSizeCache.get(controlId)
+							} else {
+								const control = controlsController.getControl(controlId)
+								imageSize = control?.getBitmapSize() ?? undefined
+								controlImageSizeCache.set(controlId, imageSize)
+							}
+
+							updateFeedbacksPayload.feedbacks[entityId] = {
+								id: entityModel.id,
+								controlId: controlId,
+								feedbackId: entityModel.definitionId,
+								options: parsedOptions,
+
+								image: imageSize,
+
+								isInverted: !!entityModel.isInverted,
+
+								upgradeIndex: entityModel.upgradeIndex ?? null,
+								disabled: !!entityModel.disabled,
+							}
+							break
+						}
+						default:
+							assertNever(entityModel)
+							logger.warn('Unknown entity type', entityType)
+					}
+				} else {
+					assertNever(entityInfo)
+				}
+			}
+
+			if (Object.keys(updateActionsPayload.actions).length > 0) {
+				ipcWrapper.sendWithCb('updateActions', updateActionsPayload).catch((e) => {
+					logger.error('Error sending updateActions', e)
+				})
+			}
+			if (Object.keys(updateFeedbacksPayload.feedbacks).length > 0) {
+				ipcWrapper.sendWithCb('updateFeedbacks', updateFeedbacksPayload).catch((e) => {
+					logger.error('Error sending updateFeedbacks', e)
+				})
+			}
+		},
+
+		async upgradeEntities(entities, currentUpgradeIndex) {
+			const upgradePayload: UpgradeActionAndFeedbackInstancesMessage = {
+				actions: [],
+				feedbacks: [],
+				defaultUpgradeIndex: 0, // TODO - remove this!
+			}
+
+			for (const { controlId, entityModel } of entities) {
+				const entityType = entityModel.type
+				switch (entityModel.type) {
+					case EntityModelType.Action:
+						upgradePayload.actions.push({
+							id: entityModel.id,
+							controlId: controlId,
+							actionId: entityModel.definitionId,
+							options: entityModel.options,
+
+							upgradeIndex: entityModel.upgradeIndex ?? null,
+							disabled: !!entityModel.disabled,
+						})
+						break
+					case EntityModelType.Feedback:
+						upgradePayload.feedbacks.push({
+							id: entityModel.id,
+							controlId: controlId,
+							feedbackId: entityModel.definitionId,
+							options: entityModel.options,
+
+							isInverted: !!entityModel.isInverted,
+
+							upgradeIndex: entityModel.upgradeIndex ?? null,
+							disabled: !!entityModel.disabled,
+						})
+						break
+					default:
+						assertNever(entityModel)
+						logger.warn('Unknown entity type', entityType)
+				}
+			}
+
+			const upgradeResult = await ipcWrapper.sendWithCb('upgradeActionsAndFeedbacks', upgradePayload)
+
+			const replacableModels: SomeReplaceableEntityModel[] = []
+
+			for (const action of upgradeResult.updatedActions) {
+				replacableModels.push({
+					id: action.id,
+					type: EntityModelType.Action,
+					definitionId: action.actionId,
+					options: action.options,
+					upgradeIndex: currentUpgradeIndex,
+				})
+			}
+			for (const feedback of upgradeResult.updatedFeedbacks) {
+				replacableModels.push({
+					id: feedback.id,
+					type: EntityModelType.Feedback,
+					definitionId: feedback.feedbackId,
+					options: feedback.options,
+					style: feedback.style,
+					isInverted: feedback.isInverted,
+					upgradeIndex: currentUpgradeIndex,
+				})
+			}
+
+			return replacableModels
+		},
+	}
+
+	return new EntityManager(instanceMethods, controlsController, connectionId)
+}

--- a/companion/lib/Instance/Wrapper.ts
+++ b/companion/lib/Instance/Wrapper.ts
@@ -53,7 +53,8 @@ import type { ClientEntityDefinition } from '@companion-app/shared/Model/EntityD
 import type { Complete } from '@companion-module/base/dist/util.js'
 import type { RespawnMonitor } from '@companion-app/shared/Respawn.js'
 import { doesModuleExpectLabelUpdates, doesModuleUseSeparateUpgradeMethod } from './ApiVersions.js'
-import { InstanceEntityManager } from './EntityManager.js'
+import type { EntityManager } from './EntityManager/EntityManager.js'
+import { createInstanceEntityManager } from './EntityManager/InstanceEntityManager.js'
 import type { ControlEntityInstance } from '../Controls/Entities/EntityInstance.js'
 import { translateEntityInputFields } from './ConfigFields.js'
 
@@ -90,7 +91,7 @@ export class SocketEventsHandler {
 
 	#expectsLabelUpdates: boolean = false
 
-	readonly #entityManager: InstanceEntityManager | null
+	readonly #entityManager: EntityManager | null
 
 	#currentUpgradeIndex: number | null = null
 
@@ -154,7 +155,7 @@ export class SocketEventsHandler {
 		)
 
 		this.#entityManager = doesModuleUseSeparateUpgradeMethod(apiVersion)
-			? new InstanceEntityManager(this.#ipcWrapper, this.#deps.controls, this.connectionId)
+			? createInstanceEntityManager(this.#ipcWrapper, this.#deps.controls, this.connectionId)
 			: null
 
 		const messageHandler = (msg: any) => {

--- a/companion/lib/Instance/Wrapper.ts
+++ b/companion/lib/Instance/Wrapper.ts
@@ -715,6 +715,7 @@ export class SocketEventsHandler {
 
 				feedbackType: null,
 				feedbackStyle: undefined,
+				internalUsesAutoParser: false,
 			} satisfies Complete<ClientEntityDefinition>
 		}
 
@@ -751,6 +752,7 @@ export class SocketEventsHandler {
 
 				showButtonPreview: false,
 				supportsChildGroups: [],
+				internalUsesAutoParser: false,
 			} satisfies Complete<ClientEntityDefinition>
 		}
 

--- a/companion/lib/Internal/ActionRecorder.ts
+++ b/companion/lib/Internal/ActionRecorder.ts
@@ -15,7 +15,7 @@ import type { IPageStore } from '../Page/Store.js'
 import type {
 	ActionForVisitor,
 	FeedbackForVisitor,
-	FeedbackEntityModelExt,
+	FeedbackForInternalExecution,
 	InternalModuleFragment,
 	InternalVisitor,
 	InternalActionDefinition,
@@ -315,12 +315,14 @@ export class InternalActionRecorder
 	/**
 	 * Get an updated value for a feedback
 	 */
-	executeFeedback(feedback: FeedbackEntityModelExt): boolean | void {
+	executeFeedback(feedback: FeedbackForInternalExecution): boolean | void {
 		if (feedback.definitionId === 'action_recorder_check_connections') {
 			const session = this.#actionRecorder.getSession()
 			if (!session) return false
 
-			if (feedback.options.connections.length === 0) {
+			const connectionIds = feedback.options.connections as string[]
+
+			if (connectionIds.length === 0) {
 				// shortcut for when there are no connections selected
 				return !!session.isRunning && feedback.options.state === 'recording'
 			}
@@ -328,7 +330,7 @@ export class InternalActionRecorder
 			// check each selected connection
 			const matchAll = feedback.options.mode === 'all'
 			let matches = matchAll
-			for (const id of feedback.options.connections) {
+			for (const id of connectionIds) {
 				if (matchAll) {
 					matches = matches && session.connectionIds.includes(id)
 				} else {

--- a/companion/lib/Internal/Controls.ts
+++ b/companion/lib/Internal/Controls.ts
@@ -23,6 +23,7 @@ import type {
 	InternalFeedbackDefinition,
 	InternalModuleFragmentEvents,
 	FeedbackForInternalExecution,
+	ActionForInternalExecution,
 } from './Types.js'
 import type { GraphicsController } from '../Graphics/Controller.js'
 import type { ControlsController } from '../Controls/Controller.js'
@@ -36,7 +37,6 @@ import {
 	type ActionEntityModel,
 	type FeedbackEntityModel,
 } from '@companion-app/shared/Model/EntityModel.js'
-import type { ControlEntityInstance } from '../Controls/Entities/EntityInstance.js'
 import { nanoid } from 'nanoid'
 import { CHOICES_DYNAMIC_LOCATION, type InternalModuleUtils } from './Util.js'
 import { EventEmitter } from 'events'
@@ -833,102 +833,102 @@ export class InternalControls extends EventEmitter<InternalModuleFragmentEvents>
 		if (changed) return action
 	}
 
-	executeAction(action: ControlEntityInstance, extras: RunActionExtras): boolean {
+	executeAction(action: ActionForInternalExecution, extras: RunActionExtras): boolean {
 		if (action.definitionId === 'button_pressrelease') {
-			const { theControlId } = this.#fetchLocationAndControlId(action.rawOptions, extras, true)
+			const { theControlId } = this.#fetchLocationAndControlId(action.options, extras, true)
 			if (!theControlId) return true
 
-			const forcePress = !!action.rawOptions.force
+			const forcePress = !!action.options.force
 
 			this.#controlsController.pressControl(theControlId, true, extras.surfaceId, forcePress)
 			this.#controlsController.pressControl(theControlId, false, extras.surfaceId, forcePress)
 			return true
 		} else if (action.definitionId === 'button_press') {
-			const { theControlId } = this.#fetchLocationAndControlId(action.rawOptions, extras, true)
+			const { theControlId } = this.#fetchLocationAndControlId(action.options, extras, true)
 			if (!theControlId) return true
 
-			this.#controlsController.pressControl(theControlId, true, extras.surfaceId, !!action.rawOptions.force)
+			this.#controlsController.pressControl(theControlId, true, extras.surfaceId, !!action.options.force)
 			return true
 		} else if (action.definitionId === 'button_release') {
-			const { theControlId } = this.#fetchLocationAndControlId(action.rawOptions, extras, true)
+			const { theControlId } = this.#fetchLocationAndControlId(action.options, extras, true)
 			if (!theControlId) return true
 
-			this.#controlsController.pressControl(theControlId, false, extras.surfaceId, !!action.rawOptions.force)
+			this.#controlsController.pressControl(theControlId, false, extras.surfaceId, !!action.options.force)
 			return true
 		} else if (action.definitionId === 'button_rotate_left') {
-			const { theControlId } = this.#fetchLocationAndControlId(action.rawOptions, extras, true)
+			const { theControlId } = this.#fetchLocationAndControlId(action.options, extras, true)
 			if (!theControlId) return true
 
 			this.#controlsController.rotateControl(theControlId, false, extras.surfaceId)
 			return true
 		} else if (action.definitionId === 'button_rotate_right') {
-			const { theControlId } = this.#fetchLocationAndControlId(action.rawOptions, extras, true)
+			const { theControlId } = this.#fetchLocationAndControlId(action.options, extras, true)
 			if (!theControlId) return true
 
 			this.#controlsController.rotateControl(theControlId, true, extras.surfaceId)
 			return true
 		} else if (action.definitionId === 'bgcolor') {
-			const { theControlId } = this.#fetchLocationAndControlId(action.rawOptions, extras, true)
+			const { theControlId } = this.#fetchLocationAndControlId(action.options, extras, true)
 			if (!theControlId) return true
 
 			const control = this.#controlsController.getControl(theControlId)
 			if (control && control.supportsStyle) {
-				control.styleSetFields({ bgcolor: action.rawOptions.color })
+				control.styleSetFields({ bgcolor: action.options.color })
 			}
 			return true
 		} else if (action.definitionId === 'textcolor') {
-			const { theControlId } = this.#fetchLocationAndControlId(action.rawOptions, extras, true)
+			const { theControlId } = this.#fetchLocationAndControlId(action.options, extras, true)
 			if (!theControlId) return true
 
 			const control = this.#controlsController.getControl(theControlId)
 			if (control && control.supportsStyle) {
-				control.styleSetFields({ color: action.rawOptions.color })
+				control.styleSetFields({ color: action.options.color })
 			}
 			return true
 		} else if (action.definitionId === 'button_text') {
-			const { theControlId } = this.#fetchLocationAndControlId(action.rawOptions, extras, true)
+			const { theControlId } = this.#fetchLocationAndControlId(action.options, extras, true)
 			if (!theControlId) return true
 
 			const control = this.#controlsController.getControl(theControlId)
 			if (control && control.supportsStyle) {
-				control.styleSetFields({ text: action.rawOptions.label })
+				control.styleSetFields({ text: action.options.label })
 			}
 
 			return true
 		} else if (action.definitionId === 'panic_bank') {
-			const { theControlId } = this.#fetchLocationAndControlId(action.rawOptions, extras, true)
+			const { theControlId } = this.#fetchLocationAndControlId(action.options, extras, true)
 			if (!theControlId) return true
 
 			const control = this.#controlsController.getControl(theControlId)
 			if (control && control.supportsActions) {
-				const rawControlId = action.rawOptions.location_target
+				const rawControlId = action.options.location_target
 				if (rawControlId === 'this') {
-					control.abortDelayedActions(action.rawOptions.unlatch, extras.abortDelayed)
+					control.abortDelayedActions(Boolean(action.options.unlatch), extras.abortDelayed)
 				} else if (rawControlId === 'this:only-this-run') {
-					control.abortDelayedActionsSingle(action.rawOptions.unlatch, extras.abortDelayed)
+					control.abortDelayedActionsSingle(Boolean(action.options.unlatch), extras.abortDelayed)
 				} else {
-					control.abortDelayedActions(action.rawOptions.unlatch, null)
+					control.abortDelayedActions(Boolean(action.options.unlatch), null)
 				}
 			}
 
 			return true
 		} else if (action.definitionId === 'panic_page') {
-			const { thePage } = this.#fetchPage(action.rawOptions, extras)
+			const { thePage } = this.#fetchPage(action.options, extras)
 			if (thePage === null) return true
 
 			const controlIdsOnPage = this.#pageStore.getAllControlIdsOnPage(thePage)
 			for (const controlId of controlIdsOnPage) {
-				if (action.rawOptions.ignoreSelf && controlId === extras.controlId) continue
+				if (action.options.ignoreSelf && controlId === extras.controlId) continue
 
 				const control = this.#controlsController.getControl(controlId)
 				if (control && control.supportsActions) {
-					control.abortDelayedActions(false, action.rawOptions.ignoreCurrent ? extras.abortDelayed : null)
+					control.abortDelayedActions(false, action.options.ignoreCurrent ? extras.abortDelayed : null)
 				}
 			}
 
 			return true
 		} else if (action.definitionId === 'panic_trigger') {
-			const rawControlId = action.rawOptions.trigger_id
+			const rawControlId = String(action.options.trigger_id)
 			let controlId = rawControlId
 			if (controlId === 'self' || controlId?.startsWith('self:')) controlId = extras.controlId
 
@@ -947,13 +947,13 @@ export class InternalControls extends EventEmitter<InternalModuleFragmentEvents>
 
 			return true
 		} else if (action.definitionId === 'panic') {
-			this.#controlsController.abortAllDelayedActions(action.rawOptions.ignoreCurrent ? extras.abortDelayed : null)
+			this.#controlsController.abortAllDelayedActions(action.options.ignoreCurrent ? extras.abortDelayed : null)
 			return true
 		} else if (action.definitionId == 'bank_current_step') {
-			const { theControlId } = this.#fetchLocationAndControlId(action.rawOptions, extras, true)
+			const { theControlId } = this.#fetchLocationAndControlId(action.options, extras, true)
 			if (!theControlId) return true
 
-			const theStep = this.#fetchStep(action.rawOptions, extras)
+			const theStep = this.#fetchStep(action.options, extras)
 
 			const control = this.#controlsController.getControl(theControlId)
 
@@ -962,13 +962,13 @@ export class InternalControls extends EventEmitter<InternalModuleFragmentEvents>
 			}
 			return true
 		} else if (action.definitionId == 'bank_current_step_delta') {
-			const { theControlId } = this.#fetchLocationAndControlId(action.rawOptions, extras, true)
+			const { theControlId } = this.#fetchLocationAndControlId(action.options, extras, true)
 			if (!theControlId) return true
 
 			const control = this.#controlsController.getControl(theControlId)
 
 			if (control && control.supportsActionSets) {
-				control.actionSets.stepAdvanceDelta(action.rawOptions.amount)
+				control.actionSets.stepAdvanceDelta(Number(action.options.amount))
 			}
 			return true
 		} else {

--- a/companion/lib/Internal/Controls.ts
+++ b/companion/lib/Internal/Controls.ts
@@ -15,7 +15,6 @@ import { ButtonStyleProperties } from '@companion-app/shared/Style.js'
 import debounceFn from 'debounce-fn'
 import type {
 	FeedbackForVisitor,
-	FeedbackEntityModelExt,
 	InternalModuleFragment,
 	InternalVisitor,
 	ExecuteFeedbackResultWithReferences,
@@ -23,6 +22,7 @@ import type {
 	InternalActionDefinition,
 	InternalFeedbackDefinition,
 	InternalModuleFragmentEvents,
+	FeedbackForInternalExecution,
 } from './Types.js'
 import type { GraphicsController } from '../Graphics/Controller.js'
 import type { ControlsController } from '../Controls/Controller.js'
@@ -162,7 +162,7 @@ export class InternalControls extends EventEmitter<InternalModuleFragmentEvents>
 
 	#fetchLocationAndControlId(
 		options: Record<string, any>,
-		extras: RunActionExtras | FeedbackEntityModelExt,
+		extras: RunActionExtras | FeedbackForInternalExecution,
 		useVariableFields = false
 	): {
 		theControlId: string | null
@@ -535,7 +535,7 @@ export class InternalControls extends EventEmitter<InternalModuleFragmentEvents>
 		if (changed) return feedback
 	}
 
-	executeFeedback(feedback: FeedbackEntityModelExt): ExecuteFeedbackResultWithReferences | void {
+	executeFeedback(feedback: FeedbackForInternalExecution): ExecuteFeedbackResultWithReferences | void {
 		if (feedback.definitionId === 'bank_style') {
 			const { theLocation, referencedVariables } = this.#fetchLocationAndControlId(feedback.options, feedback, true)
 
@@ -570,7 +570,7 @@ export class InternalControls extends EventEmitter<InternalModuleFragmentEvents>
 				} else {
 					const newStyle: Record<string, any> = {}
 
-					for (const prop of feedback.options.properties) {
+					for (const prop of feedback.options.properties as any) {
 						// @ts-expect-error mismatch in prop type
 						newStyle[prop] = render.style[prop]
 					}

--- a/companion/lib/Internal/Instance.ts
+++ b/companion/lib/Internal/Instance.ts
@@ -16,12 +16,12 @@ import type { RunActionExtras, VariableDefinitionTmp } from '../Instance/Wrapper
 import type {
 	ActionForVisitor,
 	FeedbackForVisitor,
-	FeedbackEntityModelExt,
 	InternalModuleFragment,
 	InternalVisitor,
 	InternalActionDefinition,
 	InternalFeedbackDefinition,
 	InternalModuleFragmentEvents,
+	FeedbackForInternalExecution,
 } from './Types.js'
 import type { CompanionFeedbackButtonStyleResult, CompanionVariableValues } from '@companion-module/base'
 import type { ControlEntityInstance } from '../Controls/Entities/EntityInstance.js'
@@ -326,65 +326,65 @@ export class InternalInstance extends EventEmitter<InternalModuleFragmentEvents>
 		}
 	}
 
-	executeFeedback(feedback: FeedbackEntityModelExt): CompanionFeedbackButtonStyleResult | boolean | void {
+	executeFeedback(feedback: FeedbackForInternalExecution): CompanionFeedbackButtonStyleResult | boolean | void {
 		if (feedback.definitionId === 'instance_status') {
 			if (feedback.options.instance_id == 'all') {
 				if (this.#instancesError > 0) {
 					return {
-						color: feedback.options.error_fg,
-						bgcolor: feedback.options.error_bg,
+						color: feedback.options.error_fg as any,
+						bgcolor: feedback.options.error_bg as any,
 					}
 				}
 
 				if (this.#instancesWarning > 0) {
 					return {
-						color: feedback.options.warning_fg,
-						bgcolor: feedback.options.warning_bg,
+						color: feedback.options.warning_fg as any,
+						bgcolor: feedback.options.warning_bg as any,
 					}
 				}
 
 				return {
-					color: feedback.options.ok_fg,
-					bgcolor: feedback.options.ok_bg,
+					color: feedback.options.ok_fg as any,
+					bgcolor: feedback.options.ok_bg as any,
 				}
 			}
 
-			const cur_instance = this.#instanceController.getConnectionStatus(feedback.options.instance_id)
+			const cur_instance = this.#instanceController.getConnectionStatus(String(feedback.options.instance_id))
 			if (cur_instance !== undefined) {
 				switch (cur_instance.category) {
 					case 'error':
 						return {
-							color: feedback.options.error_fg,
-							bgcolor: feedback.options.error_bg,
+							color: feedback.options.error_fg as any,
+							bgcolor: feedback.options.error_bg as any,
 						}
 					case 'warning':
 						return {
-							color: feedback.options.warning_fg,
-							bgcolor: feedback.options.warning_bg,
+							color: feedback.options.warning_fg as any,
+							bgcolor: feedback.options.warning_bg as any,
 						}
 					case 'good':
 						return {
-							color: feedback.options.ok_fg,
-							bgcolor: feedback.options.ok_bg,
+							color: feedback.options.ok_fg as any,
+							bgcolor: feedback.options.ok_bg as any,
 						}
 					default:
 						return {
-							color: feedback.options.disabled_fg,
-							bgcolor: feedback.options.disabled_bg,
+							color: feedback.options.disabled_fg as any,
+							bgcolor: feedback.options.disabled_bg as any,
 						}
 				}
 			}
 			// disabled has no 'status' entry
 			return {
-				color: feedback.options.disabled_fg,
-				bgcolor: feedback.options.disabled_bg,
+				color: feedback.options.disabled_fg as any,
+				bgcolor: feedback.options.disabled_bg as any,
 			}
 		} else if (feedback.definitionId === 'instance_custom_state') {
 			const selected_status = this.#instanceStatuses[String(feedback.options.instance_id)]?.category ?? null
 
 			return selected_status == feedback.options.state
 		} else if (feedback.definitionId === 'connection_collection_enabled') {
-			const state = this.#instanceController.collections.isCollectionEnabled(feedback.options.collection_id)
+			const state = this.#instanceController.collections.isCollectionEnabled(String(feedback.options.collection_id))
 			const target = feedback.options.enable == 'true'
 			return state == target
 		}

--- a/companion/lib/Internal/Instance.ts
+++ b/companion/lib/Internal/Instance.ts
@@ -22,9 +22,9 @@ import type {
 	InternalFeedbackDefinition,
 	InternalModuleFragmentEvents,
 	FeedbackForInternalExecution,
+	ActionForInternalExecution,
 } from './Types.js'
 import type { CompanionFeedbackButtonStyleResult, CompanionVariableValues } from '@companion-module/base'
-import type { ControlEntityInstance } from '../Controls/Entities/EntityInstance.js'
 import { FeedbackEntitySubType } from '@companion-app/shared/Model/EntityModel.js'
 import { EventEmitter } from 'events'
 import type { InternalModuleUtils } from './Util.js'
@@ -304,22 +304,22 @@ export class InternalInstance extends EventEmitter<InternalModuleFragmentEvents>
 		}
 	}
 
-	executeAction(action: ControlEntityInstance, _extras: RunActionExtras): boolean {
+	executeAction(action: ActionForInternalExecution, _extras: RunActionExtras): boolean {
 		if (action.definitionId === 'instance_control') {
-			let newState = action.rawOptions.enable == 'true'
-			if (action.rawOptions.enable == 'toggle') {
-				const curState = this.#instanceController.getConnectionStatus(action.rawOptions.instance_id)
+			let newState = action.options.enable == 'true'
+			if (action.options.enable == 'toggle') {
+				const curState = this.#instanceController.getConnectionStatus(String(action.options.instance_id))
 
 				newState = !curState?.category
 			}
 
-			this.#instanceController.enableDisableInstance(action.rawOptions.instance_id, newState)
+			this.#instanceController.enableDisableInstance(String(action.options.instance_id), newState)
 			return true
 		} else if (action.definitionId === 'connection_collection_enabled') {
-			let newState: boolean | 'toggle' = action.rawOptions.enable == 'true'
-			if (action.rawOptions.enable == 'toggle') newState = 'toggle'
+			let newState: boolean | 'toggle' = action.options.enable == 'true'
+			if (action.options.enable == 'toggle') newState = 'toggle'
 
-			this.#instanceController.collections.setCollectionEnabled(action.rawOptions.collection_id, newState)
+			this.#instanceController.collections.setCollectionEnabled(String(action.options.collection_id), newState)
 			return true
 		} else {
 			return false

--- a/companion/lib/Internal/Surface.ts
+++ b/companion/lib/Internal/Surface.ts
@@ -27,7 +27,11 @@ import type { IPageStore } from '../Page/Store.js'
 import type { SurfaceController } from '../Surface/Controller.js'
 import type { RunActionExtras, VariableDefinitionTmp } from '../Instance/Wrapper.js'
 import type { SomeCompanionInputField } from '@companion-app/shared/Model/Options.js'
-import { FeedbackEntitySubType, type ActionEntityModel } from '@companion-app/shared/Model/EntityModel.js'
+import {
+	FeedbackEntityModel,
+	FeedbackEntitySubType,
+	type ActionEntityModel,
+} from '@companion-app/shared/Model/EntityModel.js'
 import type { ControlEntityInstance } from '../Controls/Entities/EntityInstance.js'
 import type { InternalModuleUtils } from './Util.js'
 import { EventEmitter } from 'events'
@@ -405,6 +409,13 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 			action.options.controller = 'emulator:emulator'
 
 			return action
+		}
+	}
+
+	feedbackUpgrade(feedback: FeedbackEntityModel, controlId: string): FeedbackEntityModel | void {
+		//
+		if (feedback.definitionId === 'surface_on_page' && feedback.options.surfaceId === undefined) {
+			// TODO
 		}
 	}
 
@@ -792,7 +803,7 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 					{
 						type: 'internal:surface_serial',
 						label: 'Surface / group',
-						id: 'controller',
+						id: 'surfaceId',
 						includeSelf: false,
 						default: '',
 					},
@@ -805,13 +816,14 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 						default: 0,
 					},
 				],
+				internalUsesAutoParser: true,
 			},
 		}
 	}
 
 	executeFeedback(feedback: FeedbackForInternalExecution): boolean | void {
 		if (feedback.definitionId == 'surface_on_page') {
-			const surfaceId = this.#fetchSurfaceId(feedback.options, feedback, false)
+			const surfaceId = this.#fetchSurfaceIdNew(feedback.options, feedback)
 			if (!surfaceId) return false
 
 			const thePage = this.#fetchPage(feedback.options, feedback, false, surfaceId)

--- a/companion/lib/Internal/Surface.ts
+++ b/companion/lib/Internal/Surface.ts
@@ -15,12 +15,12 @@ import debounceFn from 'debounce-fn'
 import type {
 	ActionForVisitor,
 	FeedbackForVisitor,
-	FeedbackEntityModelExt,
 	InternalModuleFragment,
 	InternalVisitor,
 	InternalActionDefinition,
 	InternalFeedbackDefinition,
 	InternalModuleFragmentEvents,
+	FeedbackForInternalExecution,
 } from './Types.js'
 import type { ControlsController } from '../Controls/Controller.js'
 import type { IPageStore } from '../Page/Store.js'
@@ -209,7 +209,7 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 
 	#fetchSurfaceId(
 		options: Record<string, any>,
-		info: RunActionExtras | FeedbackEntityModelExt,
+		info: RunActionExtras | FeedbackForInternalExecution,
 		useVariableFields: boolean
 	): string | undefined {
 		let surfaceId: string | undefined = options.controller + ''
@@ -227,7 +227,7 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 
 	#fetchPage(
 		options: Record<string, any>,
-		extras: RunActionExtras | FeedbackEntityModelExt,
+		extras: RunActionExtras | FeedbackForInternalExecution,
 		useVariableFields: boolean,
 		surfaceId: string | undefined
 	): string | 'back' | 'forward' | '+1' | '-1' | undefined {
@@ -785,7 +785,7 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 		}
 	}
 
-	executeFeedback(feedback: FeedbackEntityModelExt): boolean | void {
+	executeFeedback(feedback: FeedbackForInternalExecution): boolean | void {
 		if (feedback.definitionId == 'surface_on_page') {
 			const surfaceId = this.#fetchSurfaceId(feedback.options, feedback, false)
 			if (!surfaceId) return false

--- a/companion/lib/Internal/Surface.ts
+++ b/companion/lib/Internal/Surface.ts
@@ -171,7 +171,7 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 			return thePageNumber
 		}
 
-		return this.#pageStore.getPageInfo(Number(`thePageNumber`))?.id
+		return this.#pageStore.getPageInfo(Number(thePageNumber))?.id
 	}
 
 	getVariableDefinitions(): VariableDefinitionTmp[] {
@@ -425,7 +425,7 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 					{
 						type: 'number',
 						label: 'Surface / group index',
-						id: 'surfaceId',
+						id: 'surfaceIndex',
 						tooltip: 'Check the ID column in the surfaces tab',
 						min: 0,
 						max: 100,
@@ -563,22 +563,16 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 			if (!surfaceId) return true
 
 			const thePage = this.#fetchPage(action.options, extras, surfaceId)
+			console.log('set', thePage)
+
 			if (thePage === undefined) return true
 
 			this.#changeSurfacePage(surfaceId, thePage)
 			return true
 		} else if (action.definitionId === 'set_page_byindex') {
-			let surfaceIndex = action.options.controller
-			if (action.options.controller_from_variable) {
-				surfaceIndex = this.#internalUtils.parseVariablesForInternalActionOrFeedback(
-					String(action.options.controller_variable),
-					extras
-				).text
-			}
-
-			const surfaceIndexNumber = Number(surfaceIndex)
+			const surfaceIndexNumber = Number(action.options.surfaceIndex)
 			if (isNaN(surfaceIndexNumber) || surfaceIndexNumber < 0) {
-				this.#logger.warn(`Trying to set controller #${surfaceIndex} but it isn't a valid index.`)
+				this.#logger.warn(`Trying to set controller #${action.options.surfaceIndex} but it isn't a valid index.`)
 				return true
 			}
 

--- a/companion/lib/Internal/Surface.ts
+++ b/companion/lib/Internal/Surface.ts
@@ -64,10 +64,6 @@ const CHOICES_PAGE: SomeCompanionInputField = {
 	includeStartup: true,
 	includeDirection: true,
 	default: 0,
-	isVisibleUi: {
-		type: 'expression',
-		fn: '!$(options:page_from_variable)',
-	},
 }
 
 export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> implements InternalModuleFragment {
@@ -352,6 +348,21 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 			)
 		}
 
+		if (action.definitionId === 'set_page_byindex' && action.options.controller_from_variable !== undefined) {
+			changed = true
+
+			convertOldSplitOptionToExpression(
+				action.options,
+				{
+					useVariables: 'controller_from_variable',
+					simple: 'controller',
+					variable: 'controller_variable',
+					result: 'surfaceId',
+				},
+				true
+			)
+		}
+
 		if (action.definitionId === 'surface_set_position') {
 			changed = convertSimplePropertyToExpresionValue(action.options, 'x_offset') || changed
 			changed = convertSimplePropertyToExpresionValue(action.options, 'y_offset') || changed
@@ -360,8 +371,6 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 			changed = convertSimplePropertyToExpresionValue(action.options, 'x_adjustment') || changed
 			changed = convertSimplePropertyToExpresionValue(action.options, 'y_adjustment') || changed
 		}
-
-		// TODO - set_page_byindex controller
 
 		if (changed) return action
 	}
@@ -414,41 +423,14 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 				description: undefined,
 				options: [
 					{
-						type: 'checkbox',
-						label: 'Use variables for surface',
-						id: 'controller_from_variable',
-						default: false,
-						disableAutoExpression: true,
-					},
-					{
 						type: 'number',
 						label: 'Surface / group index',
-						id: 'controller',
+						id: 'surfaceId',
 						tooltip: 'Check the ID column in the surfaces tab',
 						min: 0,
 						max: 100,
 						default: 0,
 						range: false,
-						isVisibleUi: {
-							type: 'expression',
-							fn: '!$(options:controller_from_variable)',
-						},
-						disableAutoExpression: true,
-					},
-					{
-						type: 'textinput',
-						label: 'Surface / group index',
-						id: 'controller_variable',
-						tooltip: 'Check the ID column in the surfaces tab',
-						default: '0',
-						isVisibleUi: {
-							type: 'expression',
-							fn: '!!$(options:controller_from_variable)',
-						},
-						useVariables: {
-							local: true,
-						},
-						disableAutoExpression: true,
 					},
 
 					CHOICES_PAGE,

--- a/companion/lib/Internal/Surface.ts
+++ b/companion/lib/Internal/Surface.ts
@@ -21,6 +21,7 @@ import type {
 	InternalFeedbackDefinition,
 	InternalModuleFragmentEvents,
 	FeedbackForInternalExecution,
+	ActionForInternalExecution,
 } from './Types.js'
 import type { ControlsController } from '../Controls/Controller.js'
 import type { IPageStore } from '../Page/Store.js'
@@ -32,7 +33,6 @@ import {
 	FeedbackEntitySubType,
 	type ActionEntityModel,
 } from '@companion-app/shared/Model/EntityModel.js'
-import type { ControlEntityInstance } from '../Controls/Entities/EntityInstance.js'
 import {
 	convertOldSplitOptionToExpression,
 	convertSimplePropertyToExpresionValue,
@@ -550,27 +550,28 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 		}
 	}
 
-	executeAction(action: ControlEntityInstance, extras: RunActionExtras): boolean {
+	executeAction(action: ActionForInternalExecution, extras: RunActionExtras): boolean {
 		if (action.definitionId === 'set_brightness') {
-			const surfaceId = this.#fetchSurfaceId(action.rawOptions, extras)
+			const surfaceId = this.#fetchSurfaceId(action.options, extras)
 			if (!surfaceId) return true
 
-			this.#surfaceController.setDeviceBrightness(surfaceId, action.rawOptions.brightness, true)
+			this.#surfaceController.setDeviceBrightness(surfaceId, Number(action.options.brightness), true)
 			return true
 		} else if (action.definitionId === 'set_page') {
-			const surfaceId = this.#fetchSurfaceId(action.rawOptions, extras)
+			console.log('set', action.options)
+			const surfaceId = this.#fetchSurfaceId(action.options, extras)
 			if (!surfaceId) return true
 
-			const thePage = this.#fetchPage(action.rawOptions, extras, surfaceId)
+			const thePage = this.#fetchPage(action.options, extras, surfaceId)
 			if (thePage === undefined) return true
 
 			this.#changeSurfacePage(surfaceId, thePage)
 			return true
 		} else if (action.definitionId === 'set_page_byindex') {
-			let surfaceIndex = action.rawOptions.controller
-			if (action.rawOptions.controller_from_variable) {
+			let surfaceIndex = action.options.controller
+			if (action.options.controller_from_variable) {
 				surfaceIndex = this.#internalUtils.parseVariablesForInternalActionOrFeedback(
-					action.rawOptions.controller_variable,
+					String(action.options.controller_variable),
 					extras
 				).text
 			}
@@ -583,30 +584,30 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 
 			const surfaceId = this.#surfaceController.getDeviceIdFromIndex(surfaceIndexNumber)
 			if (surfaceId === undefined || surfaceId === '') {
-				this.#logger.warn(`Trying to set controller #${action.rawOptions.controller} but it isn't available.`)
+				this.#logger.warn(`Trying to set controller #${action.options.controller} but it isn't available.`)
 				return true
 			}
 
-			const thePage = this.#fetchPage(action.rawOptions, extras, surfaceId)
+			const thePage = this.#fetchPage(action.options, extras, surfaceId)
 			if (thePage === undefined) return true
 
 			this.#changeSurfacePage(surfaceId, thePage)
 			return true
 		} else if (action.definitionId === 'inc_page') {
-			const surfaceId = this.#fetchSurfaceId(action.rawOptions, extras)
+			const surfaceId = this.#fetchSurfaceId(action.options, extras)
 			if (!surfaceId) return true
 
 			this.#changeSurfacePage(surfaceId, '+1')
 			return true
 		} else if (action.definitionId === 'dec_page') {
-			const surfaceId = this.#fetchSurfaceId(action.rawOptions, extras)
+			const surfaceId = this.#fetchSurfaceId(action.options, extras)
 			if (!surfaceId) return true
 
 			this.#changeSurfacePage(surfaceId, '-1')
 			return true
 		} else if (action.definitionId === 'lockout_device') {
 			if (this.#surfaceController.isPinLockEnabled()) {
-				const surfaceId = this.#fetchSurfaceId(action.rawOptions, extras)
+				const surfaceId = this.#fetchSurfaceId(action.options, extras)
 				if (!surfaceId) return true
 
 				if (extras.controlId && extras.surfaceId == surfaceId) {
@@ -623,7 +624,7 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 			}
 			return true
 		} else if (action.definitionId === 'unlockout_device') {
-			const surfaceId = this.#fetchSurfaceId(action.rawOptions, extras)
+			const surfaceId = this.#fetchSurfaceId(action.options, extras)
 			if (!surfaceId) return true
 
 			setImmediate(() => {
@@ -657,11 +658,11 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 			})
 			return true
 		} else if (action.definitionId === 'surface_set_position') {
-			const surfaceId = this.#fetchSurfaceId(action.rawOptions, extras)
+			const surfaceId = this.#fetchSurfaceId(action.options, extras)
 			if (!surfaceId) return true
 
-			const xOffset = Number(action.rawOptions.x_offset)
-			const yOffset = Number(action.rawOptions.y_offset)
+			const xOffset = Number(action.options.x_offset)
+			const yOffset = Number(action.options.y_offset)
 
 			if (isNaN(xOffset) || isNaN(yOffset)) {
 				this.#logger.warn(`Invalid position offsets: x=${xOffset}, y=${yOffset}`)
@@ -671,11 +672,11 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 			this.#surfaceController.setDevicePosition(surfaceId, xOffset, yOffset, true)
 			return true
 		} else if (action.definitionId === 'surface_adjust_position') {
-			const surfaceId = this.#fetchSurfaceId(action.rawOptions, extras)
+			const surfaceId = this.#fetchSurfaceId(action.options, extras)
 			if (!surfaceId) return true
 
-			const xAdjustment = Number(action.rawOptions.x_adjustment)
-			const yAdjustment = Number(action.rawOptions.y_adjustment)
+			const xAdjustment = Number(action.options.x_adjustment)
+			const yAdjustment = Number(action.options.y_adjustment)
 
 			if (isNaN(xAdjustment) || isNaN(yAdjustment)) {
 				this.#logger.warn(`Invalid position adjustments: x=${xAdjustment}, y=${yAdjustment}`)

--- a/companion/lib/Internal/Surface.ts
+++ b/companion/lib/Internal/Surface.ts
@@ -99,6 +99,17 @@ const CHOICES_SURFACE_ID_WITH_VARIABLES: SomeCompanionInputField[] = [
 	},
 ]
 
+const CHOICES_SURFACE_ID_NEW: SomeCompanionInputField[] = [
+	{
+		type: 'internal:surface_serial',
+		label: 'Surface / group',
+		id: 'surfaceId',
+		default: 'self',
+		includeSelf: true,
+		useRawSurfaces: true,
+	},
+]
+
 const CHOICES_PAGE_WITH_VARIABLES: SomeCompanionInputField[] = [
 	{
 		type: 'checkbox',
@@ -219,6 +230,17 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 		}
 
 		surfaceId = surfaceId.trim()
+
+		if (info && surfaceId === 'self' && 'surfaceId' in info) surfaceId = info.surfaceId
+
+		return surfaceId
+	}
+
+	#fetchSurfaceIdNew(
+		options: Record<string, any>,
+		info: RunActionExtras | FeedbackForInternalExecution
+	): string | undefined {
+		let surfaceId: string | undefined = String(options.surfaceId).trim()
 
 		if (info && surfaceId === 'self' && 'surfaceId' in info) surfaceId = info.surfaceId
 
@@ -392,7 +414,7 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 				label: 'Surface: Set to brightness',
 				description: undefined,
 				options: [
-					...CHOICES_SURFACE_ID_WITH_VARIABLES,
+					...CHOICES_SURFACE_ID_NEW,
 
 					{
 						type: 'number',
@@ -405,6 +427,8 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 						range: true,
 					},
 				],
+
+				internalUsesAutoParser: true,
 			},
 
 			set_page: {
@@ -552,7 +576,7 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 
 	executeAction(action: ControlEntityInstance, extras: RunActionExtras): boolean {
 		if (action.definitionId === 'set_brightness') {
-			const surfaceId = this.#fetchSurfaceId(action.rawOptions, extras, true)
+			const surfaceId = this.#fetchSurfaceIdNew(action.rawOptions, extras)
 			if (!surfaceId) return true
 
 			this.#surfaceController.setDeviceBrightness(surfaceId, action.rawOptions.brightness, true)

--- a/companion/lib/Internal/Surface.ts
+++ b/companion/lib/Internal/Surface.ts
@@ -26,7 +26,7 @@ import type { ControlsController } from '../Controls/Controller.js'
 import type { IPageStore } from '../Page/Store.js'
 import type { SurfaceController } from '../Surface/Controller.js'
 import type { RunActionExtras, VariableDefinitionTmp } from '../Instance/Wrapper.js'
-import type { SomeCompanionInputField } from '@companion-app/shared/Model/Options.js'
+import type { ExpressionOrValue, SomeCompanionInputField } from '@companion-app/shared/Model/Options.js'
 import {
 	FeedbackEntityModel,
 	FeedbackEntitySubType,
@@ -412,10 +412,14 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 		}
 	}
 
-	feedbackUpgrade(feedback: FeedbackEntityModel, controlId: string): FeedbackEntityModel | void {
-		//
+	feedbackUpgrade(feedback: FeedbackEntityModel, _controlId: string): FeedbackEntityModel | void {
 		if (feedback.definitionId === 'surface_on_page' && feedback.options.surfaceId === undefined) {
-			// TODO
+			// Convert to new expression format
+			feedback.options.surfaceId = {
+				isExpression: false,
+				value: feedback.options.controller || 'self',
+			} satisfies ExpressionOrValue<string>
+			delete feedback.options.controller
 		}
 	}
 

--- a/companion/lib/Internal/Triggers.ts
+++ b/companion/lib/Internal/Triggers.ts
@@ -14,12 +14,12 @@ import debounceFn from 'debounce-fn'
 import type {
 	ActionForVisitor,
 	FeedbackForVisitor,
-	FeedbackEntityModelExt,
 	InternalModuleFragment,
 	InternalVisitor,
 	InternalActionDefinition,
 	InternalFeedbackDefinition,
 	InternalModuleFragmentEvents,
+	FeedbackForInternalExecution,
 } from './Types.js'
 import type { ControlsController } from '../Controls/Controller.js'
 import type { RunActionExtras } from '../Instance/Wrapper.js'
@@ -200,16 +200,16 @@ export class InternalTriggers extends EventEmitter<InternalModuleFragmentEvents>
 		}
 	}
 
-	executeFeedback(feedback: FeedbackEntityModelExt): boolean | void {
+	executeFeedback(feedback: FeedbackForInternalExecution): boolean | void {
 		if (feedback.definitionId === 'trigger_enabled') {
-			const control = this.#controlsController.getControl(feedback.options.trigger_id)
+			const control = this.#controlsController.getControl(String(feedback.options.trigger_id))
 			if (!control || control.type !== 'trigger' || !control.supportsOptions) return false
 
 			const state = control.options.enabled
 			const target = feedback.options.enable == 'true'
 			return state == target
 		} else if (feedback.definitionId === 'trigger_collection_enabled') {
-			const state = this.#controlsController.isTriggerCollectionEnabled(feedback.options.collection_id, true)
+			const state = this.#controlsController.isTriggerCollectionEnabled(String(feedback.options.collection_id), true)
 			const target = feedback.options.enable == 'true'
 			return state == target
 		}

--- a/companion/lib/Internal/Triggers.ts
+++ b/companion/lib/Internal/Triggers.ts
@@ -20,11 +20,11 @@ import type {
 	InternalFeedbackDefinition,
 	InternalModuleFragmentEvents,
 	FeedbackForInternalExecution,
+	ActionForInternalExecution,
 } from './Types.js'
 import type { ControlsController } from '../Controls/Controller.js'
 import type { RunActionExtras } from '../Instance/Wrapper.js'
 import { FeedbackEntitySubType, type ActionEntityModel } from '@companion-app/shared/Model/EntityModel.js'
-import type { ControlEntityInstance } from '../Controls/Entities/EntityInstance.js'
 import { EventEmitter } from 'events'
 import type { InternalModuleUtils } from './Util.js'
 
@@ -118,22 +118,22 @@ export class InternalTriggers extends EventEmitter<InternalModuleFragmentEvents>
 		}
 	}
 
-	executeAction(action: ControlEntityInstance, _extras: RunActionExtras): boolean {
+	executeAction(action: ActionForInternalExecution, _extras: RunActionExtras): boolean {
 		if (action.definitionId === 'trigger_enabled') {
-			const control = this.#controlsController.getControl(action.rawOptions.trigger_id)
+			const control = this.#controlsController.getControl(String(action.options.trigger_id))
 			if (!control || control.type !== 'trigger' || !control.supportsOptions) return false
 
-			let newState = action.rawOptions.enable == 'true'
-			if (action.rawOptions.enable == 'toggle') newState = !control.options.enabled
+			let newState = action.options.enable == 'true'
+			if (action.options.enable == 'toggle') newState = !control.options.enabled
 
 			control.optionsSetField('enabled', newState)
 
 			return true
 		} else if (action.definitionId === 'trigger_collection_enabled') {
-			let newState: boolean | 'toggle' = action.rawOptions.enable == 'true'
-			if (action.rawOptions.enable == 'toggle') newState = 'toggle'
+			let newState: boolean | 'toggle' = action.options.enable == 'true'
+			if (action.options.enable == 'toggle') newState = 'toggle'
 
-			this.#controlsController.setTriggerCollectionEnabled(action.rawOptions.collection_id, newState)
+			this.#controlsController.setTriggerCollectionEnabled(String(action.options.collection_id), newState)
 
 			return true
 		} else {

--- a/companion/lib/Internal/Types.ts
+++ b/companion/lib/Internal/Types.ts
@@ -13,11 +13,16 @@ import type { ClientEntityDefinition } from '@companion-app/shared/Model/EntityD
 import type { ControlEntityInstance } from '../Controls/Entities/EntityInstance.js'
 import type { ActionRunner } from '../Controls/ActionRunner.js'
 import type { EventEmitter } from 'events'
+import { OptionsObject } from '@companion-module/base/dist/util.js'
 
-export interface FeedbackEntityModelExt extends FeedbackEntityModel {
+export interface FeedbackForInternalExecution {
 	controlId: string
 	location: ControlLocation | undefined
-	referencedVariables: string[] | null
+
+	id: string
+	definitionId: string
+
+	options: OptionsObject
 }
 
 export type InternalVisitor = VisitorReferencesCollectorVisitor | VisitorReferencesUpdaterVisitor
@@ -72,7 +77,7 @@ export interface InternalModuleFragment extends EventEmitter<InternalModuleFragm
 	 * Get an updated value for a feedback
 	 */
 	executeFeedback?: (
-		feedback: FeedbackEntityModelExt
+		feedback: FeedbackForInternalExecution
 	) => CompanionFeedbackButtonStyleResult | boolean | ExecuteFeedbackResultWithReferences | void
 
 	feedbackUpgrade?: (feedback: FeedbackEntityModel, controlId: string) => FeedbackEntityModel | void
@@ -100,10 +105,15 @@ export type InternalActionDefinition = SetOptional<
 		ClientEntityDefinition,
 		'entityType' | 'showInvert' | 'feedbackType' | 'feedbackStyle' | 'hasLifecycleFunctions'
 	>,
-	'hasLearn' | 'learnTimeout' | 'showButtonPreview' | 'supportsChildGroups' | 'optionsToIgnoreForSubscribe'
+	| 'hasLearn'
+	| 'learnTimeout'
+	| 'showButtonPreview'
+	| 'supportsChildGroups'
+	| 'optionsToIgnoreForSubscribe'
+	| 'internalUsesAutoParser'
 >
 
 export type InternalFeedbackDefinition = SetOptional<
 	Omit<ClientEntityDefinition, 'entityType' | 'hasLifecycleFunctions' | 'optionsToIgnoreForSubscribe'>,
-	'hasLearn' | 'learnTimeout' | 'showButtonPreview' | 'supportsChildGroups'
+	'hasLearn' | 'learnTimeout' | 'showButtonPreview' | 'supportsChildGroups' | 'internalUsesAutoParser'
 >

--- a/companion/lib/Internal/Types.ts
+++ b/companion/lib/Internal/Types.ts
@@ -10,10 +10,10 @@ import type { RunActionExtras, VariableDefinitionTmp } from '../Instance/Wrapper
 import type { SetOptional } from 'type-fest'
 import type { ActionEntityModel, FeedbackEntityModel } from '@companion-app/shared/Model/EntityModel.js'
 import type { ClientEntityDefinition } from '@companion-app/shared/Model/EntityDefinitionModel.js'
-import type { ControlEntityInstance } from '../Controls/Entities/EntityInstance.js'
 import type { ActionRunner } from '../Controls/ActionRunner.js'
 import type { EventEmitter } from 'events'
-import { OptionsObject } from '@companion-module/base/dist/util.js'
+import type { OptionsObject } from '@companion-module/base/dist/util.js'
+import type { ControlEntityInstance } from '../Controls/Entities/EntityInstance.js'
 
 export interface FeedbackForInternalExecution {
 	controlId: string
@@ -23,6 +23,18 @@ export interface FeedbackForInternalExecution {
 	definitionId: string
 
 	options: OptionsObject
+}
+
+export interface ActionForInternalExecution {
+	// controlId: string
+	// location: ControlLocation | undefined
+
+	id: string
+	definitionId: string
+
+	options: OptionsObject
+
+	rawEntity: ControlEntityInstance
 }
 
 export type InternalVisitor = VisitorReferencesCollectorVisitor | VisitorReferencesUpdaterVisitor
@@ -60,7 +72,7 @@ export interface InternalModuleFragment extends EventEmitter<InternalModuleFragm
 	 * @returns Whether the action was handled
 	 */
 	executeAction?(
-		action: ControlEntityInstance,
+		action: ActionForInternalExecution,
 		extras: RunActionExtras,
 		actionRunner: ActionRunner
 	): Promise<boolean> | boolean

--- a/companion/lib/Internal/Util.ts
+++ b/companion/lib/Internal/Util.ts
@@ -294,6 +294,26 @@ export function convertOldSplitOptionToExpression(
 	}
 
 	delete options[keys.useVariables]
-	delete options[keys.simple]
 	delete options[keys.variable]
+	if (keys.simple !== keys.result) delete options[keys.simple]
+}
+
+export function convertSimplePropertyToExpresionValue(
+	options: Record<string, any>,
+	key: string,
+	oldKey?: string,
+	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+	defaultValue?: any
+): boolean {
+	if (typeof options[oldKey ?? key] === 'string' || typeof options[oldKey ?? key] === 'number') {
+		options[key] = {
+			isExpression: false,
+			value: options[oldKey ?? key] ?? defaultValue,
+		} satisfies ExpressionOrValue<any>
+		if (oldKey) delete options[oldKey]
+
+		return true
+	} else {
+		return false
+	}
 }

--- a/companion/lib/Internal/Util.ts
+++ b/companion/lib/Internal/Util.ts
@@ -1,7 +1,7 @@
 import { oldBankIndexToXY } from '@companion-app/shared/ControlId.js'
 import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
 import type { VariablesAndExpressionParser } from '../Variables/VariablesAndExpressionParser.js'
-import { SomeCompanionInputField } from '@companion-app/shared/Model/Options.js'
+import { ExpressionOrValue, SomeCompanionInputField } from '@companion-app/shared/Model/Options.js'
 import LogController, { type Logger } from '../Log/Controller.js'
 import type { ParseVariablesResult } from '../Variables/Util.js'
 import type { CompanionVariableValues } from '@companion-module/base'
@@ -262,4 +262,38 @@ export class InternalModuleUtils {
 			'$(this:surface_id)': extras.surfaceId,
 		}
 	}
+}
+
+export function convertOldSplitOptionToExpression(
+	options: Record<string, any>,
+	keys: {
+		useVariables: string
+		simple: string
+		variable: string
+		result: string
+	},
+	variableIsExpression: boolean
+): void {
+	if (options[keys.useVariables]) {
+		if (variableIsExpression) {
+			options[keys.result] = {
+				isExpression: true,
+				value: options[keys.variable] || '',
+			} satisfies ExpressionOrValue<string>
+		} else {
+			options[keys.result] = {
+				isExpression: true,
+				value: options[keys.variable] === undefined ? '' : `parseVariables(\`${options[keys.variable]}\`)`,
+			} satisfies ExpressionOrValue<string>
+		}
+	} else {
+		options[keys.result] = {
+			isExpression: false,
+			value: options[keys.simple] || '',
+		} satisfies ExpressionOrValue<string>
+	}
+
+	delete options[keys.useVariables]
+	delete options[keys.simple]
+	delete options[keys.variable]
 }

--- a/companion/lib/Internal/Util.ts
+++ b/companion/lib/Internal/Util.ts
@@ -6,7 +6,7 @@ import LogController, { type Logger } from '../Log/Controller.js'
 import type { ParseVariablesResult } from '../Variables/Util.js'
 import type { CompanionVariableValues } from '@companion-module/base'
 import type { RunActionExtras } from '../Instance/Wrapper.js'
-import type { FeedbackEntityModelExt } from './Types.js'
+import type { FeedbackForInternalExecution } from './Types.js'
 import type { ControlsController } from '../Controls/Controller.js'
 import type { ExecuteExpressionResult } from '@companion-app/shared/Expression/ExpressionResult.js'
 
@@ -187,7 +187,7 @@ export class InternalModuleUtils {
 	 */
 	executeExpressionForInternalActionOrFeedback(
 		str: string,
-		extras: RunActionExtras | FeedbackEntityModelExt,
+		extras: RunActionExtras | FeedbackForInternalExecution,
 		requiredType?: string
 		// injectedVariableValues?: CompanionVariableValues
 	): ExecuteExpressionResult {
@@ -213,7 +213,7 @@ export class InternalModuleUtils {
 	 */
 	parseVariablesForInternalActionOrFeedback(
 		str: string,
-		extras: RunActionExtras | FeedbackEntityModelExt
+		extras: RunActionExtras | FeedbackForInternalExecution
 		// injectedVariableValues?: VariablesCache
 	): ParseVariablesResult {
 		const injectedVariableValuesComplete = {
@@ -233,7 +233,7 @@ export class InternalModuleUtils {
 	 *
 	 */
 	parseInternalControlReferenceForActionOrFeedback(
-		extras: RunActionExtras | FeedbackEntityModelExt,
+		extras: RunActionExtras | FeedbackForInternalExecution,
 		options: Record<string, any>,
 		useVariableFields: boolean
 	): {

--- a/companion/lib/Variables/CustomVariable.ts
+++ b/companion/lib/Variables/CustomVariable.ts
@@ -202,7 +202,7 @@ export class VariablesCustomVariable extends EventEmitter<VariablesCustomVariabl
 	 * @param defaultVal Default value of the variable (string)
 	 * @returns null or failure reason
 	 */
-	createVariable(name: string, defaultVal: string): string | null {
+	createVariable(name: string, defaultVal: CompanionVariableValue | undefined): string | null {
 		if (this.#custom_variables[name]) {
 			return `Variable "${name}" already exists`
 		}

--- a/companion/lib/Variables/VariablesAndExpressionParser.ts
+++ b/companion/lib/Variables/VariablesAndExpressionParser.ts
@@ -106,8 +106,6 @@ export class VariablesAndExpressionParser {
 		if (entityDefinition.internalUsesAutoParser) {
 			// If the entity uses the auto parser, we can just parse all
 
-			console.log('parsing options', options)
-
 			for (const field of entityDefinition.options) {
 				const rawValue = options[field.id] as ExpressionOrValue<any> | undefined
 				if (typeof rawValue === 'object' && 'isExpression' in rawValue && typeof rawValue.isExpression === 'boolean') {

--- a/companion/test/Instance/EntityManager.test.ts
+++ b/companion/test/Instance/EntityManager.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { InstanceEntityManager } from '../../lib/Instance/EntityManager.js'
+import type { EntityManager } from '../../lib/Instance/EntityManager/EntityManager.js'
+import { createInstanceEntityManager } from '../../lib/Instance/EntityManager/InstanceEntityManager.js'
 import { EntityModelType } from '@companion-app/shared/Model/EntityModel.js'
-import { ControlLocation } from '@companion-app/shared/Model/Common.js'
 import { UpdateActionInstancesMessage } from '@companion-module/base/dist/host-api/api.js'
 
 // Mock dependencies
@@ -38,13 +38,13 @@ describe('InstanceEntityManager', () => {
 		createVariablesAndExpressionParser: vi.fn().mockReturnValue(mockVariablesParser),
 	}
 
-	let entityManager: InstanceEntityManager
+	let entityManager: EntityManager
 
 	// Reset mocks before each test
 	beforeEach(() => {
 		vi.clearAllMocks()
 		// Create a new instance for each test
-		entityManager = new InstanceEntityManager(
+		entityManager = createInstanceEntityManager(
 			mockIpcWrapper as any,
 			mockControlsController as any,
 			'test-connection-id'

--- a/shared-lib/lib/Model/EntityDefinitionModel.ts
+++ b/shared-lib/lib/Model/EntityDefinitionModel.ts
@@ -16,6 +16,8 @@ export interface ClientEntityDefinition {
 	learnTimeout: number | undefined
 	showInvert: boolean
 
+	internalUsesAutoParser: boolean
+
 	showButtonPreview: boolean
 	supportsChildGroups: EntitySupportedChildGroupDefinition[]
 }

--- a/shared-lib/lib/Model/Options.ts
+++ b/shared-lib/lib/Model/Options.ts
@@ -223,3 +223,8 @@ export interface IsVisibleUiFn {
 }
 
 export type SomeCompanionInputField = ExtendedInputField | SomeCompanionConfigInputField | InternalInputField
+
+export type ExpressionOrValue<T> = { value: T; isExpression: false } | { value: string; isExpression: true }
+export type ExpressionableOptionsObject = {
+	[key: string]: ExpressionOrValue<any> | undefined
+}

--- a/shared-lib/lib/Model/Options.ts
+++ b/shared-lib/lib/Model/Options.ts
@@ -40,6 +40,8 @@ export interface CompanionInputFieldBaseExtended {
 	isVisibleUi?: IsVisibleUiFn
 
 	width?: number // For connection config
+
+	disableAutoExpression?: boolean
 }
 
 export interface InternalInputFieldTime extends CompanionInputFieldBaseExtended {

--- a/webui/src/Components/FieldOrExpression.tsx
+++ b/webui/src/Components/FieldOrExpression.tsx
@@ -1,0 +1,76 @@
+import { CButton } from '@coreui/react'
+import { faFilter, faSquareRootVariable } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import React, { useCallback } from 'react'
+import { TextInputField } from '~/Components/TextInputField.js'
+import type { LocalVariablesStore } from '~/Controls/LocalVariablesStore.js'
+import { observer } from 'mobx-react-lite'
+import type { ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
+
+interface FormPropertyFieldProps {
+	localVariablesStore: LocalVariablesStore
+	value: ExpressionOrValue<any>
+	setValue: (value: ExpressionOrValue<any>) => void
+	children: React.ReactNode
+}
+export const FieldOrExpression = observer(function FieldOrExpression({
+	localVariablesStore,
+	value,
+	setValue,
+	children,
+}: FormPropertyFieldProps) {
+	const setExpression = useCallback(
+		(value: any) => {
+			console.log('set expression', value)
+			setValue({
+				isExpression: true,
+				value,
+			})
+		},
+		[setValue]
+	)
+
+	const setIsExpression = useCallback(
+		(isExpression: boolean) => {
+			console.log('setIsExpression', isExpression)
+			setValue({
+				isExpression,
+				value: value.value,
+			})
+		},
+		[setValue, value]
+	)
+
+	const toggleExpression = useCallback(
+		() => setIsExpression(!value.isExpression),
+		[setIsExpression, value.isExpression]
+	)
+
+	return (
+		<div className="field-with-expression">
+			<div className="expression-field">
+				{value.isExpression ? (
+					<TextInputField
+						setValue={setExpression as (value: string) => void}
+						value={value.value ?? ''}
+						useVariables
+						localVariables={localVariablesStore.getOptions(null, false, true)} // TODO - the args here
+						isExpression
+					/>
+				) : (
+					children
+				)}
+			</div>
+			<div className="expression-toggle-button">
+				<CButton
+					color="info"
+					variant="outline"
+					onClick={toggleExpression}
+					title={value.isExpression ? 'Expression mode ' : 'Value mode'}
+				>
+					<FontAwesomeIcon icon={value.isExpression ? faSquareRootVariable : faFilter} />
+				</CButton>
+			</div>
+		</div>
+	)
+})

--- a/webui/src/Components/FieldOrExpression.tsx
+++ b/webui/src/Components/FieldOrExpression.tsx
@@ -30,6 +30,9 @@ export const FieldOrExpression = observer(function FieldOrExpression({
 		[setValue]
 	)
 
+	// Sanitise value a little
+	if (!value) value = { isExpression: false, value: undefined }
+
 	const setIsExpression = useCallback(
 		(isExpression: boolean) => {
 			console.log('setIsExpression', isExpression)

--- a/webui/src/Controls/Components/EntityCommonCells.tsx
+++ b/webui/src/Controls/Components/EntityCommonCells.tsx
@@ -128,6 +128,7 @@ export const EntityCommonCells = observer(function EntityCommonCells({
 								visibility={optionVisibility[opt.id] ?? true}
 								readonly={readonly}
 								localVariablesStore={localVariablesStore}
+								fieldsSupportExpressions={entityDefinition.internalUsesAutoParser}
 							/>
 						</MyErrorBoundary>
 					))}

--- a/webui/src/Controls/Components/EntityCommonCells.tsx
+++ b/webui/src/Controls/Components/EntityCommonCells.tsx
@@ -128,7 +128,7 @@ export const EntityCommonCells = observer(function EntityCommonCells({
 								visibility={optionVisibility[opt.id] ?? true}
 								readonly={readonly}
 								localVariablesStore={localVariablesStore}
-								fieldsSupportExpressions={entityDefinition.internalUsesAutoParser}
+								fieldsSupportExpressions={entityDefinition.internalUsesAutoParser && !opt.disableAutoExpression}
 							/>
 						</MyErrorBoundary>
 					))}

--- a/webui/src/Triggers/EventEditor.tsx
+++ b/webui/src/Triggers/EventEditor.tsx
@@ -311,6 +311,7 @@ const EventEditor = observer(function EventEditor({
 									setValue={service.setValue}
 									visibility={optionVisibility[opt.id] ?? true}
 									localVariablesStore={localVariablesStore}
+									fieldsSupportExpressions={false} // Events do not support expressions
 								/>
 							</MyErrorBoundary>
 						))}

--- a/webui/src/scss/_common.scss
+++ b/webui/src/scss/_common.scss
@@ -349,3 +349,21 @@ svg.pad-left {
 .text-decoration-none {
 	--cui-link-decoration: none;
 }
+
+.field-with-expression {
+	display: flex;
+	gap: 0.5rem;
+
+	.expression-field {
+		flex-grow: 1;
+	}
+
+	.expression-toggle-button {
+		justify-self: flex-end;
+
+		.btn {
+			height: 100%;
+			width: 3em;
+		}
+	}
+}


### PR DESCRIPTION
This is a WIP, and is in the process of being applied to all the internal code, please raise any objections/concerns around the changes asap, it would be good to know if anything needs reworking before every internal action is updated and tested for the changes.

This starts on implementing #2345, starting with considering just the internal actions and feedbacks.

The aim is to figure out how this will work technically, while it is easier to do on just the code in this repo before attempting to roll it out to modules.

The ui looks pretty similar to what was done for the graphics overhaul. Fields which support this gain a new button to the right of the field, which toggles it between the usual mode and expressions:
<img width="1277" height="608" alt="image" src="https://github.com/user-attachments/assets/74386c49-3ec6-41c3-80f2-14eff57bddb0" />

Internally, the options object now contains something of the form: `{ isExpression: false, value: 123 }`, with the execution auto-parsing, and the ui updating this. It is opt-in per entity for now, to avoid breaking everything while this is WIP, that may or may not remain once complete.