### PR TITLE
fix: remove nonsense tooltip

### DIFF
--- a/companion/lib/Surface/IP/ElgatoEmulator.ts
+++ b/companion/lib/Surface/IP/ElgatoEmulator.ts
@@ -64,7 +64,6 @@ const configFields: CompanionSurfaceConfigField[] = [
 		type: 'checkbox',
 		label: 'Prompt to enter fullscreen',
 		default: true,
-		tooltip: 'testfingsdg ',
 	},
 	...LockConfigFields,
 ]


### PR DESCRIPTION
Remove nonsense tooltip from surfaces/emulator settings tab.

<img width="398" height="169" alt="image" src="https://github.com/user-attachments/assets/ff7d3d21-daa6-4fcf-9d3a-299e69eb4454" />
