### PR TITLE
FIX: Negative value in msToTimestamp

### DIFF
--- a/docs/4_secondary_admin_controls/expressions/functions.md
+++ b/docs/4_secondary_admin_controls/expressions/functions.md
@@ -242,7 +242,7 @@ You can do the reverse of this with `secondsToTimestamp(str)`
 
 Convert a number of seconds into a timestamp of format 'HH:mm:ss'.
 
-Note: If the value is less than 0, it will report 0. There is no limit to the number of hours shown, it will display values greater than 24.
+Note: There is no limit to the number of hours shown, it will display values greater than 24.
 
 By supplying the format parameter, you can choose which components will be included in the output string.
 
@@ -256,7 +256,7 @@ The following components are allowed:
 
 Convert a number of milliseconds into a timestamp of format 'HH:mm:ss.SSS'.
 
-Note: If the value is less than 0, it will report 0. There is no limit to the number of hours shown, it will display values greater than 24.
+Note: There is no limit to the number of hours shown, it will display values greater than 24.
 
 By supplying the format parameter, you can choose which components will be included in the output string.
 

--- a/shared-lib/lib/Expression/ExpressionFunctions.ts
+++ b/shared-lib/lib/Expression/ExpressionFunctions.ts
@@ -167,12 +167,11 @@ export const ExpressionFunctions: Record<string, (...args: any[]) => any> = {
 	secondsToTimestamp: (v, type) => {
 		const negative = v < 0
 		v = Math.abs(v)
+		type = type ? type : 'hh:mm:ss'
 
 		const seconds = pad(Math.floor(v) % 60, '0', 2)
 		const minutes = pad(Math.floor(v / 60) % 60, '0', 2)
 		const hours = pad(Math.floor(v / 3600), '0', 2)
-
-		if (!type) return `${negative ? '-' : ''}${hours}:${minutes}:${seconds}`
 
 		const timestamp = []
 		if (type.includes('HH') || type.includes('hh')) timestamp.push(hours)
@@ -182,14 +181,14 @@ export const ExpressionFunctions: Record<string, (...args: any[]) => any> = {
 		return (negative ? '-' : '') + timestamp.join(':')
 	},
 	msToTimestamp: (v, type) => {
-		v = Math.max(0, v)
+		const negative = v < 0
+		v = Math.abs(v)
+		type = type ? type : 'mm:ss.ms'
 
 		const ms = v % 1000
 		const seconds = pad(Math.floor(v / 1000) % 60, '0', 2)
 		const minutes = pad(Math.floor(v / 60000) % 60, '0', 2)
 		const hours = pad(Math.floor(v / 3600000), '0', 2)
-
-		if (!type) return `${minutes}:${seconds}.${Math.floor(ms / 100)}`
 
 		const timestamp = []
 		if (type.includes('HH') || type.includes('hh')) timestamp.push(hours)
@@ -204,8 +203,7 @@ export const ExpressionFunctions: Record<string, (...args: any[]) => any> = {
 		} else if (type.endsWith('.SSS')) {
 			timestampStr += `.${pad(ms, '0', 3)}`
 		}
-
-		return timestampStr
+		return (negative ? '-' : '') + timestampStr
 	},
 	timeOffset: (time, offset, hr12 = false) => {
 		const date = new Date()

--- a/shared-lib/lib/__tests__/expressions-functions.test.ts
+++ b/shared-lib/lib/__tests__/expressions-functions.test.ts
@@ -431,6 +431,7 @@ describe('functions', () => {
 			expect(ExpressionFunctions.secondsToTimestamp(11, 'hh:mm:ss')).toBe('00:00:11')
 			expect(ExpressionFunctions.secondsToTimestamp(9999, 'hh:mm:ss')).toBe('02:46:39')
 			expect(ExpressionFunctions.secondsToTimestamp(1234567, 'hh:mm:ss')).toBe('342:56:07')
+			expect(ExpressionFunctions.secondsToTimestamp(-1234567, 'hh:mm:ss')).toBe('-342:56:07')
 
 			// hh:ss
 			expect(ExpressionFunctions.secondsToTimestamp(11, 'hh:ss')).toBe('00:11')
@@ -466,11 +467,13 @@ describe('functions', () => {
 
 			expect(ExpressionFunctions.msToTimestamp('9900')).toBe('00:09.9')
 			expect(ExpressionFunctions.msToTimestamp(false)).toBe('00:00.0')
-			expect(ExpressionFunctions.msToTimestamp(-11)).toBe('00:00.0')
+			expect(ExpressionFunctions.msToTimestamp(-11)).toBe('-00:00.0')
 
 			expect(ExpressionFunctions.msToTimestamp(11000, 'hh:mm:ss')).toBe('00:00:11')
+			expect(ExpressionFunctions.msToTimestamp(-11000, 'hh:mm:ss')).toBe('-00:00:11')
 			expect(ExpressionFunctions.msToTimestamp(9999000, 'hh:mm:ss')).toBe('02:46:39')
 			expect(ExpressionFunctions.msToTimestamp(1234567890, 'hh:mm:ss')).toBe('342:56:07')
+			expect(ExpressionFunctions.msToTimestamp(-1234567890, 'hh:mm:ss')).toBe('-342:56:07')
 
 			expect(ExpressionFunctions.msToTimestamp(11000, 'hh:mm')).toBe('00:00')
 			expect(ExpressionFunctions.msToTimestamp(9999000, 'hh:mm')).toBe('02:46')


### PR DESCRIPTION
**The issue**
`secondsToTimestamp` prepends negative number with a minus sign while `msToTimestamp` dose not

**Other stuff**
add test for the representing the new functionality.
unified the path for timestamp generation in both the millisecond and seconds case 

**Questions**
I could add formatting for days as well to fix the note about more than 24 hours?
I could implement a non padding option, "h:mm:s" -> 1:05:30 ?