### PR TITLE
fix: very old contour shuttle pro v1 has an XKey vendor ID

### DIFF
--- a/companion/lib/Surface/Controller.ts
+++ b/companion/lib/Surface/Controller.ts
@@ -1134,6 +1134,10 @@ export class SurfaceController extends EventEmitter<SurfaceControllerEvents> {
 										(deviceInfo.productId === 0x1f40 || deviceInfo.productId === 0x1f41)
 									) {
 										await this.#addDevice(deviceInfo.path, {}, 'infinitton', SurfaceUSBInfinitton)
+									} else if (isAShuttleDevice(deviceInfo)) {
+										if (this.#handlerDependencies.userconfig.getKey('contour_shuttle_enable')) {
+											await this.#addDevice(deviceInfo.path, {}, 'contour-shuttle', SurfaceUSBContourShuttle)
+										}
 									} else if (
 										// More specific match has to be above xkeys
 										deviceInfo.vendorId === vecFootpedal.vids.VEC &&
@@ -1145,10 +1149,6 @@ export class SurfaceController extends EventEmitter<SurfaceControllerEvents> {
 									} else if (deviceInfo.vendorId === 1523 && deviceInfo.interface === 0) {
 										if (this.#handlerDependencies.userconfig.getKey('xkeys_enable')) {
 											await this.#addDevice(deviceInfo.path, {}, 'xkeys', SurfaceUSBXKeys)
-										}
-									} else if (isAShuttleDevice(deviceInfo)) {
-										if (this.#handlerDependencies.userconfig.getKey('contour_shuttle_enable')) {
-											await this.#addDevice(deviceInfo.path, {}, 'contour-shuttle', SurfaceUSBContourShuttle)
 										}
 									} else if (
 										deviceInfo.vendorId === 0x32ac && // frame.work


### PR DESCRIPTION
See my related PR in: https://github.com/nytamin/contour-shuttle/pull/3

This fix moves the test for contour shuttle before the XKey tests. Otherwise and error is generated saying that the (older-model) Contour Shuttle is an unknown XKey device.