### PR TITLE
Fix: Preset previewStyle is overridden by feedback

### DIFF
--- a/companion/lib/Instance/Definitions.ts
+++ b/companion/lib/Instance/Definitions.ts
@@ -282,6 +282,10 @@ export class InstanceDefinitions extends EventEmitter<InstanceDefinitionsEvents>
 			style: definition.previewStyle ? convertPresetStyleToDrawStyle(definition.previewStyle) : definition.model.style,
 			steps: {},
 		}
+		if ('previewStyle' in definition && definition.previewStyle !== undefined) {
+			// don't let feedbacks override the previewStyle.
+			result.feedbacks = []
+		}
 
 		// Omit actions, as they can't be executed in the preview. By doing this we avoid bothering the module with lifecycle methods for them
 		for (const [stepId, step] of Object.entries(definition.model.steps)) {


### PR DESCRIPTION
Fixes Issue #3669

This is what I meant by my "proposal" in the comments and I think it's also what [you are suggesting](https://github.com/bitfocus/companion/issues/3669#issuecomment-3366580776), but if not then it's a point of departure for discussion.

While we could try to be more clever about how much of the feedback one is overriding, it will generally fail with "advanced" feedbacks, since the style information is missing then.