### PR TITLE
feat: draw button 'error' state as a red warning triangle

### DIFF
--- a/companion/lib/Graphics/Image.ts
+++ b/companion/lib/Graphics/Image.ts
@@ -411,14 +411,16 @@ export class Image {
 		color: string,
 		fontsize: number,
 		halignment: HorizontalAlignment = 'center',
-		valignment: VerticalAlignment = 'center'
+		valignment: VerticalAlignment = 'center',
+		weight: 'normal' | 'bold' = 'normal'
 	): number {
 		text = this.#sanitiseText(text)
 
 		if (text === undefined || text.length == 0) return 0
 		if (halignment != 'left' && halignment != 'center' && halignment != 'right') halignment = 'left'
+		if (weight != 'normal' && weight != 'bold') weight = 'normal'
 
-		this.context2d.font = `${fontsize}px ${DEFAULT_FONTS}`
+		this.context2d.font = `${weight} ${fontsize}px ${DEFAULT_FONTS}`
 		this.context2d.fillStyle = color
 		this.context2d.textAlign = halignment
 

--- a/companion/lib/Graphics/Renderer.ts
+++ b/companion/lib/Graphics/Renderer.ts
@@ -322,23 +322,27 @@ export class GraphicsRenderer {
 
 		// next error or warning icon
 		if (location) {
+			let statusColor: string | undefined
 			switch (drawStyle.button_status) {
 				case 'error':
-					img.box(rightMax - 10, 3, rightMax - 2, 11, 'red')
-					rightMax -= 10
+					statusColor = 'red'
 					break
 				case 'warning':
-					img.drawFilledPath(
-						[
-							[rightMax - 10, 11],
-							[rightMax - 2, 11],
-							[rightMax - 6, 3],
-						],
-						'rgb(255, 127, 0)'
-					)
-					img.drawTextLineAligned(rightMax - 6, 11, '!', colorBlack, 7, 'center', 'bottom')
-					rightMax -= 10
+					statusColor = 'rgb(255, 127, 0)'
 					break
+			}
+
+			if (statusColor) {
+				img.drawFilledPath(
+					[
+						[rightMax - 11, 11],
+						[rightMax - 2, 11],
+						[rightMax - 6.5, 2],
+					],
+					statusColor
+				)
+				img.drawTextLineAligned(rightMax - 6.5, 11, '!', colorBlack, 7, 'center', 'bottom', 'bold')
+				rightMax -= 11
 			}
 
 			// last running icon


### PR DESCRIPTION
I have seen a few posts from users confused as to what the red square is for. hopefully this will clarify it as a status by showing it as a warning icon

Before:
<img width="232" height="116" alt="image" src="https://github.com/user-attachments/assets/13c5c6e1-ed1e-4063-ad0e-e81e4c6eac05" />


After:
<img width="232" height="116" alt="image" src="https://github.com/user-attachments/assets/cb3e090b-f539-455b-b44a-c1504b965789" />
