### PR TITLE
fix: Page up button/Page down button don't set page-history

### DIFF
--- a/companion/lib/Internal/Surface.ts
+++ b/companion/lib/Internal/Surface.ts
@@ -545,13 +545,6 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 		}
 	}
 
-	incrPage(surfaceId: string, forward: boolean): boolean {
-		//const surfaceId = this.#fetchSurfaceId({controller: surfaceId}, undefined as unknown as RunActionExtras,  false)
-		if (!surfaceId) return true
-		this.#changeSurfacePage(surfaceId, forward ? '+1' : '-1')
-		return true
-	}
-
 	executeAction(action: ControlEntityInstance, extras: RunActionExtras): boolean {
 		if (action.definitionId === 'set_brightness') {
 			const surfaceId = this.#fetchSurfaceId(action.rawOptions, extras, true)


### PR DESCRIPTION
Resolves #3678

This was a bit of a puzzle that I couldn't put down but put simply: `ControlButtonPageDown` and `ControlButtonPageUp` take very different paths from normal buttons (`ControlButtonNormal`) starting from `ControlsController.pressControl`.  The paths don't merge until `SurfaceGroup.setCurrentPage` so getting PageUp/Down buttons to register their history would have to take place over there (i.e. in `SurfaceGroup`).   Upon reflection, it actually make sense to keep history in the SurfaceGroup object, so it's hopefully a happy "coincidence."

Bottom line: I moved the function that maintains page history into *Groups.ts* ~`SurfaceGroup.changePage`~ `SurfaceGroup.setCurrentPage` from `InternalSurface#changeSurfacePage` and then made some fairly minor changes to make it the main point of entry for changing pages.

Just to keep the mods clear, I left some original code in comments in ~`SurfaceGroup.changePage`~ `SurfaceGroup.setCurrentPage` These comments can be deleted before merging, if you prefer.

I hope you agree with my choices!  It works correctly in a basic test of mixing presses of "back" and PageDown/PageUp...