### PR TITLE
Fix: Surface Groups should always show "Current Page"

### DIFF
--- a/webui/src/Surfaces/EditPanel.tsx
+++ b/webui/src/Surfaces/EditPanel.tsx
@@ -362,7 +362,7 @@ const SurfaceEditPanelContent = observer<SurfaceEditPanelOldProps>(function Surf
 								</CFormLabel>
 								<CCol sm={8}>
 									<InternalPageIdDropdown
-										disabled={surfaceId !== null && !surfaceInfo?.isConnected && !groupConfig.config.use_last_page}
+										disabled={false}
 										includeDirection={false}
 										includeStartup={false}
 										value={groupConfig.config.last_page_id}


### PR DESCRIPTION
Currently a standalone surface will show and allow the user to adjust the current page but a group won't unless "Use Last Page At Startup" is true. This PR fixes it so groups behave similarly to standalone surfaces. 

(It's  useful in an emergency case - such as user accidentally went to a page with no back arrows -- typically during page-layout development...)