### PR TITLE
Add missing `solid-js` package to webui

### DIFF
--- a/webui/package.json
+++ b/webui/package.json
@@ -89,6 +89,7 @@
     "serve": "vite preview"
   },
   "devDependencies": {
-    "jsdom": "^27.0.0"
+    "jsdom": "^27.0.0",
+    "solid-js": "^1.9.9"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1461,6 +1461,7 @@ __metadata:
     remark-gfm: "npm:^4.0.1"
     sanitize-html: "npm:^2.17.0"
     sass-embedded: "npm:^1.93.2"
+    solid-js: "npm:^1.9.9"
     terser: "npm:^5.44.0"
     typescript: "npm:~5.9.3"
     use-deep-compare: "npm:^1.3.0"
@@ -9011,7 +9012,7 @@ asn1@evs-broadcast/node-asn1:
   languageName: node
   linkType: hard
 
-"csstype@npm:^3.0.2, csstype@npm:^3.1.2":
+"csstype@npm:^3.0.2, csstype@npm:^3.1.0, csstype@npm:^3.1.2":
   version: 3.1.3
   resolution: "csstype@npm:3.1.3"
   checksum: 10c0/80c089d6f7e0c5b2bd83cf0539ab41474198579584fa10d86d0cafe0642202343cbc119e076a0b1aece191989477081415d66c9fefbf3c957fc2fc4b7009f248
@@ -16660,7 +16661,16 @@ asn1@evs-broadcast/node-asn1:
   languageName: node
   linkType: hard
 
-"seroval@npm:^1.3.2":
+"seroval-plugins@npm:~1.3.0":
+  version: 1.3.3
+  resolution: "seroval-plugins@npm:1.3.3"
+  peerDependencies:
+    seroval: ^1.0
+  checksum: 10c0/cb6d0119ddf26241d62b78cf924a701bfde2d1a4f8fed924f0076b1edde5f8c6f3e38d8c71975010ba58e94804619c9aed59cb3985774ce7a725aa882dc021f1
+  languageName: node
+  linkType: hard
+
+"seroval@npm:^1.3.2, seroval@npm:~1.3.0":
   version: 1.3.2
   resolution: "seroval@npm:1.3.2"
   checksum: 10c0/19e74825643786d22e5c58054bd28065238de0156545afba82f9a7d3ee70ea4f0249b427f317bc6bf983849dde8e4190264728d90c84620aa163bfbc5971f1bc
@@ -16983,6 +16993,17 @@ asn1@evs-broadcast/node-asn1:
     ip-address: "npm:^9.0.5"
     smart-buffer: "npm:^4.2.0"
   checksum: 10c0/d54a52bf9325165770b674a67241143a3d8b4e4c8884560c4e0e078aace2a728dffc7f70150660f51b85797c4e1a3b82f9b7aa25e0a0ceae1a243365da5c51a7
+  languageName: node
+  linkType: hard
+
+"solid-js@npm:^1.9.9":
+  version: 1.9.9
+  resolution: "solid-js@npm:1.9.9"
+  dependencies:
+    csstype: "npm:^3.1.0"
+    seroval: "npm:~1.3.0"
+    seroval-plugins: "npm:~1.3.0"
+  checksum: 10c0/bd3fda22b66c4955bb4f29236b622dcfb11b7f37ec7fa974f366292bef1076750fade2e656d584cd977f50354b23cfca4026e8ae5153e991c8c112b15b21c9e3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
vite crashed (`yarn dev` in webui or `yarn dev:webui`) on startup, complaining that it couldn't find solid-js, so I added it to devdependencies in webui (`yarn add --dev solid-js`)

(It doesn't seem necessary to build the webui.)