### PR TITLE
Clean up side-by-side HTML/React for "Import" button / "full reset" checkbox

### DIFF
--- a/webui/src/ImportExport/Import/Full.tsx
+++ b/webui/src/ImportExport/Import/Full.tsx
@@ -320,32 +320,25 @@ function FullImportTab({ snapshot }: FullImportTabProps) {
 				<h5>Import Selected Components</h5>
 				<p>
 					Full Import always resets the selected components before importing them. <br />
-					Checking "Perform full reset" will reset <strong>all</strong> components before importing the selected ones.
+					Checking{' '}
+					<em>
+						<strong>Perform full reset</strong>
+					</em>{' '}
+					will reset <strong>all</strong> components before importing the selected ones.
 					<br />
 					Full reset is generally the safer option as it reduces the chance of producing an inconsistent setup.
 				</p>
-				<table>
-					<tr>
-						<td>
-							<CButton
-								color={fullReset ? 'danger' : 'success'}
-								onClick={doImport}
-								disabled={validConfigKeys.length === 0}
-							>
-								<FontAwesomeIcon icon={faFileImport} /> Import Selected Components
-							</CButton>
-						</td>
-						<td style={{ paddingLeft: '20px' }}>
-							<CFormCheck
-								id={'check_full_reset'}
-								label={'Perform full reset'}
-								checked={fullReset}
-								onChange={() => setFullReset((fullReset) => !fullReset)}
-								disabled={false}
-							/>
-						</td>
-					</tr>
-				</table>
+				<CButton color={fullReset ? 'danger' : 'success'} onClick={doImport} disabled={validConfigKeys.length === 0}>
+					<FontAwesomeIcon icon={faFileImport} /> Import Selected Components
+				</CButton>
+				<CFormCheck
+					id={'check_full_reset'}
+					label={'Perform full reset'}
+					checked={fullReset}
+					onChange={() => setFullReset((fullReset) => !fullReset)}
+					inline
+					style={{ marginLeft: '1em' }}
+				/>
 			</CCallout>
 		</>
 	)


### PR DESCRIPTION

This way seems more appropriate....and simpler too.

(And don't blame me for lint's weird text formatting!)

Note: this can be merged on its own, as it's essentially a tidy-up of React code in #3708 , or else I/we can rename this PR and make it the start of addressing the remaining issues. (My branch name is generic enough to work either way.)