### PR TITLE
Fix inconsistencies in handling of SurfacePanel.configFields

### DIFF
--- a/companion/lib/Instance/ConfigFields.ts
+++ b/companion/lib/Instance/ConfigFields.ts
@@ -245,6 +245,7 @@ function translateCustomVariableField(
 		...translateCommonFields(field),
 		type: 'custom-variable',
 		width: width,
+		default: undefined, // type-check complains otherwise
 	}
 }
 

--- a/companion/lib/Surface/Config.ts
+++ b/companion/lib/Surface/Config.ts
@@ -25,12 +25,26 @@ export function createOrSanitizeSurfaceHandlerConfig(
 	let panelConfig = existingConfig?.config
 	if (!panelConfig) {
 		panelConfig = cloneDeep(PanelDefaults)
+		// add properties & defaults from their UI definitions (so a redundant `getDefaultConfig()` is not needed)
+		for (const cfield of panel.info.configFields) {
+			if (!(cfield.id in panelConfig) || 'default' in cfield) {
+				Object.assign(panelConfig, { [cfield.id]: cfield.default })
+			}
+		}
+		// if `panel.getDefaultConfig() is present, let it override the previous sources...
 		if (typeof panel.getDefaultConfig === 'function') {
 			Object.assign(panelConfig, panel.getDefaultConfig())
 		}
 
 		panelConfig.xOffset = Math.max(0, gridSize.minColumn)
 		panelConfig.yOffset = Math.max(0, gridSize.minRow)
+	} else {
+		// check for new properties but don't change existing fields
+		for (const cfield of panel.info.configFields) {
+			if (!(cfield.id in panelConfig)) {
+				Object.assign(panelConfig, { [cfield.id]: cfield.default })
+			}
+		}
 	}
 
 	if (panelConfig.xOffset === undefined || panelConfig.yOffset === undefined) {

--- a/companion/lib/Surface/Handler.ts
+++ b/companion/lib/Surface/Handler.ts
@@ -727,6 +727,15 @@ export class SurfaceHandler extends EventEmitter<SurfaceHandlerEvents> {
 			redraw = true
 		}
 
+		// if this is an import, the config file may have been missing fields:
+		//  (note: import does not call `createOrSanitizeSurfaceHandlerConfig`, which might be a better option?)
+		for (const cfield of this.panel.info.configFields) {
+			if (!(cfield.id in newconfig)) {
+				Object.assign(newconfig, { [cfield.id]: cfield.default })
+				redraw = true
+			}
+		}
+
 		this.#surfaceConfig.config = newconfig
 		this.#saveConfig()
 

--- a/shared-lib/lib/Model/Options.ts
+++ b/shared-lib/lib/Model/Options.ts
@@ -190,6 +190,7 @@ export interface CompanionInputFieldCheckboxExtended extends CompanionInputField
 }
 export interface CompanionInputFieldCustomVariableExtended extends CompanionInputFieldBaseExtended {
 	type: 'custom-variable'
+	default?: never // needed to avoid TypeScript errors (all other input fields have default props)
 }
 
 export type ExtendedInputField =


### PR DESCRIPTION
* Ensure all `configFields` properties are added to to panelConfig
* Ensure that defaults specified in `configFields` are honored by the WebUI
* Ensure that missing fields are added when importing a preexisting export.
* Deal with TypeScript oddities