### PR TITLE
Fix "Sentry DSN not located" error in launcher

### DIFF
--- a/launcher/main.js
+++ b/launcher/main.js
@@ -159,7 +159,6 @@ if (!lock) {
 
 	let sentryDsn
 	try {
-		//console.log('Looking for sentry at: ' + new URL('../SENTRY', import.meta.url))
 		sentryDsn = fs
 			.readFileSync(new URL('../SENTRY', import.meta.url))
 			.toString()


### PR DESCRIPTION
- To see the error use `yarn dev` or run Companion.exe (if Windows) from a cmd prompt or powershell.
- Note that dev builds will still say "Sentry error reporting is disabled". This is not an error, it is because the file: SENTRY is empty.