### PR TITLE
Fix: Export is saving twice

### DIFF
--- a/webui/src/ImportExport/Export.tsx
+++ b/webui/src/ImportExport/Export.tsx
@@ -238,16 +238,7 @@ export const ExportWizardModal = observer(
 										<CButton color="secondary" onClick={doClose} disabled={isSubmitting}>
 											Close
 										</CButton>
-										<CButton
-											color="primary"
-											disabled={!canSubmit || isSubmitting}
-											type="submit"
-											onClick={() => {
-												form.handleSubmit().catch((err) => {
-													console.error('Form submission error', err)
-												})
-											}}
-										>
+										<CButton color="primary" disabled={!canSubmit || isSubmitting} type="submit">
 											Download {isSubmitting ? '...' : ''}
 										</CButton>
 									</>


### PR DESCRIPTION
The form has two submit callbacks: removed one of them.

Note that the dev environment seems a bit more fragile -- once there's a timeout, the buttons stop saving. This may be something on the server side or in the communication method, since the UI side appears to be working correctly.