### PR TITLE
Fix handling of variables in Template Literals in button text expressions

### DIFF
--- a/companion/lib/Controls/ControlTypes/Button/Util.ts
+++ b/companion/lib/Controls/ControlTypes/Button/Util.ts
@@ -36,7 +36,17 @@ export function parseVariablesInButtonStyle(
 				logger.error(`Expression parse error: ${parseResult.error}`)
 				style.text = 'ERR'
 			}
-			return parseResult.variableIds.size > 0 ? parseResult.variableIds : null
+			if (parseResult.variableIds.size > 0) {
+				// some variables were processed, assume they all were
+				return parseResult.variableIds
+			} else if (style.text.includes('$(')) {
+				// reparse for variables, since the jsep output doesn't resolve Companion variables
+				const parseResult = parser.parseVariables(style.text)
+				style.text = parseResult.text
+				return parseResult.variableIds.size > 0 ? parseResult.variableIds : null
+			} else {
+				return null
+			}
 		} else {
 			const parseResult = parser.parseVariables(style.text)
 			style.text = parseResult.text

--- a/shared-lib/lib/Expression/ExpressionResolve.ts
+++ b/shared-lib/lib/Expression/ExpressionResolve.ts
@@ -161,6 +161,16 @@ export function ResolveExpression(
 							}
 						}
 
+						// // resolve embedded Companion variables
+						// let startIdx;
+						// while ((startIdx = result.search(/\$\(/)) >= 0) {
+						// 	const endIdx = result.indexOf(')', startIdx + 2)
+						// 	if (endIdx < 0 ) break  // or throw error?
+						// 	const varname = result.substring(startIdx+2, endIdx)
+						// 	const value = getVariableValue(varname)?.toString() ?? ''
+						// 	result = result.replaceAll(`$(${varname})`, value)
+						// }
+
 						return result
 					}
 					case 'Compound': {


### PR DESCRIPTION
This PR simplifies handling of Companion variables in button text-expressions so the user can write `` `Prefix_$(custom:var)` `` rather than `` `Prefix_${$(custom:var)}` ``, which is currently required.

Details: Currently button text expressions have a curious behavior:

If you put a companion variable in a template literal, the variable is not evaluated so the button shows the name of the variable instead of its value, so to evaluate it you'd have to write: `` `${$(my:var)}` ``, which is rather awkward.

OTOH, if you set a variable, say `$(custom:myvar)`, to the original template literal, i.e. `` `$(my:var)` ``, and then use the new variable as the button text value (whether expression or text), the button now shows the _value_ of `$(my:var)` rather than the string "$(my:var)" -- even though the string is shown as the value of `$(custom:myvar)` in the Variables tab.

This PR fixes the immediate problem for button text expressions and also suggests an alternate option, which is to resolve variables in backtick expressions at parse-eval time, just as is already done for rest of the template literal. (i.e. if  `$(custom:myvar)` is set to the expression `` `$(internal:time_s) ${unixNow()}` `` , the value shown on the button will update every second for the Companion Variable but not the function call.)

And tangentially: I realize now that I've blurred the distinction between "expression variables" and "custom variables" by using an expression in a custom variable! (But that's not really relevant to the button-text problem, just an aside...)

Edit:
Just to add a little confusion: if the button expression is `concat($(internal:time_s), '\n', unixNow())` then both values update once a second, as does `` `${$(internal:time_s)} ${unixNow()}` `` -- or `` `$(internal:time_s) ${unixNow()}` `` in this PR.

And finally, this PR does not break the current syntax, it just makes it unnecessary.