### PR TITLE
feat: Support major firmware update of mirabox 293S variant

### DIFF
--- a/companion/lib/Surface/Controller.ts
+++ b/companion/lib/Surface/Controller.ts
@@ -1213,18 +1213,16 @@ export class SurfaceController extends EventEmitter<SurfaceControllerEvents> {
 											await this.#addDevice(deviceInfo.path, {}, '203-mystrix', SurfaceUSB203SystemsMystrix)
 										}
 									} else if (
-										(deviceInfo.vendorId === 0x1500 ||
-											deviceInfo.vendorId === 0x6602 ||
-											deviceInfo.vendorId === 0x6603 ||
-											deviceInfo.vendorId === 0x5548) && // Mirabox
-										(deviceInfo.productId === 0x1001 ||
-											deviceInfo.productId === 0x1003 ||
-											deviceInfo.productId === 0x1007 ||
-											deviceInfo.productId === 0x1005 ||
-											deviceInfo.productId === 0x1014 || // Stream Dock HSV 293S
-											deviceInfo.productId === 0x3003 || // Another 293S variant (firmware V3)
-											deviceInfo.productId === 0x6670 || // Another 293S variant (firmware V2)
-											deviceInfo.productId === 0x1006) && // Stream Dock N4 or 293V3
+										(((deviceInfo.vendorId === 0x6602 || deviceInfo.vendorId === 0x6603) && // Mirabox
+											(deviceInfo.productId === 0x1001 ||
+												deviceInfo.productId === 0x1003 ||
+												deviceInfo.productId === 0x1007 ||
+												deviceInfo.productId === 0x1005 ||
+												deviceInfo.productId === 0x1014 || // Stream Dock HSV 293S
+												deviceInfo.productId === 0x1006)) || // Stream Dock N4 or 293V3
+											// Mirabox variants (OEM branded)
+											(deviceInfo.vendorId === 0x5548 && deviceInfo.productId === 0x6670) || // Mirabox HSV 293S (XF-CN001 firmware V2)
+											(deviceInfo.vendorId === 0x1500 && deviceInfo.productId === 0x3003)) && // Mirabox HSV 293S (XF-CN001 firmware V3)
 										deviceInfo.interface === 0
 									) {
 										if (this.#handlerDependencies.userconfig.getKey('mirabox_streamdock_enable')) {

--- a/companion/lib/Surface/USB/MiraboxStreamDock.ts
+++ b/companion/lib/Surface/USB/MiraboxStreamDock.ts
@@ -2302,9 +2302,9 @@ class StreamDock extends EventEmitter {
 			this.model = StreamDock.models['293N3']
 		} else if (this.info.productId === 0x1014) {
 			this.model = StreamDock.models['HSV 293S']
-		} else if (this.info.productId === 0x3003) {
+		} else if (this.info.vendorId === 0x1500 && this.info.productId === 0x3003) {
 			this.model = StreamDock.models['HSV 293S-3']
-		} else if (this.info.productId === 0x6670) {
+		} else if (this.info.vendorId === 0x5548 && this.info.productId === 0x6670) {
 			this.model = StreamDock.models['HSV 293S-2']
 			this.packetSize = 512
 		} else {


### PR DESCRIPTION
This is a follow-up PR of https://github.com/bitfocus/companion/pull/3632
Soomfon is now shipping their XF-CN001 with a new firmware (V3), which fixes pretty much all the issues that limited the previous version:
- Supports up/down events
- Tile refreshing is much faster
- Screen tiles can be configured to be larger to better fit the buttons.

Sadly, there's no firmware update publicly available to patch older units, probably because it would break whatever config was created with the previous firmware version. So the other implementation is still very useful for older units.
