### PR TITLE
Restore default webpack optimizations

### DIFF
--- a/companion/webpack.config.js
+++ b/companion/webpack.config.js
@@ -83,22 +83,4 @@ export default {
 				})
 			: '',
 	].filter(Boolean),
-	optimization: {
-		// The following optimizations are enabled only in 'production' mode
-		// 	flagIncludedChunks: optimizeUseProduction,
-		// 	moduleIds: 'named', // optimizeUseProduction ? "deterministic" : 'named'
-		// 	chunkIds: 'named', // optimizeUseProduction ? "deterministic" : 'named'
-		// 	sideEffects: 'flag', // () => (production ? true : "flag"),
-		// 	usedExports: optimizeUseProduction,
-		// 	innerGraph: optimizeUseProduction,
-		// 	mangleExports: optimizeUseProduction,
-		// avoid error in webpack 5.102.1 (fixed in 5.103.0)
-		// concatenateModules: false, // default: optimizeUseProduction,
-		// 	avoidEntryIife: optimizeUseProduction,
-		// 	emitOnErrors: !optimizeUseProduction,
-		// 	checkWasmTypes: optimizeUseProduction,
-		// 	realContentHash: optimizeUseProduction,
-		// 	minimize: optimizeUseProduction,
-		// 	//nodeEnv: devMode// probably best never to alther this one.
-	},
 }


### PR DESCRIPTION
The optimization had been removed because of a bug in 5.102.1 that is fixed in 5.103.0

FWIW, my previous testing suggested it doesn't do too much, but it does reduce the number of modules in the final build, which in theory can improve performance.
