### PR TITLE
chore: require double-quotes in YAML

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -2,7 +2,7 @@ name: Bug report
 description: Create a bug report to help us improve.
 labels:
   - BUG
-title: '[BUG]'
+title: "[BUG]"
 body:
   - type: markdown
     attributes:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,36 +1,36 @@
 version: 2
 updates:
-  - package-ecosystem: 'github-actions'
-    directory: '/'
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: 'weekly'
+      interval: "weekly"
 
-  - package-ecosystem: 'npm'
-    directory: '/'
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
-      interval: 'daily'
+      interval: "daily"
     # Labels on pull requests for security and version updates
     labels:
-      - 'type/dependencies'
+      - "type/dependencies"
     # Disable version updates for npm dependencies (we only want security updates)
     open-pull-requests-limit: 0
 
-  - package-ecosystem: 'npm'
-    directory: '/webui'
+  - package-ecosystem: "npm"
+    directory: "/webui"
     schedule:
-      interval: 'daily'
+      interval: "daily"
     # Labels on pull requests for security and version updates
     labels:
-      - 'type/dependencies'
+      - "type/dependencies"
     # Disable version updates for npm dependencies (we only want security updates)
     open-pull-requests-limit: 0
 
-  - package-ecosystem: 'npm'
-    directory: '/launcher'
+  - package-ecosystem: "npm"
+    directory: "/launcher"
     schedule:
-      interval: 'daily'
+      interval: "daily"
     # Labels on pull requests for security and version updates
     labels:
-      - 'type/dependencies'
+      - "type/dependencies"
     # Disable version updates for npm dependencies (we only want security updates)
     open-pull-requests-limit: 0

--- a/.github/issue_label_bot.yaml
+++ b/.github/issue_label_bot.yaml
@@ -1,3 +1,3 @@
 label-alias:
-  bug: 'BUG'
-  feature_request: 'Enhancement'
+  bug: "BUG"
+  feature_request: "Enhancement"

--- a/.github/workflows/beta-offline-module-bundle.yml
+++ b/.github/workflows/beta-offline-module-bundle.yml
@@ -4,10 +4,10 @@ on:
   workflow_dispatch:
   # Run every week
   schedule:
-    - cron: '43 5 * * 0'
+    - cron: "43 5 * * 0"
   push:
     tags:
-      - '**'
+      - "**"
 
 permissions:
   contents: read
@@ -26,7 +26,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version-file: '.node-version'
+          node-version-file: ".node-version"
 
       - name: Cache build sources
         uses: actions/cache@v4
@@ -76,5 +76,5 @@ jobs:
           s3-secret-key: ${{ secrets.S3_SECRET }}
 
           api-product: companion-offline-module-bundle
-          api-target: 'generic'
+          api-target: "generic"
           api-secret: ${{ secrets.BITFOCUS_API_PROJECT_SECRET }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version-file: '.node-version'
+          node-version-file: ".node-version"
       - name: yarn install
         run: |
           corepack enable

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version-file: '.node-version'
+          node-version-file: ".node-version"
 
       - name: Prepare
         run: |
@@ -51,7 +51,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version-file: '.node-version'
+          node-version-file: ".node-version"
 
       - name: Cache build sources
         uses: actions/cache@v4
@@ -113,7 +113,7 @@ jobs:
           s3-secret-key: ${{ secrets.S3_SECRET }}
 
           api-product: companion
-          api-target: 'linux-tgz'
+          api-target: "linux-tgz"
           api-secret: ${{ secrets.BITFOCUS_API_PROJECT_SECRET }}
 
   linux-arm64:
@@ -130,7 +130,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version-file: '.node-version'
+          node-version-file: ".node-version"
 
       - name: Cache build sources
         uses: actions/cache@v4
@@ -191,7 +191,7 @@ jobs:
           s3-secret-key: ${{ secrets.S3_SECRET }}
 
           api-product: companion
-          api-target: 'linux-arm64-tgz'
+          api-target: "linux-arm64-tgz"
           api-secret: ${{ secrets.BITFOCUS_API_PROJECT_SECRET }}
 
   osx-x64:
@@ -208,7 +208,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version-file: '.node-version'
+          node-version-file: ".node-version"
 
       - name: Cache build sources
         uses: actions/cache@v4
@@ -271,7 +271,7 @@ jobs:
           s3-secret-key: ${{ secrets.S3_SECRET }}
 
           api-product: companion
-          api-target: 'mac-intel'
+          api-target: "mac-intel"
           api-secret: ${{ secrets.BITFOCUS_API_PROJECT_SECRET }}
 
   osx-arm64:
@@ -288,7 +288,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version-file: '.node-version'
+          node-version-file: ".node-version"
 
       - name: Cache build sources
         uses: actions/cache@v4
@@ -353,7 +353,7 @@ jobs:
           s3-secret-key: ${{ secrets.S3_SECRET }}
 
           api-product: companion
-          api-target: 'mac-arm'
+          api-target: "mac-arm"
           api-secret: ${{ secrets.BITFOCUS_API_PROJECT_SECRET }}
 
   win32-x64:
@@ -370,7 +370,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version-file: '.node-version'
+          node-version-file: ".node-version"
 
       - name: Cache build sources
         uses: actions/cache@v4
@@ -446,7 +446,7 @@ jobs:
           s3-secret-key: ${{ secrets.S3_SECRET }}
 
           api-product: companion
-          api-target: 'win-x64'
+          api-target: "win-x64"
           api-secret: ${{ secrets.BITFOCUS_API_PROJECT_SECRET }}
 
   docker-image:
@@ -517,6 +517,6 @@ jobs:
           platforms: linux/amd64,linux/arm64/v8
           push: true
           labels: ${{ steps.meta.outputs.labels }}
-          tags: '${{ steps.meta.outputs.tags }}'
+          tags: "${{ steps.meta.outputs.tags }}"
           build-args: |
             build_name=${{ needs.linux-x64.outputs.version }}

--- a/.github/workflows/pr-type-check.yaml
+++ b/.github/workflows/pr-type-check.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version-file: '.node-version'
+          node-version-file: ".node-version"
 
       - name: Prepare
         run: |

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -6,7 +6,7 @@ on:
       - main
       - stable-*
     paths:
-      - 'docs/user-guide/**'
+      - "docs/user-guide/**"
   workflow_dispatch:
 
 concurrency:
@@ -53,8 +53,8 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           repository: website
-          commit_message: 'Sync user-guide from companion'
-          file_pattern: 'user-guide/** whats-new/**'
+          commit_message: "Sync user-guide from companion"
+          file_pattern: "user-guide/** whats-new/**"
 
       - name: Sync user-guide folder (release)
         if: github.ref != 'refs/heads/main'
@@ -87,5 +87,5 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           repository: website
-          commit_message: 'Sync user-guide (v${{ steps.sync_release.outputs.version }}) from companion'
-          file_pattern: 'versioned_docs/** versioned_sidebars/** versions.json'
+          commit_message: "Sync user-guide (v${{ steps.sync_release.outputs.version }}) from companion"
+          file_pattern: "versioned_docs/** versioned_sidebars/** versions.json"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version-file: '.node-version'
+          node-version-file: ".node-version"
       - name: yarn install
         run: |
           corepack enable
@@ -42,7 +42,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version-file: '.node-version'
+          node-version-file: ".node-version"
       - name: yarn install
         run: |
           corepack enable

--- a/.github/workflows/update-nodejs.yaml
+++ b/.github/workflows/update-nodejs.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   # Run every week
   schedule:
-    - cron: '43 5 * * 0'
+    - cron: "43 5 * * 0"
 
 env:
   COMPANION_BRANCH: main
@@ -31,7 +31,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version-file: '.node-version'
+          node-version-file: ".node-version"
 
       - name: Setup environment
         run: |
@@ -45,13 +45,13 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
-          commit-message: 'chore: update Node.js versions'
-          title: 'chore: update Node.js versions'
-          body: 'This PR updates the Node.js versions in the Companion.'
+          commit-message: "chore: update Node.js versions"
+          title: "chore: update Node.js versions"
+          body: "This PR updates the Node.js versions in the Companion."
           delete-branch: true
-          branch: 'chore/update-nodejs'
-          committer: 'Companion Bot <companion-module-bot@users.noreply.github.com>'
-          author: 'Companion Bot <companion-module-bot@users.noreply.github.com>'
+          branch: "chore/update-nodejs"
+          committer: "Companion Bot <companion-module-bot@users.noreply.github.com>"
+          author: "Companion Bot <companion-module-bot@users.noreply.github.com>"
           add-paths: |
             package.json
             */package.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,7 +9,6 @@ webui/build/
 webui/public/legacy
 webui/src/routeTree.gen.ts
 /LICENSE.md
-/.yarnrc.yml
 
 module-local-dev
 bundled-modules

--- a/.prettierrc
+++ b/.prettierrc
@@ -6,5 +6,13 @@
 	"singleQuote": true,
 	"useTabs": true,
 	"endOfLine": "lf",
-	"trailingComma": "es5"
+	"trailingComma": "es5",
+	"overrides": [
+		{
+			"files": ["*.yml", "*.yaml"],
+			"options": {
+				"singleQuote": false
+			}
+		}
+	]
 }


### PR DESCRIPTION
Consider this PR as a suggestion...

Currently prettier config requires single-quotes in YAML files, but double-quotes are probably preferred since it allows escape sequences.  (See for example [Github's own examples](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/find-and-customize-actions#using-inputs-and-outputs-with-an-action).)

This PR removes the need for excluding _.yarnrc.yml_ but does require "reformatting" the github workflow files (done in this PR).

FWIW, prettier preserves single quotes if it would change the meaning. For example, if you have a value such as `'\n means EOL'`, prettier will leave the single-quotes.