### PR TITLE
patch emberplus connection

### DIFF
--- a/.yarn/patches/emberplus-connection-npm-0.2.2-7dc017dd22.patch
+++ b/.yarn/patches/emberplus-connection-npm-0.2.2-7dc017dd22.patch
@@ -1,0 +1,18 @@
+diff --git a/dist/Ember/Server/index.js b/dist/Ember/Server/index.js
+index 209729f1858218bab9a6d733d4b6674abe981982..7b16ed5fb89580a6623e71046d97079e71b894ba 100644
+--- a/dist/Ember/Server/index.js
++++ b/dist/Ember/Server/index.js
+@@ -74,7 +74,12 @@ class EmberServer extends eventemitter3_1.EventEmitter {
+         const data = (0, ber_1.berEncode)([el], types_1.RootType.Elements);
+         let elPath = el.path;
+         if (el.contents.type !== model_1.ElementType.Node && !('targets' in update || 'sources' in update)) {
+-            elPath = elPath.slice(0, -2); // remove the last element number
++            const lastDotIndex = elPath.lastIndexOf('.')
++			if (lastDotIndex > -1) {
++				elPath = elPath.slice(0, lastDotIndex)
++			} else {
++				elPath = ''
++			}
+         }
+         for (const [path, clients] of Object.entries(this._subscriptions)) {
+             if (elPath === path) {

--- a/companion/package.json
+++ b/companion/package.json
@@ -69,7 +69,7 @@
     "dayjs": "^1.11.19",
     "debounce-fn": "^6.0.0",
     "ejson": "^2.2.3",
-    "emberplus-connection": "^0.2.2",
+    "emberplus-connection": "patch:emberplus-connection@npm%3A0.2.2#~/.yarn/patches/emberplus-connection-npm-0.2.2-7dc017dd22.patch",
     "env-paths": "^3.0.0",
     "express": "^5.1.0",
     "express-serve-zip": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11147,7 +11147,7 @@ asn1@evs-broadcast/node-asn1:
     dayjs: "npm:^1.11.19"
     debounce-fn: "npm:^6.0.0"
     ejson: "npm:^2.2.3"
-    emberplus-connection: "npm:^0.2.2"
+    emberplus-connection: "patch:emberplus-connection@npm%3A0.2.2#~/.yarn/patches/emberplus-connection-npm-0.2.2-7dc017dd22.patch"
     env-paths: "npm:^3.0.0"
     express: "npm:^5.1.0"
     express-serve-zip: "npm:^1.1.0"
@@ -12583,7 +12583,7 @@ asn1@evs-broadcast/node-asn1:
   languageName: node
   linkType: hard
 
-"emberplus-connection@npm:^0.2.2":
+"emberplus-connection@npm:0.2.2":
   version: 0.2.2
   resolution: "emberplus-connection@npm:0.2.2"
   dependencies:
@@ -12594,6 +12594,20 @@ asn1@evs-broadcast/node-asn1:
     smart-buffer: "npm:^3.0.3"
     tslib: "npm:^2.6.2"
   checksum: 10c0/e7674b2990733800f3838f8ec4d9679b26336bc6c2e83b78dce2c10e9552c26f8fc3f08fbaa0ce8f089812c26ef7d4c3057b20cb90527a5e34e53cc6b4203430
+  languageName: node
+  linkType: hard
+
+"emberplus-connection@patch:emberplus-connection@npm%3A0.2.2#~/.yarn/patches/emberplus-connection-npm-0.2.2-7dc017dd22.patch":
+  version: 0.2.2
+  resolution: "emberplus-connection@patch:emberplus-connection@npm%3A0.2.2#~/.yarn/patches/emberplus-connection-npm-0.2.2-7dc017dd22.patch::version=0.2.2&hash=03d251"
+  dependencies:
+    asn1: evs-broadcast/node-asn1
+    debug: "npm:^4.3.4"
+    eventemitter3: "npm:^4.0.7"
+    long: "npm:^3.2.0"
+    smart-buffer: "npm:^3.0.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/8861056d1012fa0830d70bff0f845ccc27e9169fba1e07198b22a97143cce04a7f39505b853da8ae4ec180d1bb5b1eae0a9b1ba741e0041c4b2b56d047276ff7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Patch commit [`3722d65`](https://github.com/Sofie-Automation/sofie-emberplus-connection/commit/3722d65b480b7efc8ffad0cd4eb58984125d2160) from sofie-emberplus-connection to v0.2.2

Testing with emberplus viewer, behavior seems better when the internal variable parameters are defined in a flat structure (as opposed to a container node for each parameter). Previously, when testing during development of this feature, emberplus viewer could see the parameters, but subscriptions for updates were broken.

However altering the ember tree structure would be a breaking change and isn't part of this pull request.

As such this patch provides no immediate fix or improvement to Companion, but should put the emberplus api in a better place to accommodate any future development.