### PR TITLE
feat: Report UI/Server URL at end of startup (feat for developers)

### DIFF
--- a/companion/lib/Registry.ts
+++ b/companion/lib/Registry.ts
@@ -478,7 +478,7 @@ export class Registry {
 		this.services.https.updateBindIp(bindIp)
 		this.internalModule.updateBindIp(bindIp, bindPort)
 		this.usageStatistics.updateBindIp(bindIp)
-		setTimeout(() => this.ui.server.rebindHttp(bindIp, bindPort), 2000)
+		this.ui.server.rebindHttp(bindIp, bindPort)
 	}
 }
 

--- a/companion/lib/UI/Server.ts
+++ b/companion/lib/UI/Server.ts
@@ -48,7 +48,7 @@ export class UIServer extends HttpServer {
 
 				const ip = bindIp == '0.0.0.0' ? '127.0.0.1' : bindIp
 				const url = `http://${ip}:${address?.port}/`
-				this.#logger.info(`new url: ${url}`)
+				setTimeout(() => this.#logger.info(`new url: ${url}`), 2000)
 
 				const info = bindIp == '0.0.0.0' ? `All Interfaces: e.g. ${url}` : url
 				sendOverIpc({
@@ -59,7 +59,7 @@ export class UIServer extends HttpServer {
 				})
 			})
 		} catch (e) {
-			this.#logger.error(`http bind error: ${e}`)
+			setTimeout(() => this.#logger.error(`http bind error: ${e}`), 2000)
 		}
 	}
 }


### PR DESCRIPTION
Near the end of startup, Companion reports something of the form:

> info UI/Server new url: http://127.0.0.1:8000/

In VS Code and PowerShell ctrl-click on this text provides a convenient way to start the Admin UI, but with the extra reporting coming from the new surface module feature, many items are logged after this line, making it difficult to find.

This PR delays the the call to `UIServer.rebindHttp` briefly so that the log line ends up near the end of the log at startup. (Also: log the same URL as is sent out over IPC.)

Note: moving the call to the end of the calling function was not sufficient. OTOH, I could just delay the log message rather than the whole call...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Ensure binding configuration updates are applied before triggering the HTTP rebind operation.
  * Delay server connection and error log messages by 2 seconds for clearer, formatted URL output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->