### PR TITLE
Update Blackmagic controllers documentation for clarity

### DIFF
--- a/docs/user-guide/7_surfaces/blackmagic-controllers.md
+++ b/docs/user-guide/7_surfaces/blackmagic-controllers.md
@@ -9,10 +9,10 @@ It is possible to use a few of the Blackmagic Design USB/bluetooth controllers w
 We currently support the following models:
 
 - ATEM Micro Panel since v3.4
-- Resolve Replay Editor since v4.0
-- Resolve Speed Editor since v4.2
+- Resolve Replay Editor since v4.0 [USB only]
+- Resolve Speed Editor since v4.2  [USB only]
 
-Enable support for it in Companion's settings and rescan for USB devices. This works over both USB and Bluetooth.
+Enable support for it in Companion's settings and rescan for USB devices. This works over both USB for all devices and additionally Bluetooth for ATEM Micro Panel.
 
 :::danger
 Do not run the ATEM software at the same time when using the ATEM Micro Panel â€” both programs will listen to presses and update colours.
@@ -21,3 +21,5 @@ Do not run the ATEM software at the same time when using the ATEM Micro Panel â€
 The layout matches the device's natural grid when blank spaces are compacted. The T-bar occupies a column in this layout.
 
 To use the T-bar, go to the surface settings and select a custom variable to receive the value. You can also provide an expression to control how the T-bar LEDs are lit.
+
+LEDs on keys (on/off) respond to setting background color.


### PR DESCRIPTION
Clarified USB support for Resolve Replay Editor and Speed Editor. Specified Bluetooth compatibility for ATEM Micro Panel.

See also: [Speed Editor no BT? #7](https://github.com/bitfocus/companion-surface-blackmagic-controller/issues/7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated device compatibility information for Blackmagic controllers with USB-only designation for select models.
  * Clarified USB and Bluetooth connectivity support specifications across the controller range.
  * Added documentation on LED key functionality and behavior when responding to background color settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->