### PR TITLE
Update Blackmagic controllers guide with Bluetooth info

### DIFF
--- a/docs/user-guide/7_surfaces/blackmagic-controllers.md
+++ b/docs/user-guide/7_surfaces/blackmagic-controllers.md
@@ -4,7 +4,7 @@ sidebar_position: 8
 description: Setup guide for Blackmagic ATEM and Resolve controllers.
 ---
 
-It is possible to use a few of the Blackmagic Design USB/bluetooth controllers with Companion. 
+It is possible to use a few of the Blackmagic Design USB/bluetooth controllers with Companion.
 
 We currently support the following models:
 
@@ -14,7 +14,8 @@ We currently support the following models:
 
 Enable support for it in Companion's settings and rescan for USB devices. This works over both USB and Bluetooth.
 
-Bluetooth on macOS is not operational for Replay Editor and Speed Editor. There are reports with similar issues on Linux. The maintainer is aware and will look into it, but no ETA given. 
+Bluetooth should work for all models, but can be picker than USB. If you are having issues, please report it on Github.  
+In particular there may be issues with bluetooth on Linux, depending on the system.
 
 :::danger
 Do not run the ATEM software at the same time when using the ATEM Micro Panel — both programs will listen to presses and update colours.


### PR DESCRIPTION
Clarified Bluetooth support status for controllers on MacOS and Linux. Added information reg. LED use on panels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Blackmagic controllers guide: Bluetooth generally works across models but may offer lower reliability or latency than USB; potential Linux-specific Bluetooth problems noted and under investigation. Users are asked to report reproducible issues via the project issue tracker.
  * Clarified LED behavior: key LEDs (on/off) follow the configured background color.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->