### PR TITLE
Fix 49 DOM errors related to Sidebar; improve toggling consistency

### DIFF
--- a/webui/src/Layout/Sidebar.tsx
+++ b/webui/src/Layout/Sidebar.tsx
@@ -500,18 +500,21 @@ function CNavGroup({
 	return (
 		<li className={classNames('nav-group', { show: _visible }, className)} {...rest}>
 			{to ? (
-				<a className="nav-link nav-group-toggle nav-group-toggle-link" onClick={(event) => handleTogglerOnCLick(event)}>
+				<div
+					className="nav-link nav-group-toggle nav-group-toggle-link"
+					onClick={(event) => handleTogglerOnCLick(event)}
+				>
 					<Link
 						to={to}
 						className="nav-link"
 						onClick={(e) => {
 							e.stopPropagation()
-							setVisible(true)
+							setVisible(!_visible)
 						}}
 					>
 						{toggler}
 					</Link>
-				</a>
+				</div>
 			) : (
 				<a
 					className="nav-link nav-group-toggle nav-group-toggle-basic"


### PR DESCRIPTION
- The browser (Chrome) complains about `<a>` elements nesting in another `<a>` element, and 48 other errors. Fixing the one removes the remaining error messages.
- NOTE: the errors only show (in the browser console) when running webui in dev mode. Presumably webpack fixes the error on packaging.
- **Toggling fix**: Currently clicking anywhere on a sidebar group header opens it, but you must click the caret to close the group. This PR fixes it so clicking anywhere in the group header toggles the group.

(Note: for the toggling fix it would have been nicer to remove the wrapping `<div>` altogether and just add the classes to the `<Link>`, but this messed up the formatting...)

<img width="713" height="369" alt="image" src="https://github.com/user-attachments/assets/b70f9a4b-2997-4907-b5b2-4e16e35a15f7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected navigation sidebar group toggle to properly alternate between open and closed states instead of always expanding.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->