### PR TITLE
Fix: "Unset" surface variable "breaks" equipment

### DIFF
--- a/companion/lib/Internal/Surface.ts
+++ b/companion/lib/Internal/Surface.ts
@@ -155,6 +155,14 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 		this.#controlsController = controlsController
 		this.#pageStore = pageStore
 
+		setImmediate(() => {
+			this.emit('setVariables', {
+				't-bar': 0,
+				jog: 0,
+				shuttle: 0,
+			})
+		})
+
 		const debounceUpdateVariableDefinitions = debounceFn(() => this.emit('regenerateVariables'), {
 			maxWait: 100,
 			wait: 20,
@@ -248,7 +256,20 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 	}
 
 	getVariableDefinitions(): VariableDefinitionTmp[] {
-		const variables: VariableDefinitionTmp[] = []
+		const variables: VariableDefinitionTmp[] = [
+			{
+				label: 'Legacy T-bar position (deprecated)',
+				name: 't-bar',
+			},
+			{
+				label: 'Legacy Shuttle position (deprecated)',
+				name: 'shuttle',
+			},
+			{
+				label: 'Legacy Jog position (deprecated)',
+				name: 'jog',
+			},
+		]
 
 		const surfaceInfos = this.#surfaceController.getDevicesList()
 		for (const surfaceGroup of surfaceInfos) {

--- a/companion/lib/Surface/Handler.ts
+++ b/companion/lib/Surface/Handler.ts
@@ -261,6 +261,7 @@ export class SurfaceHandler extends EventEmitter<SurfaceHandlerEvents> {
 		this.panel.on('pincodeKey', this.#onDevicePincodeKey.bind(this))
 		this.panel.on('remove', this.#onDeviceRemove.bind(this))
 		this.panel.on('resized', this.#onDeviceResized.bind(this))
+		this.panel.on('setVariable', this.#onSetVariable.bind(this))
 		this.panel.on('setCustomVariable', this.#onSetCustomVariable.bind(this))
 
 		setImmediate(() => {
@@ -668,6 +669,14 @@ export class SurfaceHandler extends EventEmitter<SurfaceHandlerEvents> {
 				},
 			])
 		}
+	}
+
+	/**
+	 * Set the value of a variable
+	 */
+	#onSetVariable(name: string, value: CompanionVariableValue): void {
+		name = name.replace(/^internal:/, '')
+		this.#variables.values.setVariableValues('internal', [{ id: name, value: value }])
 	}
 
 	/**

--- a/companion/lib/Surface/Types.ts
+++ b/companion/lib/Surface/Types.ts
@@ -76,6 +76,7 @@ export interface SurfacePanelEvents {
 	changePage: [forward: boolean]
 	pincodeKey: [key: number]
 
+	setVariable: [variableId: string, value: CompanionVariableValue]
 	setCustomVariable: [variableId: string, value: CompanionVariableValue]
 
 	resized: []

--- a/companion/lib/Surface/USB/ContourShuttle.ts
+++ b/companion/lib/Surface/USB/ContourShuttle.ts
@@ -235,14 +235,14 @@ export class SurfaceUSBContourShuttle extends EventEmitter<SurfacePanelEvents> i
 			}
 
 			//console.log(`Jog position has changed`, delta)
-			const jogVariableName = this.config.jogValueVariable
-			if (jogVariableName) {
-				this.#logger.debug(`Setting jog variable ${jogVariableName} to ${delta}`)
-				this.emit('setCustomVariable', jogVariableName, delta)
-				setTimeout(() => {
-					this.emit('setCustomVariable', jogVariableName, 0)
-				}, 20)
-			}
+			const useCustom = !!this.config.jogValueVariable
+			const jogVariableName = useCustom ? this.config.jogValueVariable : 'internal:jog'
+			const setVariableCmd = useCustom ? 'setCustomVariable' : 'setVariable'
+			this.#logger.debug(`Setting jog variable ${jogVariableName} to ${delta}`)
+			this.emit(setVariableCmd, jogVariableName, delta)
+			setTimeout(() => {
+				this.emit(setVariableCmd, jogVariableName, 0)
+			}, 20)
 
 			this.emit('rotate', ...xy, delta == 1)
 		})
@@ -266,11 +266,11 @@ export class SurfaceUSBContourShuttle extends EventEmitter<SurfacePanelEvents> i
 			}
 
 			// do this before emitting any events:
-			const shuttleVariableName = this.config.shuttleValueVariable
-			if (shuttleVariableName) {
-				this.#logger.debug(`Setting shuttle variable ${shuttleVariableName} to ${shuttle}`)
-				this.emit('setCustomVariable', shuttleVariableName, shuttle)
-			}
+			const useCustom = !!this.config.shuttleValueVariable
+			const shuttleVariableName = useCustom ? this.config.shuttleValueVariable : 'internal:shuttle'
+			const setVariableCmd = useCustom ? 'setCustomVariable' : 'setVariable'
+			this.#logger.debug(`Setting shuttle variable ${shuttleVariableName} to ${shuttle}`)
+			this.emit(setVariableCmd, shuttleVariableName, shuttle)
 
 			// Direction of rotation events (true triggers "rotate-right") is different than for knobs
 			// because the ring has limited travel and always springs back to zero. In typical usage,

--- a/companion/lib/Surface/USB/Loupedeck.ts
+++ b/companion/lib/Surface/USB/Loupedeck.ts
@@ -164,13 +164,14 @@ export class SurfaceUSBLoupedeck extends EventEmitter<SurfacePanelEvents> implem
 				const touch = data.changedTouches.find(
 					(touch) => touch.target.screen == LoupedeckDisplayId.Right || touch.target.screen == LoupedeckDisplayId.Left
 				)
-				if (touch && touch.target.screen == LoupedeckDisplayId.Right && this.config.rightFaderValueVariable) {
+				if (touch && touch.target.screen == LoupedeckDisplayId.Right) {
 					const val = Math.min(touch.y + 7, 256) // map the touch screen height of 270 to 256 by capping top and bottom 7 pixels
-					this.emit(
-						'setCustomVariable',
-						this.config.rightFaderValueVariable,
-						this.config.invertFaderValues ? 256 - val : val
-					)
+
+					const useCustom = !!this.config.rightFaderValueVariable
+					const tbarVariableName = useCustom ? this.config.rightFaderValueVariable : 'internal:t-bar'
+					const setVariableCmd = useCustom ? 'setCustomVariable' : 'setVariable'
+					this.emit(setVariableCmd, tbarVariableName, this.config.invertFaderValues ? 256 - val : val)
+
 					this.DisplayColors.RightValue = val
 					if (this.config.invertFaderValues) {
 						// Draw from bottom → up
@@ -197,13 +198,14 @@ export class SurfaceUSBLoupedeck extends EventEmitter<SurfacePanelEvents> implem
 								this.#logger.error('Drawing right fader value ' + touch.y + ' to loupedeck failed: ' + e)
 							})
 					}
-				} else if (touch && touch.target.screen == LoupedeckDisplayId.Left && this.config.leftFaderValueVariable) {
+				} else if (touch && touch.target.screen == LoupedeckDisplayId.Left) {
 					const val = Math.min(touch.y + 7, 256) // map the touch screen height of 270 to 256 by capping top and bottom 7 pixels
-					this.emit(
-						'setCustomVariable',
-						this.config.leftFaderValueVariable,
-						this.config.invertFaderValues ? 256 - val : val
-					)
+
+					const useCustom = !!this.config.leftFaderValueVariable
+					const shuttleVariableName = useCustom ? this.config.leftFaderValueVariable : 'internal:shuttle'
+					const setVariableCmd = useCustom ? 'setCustomVariable' : 'setVariable'
+					this.emit(setVariableCmd, shuttleVariableName, this.config.invertFaderValues ? 256 - val : val)
+
 					this.DisplayColors.LeftValue = val
 					if (this.config.invertFaderValues) {
 						// Draw from bottom → up

--- a/companion/lib/Surface/USB/XKeys.ts
+++ b/companion/lib/Surface/USB/XKeys.ts
@@ -172,13 +172,14 @@ export class SurfaceUSBXKeys extends EventEmitter<SurfacePanelEvents> implements
 		if (panel.info.hasJog) {
 			this.info.configFields.push(jogConfigField)
 			this.#myXkeysPanel.on('jog', (index, deltaPos, metadata) => {
-				const jogVariableName = this.config.jogValueVariable
-				if (!jogVariableName) return
+				const useCustom = !!this.config.jogValueVariable
+				const jogVariableName = useCustom ? this.config.jogValueVariable : 'internal:jog'
+				const setVariableCmd = useCustom ? 'setCustomVariable' : 'setVariable'
 
 				this.#logger.silly(`Jog ${index} position has changed`, deltaPos, metadata)
-				this.emit('setCustomVariable', jogVariableName, deltaPos)
+				this.emit(setVariableCmd, jogVariableName, deltaPos)
 				setTimeout(() => {
-					this.emit('setCustomVariable', jogVariableName, 0)
+					this.emit(setVariableCmd, jogVariableName, 0)
 				}, 20)
 			})
 		}
@@ -187,11 +188,12 @@ export class SurfaceUSBXKeys extends EventEmitter<SurfacePanelEvents> implements
 		if (panel.info.hasShuttle) {
 			this.info.configFields.push(shuttleConfigField)
 			this.#myXkeysPanel.on('shuttle', (index, shuttlePos, metadata) => {
-				const shuttleVariableName = this.config.shuttleValueVariable
-				if (!shuttleVariableName) return
+				const useCustom = !!this.config.shuttleValueVariable
+				const shuttleVariableName = useCustom ? this.config.shuttleValueVariable : 'internal:shuttle'
+				const setVariableCmd = useCustom ? 'setCustomVariable' : 'setVariable'
 
 				this.#logger.silly(`Shuttle ${index} position has changed`, shuttlePos, metadata)
-				this.emit('setCustomVariable', shuttleVariableName, shuttlePos)
+				this.emit(setVariableCmd, shuttleVariableName, shuttlePos)
 			})
 		}
 		// Listen to joystick changes:
@@ -206,11 +208,12 @@ export class SurfaceUSBXKeys extends EventEmitter<SurfacePanelEvents> implements
 			this.info.configFields.push(tbarConfigField)
 			// Listen to t-bar changes:
 			this.#myXkeysPanel.on('tbar', (index, position, metadata) => {
-				const tbarVariableName = this.config.tbarValueVariable
-				if (!tbarVariableName) return
+				const useCustom = !!this.config.tbarValueVariable
+				const tbarVariableName = useCustom ? this.config.tbarValueVariable : 'internal:t-bar'
+				const setVariableCmd = useCustom ? 'setCustomVariable' : 'setVariable'
 
 				this.#logger.silly(`T-bar ${index} position has changed`, position, metadata)
-				this.emit('setCustomVariable', tbarVariableName, position)
+				this.emit(setVariableCmd, tbarVariableName, position)
 			})
 		}
 	}


### PR DESCRIPTION
Companion v4.2 eliminated the internal jog/shuttle/t-bar variables in favor of user-specified custom variables. While this is a clear improvement in behavior, the default of "none" (no variable) causes "null" values to be sent to my mixer, which caused it to fail internally (needed reboot to restore full functionality).

This PR restores the now-deprecated internal variables in the case that 'none' is selected, so that it becomes non-breaking. (A very minor side-effect: a variable will always be set upon one of the surface events, even if 'none' is selected. Since this corresponds to the behavior in v4.1, it shouldn't be an issue.)

**Note that this PR is a hotfix for v4.2**: it restores v4.2 to be non-breaking (at least in this regard) as might be expected in SemVer....

If this PR is accepted, I will leave it to Julian to decide whether this should be implemented in v4.3 (i.e. `main`) as well, where surfaces are in independent modules. (And whether he wants me to do it!)

**Note 2**: I tested this on a Contour Shuttle and assume it will therefore work with the XKeys and Loupedecks as well.

**Note 3**: BlackmagicController is not reverted here because it was already using variables prior to v4.2