### PR TITLE
Fix invalid values being sent to a surface

### DIFF
--- a/companion/lib/Internal/Surface.ts
+++ b/companion/lib/Internal/Surface.ts
@@ -256,23 +256,7 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 	}
 
 	getVariableDefinitions(): VariableDefinition[] {
-		const variables: VariableDefinition[] = [
-			{
-				name: 't-bar',
-				description:
-					'DEPRECATED Legacy T-bar position. Value is never updated: link a custom variable in the surfaces page instead.',
-			},
-			{
-				name: 'shuttle',
-				description:
-					'DEPRECATED Legacy Shuttle position. Value is never updated: link a custom variable in the surfaces page instead.',
-			},
-			{
-				name: 'jog',
-				description:
-					'DEPRECATED Legacy Jog position. Value is never updated: link a custom variable in the surfaces page instead.',
-			},
-		]
+		const variables: VariableDefinition[] = []
 
 		const surfaceInfos = this.#surfaceController.getDevicesList()
 		for (const surfaceGroup of surfaceInfos) {


### PR DESCRIPTION
This restores the internal t-bar/jog/shuttle variables and marks them as deprecated. The variables are never updated but exist to prevent null values being sent to a surface.  See PR #3869 for details.

**NOTE: I am posting this as a convenience, not a nudge**! If you disagree with the proposal in [my comment on 3869](https://github.com/bitfocus/companion/pull/3869#issuecomment-3697186142) just ignore or close this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Legacy surface controls (t-bar, jog, shuttle) are now emitted and initialized immediately when the surface starts, ensuring these controls are defined and available for use right at startup. This improves reliability of control state on launch and prevents transient unavailability during initial setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->