### PR TITLE
feat: add experimental switch to remove sidebar help

### DIFF
--- a/webui/src/Layout/Sidebar.tsx
+++ b/webui/src/Layout/Sidebar.tsx
@@ -164,6 +164,11 @@ export const MySidebar = memo(function MySidebar() {
 	const { whatsNewModal, showWizard } = useContext(RootAppStoreContext)
 	const [unfoldable, setUnfoldable] = useLocalStorage('sidebar-foldable', false)
 
+	const [hideHelp, _setHideHelp] = useLocalStorage('hide_sidebar_help', false)
+	const [showCloud, _setShowCloud] = useLocalStorage('show_companion_cloud', '0')
+
+	const showHelpButtons = !hideHelp
+
 	const doToggle = useCallback(() => setUnfoldable((val) => !val), [setUnfoldable])
 
 	const whatsNewOpen = useCallback(() => whatsNewModal.current?.show(), [whatsNewModal])
@@ -224,9 +229,7 @@ export const MySidebar = memo(function MySidebar() {
 				</SidebarMenuItemGroup>
 				<SidebarMenuItem name="Import / Export" icon={faFileImport} path="/import-export" />
 				<SidebarMenuItem name="Log" icon={faClipboardList} path="/log" />
-				{window.localStorage.getItem('show_companion_cloud') === '1' && (
-					<SidebarMenuItem name="Cloud" icon={faCloud} path="/cloud" />
-				)}
+				{showCloud === '1' && <SidebarMenuItem name="Cloud" icon={faCloud} path="/cloud" />}
 				<SidebarMenuItemGroup name="Interactive Buttons" icon={faSquareCaretRight}>
 					<SidebarMenuItem name="Emulator" icon={null} path="/emulator" target="_blank" />
 					<SidebarMenuItem name="Web buttons" icon={null} path="/tablet" target="_blank" />
@@ -235,16 +238,18 @@ export const MySidebar = memo(function MySidebar() {
 			<div className="sidebar-bottom-shadow-container">
 				<div className="sidebar-bottom-shadow" />
 			</div>
-			<CSidebarNav className="nav-secondary border-top">
-				<SidebarMenuItem name="What's New" icon={faStar} onClick={whatsNewOpen} />
-				<SidebarMenuItem name="User Guide" icon={faInfo} path="/user-guide/" target="_blank" />
-				<SidebarMenuItemGroup name="Support" icon={faHeadset}>
-					<SidebarMenuItem name="Bugs & Features" icon={faBug} path="https://bfoc.us/fiobkz0yqs" target="_blank" />
-					<SidebarMenuItem name="Community Forum" icon={faUsers} path="https://bfoc.us/qjk0reeqmy" target="_blank" />
-					<SidebarMenuItem name="Slack Chat" icon={faComments} path="https://bfoc.us/ke7e9dqgaz" target="_blank" />
-					<SidebarMenuItem name="Donate" icon={faDollarSign} path="https://bfoc.us/ccfbf8wm2x" target="_blank" />
-				</SidebarMenuItemGroup>
-			</CSidebarNav>
+			{showHelpButtons && (
+				<CSidebarNav className="nav-secondary border-top">
+					<SidebarMenuItem name="What's New" icon={faStar} onClick={whatsNewOpen} />
+					<SidebarMenuItem name="User Guide" icon={faInfo} path="/user-guide/" target="_blank" />
+					<SidebarMenuItemGroup name="Support" icon={faHeadset}>
+						<SidebarMenuItem name="Bugs & Features" icon={faBug} path="https://bfoc.us/fiobkz0yqs" target="_blank" />
+						<SidebarMenuItem name="Community Forum" icon={faUsers} path="https://bfoc.us/qjk0reeqmy" target="_blank" />
+						<SidebarMenuItem name="Slack Chat" icon={faComments} path="https://bfoc.us/ke7e9dqgaz" target="_blank" />
+						<SidebarMenuItem name="Donate" icon={faDollarSign} path="https://bfoc.us/ccfbf8wm2x" target="_blank" />
+					</SidebarMenuItemGroup>
+				</CSidebarNav>
+			)}
 			<CSidebarHeader className="border-top d-none d-lg-flex sidebar-header-toggler">
 				<SidebarTogglerAndVersion doToggle={doToggle} />
 			</CSidebarHeader>

--- a/webui/src/UserConfig/Sections/ExperimentsConfig.tsx
+++ b/webui/src/UserConfig/Sections/ExperimentsConfig.tsx
@@ -3,20 +3,56 @@ import { CAlert, CFormSwitch } from '@coreui/react'
 import { observer } from 'mobx-react-lite'
 import { UserConfigHeadingRow } from '../Components/UserConfigHeadingRow.js'
 import type { UserConfigProps } from '../Components/Common.js'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons'
+import { InlineHelp } from '~/Components/InlineHelp.js'
+import { useLocalStorage } from 'usehooks-ts'
 
 export const ExperimentsConfig = observer(function ExperimentsConfig(_props: UserConfigProps) {
+	const [hideSidebarHelp, setHideSidebarHelp] = useLocalStorage('hide_sidebar_help', false)
+	const [showCloud, setShowCloud] = useLocalStorage('show_companion_cloud', '0')
+
 	return (
 		<>
 			<UserConfigHeadingRow label="Experiments" />
 
 			<tr>
 				<td colSpan={3}>
+					<p>
+						Please note that the following are saved to the local browser and may reset if you change the "GUI
+						Interface" address (hostname) in the launcher.
+					</p>
 					<CAlert color="danger">Do not touch these settings unless you know what you are doing!</CAlert>
 				</td>
 			</tr>
 
 			<tr>
-				<td>Use TouchBackend for Drag and Drop</td>
+				<td>
+					Hide the Sidebar Help Buttons{' '}
+					<InlineHelp help="All help is still accessible from the new help menu at the top-right, so this just frees up space in the sidebar. This option is stored in your browser, not the Companion database, so you set it once per browser.">
+						<FontAwesomeIcon icon={faQuestionCircle} size="lg" />
+					</InlineHelp>
+				</td>
+				<td>
+					<CFormSwitch
+						className="float-right"
+						color="success"
+						checked={hideSidebarHelp}
+						size="xl"
+						onChange={(e) => {
+							setHideSidebarHelp(e.currentTarget.checked)
+						}}
+					/>
+				</td>
+				<td>&nbsp;</td>
+			</tr>
+			<tr>
+				<td>
+					Use TouchBackend for Drag and Drop{' '}
+					<InlineHelp help="Allow touch gestures to trigger drag-and-drop. It works but is a bit buggy, visually. This option is stored in your browser, not the Companion database, so you set it once per browser.">
+						<FontAwesomeIcon icon={faQuestionCircle} size="lg" />
+					</InlineHelp>
+				</td>
 				<td>
 					<CFormSwitch
 						className="float-right"
@@ -32,16 +68,21 @@ export const ExperimentsConfig = observer(function ExperimentsConfig(_props: Use
 				<td>&nbsp;</td>
 			</tr>
 			<tr>
-				<td>Companion Cloud Tab (Deprecated)</td>
+				<td>
+					Companion Cloud Tab (Deprecated){' '}
+					<InlineHelp help="This is a paid service that we anticipate being replaced by buttons. Consider using Companion Satellite as an alternative. This option is stored in your browser, not the Companion database, so you set it once per browser.">
+						<FontAwesomeIcon icon={faQuestionCircle} size="lg" />
+					</InlineHelp>
+				</td>
 				<td>
 					<CFormSwitch
 						className="float-right"
 						color="success"
-						checked={window.localStorage.getItem('show_companion_cloud') === '1'}
+						checked={showCloud === '1'}
 						size="xl"
 						onChange={(e) => {
-							window.localStorage.setItem('show_companion_cloud', e.currentTarget.checked ? '1' : '0')
-							window.location.reload()
+							setShowCloud(e.currentTarget.checked ? '1' : '0')
+							//window.location.reload()
 						}}
 					/>
 				</td>


### PR DESCRIPTION
The help buttons are now available on the heading-bar help menu, so this PR gives the option to free up space on the sidebar. (It makes a pretty big difference, especially with Settings open, which almost always ends up requiring the scrollbar when the help buttons are there.)

Also add a little context-help to the other experimental options -- please feel free to edit the text if you like the idea but not the wording.

<img width="567" height="143" alt="image" src="https://github.com/user-attachments/assets/d4f2ad0d-f731-427b-8035-beb375f7c7fe" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable option to hide sidebar help buttons (What's New, User Guide, Support).

* **Improvements**
  * Sidebar and Cloud settings now persist per browser.
  * Companion Cloud section updated with deprecation information.
  * Removed automatic page reload when toggling Cloud settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->