### PR TITLE
fix dom errors in triggers edit panel

### DIFF
--- a/webui/src/Triggers/EditPanel.tsx
+++ b/webui/src/Triggers/EditPanel.tsx
@@ -165,18 +165,15 @@ function TriggerConfig({ controlId, options }: TriggerConfigProps) {
 
 	return (
 		<CCol sm={12} className="p-0">
-			<CForm onSubmit={PreventDefaultHandler}>
-				<CForm className="row flex-form">
-					<CCol xs={12}>
-						<CFormLabel>Name</CFormLabel>
-						<p>
-							<CInputGroup>
-								<TextInputField setValue={setName} value={options.name} />
-								<TestActionsButton controlId={controlId} hidden={!options} />
-							</CInputGroup>
-						</p>
-					</CCol>
-				</CForm>
+			<CForm onSubmit={PreventDefaultHandler} className="row flex-form">
+				<CCol xs={12}>
+					<CFormLabel>Name</CFormLabel>
+					<br />
+					<CInputGroup>
+						<TextInputField setValue={setName} value={options.name} />
+						<TestActionsButton controlId={controlId} hidden={!options} />
+					</CInputGroup>
+				</CCol>
 			</CForm>
 		</CCol>
 	)


### PR DESCRIPTION
- Forms are not allowed to be nested
- `<div>` can't be nested inside `<p>` or somesuch
- Also removes excessive vertical spacing between the Name input and Events.

The DOM errors show up in the browser console with `yarn dev:webui`. I see the nested `<form>`s and extra spacing in the 4.2.2 release, so am guessing that webpack doesn't clean it up, though the console doesn't report the DOM errors, perhaps because it's in production mode?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Streamlined the trigger configuration editing panel interface by reorganizing and simplifying the layout structure. Removed unnecessary wrapper elements to enhance visual clarity, improve presentation, and create a cleaner, more polished appearance with an optimized user experience for configuring triggers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->