### PR TITLE
fix: added TMPDIR to preserved env vars list

### DIFF
--- a/companion/lib/Instance/Environment.ts
+++ b/companion/lib/Instance/Environment.ts
@@ -17,6 +17,7 @@ export function PreserveEnvVars(): Record<string, string> {
 		'USERPROFILE',
 		'TMP',
 		'TEMP',
+		'TMPDIR',
 
 		// Companion settings that are relevant to modules
 		'DISABLE_IPV6',


### PR DESCRIPTION
It was recently discovered in https://github.com/bitfocus/companion-module-discord-api/issues/51 that on a Mac a Discord IPC connection relies on `$TMPDIR/discord-ipc-0` as the module connects to the Discord client on the Companion machine itself so this PR adds this env var to the preserved list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The TMPDIR environment variable is now properly preserved and passed to child processes when defined, ensuring compatibility with systems that rely on custom temporary directory configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->