### PR TITLE
feat: refine styling/navbar links and CSS in general (core companion)

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -22,6 +22,7 @@
 	--ifm-navbar-link-color: white;
 	--ifm-navbar-link-hover-color: white;
 
+	--companion-navbar-item-hover-bg: rgb(255 255 255 / 20%);
 	--companion-active-tab-color: var(--ifm-font-color-base);
 	--companion-active-tab-bg: white;
 	--companion-active-tab-shadow-color: rgb(0 0 0 / 10%);
@@ -72,8 +73,7 @@
         Since we're clipping the left-container, the bottom-border needn't be precise -- as long as it's big enough.
    note 3: ":not(:last-child)" is to prevent tab-highlighting in the app-packaged docs, where there are no tabs.
    */
-.theme-layout-navbar-left .navbar__link,
-.theme-layout-navbar-left .navbar__brand:not(:last-child) {
+.theme-layout-navbar-left .navbar__link {
 	--vertical-padding: 0.5rem; /* make up for the reduced line-height */
 	--margin-bottom: calc(-1 * var(--ifm-navbar-height) / 2); /* move the button down to create the tab-like effect */
 	text-align: center; /* keep labels horizontally centered when they become two lines */
@@ -89,16 +89,8 @@
 	border-radius: 0.5rem 0.5rem 0 0;
 }
 
-.theme-layout-navbar-left .navbar__brand:not(:last-child) {
-	--vertical-padding: 0.1rem;
-	padding-left: 0.25rem;
-	padding-right: 0.25rem;
-	margin-right: 0.5rem; /* split the default 1rem with the padding 0.25 on each side */
-}
-
 /* Make the active link look a like a page-tab (like a browser tab or VS Code editor tabs) */
-.theme-layout-navbar-left .navbar__link--active,
-.theme-layout-navbar-left:not(:has(> .navbar__link--active)) > .navbar__brand:not(:last-child) {
+.theme-layout-navbar-left .navbar__link--active {
 	color: var(--companion-active-tab-color);
 	background-color: var(--companion-active-tab-bg);
 	/* Give the tab a glow  */
@@ -113,10 +105,13 @@
 	Note: ".navbar__item.navbar__link" excludes dropdown menus, which by default do not highlight, possibly due to dropdown--hoverable
 	*/
 .navbar__item.navbar__link:hover:not(.navbar__link--active),
-.navbar-sidebar__brand:hover,
-.navbar__brand:hover:not(:last-child),
 .navbar__toggle:hover {
-	background-color: rgb(255 255 255 / 20%);
+	background-color: var(--companion-navbar-item-hover-bg);
+}
+
+.navbar__brand:hover,
+.navbar-sidebar__close:hover {
+	opacity: 85%;
 }
 
 /* Make the dark/light mode button stand out better.
@@ -159,7 +154,7 @@
 		.fontawesome {
 			height: 1.5em;
 			width: auto;
-			/* for some reason we don't need "display: block" here. maybe flex handles it? */
+			/* "display: block" not needed here — flex container eliminates the inline spacing below the SVG */
 		}
 
 		.fontawesome-text {


### PR DESCRIPTION
The documentation has a number of style issues such as the navbar title not changing on hover and the "pull-down" version of the sidebar having poor visibility (particularly in light mode) and a red background.

This commit fixes it all by copying (my enhanced) custom.css from the website repo. While not all of the CSS is relevant here, keeping the file identical across the repos simplifies maintenance and could be useful in the future.

An added feature is making group boundaries more distinct.

Note: CodeRabbit's statement "Redesigned navbar with tab-like appearance and improved visual hierarchy" is not strictly correct, since there are no navbar tabs in the packaged documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Companion-themed navbar now displays as tab-like elements with rounded tops, glow/shadow, offset bottoms, improved two-line label handling, and refined hover/toggle/brand states.
  * Expanded light/dark tokens for active tabs, pulldown/sidebar, mode-toggle and border colors; overflow-safe spacing and continuity for tabs.
  * Pulldown/sidebar updated to companion palette; top-brand area, grouped items, collapsed sections gain borders, radii, shadows, and left-aligned carets.
  * Improved submenu/sublist and H2 indentation, responsive behavior, and TOC heading link contrast.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->