### PR TITLE
define insufficient_permissions status

### DIFF
--- a/companion/lib/Instance/Status.ts
+++ b/companion/lib/Instance/Status.ts
@@ -83,6 +83,10 @@ export class InstanceStatus extends EventEmitter<InstanceStatusEvents> {
 				category = 'warning'
 				level = 'Authentication Failure'
 				break
+			case 'insufficient_permissions':
+				category = 'warning'
+				level = 'Insufficient Permissions'
+				break
 			case 'system':
 				category = 'error'
 				break


### PR DESCRIPTION
Ties to [this PR](https://github.com/bitfocus/companion-module-base/pull/194) for `companion-module-base`.

New status enum to communicate when connection has been run without the permissions required to complete a task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added handling for insufficient permissions status, now displayed as a warning when the instance lacks required access levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->