### PR TITLE
feat: center images in docs (markdown) by default

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -294,7 +294,7 @@
 	font-size: 1.25em;
 }
 
-.markdown p > img:last-child {
+.markdown img:last-child {
 	display: block;
 	margin-left: auto;
 	margin-right: auto;


### PR DESCRIPTION
(Syncs with website.)

This improves readability and simplifies some cases. (A complete search of the repo did not reveal any cases in which this breaks the current text-flow, i.e. by breaking up a single line.)

Note a nice side-effect is that the image will always appear on its own line. (If you need to override this, it should be possible with inline html/style.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Markdown images in documentation are now centered (the final image in a markdown block is rendered as a centered block). This improves visual balance and consistency across docs pages, especially for tutorials and guides that include illustrative images, making content easier to read and more polished.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->