### PR TITLE
fix one more rabbit context-menu nitpick

### DIFF
--- a/webui/src/Layout/Sidebar.tsx
+++ b/webui/src/Layout/Sidebar.tsx
@@ -213,7 +213,7 @@ export const MySidebar = memo(function MySidebar() {
 
 	const smartExpand = useCallback(
 		(setter: (val: boolean) => void, expand: boolean) => {
-			if (accordionMode) expandAllGroups(false)
+			if (accordionMode && expand) expandAllGroups(false)
 			setter(expand)
 		},
 		[accordionMode, expandAllGroups]


### PR DESCRIPTION
- only collapse others in accordion mode if opening a group

(note this does mean that if many groups were open before starting accordion mode, closing one won't close the others. It's probably the correct behavior -- either way is an odd edge-case.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined sidebar accordion behavior. Groups now collapse only when expanding a new item in accordion mode, rather than collapsing all groups whenever accordion mode is toggled. This provides the expected accordion functionality and improves navigation experience in the sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->