### PR TITLE
fix: change debounce library for consistency

### DIFF
--- a/webui/src/Components/ColorPicker/context/useColor.tsx
+++ b/webui/src/Components/ColorPicker/context/useColor.tsx
@@ -1,4 +1,4 @@
-import { debounce } from 'lodash-es'
+import debounceFn from 'debounce-fn'
 import React, { type Context, createContext, useContext, useEffect, useMemo } from 'react'
 import type { Color, ColorResult, HexColor, HsvColor, RgbColor } from '../colors'
 import { ColorsStore } from './store'
@@ -53,7 +53,7 @@ export function ColorProvider({
 	}, [store, passedColor])
 
 	const handler = (fn: any, data: any, event: any) => fn(data, event)
-	const debouncedChangeHandler = useMemo(() => debounce(handler, 100), [])
+	const debouncedChangeHandler = useMemo(() => debounceFn(handler, { wait: 100 }), [])
 
 	const contextValue = useMemo<ColorContextType>(
 		() => ({


### PR DESCRIPTION
This is just a suggestion in case the usage was unintentional:

`useColor` is the only file that uses `lodash debounce`, so this PR changes it to `debounce-fn` for consistency with the rest of the codebase. It should have no material effect.

(There are also two places that use `p-debounce`, but presumably that's actually necessary...)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved color picker dependency management for better performance optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->