### PR TITLE
chore: fix `yarn dev:docs` startup message

### DIFF
--- a/tools/webui-dev-docs.mts
+++ b/tools/webui-dev-docs.mts
@@ -86,7 +86,7 @@ if (await isPortInUse(4000, docusaurusHost)) {
 	}
 }
 
-console.log(`Starting Vite and Docusaurus...`)
+console.log(`Starting Vite${skipDocusaurus ? '' : ' and Docusaurus'}...`)
 if (normalizedBase) console.log(`Base path: ${normalizedBase}`)
 console.log(`yarn workspace @companion-app/webui dev ${viteArgs} --clearScreen false`)
 if (!skipDocusaurus) {


### PR DESCRIPTION
- don't say "starting vite _**and docusaurus**_" if skipping docusaurus!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved accuracy of startup status messages to reflect whether all services are being initialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->