### PR TITLE
Expose http port based on ENV variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ ENV COMPANION_ADMIN_PORT=8000
 
 USER companion
 # Export ports for web, Satellite API and WebSocket (Elgato Plugin)
-EXPOSE 8000 16622 16623 28492
+EXPOSE COMPANION_ADMIN_PORT 16622 16623 28492
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD [ "sh", "-c", "curl -fSsq http://localhost:${COMPANION_ADMIN_PORT:-8000}/" ]


### PR DESCRIPTION
Now that the http port is defined by an environment variable, we need to expose the http port based on this variable as well. If there are any other reasons to keep port 8000 open, perhaps we should just add COMPANION_ADMIN_PORT to the list of ports to expose rather than replace the hardcoded port 8000?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker configuration to use an environment variable for admin port mapping, enabling flexible port configuration without rebuilding the image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->