### PR TITLE
feat: convert value when toggling between expression and raw mode #4087

### DIFF
--- a/shared-lib/lib/Expression/ExpressionParse.ts
+++ b/shared-lib/lib/Expression/ExpressionParse.ts
@@ -5,6 +5,7 @@ import jsepTemplateLiteral, { type TemplateLiteral } from '@jsep-plugin/template
 import jsepComments from '@jsep-plugin/comment'
 import { CompanionVariablesPlugin, type CompanionVariableExpression } from './Plugins/CompanionVariables.js'
 import { AssignmentPlugin, type AssignmentExpression, type UpdateExpression } from './Plugins/Assignment.js'
+import type { JsonValue } from 'type-fest'
 
 // setup plugins
 jsep.plugins.register(jsepNumbers)
@@ -27,6 +28,68 @@ export function ParseExpression(expression: string): SomeExpressionNode {
 	fixupExpression(parsed)
 
 	return parsed
+}
+
+/**
+ * Convert a JSON value to an expression literal string that round-trips cleanly.
+ * Strings are quoted, numbers/booleans are stringified, null/undefined become 'null'.
+ */
+export function valueToExpressionLiteral(value: JsonValue | undefined): string {
+	if (value === null || value === undefined) return 'null'
+	if (typeof value === 'string') return JSON.stringify(value)
+	if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+	return JSON.stringify(value)
+}
+
+/**
+ * Try to extract the raw JSON value from an expression that is a plain value definition
+ * (a literal, a negative/positive number, an array or object of plain values).
+ * Returns { value } if plain (no modal needed), or null if the expression is lossy
+ * (involves computation, variable references, etc.) and a confirmation modal should be shown.
+ */
+export function tryExtractExpressionPlainValue(node: SomeExpressionNode): { value: JsonValue } | null {
+	if (node.type === 'Literal') {
+		// jsep Literal values are string | number | boolean | null (undefined is patched in by fixupExpression)
+		return { value: node.value as JsonValue }
+	}
+
+	if (
+		node.type === 'UnaryExpression' &&
+		(node.operator === '-' || node.operator === '+') &&
+		node.argument.type === 'Literal'
+	) {
+		const argValue = (node.argument as jsep.Literal).value
+		if (typeof argValue === 'number') {
+			return { value: node.operator === '-' ? -argValue : +argValue }
+		}
+		return null
+	}
+
+	if (node.type === 'ArrayExpression') {
+		const values: JsonValue[] = []
+		for (const element of node.elements) {
+			if (!element) return null
+			const extracted = tryExtractExpressionPlainValue(element as SomeExpressionNode)
+			if (extracted === null) return null
+			values.push(extracted.value)
+		}
+		return { value: values }
+	}
+
+	if (node.type === 'ObjectExpression') {
+		const result: Record<string, JsonValue> = {}
+		for (const prop of node.properties) {
+			if (!prop.value) return null
+			const keyNode = prop.key as jsep.Literal
+			if (keyNode.type !== 'Literal' || typeof keyNode.value !== 'string') return null
+			const extracted = tryExtractExpressionPlainValue(prop.value as SomeExpressionNode)
+			if (extracted === null) return null
+			result[keyNode.value] = extracted.value
+		}
+		return { value: result }
+	}
+
+	return null
 }
 
 /**

--- a/shared-lib/lib/__tests__/expressions-parse.test.ts
+++ b/shared-lib/lib/__tests__/expressions-parse.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { ParseExpression, FindAllReferencedVariables } from '../Expression/ExpressionParse.js'
+import {
+	ParseExpression,
+	FindAllReferencedVariables,
+	tryExtractExpressionPlainValue,
+} from '../Expression/ExpressionParse.js'
 
 function ParseExpression2(str: string) {
 	const node = ParseExpression(str)
@@ -1126,6 +1130,124 @@ describe('parser', () => {
 				},
 				variableIds: [],
 			})
+		})
+	})
+})
+
+describe('tryExtractExpressionPlainValue', () => {
+	describe('plain values (should return extracted value)', () => {
+		it('string literal', () => {
+			expect(tryExtractExpressionPlainValue(ParseExpression('"major"'))).toEqual({ value: 'major' })
+		})
+
+		it('number literal', () => {
+			expect(tryExtractExpressionPlainValue(ParseExpression('42'))).toEqual({ value: 42 })
+		})
+
+		it('zero', () => {
+			expect(tryExtractExpressionPlainValue(ParseExpression('0'))).toEqual({ value: 0 })
+		})
+
+		it('float literal', () => {
+			expect(tryExtractExpressionPlainValue(ParseExpression('3.14'))).toEqual({ value: 3.14 })
+		})
+
+		it('boolean true', () => {
+			expect(tryExtractExpressionPlainValue(ParseExpression('true'))).toEqual({ value: true })
+		})
+
+		it('boolean false', () => {
+			expect(tryExtractExpressionPlainValue(ParseExpression('false'))).toEqual({ value: false })
+		})
+
+		it('null', () => {
+			expect(tryExtractExpressionPlainValue(ParseExpression('null'))).toEqual({ value: null })
+		})
+
+		it('negative number', () => {
+			expect(tryExtractExpressionPlainValue(ParseExpression('-42'))).toEqual({ value: -42 })
+		})
+
+		it('positive unary on number', () => {
+			expect(tryExtractExpressionPlainValue(ParseExpression('+5'))).toEqual({ value: 5 })
+		})
+
+		it('simple array', () => {
+			expect(tryExtractExpressionPlainValue(ParseExpression('[1, "a", true]'))).toEqual({ value: [1, 'a', true] })
+		})
+
+		it('array with negative number', () => {
+			expect(tryExtractExpressionPlainValue(ParseExpression('[-42, 0]'))).toEqual({ value: [-42, 0] })
+		})
+
+		it('simple object', () => {
+			expect(tryExtractExpressionPlainValue(ParseExpression('{ key: "a" }'))).toEqual({ value: { key: 'a' } })
+		})
+
+		it('object with numeric value', () => {
+			expect(tryExtractExpressionPlainValue(ParseExpression('{ x: 1, y: -2 }'))).toEqual({ value: { x: 1, y: -2 } })
+		})
+
+		it('nested plain value', () => {
+			expect(tryExtractExpressionPlainValue(ParseExpression('[-42, { x: 1 }]'))).toEqual({ value: [-42, { x: 1 }] })
+		})
+
+		it('empty array', () => {
+			expect(tryExtractExpressionPlainValue(ParseExpression('[]'))).toEqual({ value: [] })
+		})
+
+		it('empty object', () => {
+			expect(tryExtractExpressionPlainValue(ParseExpression('{}'))).toEqual({ value: {} })
+		})
+	})
+
+	describe('lossy values (should return null)', () => {
+		it('binary expression: addition', () => {
+			expect(tryExtractExpressionPlainValue(ParseExpression('2 + 2'))).toBeNull()
+		})
+
+		it('binary expression: string concatenation', () => {
+			expect(tryExtractExpressionPlainValue(ParseExpression('"a" + "b"'))).toBeNull()
+		})
+
+		it('variable reference', () => {
+			expect(tryExtractExpressionPlainValue(ParseExpression('$(companion:time_hms)'))).toBeNull()
+		})
+
+		it('unary minus on variable', () => {
+			expect(tryExtractExpressionPlainValue(ParseExpression('-$(var:x)'))).toBeNull()
+		})
+
+		it('function call', () => {
+			expect(tryExtractExpressionPlainValue(ParseExpression('floor(3.7)'))).toBeNull()
+		})
+
+		it('conditional expression', () => {
+			expect(tryExtractExpressionPlainValue(ParseExpression('true ? 1 : 2'))).toBeNull()
+		})
+
+		it('array containing variable', () => {
+			expect(tryExtractExpressionPlainValue(ParseExpression('[$(var:x)]'))).toBeNull()
+		})
+
+		it('array containing expression', () => {
+			expect(tryExtractExpressionPlainValue(ParseExpression('[1 + 2]'))).toBeNull()
+		})
+
+		it('object with variable value', () => {
+			expect(tryExtractExpressionPlainValue(ParseExpression('{ key: $(var:x) }'))).toBeNull()
+		})
+
+		it('object with expression value', () => {
+			expect(tryExtractExpressionPlainValue(ParseExpression('{ key: 1 + 2 }'))).toBeNull()
+		})
+
+		it('identifier (not a keyword)', () => {
+			expect(tryExtractExpressionPlainValue(ParseExpression('major'))).toBeNull()
+		})
+
+		it('unary logical not', () => {
+			expect(tryExtractExpressionPlainValue(ParseExpression('!true'))).toBeNull()
 		})
 	})
 })

--- a/webui/src/Components/ExpressionConversionModal.tsx
+++ b/webui/src/Components/ExpressionConversionModal.tsx
@@ -56,6 +56,18 @@ export function ExpressionConversionModal({
 
 	const computedValueValidation = useMemo(() => {
 		if (!fieldDefinition || !displayData?.ok) return null
+
+		const { type } = fieldDefinition
+		// These types accept any value — no validation needed
+		if (
+			type === 'textinput' ||
+			type === 'secret-text' ||
+			type === 'static-text' ||
+			type === 'bonjour-device' ||
+			type === 'expression'
+		)
+			return null
+
 		return validateInputValue(fieldDefinition, displayData.value as JsonValue | undefined)
 	}, [fieldDefinition, displayData])
 

--- a/webui/src/Components/ExpressionConversionModal.tsx
+++ b/webui/src/Components/ExpressionConversionModal.tsx
@@ -63,7 +63,7 @@ export function ExpressionConversionModal({
 		if (!displayData.ok) {
 			return <span className="text-danger">Error: {displayData.error}</span>
 		}
-		return <VariableValueDisplay value={displayData.value} showCopy={false} onCopied={() => {}} />
+		return <VariableValueDisplay value={displayData.value} showCopy={false} onCopied={() => {}} forceExpanded />
 	}
 
 	return (
@@ -97,7 +97,7 @@ export function ExpressionConversionModal({
 				<CButton color="secondary" onClick={onCancel}>
 					Cancel
 				</CButton>
-				<CButton color="primary" onClick={doConfirm}>
+				<CButton color="primary" onClick={doConfirm} disabled={!displayData?.ok}>
 					Use computed value
 				</CButton>
 			</CModalFooter>

--- a/webui/src/Components/ExpressionConversionModal.tsx
+++ b/webui/src/Components/ExpressionConversionModal.tsx
@@ -7,6 +7,7 @@ import { VariableValueDisplay } from './VariableValueDisplay.js'
 import type { JsonValue } from 'type-fest'
 import type { SomeCompanionInputField } from '@companion-app/shared/Model/Options.js'
 import { validateInputValue } from '@companion-app/shared/ValidateInputValue.js'
+import { ExpressionInputField } from './ExpressionInputField.js'
 
 interface ExpressionConversionModalProps {
 	expression: string
@@ -58,9 +59,6 @@ export function ExpressionConversionModal({
 		return validateInputValue(fieldDefinition, displayData.value as JsonValue | undefined)
 	}, [fieldDefinition, displayData])
 
-	const hasValidationError = !!computedValueValidation?.validationError
-	const hasValidationWarnings = (computedValueValidation?.validationWarnings.length ?? 0) > 0
-
 	// The value to use when confirming — sanitised when validation ran, otherwise raw
 	const sanitisedValue =
 		computedValueValidation?.sanitisedValue ?? (displayData?.ok ? (displayData.value as JsonValue) : undefined)
@@ -76,27 +74,6 @@ export function ExpressionConversionModal({
 		onConfirm(defaultValue)
 	}, [onConfirm, defaultValue])
 
-	const computedValueDisplay = (): React.ReactNode => {
-		if (!displayData) {
-			if (!showSpinner) return <em>Evaluating&hellip;</em>
-			return <CSpinner size="sm" />
-		}
-		if (!displayData.ok) {
-			return <span className="text-danger">Error: {displayData.error}</span>
-		}
-		// Show the sanitised value if validation ran, otherwise the raw computed value
-		const displayValue = computedValueValidation ? computedValueValidation.sanitisedValue : displayData.value
-		return (
-			<VariableValueDisplay
-				value={displayValue}
-				showCopy={false}
-				onCopied={() => {}}
-				forceExpanded
-				invalidReason={computedValueValidation?.validationError}
-			/>
-		)
-	}
-
 	return (
 		<CModalExt visible onClose={onCancel} transition={false}>
 			<CModalHeader closeButton>
@@ -108,39 +85,48 @@ export function ExpressionConversionModal({
 				</CAlert>
 
 				<h6>Expression</h6>
-				<pre
-					style={{
-						whiteSpace: 'pre-wrap',
-						wordBreak: 'break-all',
-						maxHeight: '8em',
-						overflowY: 'auto',
-						padding: '0.5rem 0.75rem',
-						borderRadius: '0.25rem',
-						border: '1px solid var(--cui-border-color)',
-						background: 'var(--cui-tertiary-bg)',
-					}}
-				>
-					{expression}
-				</pre>
+				<ExpressionInputField value={expression} setValue={() => null} disabled />
+
 				<hr />
+
 				<h6>Computed value</h6>
-				{hasValidationError && (
-					<CAlert color="danger" className="mb-2 py-2">
-						{computedValueValidation?.validationError}
-					</CAlert>
-				)}
-				{computedValueDisplay()}
-				{!hasValidationError && hasValidationWarnings && (
-					<CAlert color="warning" className="mt-2 mb-0 py-2">
-						{computedValueValidation!.validationWarnings.join(', ')}
-					</CAlert>
+				{!displayData ? (
+					showSpinner ? (
+						<CSpinner size="sm" />
+					) : (
+						<em>Evaluating&hellip;</em>
+					)
+				) : !displayData.ok ? (
+					<span className="text-danger">Error: {displayData.error}</span>
+				) : (
+					<>
+						{!!computedValueValidation?.validationError && (
+							<CAlert color="danger" className="mb-2 py-2">
+								{computedValueValidation.validationError}
+							</CAlert>
+						)}
+						<VariableValueDisplay
+							value={
+								computedValueValidation ? computedValueValidation.sanitisedValue : (displayData.value as JsonValue)
+							}
+							showCopy={false}
+							onCopied={() => {}}
+							forceExpanded
+						/>
+						{!computedValueValidation?.validationError &&
+							(computedValueValidation?.validationWarnings.length ?? 0) > 0 && (
+								<CAlert color="warning" className="mt-2 mb-0 py-2">
+									{computedValueValidation!.validationWarnings.join(', ')}
+								</CAlert>
+							)}
+					</>
 				)}
 			</CModalBody>
 			<CModalFooter>
 				<CButton color="secondary" onClick={onCancel}>
 					Cancel
 				</CButton>
-				{hasValidationError ? (
+				{computedValueValidation?.validationError ? (
 					<CButton color="primary" onClick={doUseDefault} disabled={defaultValue === undefined}>
 						Use default value
 					</CButton>

--- a/webui/src/Components/ExpressionConversionModal.tsx
+++ b/webui/src/Components/ExpressionConversionModal.tsx
@@ -1,0 +1,106 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { CAlert, CButton, CModalBody, CModalFooter, CModalHeader, CSpinner } from '@coreui/react'
+import { useSubscription } from '@trpc/tanstack-react-query'
+import { trpc } from '~/Resources/TRPC.js'
+import { CModalExt } from './CModalExt.js'
+import { VariableValueDisplay } from './VariableValueDisplay.js'
+import type { JsonValue } from 'type-fest'
+
+interface ExpressionConversionModalProps {
+	expression: string
+	controlId: string | null
+	onConfirm: (value: JsonValue | undefined) => void
+	onCancel: () => void
+}
+
+export function ExpressionConversionModal({
+	expression,
+	controlId,
+	onConfirm,
+	onCancel,
+}: ExpressionConversionModalProps): React.JSX.Element {
+	const sub = useSubscription(
+		trpc.preview.expressionStream.watchExpression.subscriptionOptions(
+			{
+				controlId: controlId,
+				expression: expression,
+				isVariableString: false,
+			},
+			{}
+		)
+	)
+
+	// Keep the latest result in a ref so the confirm handler always uses it, not a stale closure value
+	type SubData = typeof sub.data
+	const latestDataRef = useRef<SubData>(sub.data)
+	if (sub.data) {
+		latestDataRef.current = sub.data
+	}
+
+	const [showSpinner, setShowSpinner] = useState(false)
+	useEffect(() => {
+		if (sub.data) {
+			setShowSpinner(false)
+			return
+		}
+		const timer = setTimeout(() => setShowSpinner(true), 200)
+		return () => clearTimeout(timer)
+	}, [sub.data])
+
+	const displayData = sub.data ?? latestDataRef.current
+
+	const doConfirm = useCallback(() => {
+		const data = latestDataRef.current
+		const value = data?.ok ? data.value : undefined
+		onConfirm(value as JsonValue | undefined)
+	}, [onConfirm])
+
+	const computedValueDisplay = (): React.ReactNode => {
+		if (!displayData) {
+			if (!showSpinner) return <em>Evaluating&hellip;</em>
+			return <CSpinner size="sm" />
+		}
+		if (!displayData.ok) {
+			return <span className="text-danger">Error: {displayData.error}</span>
+		}
+		return <VariableValueDisplay value={displayData.value} showCopy={false} onCopied={() => {}} />
+	}
+
+	return (
+		<CModalExt visible onClose={onCancel} transition={false}>
+			<CModalHeader closeButton>
+				<h5>Disable expression mode</h5>
+			</CModalHeader>
+			<CModalBody>
+				<CAlert color="info">This expression will be lost and replaced with the current computed value.</CAlert>
+
+				<h6>Expression</h6>
+				<pre
+					style={{
+						whiteSpace: 'pre-wrap',
+						wordBreak: 'break-all',
+						maxHeight: '8em',
+						overflowY: 'auto',
+						padding: '0.5rem 0.75rem',
+						borderRadius: '0.25rem',
+						border: '1px solid var(--cui-border-color)',
+						background: 'var(--cui-tertiary-bg)',
+					}}
+				>
+					{expression}
+				</pre>
+				<hr />
+				<h6>Computed value</h6>
+				{computedValueDisplay()}
+			</CModalBody>
+			<CModalFooter>
+				<CButton color="secondary" onClick={onCancel}>
+					Cancel
+				</CButton>
+				<CButton color="primary" onClick={doConfirm}>
+					Use computed value
+				</CButton>
+			</CModalFooter>
+		</CModalExt>
+	)
+}

--- a/webui/src/Components/ExpressionConversionModal.tsx
+++ b/webui/src/Components/ExpressionConversionModal.tsx
@@ -1,14 +1,17 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { CAlert, CButton, CModalBody, CModalFooter, CModalHeader, CSpinner } from '@coreui/react'
 import { useSubscription } from '@trpc/tanstack-react-query'
 import { trpc } from '~/Resources/TRPC.js'
 import { CModalExt } from './CModalExt.js'
 import { VariableValueDisplay } from './VariableValueDisplay.js'
 import type { JsonValue } from 'type-fest'
+import type { SomeCompanionInputField } from '@companion-app/shared/Model/Options.js'
+import { validateInputValue } from '@companion-app/shared/ValidateInputValue.js'
 
 interface ExpressionConversionModalProps {
 	expression: string
 	controlId: string | null
+	fieldDefinition?: SomeCompanionInputField
 	onConfirm: (value: JsonValue | undefined) => void
 	onCancel: () => void
 }
@@ -16,6 +19,7 @@ interface ExpressionConversionModalProps {
 export function ExpressionConversionModal({
 	expression,
 	controlId,
+	fieldDefinition,
 	onConfirm,
 	onCancel,
 }: ExpressionConversionModalProps): React.JSX.Element {
@@ -49,11 +53,28 @@ export function ExpressionConversionModal({
 
 	const displayData = sub.data ?? latestDataRef.current
 
+	const computedValueValidation = useMemo(() => {
+		if (!fieldDefinition || !displayData?.ok) return null
+		return validateInputValue(fieldDefinition, displayData.value as JsonValue | undefined)
+	}, [fieldDefinition, displayData])
+
+	const hasValidationError = !!computedValueValidation?.validationError
+	const hasValidationWarnings = (computedValueValidation?.validationWarnings.length ?? 0) > 0
+
+	// The value to use when confirming — sanitised when validation ran, otherwise raw
+	const sanitisedValue =
+		computedValueValidation?.sanitisedValue ?? (displayData?.ok ? (displayData.value as JsonValue) : undefined)
+
+	const defaultValue =
+		fieldDefinition && 'default' in fieldDefinition ? (fieldDefinition.default as JsonValue) : undefined
+
 	const doConfirm = useCallback(() => {
-		const data = latestDataRef.current
-		const value = data?.ok ? data.value : undefined
-		onConfirm(value as JsonValue | undefined)
-	}, [onConfirm])
+		onConfirm(sanitisedValue)
+	}, [onConfirm, sanitisedValue])
+
+	const doUseDefault = useCallback(() => {
+		onConfirm(defaultValue)
+	}, [onConfirm, defaultValue])
 
 	const computedValueDisplay = (): React.ReactNode => {
 		if (!displayData) {
@@ -63,16 +84,28 @@ export function ExpressionConversionModal({
 		if (!displayData.ok) {
 			return <span className="text-danger">Error: {displayData.error}</span>
 		}
-		return <VariableValueDisplay value={displayData.value} showCopy={false} onCopied={() => {}} forceExpanded />
+		// Show the sanitised value if validation ran, otherwise the raw computed value
+		const displayValue = computedValueValidation ? computedValueValidation.sanitisedValue : displayData.value
+		return (
+			<VariableValueDisplay
+				value={displayValue}
+				showCopy={false}
+				onCopied={() => {}}
+				forceExpanded
+				invalidReason={computedValueValidation?.validationError}
+			/>
+		)
 	}
 
 	return (
 		<CModalExt visible onClose={onCancel} transition={false}>
 			<CModalHeader closeButton>
-				<h5>Disable expression mode</h5>
+				<h5>Convert to text mode</h5>
 			</CModalHeader>
 			<CModalBody>
-				<CAlert color="info">This expression will be lost and replaced with the current computed value.</CAlert>
+				<CAlert color="primary" className="py-2">
+					Do you want to replace the expression with its value? Warning: you will not be able to recover the expression!
+				</CAlert>
 
 				<h6>Expression</h6>
 				<pre
@@ -91,15 +124,31 @@ export function ExpressionConversionModal({
 				</pre>
 				<hr />
 				<h6>Computed value</h6>
+				{hasValidationError && (
+					<CAlert color="danger" className="mb-2 py-2">
+						{computedValueValidation?.validationError}
+					</CAlert>
+				)}
 				{computedValueDisplay()}
+				{!hasValidationError && hasValidationWarnings && (
+					<CAlert color="warning" className="mt-2 mb-0 py-2">
+						{computedValueValidation!.validationWarnings.join(', ')}
+					</CAlert>
+				)}
 			</CModalBody>
 			<CModalFooter>
 				<CButton color="secondary" onClick={onCancel}>
 					Cancel
 				</CButton>
-				<CButton color="primary" onClick={doConfirm} disabled={!displayData?.ok}>
-					Use computed value
-				</CButton>
+				{hasValidationError ? (
+					<CButton color="primary" onClick={doUseDefault} disabled={defaultValue === undefined}>
+						Use default value
+					</CButton>
+				) : (
+					<CButton color="primary" onClick={doConfirm} disabled={!displayData?.ok}>
+						Use computed value
+					</CButton>
+				)}
 			</CModalFooter>
 		</CModalExt>
 	)

--- a/webui/src/Components/FieldOrExpression.tsx
+++ b/webui/src/Components/FieldOrExpression.tsx
@@ -57,16 +57,22 @@ export const FieldOrExpression = observer(function FieldOrExpression({
 
 	const setIsExpression = useCallback(
 		(isExpression: boolean) => {
+			// For free-text fields, toggle mode directly — no literal wrapping or modal
+			if (fieldDefinition?.type === 'textinput' || fieldDefinition?.type === 'secret-text') {
+				setValue({ isExpression, value: stringifyVariableValue(value.value) ?? '' })
+				return
+			}
+
 			if (isExpression) {
 				setValue({
 					isExpression: true,
 					value: valueToExpressionLiteral(value.value),
 				})
 			} else {
+				const strValue = stringifyVariableValue(value.value) ?? ''
 				// If the expression is a plain value literal, extract it directly without a modal
-				const expressionStr = stringifyVariableValue(value.value) ?? ''
 				try {
-					const parsed = ParseExpression(expressionStr)
+					const parsed = ParseExpression(strValue)
 					const plain = tryExtractExpressionPlainValue(parsed)
 					if (plain !== null) {
 						// If we have a field definition, validate the extracted value against it.
@@ -86,7 +92,7 @@ export const FieldOrExpression = observer(function FieldOrExpression({
 				} catch {
 					// parse failed — fall through to modal
 				}
-				setPendingConversion(expressionStr)
+				setPendingConversion(strValue)
 			}
 		},
 		[setValue, value]

--- a/webui/src/Components/FieldOrExpression.tsx
+++ b/webui/src/Components/FieldOrExpression.tsx
@@ -5,7 +5,7 @@ import { useCallback, useState } from 'react'
 import { ExpressionInputField } from './ExpressionInputField'
 import type { LocalVariablesStore } from '~/Controls/LocalVariablesStore.js'
 import { observer } from 'mobx-react-lite'
-import type { ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
+import type { ExpressionOrValue, SomeCompanionInputField } from '@companion-app/shared/Model/Options.js'
 import type { EntityModelType } from '@companion-app/shared/Model/EntityModel.js'
 import { stringifyVariableValue } from '@companion-app/shared/Model/Variables.js'
 import {
@@ -13,6 +13,7 @@ import {
 	tryExtractExpressionPlainValue,
 	valueToExpressionLiteral,
 } from '@companion-app/shared/Expression/ExpressionParse.js'
+import { validateInputValue } from '@companion-app/shared/ValidateInputValue.js'
 import { ExpressionConversionModal } from './ExpressionConversionModal.js'
 import type { JsonValue } from 'type-fest'
 
@@ -27,6 +28,8 @@ interface FieldOrExpressionProps {
 	entityType: EntityModelType | null
 	isLocatedInGrid: boolean
 
+	fieldDefinition?: SomeCompanionInputField
+
 	children: React.ReactNode
 }
 export const FieldOrExpression = observer(function FieldOrExpression({
@@ -37,6 +40,7 @@ export const FieldOrExpression = observer(function FieldOrExpression({
 	controlId,
 	entityType,
 	isLocatedInGrid,
+	fieldDefinition,
 	children,
 }: FieldOrExpressionProps) {
 	const [pendingConversion, setPendingConversion] = useState<string | null>(null)
@@ -65,8 +69,19 @@ export const FieldOrExpression = observer(function FieldOrExpression({
 					const parsed = ParseExpression(expressionStr)
 					const plain = tryExtractExpressionPlainValue(parsed)
 					if (plain !== null) {
-						setValue({ isExpression: false, value: plain.value })
-						return
+						// If we have a field definition, validate the extracted value against it.
+						// If the value is invalid (e.g. true in a number field), fall through to modal.
+						if (fieldDefinition) {
+							const validation = validateInputValue(fieldDefinition, plain.value)
+							if (!validation.validationError && validation.validationWarnings.length === 0) {
+								setValue({ isExpression: false, value: plain.value })
+								return
+							}
+							// Invalid — fall through to modal
+						} else {
+							setValue({ isExpression: false, value: plain.value })
+							return
+						}
 					}
 				} catch {
 					// parse failed — fall through to modal
@@ -100,6 +115,7 @@ export const FieldOrExpression = observer(function FieldOrExpression({
 				<ExpressionConversionModal
 					expression={pendingConversion}
 					controlId={controlId}
+					fieldDefinition={fieldDefinition}
 					onConfirm={onConversionConfirm}
 					onCancel={onConversionCancel}
 				/>

--- a/webui/src/Components/FieldOrExpression.tsx
+++ b/webui/src/Components/FieldOrExpression.tsx
@@ -1,13 +1,19 @@
 import { CButton } from '@coreui/react'
 import { faFilter, faSquareRootVariable } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 import { ExpressionInputField } from './ExpressionInputField'
 import type { LocalVariablesStore } from '~/Controls/LocalVariablesStore.js'
 import { observer } from 'mobx-react-lite'
 import type { ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
 import type { EntityModelType } from '@companion-app/shared/Model/EntityModel.js'
 import { stringifyVariableValue } from '@companion-app/shared/Model/Variables.js'
+import {
+	ParseExpression,
+	tryExtractExpressionPlainValue,
+	valueToExpressionLiteral,
+} from '@companion-app/shared/Expression/ExpressionParse.js'
+import { ExpressionConversionModal } from './ExpressionConversionModal.js'
 import type { JsonValue } from 'type-fest'
 
 interface FieldOrExpressionProps {
@@ -15,6 +21,8 @@ interface FieldOrExpressionProps {
 	value: ExpressionOrValue<JsonValue | undefined>
 	setValue: (value: ExpressionOrValue<JsonValue | undefined>) => void
 	disabled: boolean
+
+	controlId: string | null
 
 	entityType: EntityModelType | null
 	isLocatedInGrid: boolean
@@ -26,10 +34,13 @@ export const FieldOrExpression = observer(function FieldOrExpression({
 	value,
 	setValue,
 	disabled,
+	controlId,
 	entityType,
 	isLocatedInGrid,
 	children,
 }: FieldOrExpressionProps) {
+	const [pendingConversion, setPendingConversion] = useState<string | null>(null)
+
 	const setExpression = useCallback(
 		(value: string) => {
 			setValue({
@@ -42,17 +53,26 @@ export const FieldOrExpression = observer(function FieldOrExpression({
 
 	const setIsExpression = useCallback(
 		(isExpression: boolean) => {
-			setValue(
-				isExpression
-					? {
-							isExpression: true,
-							value: stringifyVariableValue(value.value) ?? '',
-						}
-					: {
-							isExpression: false,
-							value: value.value,
-						}
-			)
+			if (isExpression) {
+				setValue({
+					isExpression: true,
+					value: valueToExpressionLiteral(value.value),
+				})
+			} else {
+				// If the expression is a plain value literal, extract it directly without a modal
+				const expressionStr = stringifyVariableValue(value.value) ?? ''
+				try {
+					const parsed = ParseExpression(expressionStr)
+					const plain = tryExtractExpressionPlainValue(parsed)
+					if (plain !== null) {
+						setValue({ isExpression: false, value: plain.value })
+						return
+					}
+				} catch {
+					// parse failed — fall through to modal
+				}
+				setPendingConversion(expressionStr)
+			}
 		},
 		[setValue, value]
 	)
@@ -62,8 +82,28 @@ export const FieldOrExpression = observer(function FieldOrExpression({
 		[setIsExpression, value.isExpression]
 	)
 
+	const onConversionConfirm = useCallback(
+		(computedValue: JsonValue | undefined) => {
+			setPendingConversion(null)
+			setValue({ isExpression: false, value: computedValue })
+		},
+		[setValue]
+	)
+
+	const onConversionCancel = useCallback(() => {
+		setPendingConversion(null)
+	}, [])
+
 	return (
 		<div className="field-with-expression">
+			{pendingConversion !== null && (
+				<ExpressionConversionModal
+					expression={pendingConversion}
+					controlId={controlId}
+					onConfirm={onConversionConfirm}
+					onCancel={onConversionCancel}
+				/>
+			)}
 			<div className="expression-field">
 				{value.isExpression ? (
 					<ExpressionInputField

--- a/webui/src/Controls/OptionsInputField.tsx
+++ b/webui/src/Controls/OptionsInputField.tsx
@@ -278,6 +278,7 @@ export const OptionsInputField = observer(function OptionsInputField({
 				value={rawExpressionValue}
 				setValue={(val) => setValue(option.id, val)}
 				disabled={!!readonly}
+				controlId={controlId ?? null}
 				entityType={entityType}
 				isLocatedInGrid={isLocatedInGrid}
 			>

--- a/webui/src/Controls/OptionsInputField.tsx
+++ b/webui/src/Controls/OptionsInputField.tsx
@@ -281,6 +281,7 @@ export const OptionsInputField = observer(function OptionsInputField({
 				controlId={controlId ?? null}
 				entityType={entityType}
 				isLocatedInGrid={isLocatedInGrid}
+				fieldDefinition={option}
 			>
 				{control}
 			</FieldOrExpression>


### PR DESCRIPTION
closes #4087

When toggling a field between expression and value mode, this will now explicitly convert it between the expression string and the value.

If it encounters a plain value, the field will be switched quietly, but if it contains an expression doing anything more than just a literal value/object, then it will show a modal to require confirmation before replacing the expression the user has written


Not 100% happy with the styling of the modal, but its better than nothing:

<img width="671" height="682" alt="image" src="https://github.com/user-attachments/assets/37a7a0be-e80a-45c5-8b66-4f3469d9bd29" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an expression-to-value conversion modal that evaluates expressions and lets users apply the computed value when switching from expression to value mode.
  * Field editing now attempts to auto-convert plain expression literals to values and prompts when needed.

* **Tests**
  * Added tests covering extraction of plain expression values and cases where conversion is not possible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->