### PR TITLE
fix: low contrast in browse-entities table

### DIFF
--- a/webui/src/scss/_collapsible-tree.scss
+++ b/webui/src/scss/_collapsible-tree.scss
@@ -6,13 +6,19 @@
 	border-collapse: collapse;
 	box-shadow: 0px 2px 21px -10px rgba(0, 0, 0, 0.2);
 	font-size: 1.05em;
-
 	--collapsible-tree-nesting-level: 0;
+
+	.modal-content & {
+		// fix color in the Browse Actions/Feedbacks window (AddEntitiesModal) or any modal
+		// override default --cui-modal-color = rgb(37 43 54 /0.95)
+		// unfortunately, we can't simply override that variable here because it sets "color:" on .modal, so we have to override color itself.
+		color: black;
+	}
 
 	.collapsible-tree-ungrouped-header {
 		background-color: #f0f0f0;
 		padding: 6px 10px;
-		padding-left: 20px;
+		//padding-left: 20px; // don't -- since this is not expandible, align it with the carets
 
 		border-bottom: 1px solid #ddd;
 
@@ -38,7 +44,6 @@
 
 		// Connection nodes get a slightly different style to stand out from collections
 		.collapsible-tree-connection-header {
-			color: #303030;
 			display: inline-flex;
 			justify-content: space-between;
 			align-items: center;


### PR DESCRIPTION
fixes #4100

override default CUI modal color.

Also reduce indent on "Ungrouped" header, so it's flush with the carets because it looks more natural.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved color consistency for collapsible tree headers through better style inheritance.
  * Enhanced visual appearance of collapsible trees displayed within modals to ensure proper color contrast.
  * Adjusted spacing alignment for tree headers to better match the caret-based layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->