### PR TITLE
fix: docusaurus aspect ratio on large images

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -308,13 +308,13 @@
 	font-size: 1.25em;
 }
 
-/* Docusaurus limits max-width to 100% but without the follow rule, the image will lose its aspect ratio if it is too wide */
+/* Docusaurus limits max-width to 100% but without the following rule, the image will lose its aspect ratio if it is too wide */
 .markdown img {
 	height: auto;
 }
 
 /* The following rule centers images on their own line. 
-    The reason for ":last-child" is to allow us to "inline" the image by placing an element after the image in the markdown text.
+   The reason for ":last-child" is to allow us to keep the image inline by placing an element after the image in the markdown document.
  */
 .markdown img:last-child {
 	display: block;

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -308,6 +308,14 @@
 	font-size: 1.25em;
 }
 
+/* Docusaurus limits max-width to 100% but without the follow rule, the image will lose its aspect ratio if it is too wide */
+.markdown img {
+	height: auto;
+}
+
+/* The following rule centers images on their own line. 
+    The reason for ":last-child" is to allow us to "inline" the image by placing an element after the image in the markdown text.
+ */
 .markdown img:last-child {
 	display: block;
 	margin-left: auto;


### PR DESCRIPTION
When viewing in Docusaurus (help), large images are limited in width but the aspect-ratio is not honored (this is apparently a CSS quirk, since Docusaurus specifies the height explicitly, the `aspect-ratio` style-prop is ignored).

This PR preserves the aspect ratio.

Example: whatsnew/v4-3-0.md  `![New surfaces UI](v4-3-0/surface-modules.png)`

(Note the problem is specific to Docusaurus -- it looks fine with react-markdown.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Documentation images now preserve their original aspect ratios when scaled, preventing vertical distortion.
  * Centered images on their own lines continue to be supported; no other visual behaviors were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->