### PR TITLE
feat: image library

### DIFF
--- a/companion/lib/Graphics/Controller.ts
+++ b/companion/lib/Graphics/Controller.ts
@@ -22,12 +22,15 @@ import type { DrawStyleButtonModel, DrawStyleModel } from '@companion-app/shared
 import type { VariableValues } from '@companion-app/shared/Model/Variables.js'
 import { assertNever, type CompanionButtonStyleProps } from '@companion-module/base'
 import type { IControlStore } from '../Controls/IControlStore.js'
+import type { DataDatabase } from '../Data/Database.js'
 import type { DataUserConfig } from '../Data/UserConfig.js'
 import LogController from '../Log/Controller.js'
 import type { IPageStore } from '../Page/Store.js'
 import { ImageWriteQueue } from '../Resources/ImageWriteQueue.js'
 import { isPackaged } from '../Resources/Util.js'
+import type { VariablesController } from '../Variables/Controller.js'
 import type { VariablesValues, VariableValueEntry } from '../Variables/Values.js'
+import { ImageLibrary } from './ImageLibrary.js'
 import type { ImageResult } from './ImageResult.js'
 import { GraphicsRenderer } from './Renderer.js'
 import { GraphicsThreadMethods } from './ThreadMethods.js'
@@ -101,6 +104,11 @@ export class GraphicsController extends EventEmitter<GraphicsControllerEvents> {
 	readonly #renderLRUCache: QuickLRU<string, ImageResult>
 
 	readonly #renderQueue: ImageWriteQueue<string, [RenderArguments, boolean]>
+
+	/**
+	 * Image library for storing and managing images
+	 */
+	readonly imageLibrary: ImageLibrary
 
 	#pool = workerPool.pool(path.join(import.meta.dirname, isPackaged() ? './RenderThread.js' : './Thread.js'), {
 		minWorkers: 2,
@@ -201,14 +209,15 @@ export class GraphicsController extends EventEmitter<GraphicsControllerEvents> {
 		controlsStore: IControlStore,
 		pageStore: IPageStore,
 		userConfigController: DataUserConfig,
-		variableValuesController: VariablesValues
+		variablesController: VariablesController,
+		db: DataDatabase
 	) {
 		super()
 
 		this.controlsStore = controlsStore
 		this.#pageStore = pageStore
 		this.#userConfigController = userConfigController
-		this.#variableValuesController = variableValuesController
+		this.#variableValuesController = variablesController.values
 
 		// Initialize render LRU cache with dynamic size based on control count
 		const initialCacheSize = this.#computeRenderCacheSize()
@@ -394,6 +403,9 @@ export class GraphicsController extends EventEmitter<GraphicsControllerEvents> {
 		GlobalFonts.registerFromPath(generateFontUrl('pf_tempesta_seven.ttf'), '5x7')
 
 		this.#logger.info('Fonts loaded')
+
+		// Initialize the image library
+		this.imageLibrary = new ImageLibrary(db, this, variablesController)
 	}
 
 	/**
@@ -641,5 +653,15 @@ export class GraphicsController extends EventEmitter<GraphicsControllerEvents> {
 		draw_style: DrawStyleModel['style'] | undefined
 	}> {
 		return this.#poolExec('drawButtonImage', [drawStyle], remainingAttempts)
+	}
+
+	/**
+	 * Create a preview image in the worker pool
+	 */
+	async executeCreatePreview(
+		originalDataUrl: string,
+		remainingAttempts: number = CRASHED_WORKER_RETRY_COUNT
+	): Promise<{ width: number; height: number; previewDataUrl: string }> {
+		return this.#poolExec('createImagePreview', [originalDataUrl], remainingAttempts)
 	}
 }

--- a/companion/lib/Graphics/ImageLibrary.ts
+++ b/companion/lib/Graphics/ImageLibrary.ts
@@ -222,20 +222,20 @@ export class ImageLibrary {
 	 */
 	createEmptyImage(name: string, description: string): string {
 		// Validate and sanitize the name
-		const sageName = makeLabelSafe(name)
-		if (!sageName) {
+		const safeName = makeLabelSafe(name)
+		if (!safeName) {
 			throw new Error('Invalid image name')
 		}
 
 		// Check if name already exists
-		if (this.#dbTable.get(sageName)) {
-			throw new Error(`Image with name "${sageName}" already exists`)
+		if (this.#dbTable.get(safeName)) {
+			throw new Error(`Image with name "${safeName}" already exists`)
 		}
 
 		const now = Date.now()
 
 		const info: ImageLibraryInfo = {
-			name: sageName,
+			name: safeName,
 			description: description,
 			originalSize: 0,
 			previewSize: 0,
@@ -252,20 +252,20 @@ export class ImageLibrary {
 			info,
 		}
 
-		this.#dbTable.set(sageName, imageData)
+		this.#dbTable.set(safeName, imageData)
 
 		// Create variable for the new image
-		this.#updateImageVariable(sageName, imageData.originalImage)
+		this.#updateImageVariable(safeName, imageData.originalImage)
 
 		// Update variable definitions
 		this.#updateImageVariableDefinitions()
 
-		this.#logger.info(`Created empty image ${sageName} (${description})`)
+		this.#logger.info(`Created empty image ${safeName} (${description})`)
 
 		// Notify clients
-		this.#events.emit('update', [{ type: 'update', itemName: sageName, info }])
+		this.#events.emit('update', [{ type: 'update', itemName: safeName, info }])
 
-		return sageName
+		return safeName
 	}
 
 	/**
@@ -449,7 +449,7 @@ export class ImageLibrary {
 		existingData.info.originalSize = dataUrlString.length
 		existingData.info.previewSize = previewDataUrl.length
 		existingData.info.modifiedAt = Date.now()
-		existingData.info.checksum = crypto.createHash('sha-1').update(dataUrlString).digest('hex')
+		existingData.info.checksum = crypto.createHash('sha1').update(dataUrlString).digest('hex')
 		existingData.info.mimeType = dataUrlMatch[1]
 
 		// Update the image data

--- a/companion/lib/Graphics/ImageLibrary.ts
+++ b/companion/lib/Graphics/ImageLibrary.ts
@@ -21,6 +21,12 @@ import { ImageLibraryCollections } from './ImageLibraryCollections.js'
 
 const MAX_IMPORT_FILE_SIZE = 1024 * 1024 * 10 // 10MB limit, just in case
 
+/** Returns the decoded byte length of a base64 string (strips padding). */
+function base64ByteLength(base64: string): number {
+	const padding = base64.endsWith('==') ? 2 : base64.endsWith('=') ? 1 : 0
+	return Math.floor((base64.length * 3) / 4) - padding
+}
+
 export interface ImageLibraryData {
 	originalImage: string // base64 data URL (empty string if not uploaded yet)
 	previewImage: string // base64 data URL (empty string if not uploaded yet)
@@ -448,9 +454,14 @@ export class ImageLibrary {
 		// Get image dimensions and create preview
 		const { width, height, previewDataUrl } = await this.#graphicsController.executeCreatePreview(dataUrlString)
 
+		// Compute actual decoded byte sizes from the base64 payloads (data-URL string length
+		// is ~33 % larger than the real binary size due to base64 encoding plus the MIME prefix).
+		const originalByteSize = base64ByteLength(dataUrlMatch[2])
+		const previewByteSize = base64ByteLength(previewDataUrl.match(/^data:[^,]+,(.*)$/)?.[1] ?? '')
+
 		// Update the existing image info
-		existingData.info.originalSize = dataUrlString.length
-		existingData.info.previewSize = previewDataUrl.length
+		existingData.info.originalSize = originalByteSize
+		existingData.info.previewSize = previewByteSize
 		existingData.info.modifiedAt = Date.now()
 		existingData.info.checksum = crypto.createHash('sha1').update(dataUrlString).digest('hex')
 		existingData.info.mimeType = dataUrlMatch[1]
@@ -462,7 +473,7 @@ export class ImageLibrary {
 		// Store in database
 		this.#dbTable.set(imageName, existingData)
 
-		this.#logger.info(`Updated image ${imageName} - ${width}x${height}, ${dataUrlString.length} bytes`)
+		this.#logger.info(`Updated image ${imageName} - ${width}x${height}, ${originalByteSize} bytes`)
 
 		// Update the variable for the image
 		this.#updateImageVariable(imageName, dataUrlString)
@@ -553,27 +564,40 @@ export class ImageLibrary {
 
 		this.#collections.replaceCollections(collections)
 
+		const importedImages: Array<{ name: string; info: ImageLibraryInfo }> = []
+
 		// Import new images with full image data
 		for (const imageData of images) {
+			// Sanitize the name and resolve any duplicates that arise within the batch
+			let safeName: string
+			try {
+				safeName = this.makeImageNameUnique(imageData.info.name)
+			} catch {
+				this.#logger.warn(`Skipping image with invalid name: "${imageData.info.name}"`)
+				continue
+			}
+
+			const info: ImageLibraryInfo = { ...imageData.info, name: safeName }
 			const fullImageData: ImageLibraryData = {
 				originalImage: imageData.originalImage,
 				previewImage: imageData.previewImage,
-				info: { ...imageData.info },
+				info,
 			}
 
-			this.#dbTable.set(imageData.info.name, fullImageData)
-			this.#logger.info(`Imported image ${imageData.info.name} with image data`)
+			this.#dbTable.set(safeName, fullImageData)
+			this.#logger.info(`Imported image ${safeName} with image data`)
+			importedImages.push({ name: safeName, info })
 		}
 
 		// Update variables for imported images
 		this.#updateAllImageVariables()
 
 		// Notify clients
-		if (this.#events.listenerCount('update') > 0 && images.length > 0) {
-			const changes: ImageLibraryUpdate[] = images.map((imageData) => ({
+		if (this.#events.listenerCount('update') > 0 && importedImages.length > 0) {
+			const changes: ImageLibraryUpdate[] = importedImages.map(({ name, info }) => ({
 				type: 'update',
-				itemName: imageData.info.name,
-				info: imageData.info,
+				itemName: name,
+				info,
 			}))
 			this.#events.emit('update', changes)
 		}

--- a/companion/lib/Graphics/ImageLibrary.ts
+++ b/companion/lib/Graphics/ImageLibrary.ts
@@ -1,0 +1,613 @@
+import crypto from 'node:crypto'
+import EventEmitter from 'node:events'
+import z from 'zod'
+import { makeLabelSafe } from '@companion-app/shared/Label.js'
+import type {
+	ImageLibraryCollection,
+	ImageLibraryExportData,
+	ImageLibraryInfo,
+	ImageLibraryUpdate,
+} from '@companion-app/shared/Model/ImageLibraryModel.js'
+import type { VariableDefinition } from '@companion-app/shared/Model/Variables.js'
+import type { DataDatabase } from '../Data/Database.js'
+import type { DataStoreTableView } from '../Data/StoreBase.js'
+import LogController from '../Log/Controller.js'
+import { MultipartUploader } from '../Resources/MultipartUploader.js'
+import { publicProcedure, router, toIterable } from '../UI/TRPC.js'
+import type { VariablesController } from '../Variables/Controller.js'
+import type { VariableValueEntry } from '../Variables/Values.js'
+import type { GraphicsController } from './Controller.js'
+import { ImageLibraryCollections } from './ImageLibraryCollections.js'
+
+const MAX_IMPORT_FILE_SIZE = 1024 * 1024 * 10 // 10MB limit, just in case
+
+export interface ImageLibraryData {
+	originalImage: string // base64 data URL (empty string if not uploaded yet)
+	previewImage: string // base64 data URL (empty string if not uploaded yet)
+	info: ImageLibraryInfo
+}
+
+export class ImageLibrary {
+	readonly #logger = LogController.createLogger('Graphics/ImageLibrary')
+	readonly #dbTable: DataStoreTableView<Record<string, ImageLibraryData>>
+	readonly #multipartUploader: MultipartUploader<string, { imageName: string }>
+	readonly #graphicsController: GraphicsController
+	readonly #variablesController: VariablesController
+	readonly #collections: ImageLibraryCollections
+
+	readonly #events = new EventEmitter<{ update: [ImageLibraryUpdate[]] }>()
+
+	constructor(db: DataDatabase, graphicsController: GraphicsController, variablesController: VariablesController) {
+		this.#dbTable = db.getTableView('image_library')
+		this.#graphicsController = graphicsController
+		this.#variablesController = variablesController
+		this.#collections = new ImageLibraryCollections(db, (validCollectionIds) =>
+			this.#cleanUnknownCollectionIds(validCollectionIds)
+		)
+		this.#multipartUploader = new MultipartUploader(
+			'Graphics/ImageLibrary',
+			MAX_IMPORT_FILE_SIZE,
+			async (_name, data, userData) => {
+				// Process the uploaded image data and update the existing image
+				const imageInfo = await this.#updateImageWithData(userData.imageName, data)
+
+				this.#events.emit('update', [{ type: 'update', itemName: userData.imageName, info: imageInfo.info }])
+
+				return userData.imageName
+			}
+		)
+
+		this.#events.setMaxListeners(0)
+
+		this.#cleanUnknownCollectionIds(this.#collections.collectAllCollectionIds())
+
+		// Initialize variables for existing images
+		this.#updateAllImageVariables()
+	}
+
+	#cleanUnknownCollectionIds(validCollectionIds: ReadonlySet<string>): void {
+		const changes: ImageLibraryUpdate[] = []
+
+		for (const [name, data] of Object.entries(this.#dbTable.all())) {
+			if (!data.info.collectionId) continue
+
+			if (validCollectionIds.has(data.info.collectionId)) continue
+
+			data.info.collectionId = undefined
+			this.#dbTable.set(name, data)
+
+			changes.push({ type: 'update', itemName: name, info: data.info })
+		}
+
+		if (this.#events.listenerCount('update') > 0 && changes.length > 0) {
+			this.#events.emit('update', changes)
+		}
+	}
+
+	createTrpcRouter() {
+		const self = this
+		return router({
+			collections: this.#collections.createTrpcRouter(),
+			upload: this.#multipartUploader.createTrpcRouter(),
+
+			watch: publicProcedure.subscription(async function* ({ signal }) {
+				const changes = toIterable(self.#events, 'update', signal)
+
+				yield [{ type: 'init', images: self.listImages() }] satisfies ImageLibraryUpdate[]
+
+				for await (const [change] of changes) {
+					yield change
+				}
+			}),
+
+			create: publicProcedure
+				.input(
+					z.object({
+						name: z.string(),
+						description: z.string(),
+					})
+				)
+				.mutation(({ input }) => {
+					return this.createEmptyImage(input.name, input.description)
+				}),
+			delete: publicProcedure
+				.input(
+					z.object({
+						imageName: z.string(),
+					})
+				)
+				.mutation(({ input }) => {
+					return this.deleteImage(input.imageName)
+				}),
+
+			reorder: publicProcedure
+				.input(
+					z.object({
+						collectionId: z.string().nullable(),
+						imageName: z.string(),
+						dropIndex: z.number(),
+					})
+				)
+				.mutation(({ input }) => {
+					return this.setImageOrder(input.collectionId, input.imageName, input.dropIndex)
+				}),
+
+			getData: publicProcedure
+				.input(
+					z.object({
+						imageName: z.string(),
+						type: z.enum(['original', 'preview']),
+					})
+				)
+				.query(({ input }) => {
+					return this.getImageDataUrl(input.imageName, input.type)
+				}),
+
+			setDescription: publicProcedure
+				.input(
+					z.object({
+						imageName: z.string(),
+						description: z.string(),
+					})
+				)
+				.mutation(({ input }) => {
+					return this.setImageDescription(input.imageName, input.description)
+				}),
+
+			setName: publicProcedure
+				.input(
+					z.object({
+						imageName: z.string(),
+						newName: z.string(),
+					})
+				)
+				.mutation(({ input }) => {
+					return this.setImageName(input.imageName, input.newName)
+				}),
+		})
+	}
+
+	/**
+	 * List all images in the library
+	 */
+	listImages(): ImageLibraryInfo[] {
+		const allData = this.#dbTable.all()
+		return Object.values(allData)
+			.map((data) => data.info)
+			.sort((a, b) => b.modifiedAt - a.modifiedAt)
+	}
+
+	/**
+	 * Get image info by ID
+	 */
+	getImageInfo(imageName: string): ImageLibraryInfo | null {
+		const data = this.#dbTable.get(imageName)
+		return data?.info || null
+	}
+
+	/**
+	 * Get image data as base64 data URL
+	 */
+	getImageDataUrl(imageName: string, type: 'original' | 'preview'): { image: string; checksum: string } | null {
+		const data = this.#dbTable.get(imageName)
+		if (!data) return null
+
+		return {
+			image: type === 'original' ? data.originalImage : data.previewImage,
+			checksum: data.info.checksum,
+		}
+	}
+
+	/**
+	 * Delete an image from the library
+	 */
+	deleteImage(imageName: string): boolean {
+		const data = this.#dbTable.get(imageName)
+		if (!data) return false
+
+		this.#dbTable.delete(imageName)
+
+		this.#logger.info(`Deleted image ${imageName} (${data.info.name})`)
+
+		this.#events.emit('update', [{ type: 'remove', itemName: imageName }])
+
+		// Remove variable for the deleted image
+		this.#removeImageVariable(imageName)
+
+		return true
+	}
+
+	/**
+	 * Create a new empty image entry
+	 */
+	createEmptyImage(name: string, description: string): string {
+		// Validate and sanitize the name
+		const sageName = makeLabelSafe(name)
+		if (!sageName) {
+			throw new Error('Invalid image name')
+		}
+
+		// Check if name already exists
+		if (this.#dbTable.get(sageName)) {
+			throw new Error(`Image with name "${sageName}" already exists`)
+		}
+
+		const now = Date.now()
+
+		const info: ImageLibraryInfo = {
+			name: sageName,
+			description: description,
+			originalSize: 0,
+			previewSize: 0,
+			createdAt: now,
+			modifiedAt: now,
+			checksum: '',
+			mimeType: '',
+			sortOrder: 0, // Will be updated when moved to collections
+		}
+
+		const imageData: ImageLibraryData = {
+			originalImage: '', // Empty until uploaded
+			previewImage: '', // Empty until uploaded
+			info,
+		}
+
+		this.#dbTable.set(sageName, imageData)
+
+		// Create variable for the new image
+		this.#updateImageVariable(sageName, imageData.originalImage)
+
+		// Update variable definitions
+		this.#updateImageVariableDefinitions()
+
+		this.#logger.info(`Created empty image ${sageName} (${description})`)
+
+		// Notify clients
+		this.#events.emit('update', [{ type: 'update', itemName: sageName, info }])
+
+		return sageName
+	}
+
+	/**
+	 * Make an image name unique by appending a number if it already exists
+	 */
+	makeImageNameUnique(baseName: string): string {
+		const safeBaseName = makeLabelSafe(baseName)
+		if (!safeBaseName) {
+			throw new Error('Invalid base image name')
+		}
+
+		if (!this.#dbTable.get(safeBaseName)) {
+			return safeBaseName
+		}
+
+		let index = 2
+		while (this.#dbTable.get(`${safeBaseName}_${index}`)) {
+			index++
+		}
+
+		return `${safeBaseName}_${index}`
+	}
+
+	/**
+	 * Set the name of an existing image
+	 */
+	setImageDescription(name: string, description: string): boolean {
+		const data = this.#dbTable.get(name)
+		if (!data) return false
+
+		// Update the description and modified timestamp
+		data.info.description = description
+		data.info.modifiedAt = Date.now()
+
+		this.#dbTable.set(name, data)
+
+		// Update variable definitions since the name is used as the label
+		this.#updateImageVariableDefinitions()
+
+		this.#logger.info(`Updated image ${name} description to "${description}"`)
+
+		// Notify clients
+		this.#events.emit('update', [{ type: 'update', itemName: name, info: data.info }])
+
+		return true
+	}
+
+	/**
+	 * Set the name of an existing image
+	 */
+	setImageName(currentName: string, newName: string): string {
+		const data = this.#dbTable.get(currentName)
+		if (!data) {
+			throw new Error(`Image with name "${currentName}" not found`)
+		}
+
+		// Validate and sanitize the new name
+		const safeNewName = makeLabelSafe(newName)
+		if (!safeNewName) {
+			throw new Error('Invalid image name')
+		}
+
+		// Check if new ID already exists and is different from current
+		if (safeNewName !== currentName && this.#dbTable.get(safeNewName)) {
+			throw new Error(`Image with name "${safeNewName}" already exists`)
+		}
+
+		// If the name is the same, no change needed
+		if (safeNewName === currentName) return safeNewName
+
+		// Update the name in the info
+		data.info.name = safeNewName
+		data.info.modifiedAt = Date.now()
+
+		// Move the data to the new key and delete the old one
+		this.#dbTable.set(safeNewName, data)
+		this.#dbTable.delete(currentName)
+
+		// Update variables: remove old and add new
+		this.#removeImageVariable(currentName)
+		this.#updateImageVariable(safeNewName, data.originalImage)
+
+		// Update variable definitions
+		this.#updateImageVariableDefinitions()
+
+		this.#logger.info(`Updated image name from "${currentName}" to "${safeNewName}"`)
+
+		// Notify clients of the removal of the old name and addition of the new one
+		this.#events.emit('update', [
+			{ type: 'remove', itemName: currentName },
+			{ type: 'update', itemName: safeNewName, info: data.info },
+		])
+
+		return safeNewName
+	}
+
+	/**
+	 * Set the order of an image within a collection
+	 */
+	setImageOrder(collectionId: string | null, imageName: string, dropIndex: number): void {
+		const imageData = this.#dbTable.get(imageName)
+		if (!imageData) return
+
+		if (!this.#collections.doesCollectionIdExist(collectionId)) return
+
+		// update the collectionId of the image being moved if needed
+		if (imageData.info.collectionId !== (collectionId ?? undefined)) {
+			imageData.info.collectionId = collectionId ?? undefined
+		}
+
+		// find all the other images with the matching collectionId
+		const sortedImages = Array.from(Object.entries(this.#dbTable.all()))
+			.filter(
+				([imgId, data]) =>
+					imgId !== imageName && ((!data.info.collectionId && !collectionId) || data.info.collectionId === collectionId)
+			)
+			.sort(([, a], [, b]) => (a.info.sortOrder || 0) - (b.info.sortOrder || 0))
+
+		if (dropIndex < 0) {
+			// Push the image to the end of the array
+			sortedImages.push([imageName, imageData])
+		} else {
+			// Insert the image at the drop index
+			sortedImages.splice(dropIndex, 0, [imageName, imageData])
+		}
+
+		const changes: ImageLibraryUpdate[] = []
+
+		// update the sort order of the images in the store, tracking which ones changed
+		sortedImages.forEach(([name, data], index) => {
+			if (data.info.sortOrder === index && name !== imageName) return // No change
+
+			data.info.sortOrder = index // Update the sort order
+			data.info.modifiedAt = Date.now()
+			this.#dbTable.set(name, data)
+
+			changes.push({ type: 'update', itemName: name, info: data.info })
+		})
+
+		if (this.#events.listenerCount('update') > 0 && changes.length > 0) {
+			this.#events.emit('update', changes)
+		}
+	}
+
+	/**
+	 * Export collections data
+	 */
+	exportCollections(): ImageLibraryCollection[] {
+		return this.#collections.collectionData
+	}
+
+	/**
+	 * Export full image library data including base64 image content
+	 */
+	exportImageLibraryData(): ImageLibraryExportData[] {
+		const allData = this.#dbTable.all()
+		return Object.values(allData)
+	}
+
+	/**
+	 * Update an existing image with uploaded data
+	 */
+	async #updateImageWithData(imageName: string, data: Buffer): Promise<ImageLibraryData> {
+		const existingData = this.#dbTable.get(imageName)
+		if (!existingData) {
+			throw new Error('Image not found')
+		}
+
+		// Parse the data URL from the uploaded buffer
+		const dataUrlString = data.toString('utf-8')
+
+		const dataUrlMatch = dataUrlString.match(/^data:(image\/[\w+]+);base64,(.+)$/)
+		if (!dataUrlMatch) {
+			throw new Error('Invalid data URL format or unsupported image format')
+		}
+
+		// Get image dimensions and create preview
+		const { width, height, previewDataUrl } = await this.#graphicsController.executeCreatePreview(dataUrlString)
+
+		// Update the existing image info
+		existingData.info.originalSize = dataUrlString.length
+		existingData.info.previewSize = previewDataUrl.length
+		existingData.info.modifiedAt = Date.now()
+		existingData.info.checksum = crypto.createHash('sha-1').update(dataUrlString).digest('hex')
+		existingData.info.mimeType = dataUrlMatch[1]
+
+		// Update the image data
+		existingData.originalImage = dataUrlString
+		existingData.previewImage = previewDataUrl
+
+		// Store in database
+		this.#dbTable.set(imageName, existingData)
+
+		this.#logger.info(`Updated image ${imageName} - ${width}x${height}, ${dataUrlString.length} bytes`)
+
+		// Update the variable for the image
+		this.#updateImageVariable(imageName, dataUrlString)
+
+		return existingData
+	}
+
+	/**
+	 * Update variables for all images in the library
+	 */
+	#updateAllImageVariables(): void {
+		const variables: VariableValueEntry[] = []
+
+		for (const [imageName, data] of Object.entries(this.#dbTable.all())) {
+			variables.push({
+				id: imageName,
+				value: data.originalImage || '',
+			})
+		}
+
+		this.#variablesController.values.setVariableValues('image', variables)
+		this.#updateImageVariableDefinitions()
+	}
+
+	/**
+	 * Update variable for a specific image
+	 */
+	#updateImageVariable(imageName: string, originalImage: string): void {
+		this.#variablesController.values.setVariableValues('image', [
+			{
+				id: imageName,
+				value: originalImage || '',
+			},
+		])
+	}
+
+	/**
+	 * Update variable definitions for all images
+	 */
+	#updateImageVariableDefinitions(): void {
+		const definitions: VariableDefinition[] = []
+
+		for (const [imageName, data] of Object.entries(this.#dbTable.all())) {
+			definitions.push({
+				name: imageName,
+				description: data.info.description || imageName,
+			})
+		}
+
+		this.#variablesController.definitions.setVariableDefinitions('image', definitions)
+	}
+
+	/**
+	 * Get variable definitions for all images
+	 */
+	getVariableDefinitions(): VariableDefinition[] {
+		const definitions: VariableDefinition[] = []
+
+		for (const [imageName, data] of Object.entries(this.#dbTable.all())) {
+			definitions.push({
+				name: imageName,
+				description: data.info.description || imageName,
+			})
+		}
+
+		return definitions
+	}
+
+	/**
+	 * Remove variable for a specific image
+	 */
+	#removeImageVariable(imageName: string): void {
+		this.#variablesController.values.setVariableValues('image', [
+			{
+				id: imageName,
+				value: undefined,
+			},
+		])
+		// Update definitions to remove the deleted image
+		this.#updateImageVariableDefinitions()
+	}
+
+	/**
+	 * Import image library data
+	 */
+	importImageLibrary(collections: ImageLibraryCollection[], images: ImageLibraryExportData[]): void {
+		this.resetImageLibrary()
+
+		this.#collections.replaceCollections(collections)
+
+		// Import new images with full image data
+		for (const imageData of images) {
+			const fullImageData: ImageLibraryData = {
+				originalImage: imageData.originalImage,
+				previewImage: imageData.previewImage,
+				info: { ...imageData.info },
+			}
+
+			this.#dbTable.set(imageData.info.name, fullImageData)
+			this.#logger.info(`Imported image ${imageData.info.name} with image data`)
+		}
+
+		// Update variables for imported images
+		this.#updateAllImageVariables()
+
+		// Notify clients
+		if (this.#events.listenerCount('update') > 0 && images.length > 0) {
+			const changes: ImageLibraryUpdate[] = images.map((imageData) => ({
+				type: 'update',
+				itemName: imageData.info.name,
+				info: imageData.info,
+			}))
+			this.#events.emit('update', changes)
+		}
+
+		this.#cleanUnknownCollectionIds(this.#collections.collectAllCollectionIds())
+	}
+
+	/**
+	 * Reset the entire image library (clear all images and collections)
+	 */
+	resetImageLibrary(): void {
+		// Get all images before clearing
+		const allImages = Object.keys(this.#dbTable.all())
+
+		if (allImages.length > 0) {
+			// Clear all images from database
+			const changes: ImageLibraryUpdate[] = []
+			const variables: VariableValueEntry[] = []
+
+			for (const imageName of allImages) {
+				this.#dbTable.delete(imageName)
+				changes.push({ type: 'remove', itemName: imageName })
+				variables.push({ id: imageName, value: undefined })
+
+				this.#logger.info(`Deleted image ${imageName}`)
+			}
+
+			this.#variablesController.values.setVariableValues('image', variables)
+
+			// Update variable definitions once
+			this.#updateImageVariableDefinitions()
+
+			// Notify clients with batched changes
+			this.#events.emit('update', changes)
+		}
+
+		// Clear all collections
+		this.#collections.discardAllCollections()
+	}
+}

--- a/companion/lib/Graphics/ImageLibrary.ts
+++ b/companion/lib/Graphics/ImageLibrary.ts
@@ -54,7 +54,10 @@ export class ImageLibrary {
 				this.#events.emit('update', [{ type: 'update', itemName: userData.imageName, info: imageInfo.info }])
 
 				return userData.imageName
-			}
+			},
+			z.object({
+				imageName: z.string(),
+			})
 		)
 
 		this.#events.setMaxListeners(0)

--- a/companion/lib/Graphics/ImageLibraryCollections.ts
+++ b/companion/lib/Graphics/ImageLibraryCollections.ts
@@ -1,0 +1,36 @@
+import z from 'zod'
+import type { ImageLibraryCollection } from '@companion-app/shared/Model/ImageLibraryModel.js'
+import type { DataDatabase } from '../Data/Database.js'
+import { CollectionsBaseController } from '../Resources/CollectionsBase.js'
+import { publicProcedure, router } from '../UI/TRPC.js'
+
+export class ImageLibraryCollections extends CollectionsBaseController<null> {
+	readonly #cleanUnknownCollectionIds: (validCollectionIds: ReadonlySet<string>) => void
+
+	constructor(db: DataDatabase, cleanUnknownCollectionIds: (validCollectionIds: ReadonlySet<string>) => void) {
+		super(db.getTableView<Record<string, ImageLibraryCollection>>('image_library_collections'))
+
+		this.#cleanUnknownCollectionIds = cleanUnknownCollectionIds
+	}
+
+	/**
+	 * Ensure that all collectionIds in images are valid collections
+	 */
+	override removeUnknownCollectionReferences(): void {
+		this.#cleanUnknownCollectionIds(this.collectAllCollectionIds())
+	}
+
+	override emitUpdateUser(_rows: ImageLibraryCollection[]): void {
+		// No-op
+	}
+
+	createTrpcRouter() {
+		return router({
+			...super.createTrpcRouterBase(),
+
+			add: publicProcedure.input(z.object({ collectionName: z.string() })).mutation(async ({ input }) => {
+				return this.collectionCreate(input.collectionName, null)
+			}),
+		})
+	}
+}

--- a/companion/lib/Graphics/Renderer.ts
+++ b/companion/lib/Graphics/Renderer.ts
@@ -9,6 +9,7 @@
  * this program.
  */
 
+import { Canvas, loadImage } from '@napi-rs/canvas'
 import QuickLRU from 'quick-lru'
 import { formatLocation } from '@companion-app/shared/ControlId.js'
 import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
@@ -368,6 +369,63 @@ export class GraphicsRenderer {
 				)
 				rightMax -= 8
 			}
+		}
+	}
+
+	/**
+	 * Create a 200px preview WebP from the original image
+	 */
+	static async createImagePreview(
+		originalDataUrl: string
+	): Promise<{ width: number; height: number; previewDataUrl: string }> {
+		try {
+			// Load the original image data directly from data URL
+			const originalImage = await loadImage(originalDataUrl)
+
+			// Get original dimensions
+			const originalWidth = originalImage.width
+			const originalHeight = originalImage.height
+
+			// Calculate preview dimensions (max 200px on longest side, but don't upsize small images)
+			const maxSize = 200
+			let previewWidth: number
+			let previewHeight: number
+
+			// Check if the image is smaller than the target preview size
+			const largestDimension = Math.max(originalWidth, originalHeight)
+
+			if (largestDimension <= maxSize) {
+				// Image is smaller than target size - don't upsize, just use original dimensions
+				previewWidth = originalWidth
+				previewHeight = originalHeight
+			} else {
+				// Image is larger than target size - downsize to fit within maxSize
+				if (originalWidth > originalHeight) {
+					previewWidth = maxSize
+					previewHeight = Math.round((originalHeight * previewWidth) / originalWidth)
+				} else {
+					previewHeight = maxSize
+					previewWidth = Math.round((originalWidth * previewHeight) / originalHeight)
+				}
+			}
+
+			// Create preview canvas
+			const canvas = new Canvas(previewWidth, previewHeight)
+			const ctx = canvas.getContext('2d')
+
+			// Draw resized image
+			ctx.drawImage(originalImage, 0, 0, previewWidth, previewHeight)
+
+			// Convert to data URL (WebP format with 75% quality)
+			const previewDataUrl = canvas.toDataURL('image/webp', 0.75)
+
+			return {
+				width: originalWidth,
+				height: originalHeight,
+				previewDataUrl,
+			}
+		} catch (_e) {
+			throw new Error('Failed to process image')
 		}
 	}
 

--- a/companion/lib/Graphics/ThreadMethods.ts
+++ b/companion/lib/Graphics/ThreadMethods.ts
@@ -13,4 +13,5 @@ import { GraphicsRenderer } from './Renderer.js'
 
 export const GraphicsThreadMethods = Object.freeze({
 	drawButtonImage: GraphicsRenderer.drawButtonImageUnwrapped.bind(GraphicsRenderer),
+	createImagePreview: GraphicsRenderer.createImagePreview.bind(GraphicsRenderer),
 })

--- a/companion/lib/ImportExport/Controller.ts
+++ b/companion/lib/ImportExport/Controller.ts
@@ -85,10 +85,10 @@ export class ImportExportController {
 		})
 	}
 
-	readonly #multipartUploader = new MultipartUploader<[string | null, ClientImportObject | null]>(
+	readonly #multipartUploader = new MultipartUploader<[string | null, ClientImportObject | null], null>(
 		'ImportExport/Controller',
 		MAX_IMPORT_FILE_SIZE,
-		async (_name, data, _updateProgress, sessionCtx) => {
+		async (_name, data, _userData, _updateProgress, sessionCtx) => {
 			// Extract ArrayBuffer from the Buffer for zero-copy transfer
 			// The buffer becomes detached/unusable in this thread after transfer
 			const arrayBuffer = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer
@@ -546,6 +546,11 @@ export class ImportExportController {
 
 		if (shouldReset(config.userconfig)) {
 			this.#userConfigController.reset()
+		}
+
+		if (shouldReset(config.imageLibrary)) {
+			// Reset image library
+			this.#graphicsController.imageLibrary.resetImageLibrary()
 		}
 
 		return 'ok'

--- a/companion/lib/ImportExport/Controller.ts
+++ b/companion/lib/ImportExport/Controller.ts
@@ -214,7 +214,8 @@ export class ImportExportController {
 
 			// rest is done from browser
 			return [null, clientObject]
-		}
+		},
+		z.null()
 	)
 
 	/**

--- a/companion/lib/ImportExport/Controller.ts
+++ b/companion/lib/ImportExport/Controller.ts
@@ -170,6 +170,7 @@ export class ImportExportController {
 				surfacesInstances: importContainsKey('surfaceInstances'),
 				surfacesRemote: importContainsKey('surfacesRemote'),
 				triggers: null,
+				imageLibrary: importContainsKey('imageLibrary'),
 			}
 
 			for (const [connectionId, connectionConfig] of Object.entries(importObject.instances || {})) {
@@ -252,6 +253,7 @@ export class ImportExportController {
 			appInfo,
 			apiRouter,
 			controls,
+			graphics,
 			instance,
 			page.store,
 			surfaces,

--- a/companion/lib/ImportExport/Export.ts
+++ b/companion/lib/ImportExport/Export.ts
@@ -30,6 +30,7 @@ import type {
 	ExportTriggersListv6,
 	SomeExportv6,
 } from '@companion-app/shared/Model/ExportModel.js'
+import type { ImageLibraryExportData } from '@companion-app/shared/Model/ImageLibraryModel.js'
 import { zodClientExportSelection, type ClientExportSelection } from '@companion-app/shared/Model/ImportExport.js'
 import { ModuleInstanceType } from '@companion-app/shared/Model/Instance.js'
 import type { PageModel } from '@companion-app/shared/Model/PageModel.js'
@@ -39,6 +40,7 @@ import { unflattenQueryParams } from '@companion-app/shared/Util/QueryParamUtil.
 import type { ControlsController } from '../Controls/Controller.js'
 import type { ControlTrigger } from '../Controls/ControlTypes/Triggers/Trigger.js'
 import type { DataUserConfig } from '../Data/UserConfig.js'
+import type { GraphicsController } from '../Graphics/Controller.js'
 import type { InstanceController } from '../Instance/Controller.js'
 import LogController, { type Logger } from '../Log/Controller.js'
 import type { IPageStore } from '../Page/Store.js'
@@ -55,6 +57,7 @@ export class ExportController {
 
 	readonly #appInfo: AppInfo
 	readonly #controlsController: ControlsController
+	readonly #graphicsController: GraphicsController
 	readonly #instancesController: InstanceController
 	readonly #pagesStore: IPageStore
 	readonly #surfacesController: SurfaceController
@@ -65,6 +68,7 @@ export class ExportController {
 		appInfo: AppInfo,
 		apiRouter: express.Router,
 		controls: ControlsController,
+		graphics: GraphicsController,
 		instance: InstanceController,
 		pageStore: IPageStore,
 		surfaces: SurfaceController,
@@ -73,6 +77,7 @@ export class ExportController {
 	) {
 		this.#appInfo = appInfo
 		this.#controlsController = controls
+		this.#graphicsController = graphics
 		this.#instancesController = instance
 		this.#pagesStore = pageStore
 		this.#surfacesController = surfaces
@@ -158,6 +163,16 @@ export class ExportController {
 				referencedConnectionCollectionIds
 			)
 
+			// Collect referenced image library items and collections
+			const referencedImages = this.#collectReferencedImages(referencedVariables)
+			const referencedImageLibraryCollectionIds = this.#collectReferencedCollectionIds(
+				referencedImages.map((img) => img.info)
+			)
+			const filteredImageLibraryCollections = this.#filterReferencedCollections(
+				this.#graphicsController.imageLibrary.exportCollections(),
+				referencedImageLibraryCollectionIds
+			)
+
 			// Export file protocol version
 			const exp: ExportPageModelv6 = {
 				version: FILE_VERSION,
@@ -167,6 +182,8 @@ export class ExportController {
 				instances: connectionsExport,
 				connectionCollections: filteredConnectionCollections,
 				oldPageNumber: page,
+				imageLibrary: referencedImages,
+				imageLibraryCollections: filteredImageLibraryCollections,
 			}
 
 			const filename = this.#generateFilename(String(req.query.filename as any), `page${page}`, 'companionconfig')
@@ -372,6 +389,16 @@ export class ExportController {
 			referencedConnectionCollectionIds
 		)
 
+		// Collect referenced image library items and collections
+		const referencedImages = this.#collectReferencedImages(referencedVariables)
+		const referencedImageLibraryCollectionIds = this.#collectReferencedCollectionIds(
+			referencedImages.map((img) => img.info)
+		)
+		const filteredImageLibraryCollections = this.#filterReferencedCollections(
+			this.#graphicsController.imageLibrary.exportCollections(),
+			referencedImageLibraryCollectionIds
+		)
+
 		return {
 			type: 'trigger_list',
 			version: FILE_VERSION,
@@ -380,6 +407,8 @@ export class ExportController {
 			triggerCollections: triggerCollections,
 			instances: connectionsExport,
 			connectionCollections: filteredConnectionCollections,
+			imageLibrary: referencedImages,
+			imageLibraryCollections: filteredImageLibraryCollections,
 		}
 	}
 
@@ -614,7 +643,42 @@ export class ExportController {
 			exp.surfaceInstanceCollections = this.#instancesController.surfaceInstanceCollections.collectionData
 		}
 
+		// Handle image library export
+		if (!config || config.imageLibrary) {
+			exp.imageLibrary = this.#graphicsController.imageLibrary.exportImageLibraryData()
+			exp.imageLibraryCollections = this.#graphicsController.imageLibrary.exportCollections()
+		}
+
 		return exp
+	}
+
+	/**
+	 * Collect referenced images from variable references
+	 */
+	#collectReferencedImages(referencedVariables: Set<string>): ImageLibraryExportData[] {
+		const referencedImages: ImageLibraryExportData[] = []
+
+		// Get all images and create a map for efficient lookup
+		const allImages = this.#graphicsController.imageLibrary.exportImageLibraryData()
+		const imageMap = new Map<string, ImageLibraryExportData>()
+		for (const imageData of allImages) {
+			imageMap.set(imageData.info.name, imageData)
+		}
+
+		// Look for image variables in the format "image:imageId"
+		for (const variable of referencedVariables) {
+			// Variable names that start with 'image:' are image references
+			if (variable.startsWith('image:')) {
+				const imageName = variable.substring(6) // Remove 'image:' prefix
+
+				const imageData = imageMap.get(imageName)
+				if (imageData) {
+					referencedImages.push(imageData)
+				}
+			}
+		}
+
+		return referencedImages
 	}
 
 	#collectReferencedCollectionIds<TItem extends { collectionId?: string }>(items: TItem[]): Set<string> {

--- a/companion/lib/ImportExport/Import.ts
+++ b/companion/lib/ImportExport/Import.ts
@@ -298,6 +298,14 @@ export class ImportController {
 				this.#controlsController.importTrigger(controlId, fixedControlObj)
 			}
 		}
+
+		// Import image library data if present
+		if (isImporting(config.imageLibrary)) {
+			this.#graphicsController.imageLibrary.importImageLibrary(
+				data.imageLibraryCollections || [],
+				data.imageLibrary || []
+			)
+		}
 	}
 
 	#performPageImport = (

--- a/companion/lib/Instance/InstalledModulesManager.ts
+++ b/companion/lib/Instance/InstalledModulesManager.ts
@@ -50,7 +50,7 @@ export class InstanceInstalledModulesManager {
 	readonly #multipartUploader = new MultipartUploader(
 		'Instance/UserModulesManager',
 		MAX_MODULE_BUNDLE_TAR_SIZE,
-		async (_name, data, updateProgress) => {
+		async (_name, data, _userData, updateProgress) => {
 			const decompressedData = await gunzipP(data)
 			if (!decompressedData) {
 				this.#logger.error(`Failed to decompress module data`)

--- a/companion/lib/Instance/InstalledModulesManager.ts
+++ b/companion/lib/Instance/InstalledModulesManager.ts
@@ -91,7 +91,8 @@ export class InstanceInstalledModulesManager {
 			}
 
 			return true
-		}
+		},
+		z.null()
 	)
 
 	constructor(

--- a/companion/lib/Registry.ts
+++ b/companion/lib/Registry.ts
@@ -202,7 +202,7 @@ export class Registry {
 		this.variables = new VariablesController(this.db)
 		const controlStore = new ControlStore(this.db, this.variables.values)
 
-		this.graphics = new GraphicsController(controlStore, pageStore, this.userconfig, this.variables.values)
+		this.graphics = new GraphicsController(controlStore, pageStore, this.userconfig, this.variables, this.db)
 
 		this.surfaces = new SurfaceController(this.db, {
 			controls: controlStore,

--- a/companion/lib/Resources/MultipartUploader.ts
+++ b/companion/lib/Resources/MultipartUploader.ts
@@ -25,6 +25,7 @@ export class MultipartUploader<TRes, TCompleteData> {
 		updateProgress: (percent: number) => void,
 		ctx: TrpcContext
 	) => Promise<TRes>
+	readonly #userDataSchema: z.ZodType<TCompleteData>
 
 	readonly #progressEvents = new EventEmitter<{ [id: `progress:${string}`]: [progress: number | null] }>()
 
@@ -37,11 +38,13 @@ export class MultipartUploader<TRes, TCompleteData> {
 			userData: TCompleteData,
 			updateProgress: (percent: number) => void,
 			ctx: TrpcContext
-		) => Promise<TRes>
+		) => Promise<TRes>,
+		userDataSchema: z.ZodType<TCompleteData>
 	) {
 		this.#logger = LogController.createLogger(logPrefix)
 		this.#maxUploadSize = maxUploadSize
 		this.#sessionCompleteCallback = sessionCompleteCallback
+		this.#userDataSchema = userDataSchema
 
 		this.#progressEvents.setMaxListeners(0)
 	}
@@ -120,7 +123,7 @@ export class MultipartUploader<TRes, TCompleteData> {
 					z.object({
 						sessionId: z.string(),
 						expectedChecksum: z.string().length(40), // SHA-1 checksum is 40
-						userData: z.any(), // TODO: figure out how to make this work with a generic
+						userData: this.#userDataSchema,
 					})
 				)
 				.mutation(async ({ input, ctx }) => {

--- a/companion/lib/Resources/MultipartUploader.ts
+++ b/companion/lib/Resources/MultipartUploader.ts
@@ -7,9 +7,11 @@ import { publicProcedure, router, toIterable, type TrpcContext } from '../UI/TRP
 
 const TIMEOUT_DURATION = 5000 // time before upload session is considered inactive and killed
 
-export type MultipartUploaderApi<TRes> = ReturnType<MultipartUploader<TRes>['createTrpcRouter']>
+export type MultipartUploaderApi<TRes, TCompleteData> = ReturnType<
+	MultipartUploader<TRes, TCompleteData>['createTrpcRouter']
+>
 
-export class MultipartUploader<TRes> {
+export class MultipartUploader<TRes, TCompleteData> {
 	#logger: Logger
 	#session: MultipartUploaderSession | null = null
 
@@ -19,6 +21,7 @@ export class MultipartUploader<TRes> {
 	readonly #sessionCompleteCallback: (
 		name: string,
 		data: Buffer,
+		userData: TCompleteData,
 		updateProgress: (percent: number) => void,
 		ctx: TrpcContext
 	) => Promise<TRes>
@@ -31,6 +34,7 @@ export class MultipartUploader<TRes> {
 		sessionCompleteCallback: (
 			name: string,
 			data: Buffer,
+			userData: TCompleteData,
 			updateProgress: (percent: number) => void,
 			ctx: TrpcContext
 		) => Promise<TRes>
@@ -116,6 +120,7 @@ export class MultipartUploader<TRes> {
 					z.object({
 						sessionId: z.string(),
 						expectedChecksum: z.string().length(40), // SHA-1 checksum is 40
+						userData: z.any(), // TODO: figure out how to make this work with a generic
 					})
 				)
 				.mutation(async ({ input, ctx }) => {
@@ -132,7 +137,7 @@ export class MultipartUploader<TRes> {
 						this.#progressEvents.emit(`progress:${input.sessionId}`, 0.5 + percent / 2)
 					}
 
-					return this.#sessionCompleteCallback(input.sessionId, data, updateProgress, ctx)
+					return this.#sessionCompleteCallback(input.sessionId, data, input.userData, updateProgress, ctx)
 						.catch((e) => {
 							this.#logger.error(`Failed to complete upload`, e)
 							hasFinished = true

--- a/companion/lib/Resources/MultipartUploader.ts
+++ b/companion/lib/Resources/MultipartUploader.ts
@@ -208,7 +208,7 @@ export class MultipartUploader<TRes, TCompleteData> {
 			this.#inactiveTimeout = null
 		}
 
-		const computedChecksum = crypto.createHash('sha-1').update(session.data).digest('hex')
+		const computedChecksum = crypto.createHash('sha1').update(session.data).digest('hex')
 		if (computedChecksum !== expectedChecksum) throw new Error('Checksum mismatch')
 
 		return session.data

--- a/companion/lib/UI/TRPC.ts
+++ b/companion/lib/UI/TRPC.ts
@@ -110,6 +110,7 @@ export function createTrpcRouter(registry: Registry) {
 		usageStatistics: registry.usageStatistics.createTrpcRouter(),
 
 		preview: registry.preview.createTrpcRouter(),
+		imageLibrary: registry.graphics.imageLibrary.createTrpcRouter(),
 	})
 }
 

--- a/shared-lib/lib/Model/ExportModel.ts
+++ b/shared-lib/lib/Model/ExportModel.ts
@@ -1,6 +1,7 @@
 import type { ConnectionCollection } from './Connections.js'
 import type { CustomVariableCollection, CustomVariablesModel } from './CustomVariableModel.js'
 import type { ExpressionVariableCollection, ExpressionVariableModel } from './ExpressionVariableModel.js'
+import type { ImageLibraryCollection, ImageLibraryExportData } from './ImageLibraryModel.js'
 import type { InstanceConfig, InstanceVersionUpdatePolicy } from './Instance.js'
 import type { SurfaceInstanceCollection } from './SurfaceInstance.js'
 import type { OutboundSurfaceInfo } from './Surfaces.js'
@@ -30,6 +31,8 @@ export interface ExportFullv6 extends ExportBase<'full'> {
 	surfacesRemote?: Record<string, OutboundSurfaceInfo> // Added in v4.2
 	surfaceInstances?: ExportInstancesv6 // Added in v4.2
 	surfaceInstanceCollections?: SurfaceInstanceCollection[] // Added in v4.2
+	imageLibrary?: ImageLibraryExportData[] // Added in v4.4
+	imageLibraryCollections?: ImageLibraryCollection[] // Added in v4.4
 }
 
 export interface ExportPageModelv6 extends ExportBase<'page'> {
@@ -37,6 +40,8 @@ export interface ExportPageModelv6 extends ExportBase<'page'> {
 	instances: ExportInstancesv6
 	connectionCollections: ConnectionCollection[] | undefined // Added in v4.1
 	oldPageNumber: number
+	imageLibrary?: ImageLibraryExportData[] // Added in v4.4
+	imageLibraryCollections?: ImageLibraryCollection[] // Added in v4.4
 }
 
 export interface ExportTriggersListv6 extends ExportBase<'trigger_list'> {
@@ -44,6 +49,8 @@ export interface ExportTriggersListv6 extends ExportBase<'trigger_list'> {
 	triggerCollections: TriggerCollection[] | undefined // Added in v4.1
 	instances: ExportInstancesv6
 	connectionCollections: ConnectionCollection[] | undefined // Added in v4.1
+	imageLibrary?: ImageLibraryExportData[] // Added in v4.4
+	imageLibraryCollections?: ImageLibraryCollection[] // Added in v4.4
 }
 
 export type ExportTriggerContentv6 = Record<string, any> // TODO

--- a/shared-lib/lib/Model/ImageLibraryModel.ts
+++ b/shared-lib/lib/Model/ImageLibraryModel.ts
@@ -1,0 +1,40 @@
+import type { CollectionBase } from './Collections.js'
+
+export interface ImageLibraryInfo {
+	name: string
+	description: string
+	originalSize: number
+	previewSize: number
+	createdAt: number
+	modifiedAt: number
+	checksum: string
+	mimeType: string
+	collectionId?: string
+	sortOrder: number
+}
+
+export interface ImageLibraryExportData {
+	info: ImageLibraryInfo
+	originalImage: string // base64 data URL
+	previewImage: string // base64 data URL
+}
+
+export type ImageLibraryCollection = CollectionBase<null>
+
+export type ImageLibraryUpdate = ImageLibraryUpdateInitOp | ImageLibraryUpdateRemoveOp | ImageLibraryUpdateUpdateOp
+
+export interface ImageLibraryUpdateInitOp {
+	type: 'init'
+	images: ImageLibraryInfo[]
+}
+
+export interface ImageLibraryUpdateRemoveOp {
+	type: 'remove'
+	itemName: string
+}
+
+export interface ImageLibraryUpdateUpdateOp {
+	type: 'update'
+	itemName: string
+	info: ImageLibraryInfo
+}

--- a/shared-lib/lib/Model/ImportExport.ts
+++ b/shared-lib/lib/Model/ImportExport.ts
@@ -52,6 +52,7 @@ export const zodClientExportSelection = z.object({
 	customVariables: zodQueryBoolean,
 	expressionVariables: zodQueryBoolean,
 	includeSecrets: zodQueryBoolean,
+	imageLibrary: zodQueryBoolean,
 	format: zodExportFormat,
 	filename: z.string().optional(),
 })
@@ -78,6 +79,7 @@ export interface ClientImportObject {
 	triggers: Record<string, { name: string }> | null
 	customVariables: boolean
 	expressionVariables: boolean
+	imageLibrary: boolean
 	oldPageNumber?: number
 	page?: ClientPageInfo
 	pages?: Record<number, ClientPageInfo>

--- a/shared-lib/lib/Model/ImportExport.ts
+++ b/shared-lib/lib/Model/ImportExport.ts
@@ -20,6 +20,7 @@ export const zodClientImportOrResetSelection = z.object({
 	expressionVariables: zodImportOrResetType,
 	connections: zodResetType, // Future: This should become zodImportOrResetType, once there is a plan for how that should work
 	userconfig: zodResetType, // Future: This should become zodImportOrResetType, or more likely an object describing subsections
+	imageLibrary: zodImportOrResetType,
 })
 
 export type ClientImportOrResetSelection = z.infer<typeof zodClientImportOrResetSelection>

--- a/webui/package.json
+++ b/webui/package.json
@@ -46,6 +46,7 @@
     "fast-json-patch": "patch:fast-json-patch@npm%3A3.1.1#~/.yarn/patches/fast-json-patch-npm-3.1.1-7e8bb70a45.patch",
     "fuzzysort": "^3.1.0",
     "html-entities": "^2.6.0",
+    "human-id": "^4.1.3",
     "intersection-observer": "^0.12.2",
     "json5": "^2.2.3",
     "lodash-es": "^4.18.1",

--- a/webui/src/App.scss
+++ b/webui/src/App.scss
@@ -32,6 +32,7 @@
 @use 'scss/collapsible-tree';
 @use 'scss/sticky-tables';
 @use 'scss/expression';
+@use 'scss/image-library';
 
 //@debug "$primary = #{$primary}"; // should be red (#d50215), not the coreui default blue (#5856d6).
 

--- a/webui/src/ContextData.tsx
+++ b/webui/src/ContextData.tsx
@@ -4,6 +4,7 @@ import { NotificationsManager, type NotificationsManagerRef } from '~/Components
 import { ConnectionsStore } from '~/Stores/ConnectionsStore.js'
 import { EntityDefinitionsStore } from '~/Stores/EntityDefinitionsStore.js'
 import { EventDefinitionsStore } from '~/Stores/EventDefinitionsStore.js'
+import { ImageLibraryStore } from '~/Stores/ImageLibraryStore.js'
 import { ModuleInfoStore } from '~/Stores/ModuleInfoStore.js'
 import { PagesStore } from '~/Stores/PagesStore.js'
 import { RootAppStoreContext, type RootAppStore } from '~/Stores/RootAppStore.js'
@@ -20,6 +21,7 @@ import { useCustomVariablesSubscription } from './Hooks/useCustomVariablesSubscr
 import { useEntityDefinitionsSubscription } from './Hooks/useEntityDefinitionsSubscription.js'
 import { useEventDefinitions } from './Hooks/useEventDefinitions.js'
 import { useExpressionVariablesListSubscription } from './Hooks/useExpressionVariablesListSubscription.js'
+import { useImageLibrarySubscription } from './Hooks/useImageLibrarySubscription.js'
 import { useInstanceStatusesSubscription } from './Hooks/useInstanceStatusesSubscription.js'
 import { useModuleInfoSubscription } from './Hooks/useModuleInfoSubscription.js'
 import { useModuleStoreListSubscription } from './Hooks/useModuleStoreListSubscription.js'
@@ -89,6 +91,8 @@ export function ContextData({ children }: Readonly<ContextDataProps>): React.JSX
 
 			userConfig: new UserConfigStore(),
 
+			imageLibrary: new ImageLibraryStore(),
+
 			moduleStoreRefreshProgress: observable.map(),
 
 			showWizardEvent,
@@ -102,6 +106,13 @@ export function ContextData({ children }: Readonly<ContextDataProps>): React.JSX
 		rootStore.entityDefinitions.actions,
 		trpc.instances.definitions.actions
 	)
+	const imageLibraryReady = useImageLibrarySubscription(rootStore.imageLibrary)
+	const imageLibraryCollectionsReady = useGenericCollectionsSubscription(
+		rootStore.imageLibrary,
+		trpc.imageLibrary.collections.watchQuery,
+		undefined
+	)
+
 	const feedbackDefinitionsReady = useEntityDefinitionsSubscription(
 		rootStore.entityDefinitions.feedbacks,
 		trpc.instances.definitions.feedbacks
@@ -177,6 +188,8 @@ export function ContextData({ children }: Readonly<ContextDataProps>): React.JSX
 		triggerGroupsReady,
 		entityDefinitionsReady,
 		activeLearnRequestsReady,
+		imageLibraryReady,
+		imageLibraryCollectionsReady,
 	]
 	const completedSteps = steps.filter((s) => !!s)
 

--- a/webui/src/Hooks/useImageLibrarySubscription.ts
+++ b/webui/src/Hooks/useImageLibrarySubscription.ts
@@ -1,0 +1,27 @@
+import { useSubscription } from '@trpc/tanstack-react-query'
+import { useState } from 'react'
+import { trpc } from '~/Resources/TRPC'
+import type { ImageLibraryStore } from '~/Stores/ImageLibraryStore.js'
+
+export function useImageLibrarySubscription(store: ImageLibraryStore): boolean {
+	const [ready, setReady] = useState(false)
+
+	useSubscription(
+		trpc.imageLibrary.watch.subscriptionOptions(undefined, {
+			onStarted: () => {
+				store.updateStore(null)
+				setReady(false)
+			},
+			onData: (data) => {
+				store.updateStore(data)
+				setReady(true)
+			},
+			onError: (error) => {
+				store.updateStore(null)
+				console.error('Failed to load image library', error)
+			},
+		})
+	)
+
+	return ready
+}

--- a/webui/src/ImageLibrary/ImageAddModal.tsx
+++ b/webui/src/ImageLibrary/ImageAddModal.tsx
@@ -2,6 +2,7 @@ import { CButton, CModal, CModalBody, CModalFooter, CModalHeader, CModalTitle } 
 import { observer } from 'mobx-react-lite'
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useState } from 'react'
 import { isLabelValid } from '@companion-app/shared/Label.js'
+import { stringifyError } from '@companion-app/shared/Stringify.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC'
 import { ImageNameInput } from './ImageNameInput'
 
@@ -41,13 +42,13 @@ export const ImageAddModal = observer(
 		const createMutation = useMutationExt(trpc.imageLibrary.create.mutationOptions())
 
 		const handleCreate = useCallback(() => {
-			if (!isLabelValid(localValue)) {
-				// The label is already shown as invalid, no need to tell them again
+			if (!localValue.trim()) {
+				setErrorMessage('Image name is required')
 				return
 			}
 
-			if (!localValue.trim()) {
-				setErrorMessage('Image name is required')
+			if (!isLabelValid(localValue)) {
+				// The label is already shown as invalid, no need to tell them again
 				return
 			}
 
@@ -71,8 +72,8 @@ export const ImageAddModal = observer(
 				.catch((err) => {
 					console.error('Failed to create image:', err)
 					// Provide more specific error messages
-					if (err.message || err) {
-						setErrorMessage(err.message || err)
+					if (err) {
+						setErrorMessage(stringifyError(err))
 					} else {
 						setErrorMessage('Failed to create image. Check the name is valid and try again.')
 					}

--- a/webui/src/ImageLibrary/ImageAddModal.tsx
+++ b/webui/src/ImageLibrary/ImageAddModal.tsx
@@ -1,0 +1,131 @@
+import { CButton, CModal, CModalBody, CModalFooter, CModalHeader, CModalTitle } from '@coreui/react'
+import { observer } from 'mobx-react-lite'
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useState } from 'react'
+import { isLabelValid } from '@companion-app/shared/Label.js'
+import { trpc, useMutationExt } from '~/Resources/TRPC'
+import { ImageNameInput } from './ImageNameInput'
+
+interface ImageAddModalProps {
+	onImageCreated?: (imageName: string) => void
+}
+
+export interface ImageAddModalRef {
+	show(): void
+}
+
+export const ImageAddModal = observer(
+	forwardRef<ImageAddModalRef, ImageAddModalProps>(function ImageAddModal({ onImageCreated }, ref) {
+		const [visible, setVisible] = useState(false)
+		const [localValue, setLocalValue] = useState('')
+		const [isCreating, setIsCreating] = useState(false)
+		const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+		useImperativeHandle(
+			ref,
+			() => ({
+				show() {
+					setVisible(true)
+				},
+			}),
+			[]
+		)
+
+		// Reset state when modal opens
+		useEffect(() => {
+			if (visible) {
+				setLocalValue('')
+				setErrorMessage(null)
+			}
+		}, [visible])
+
+		const createMutation = useMutationExt(trpc.imageLibrary.create.mutationOptions())
+
+		const handleCreate = useCallback(() => {
+			if (!isLabelValid(localValue)) {
+				// The label is already shown as invalid, no need to tell them again
+				return
+			}
+
+			if (!localValue.trim()) {
+				setErrorMessage('Image name is required')
+				return
+			}
+
+			setIsCreating(true)
+			setErrorMessage(null)
+
+			// Use the name as both the name and the description
+			createMutation
+				.mutateAsync({ name: localValue.trim(), description: localValue.trim() })
+				.then((result) => {
+					// Server returns the sanitized name on success
+					if (typeof result === 'string') {
+						const newName = result
+						// Notify parent of the new image
+						if (onImageCreated) {
+							onImageCreated(newName)
+						}
+						setVisible(false)
+					}
+				})
+				.catch((err) => {
+					console.error('Failed to create image:', err)
+					// Provide more specific error messages
+					if (err.message || err) {
+						setErrorMessage(err.message || err)
+					} else {
+						setErrorMessage('Failed to create image. Check the name is valid and try again.')
+					}
+				})
+				.finally(() => {
+					setIsCreating(false)
+				})
+		}, [createMutation, localValue, onImageCreated])
+
+		const handleCancel = useCallback(() => {
+			setLocalValue('')
+			setErrorMessage(null)
+			setVisible(false)
+		}, [])
+
+		const handleValueChange = useCallback((newValue: string) => {
+			setLocalValue(newValue)
+			setErrorMessage(null)
+		}, [])
+
+		const canCreate = isLabelValid(localValue) && localValue.trim() !== ''
+
+		const helpText = (
+			<>
+				The image name will be used to reference this image in button configurations and other places.
+				<br />
+				It must contain only letters, numbers, hyphens, and underscores.
+			</>
+		)
+
+		return (
+			<CModal visible={visible} onClose={handleCancel} backdrop="static">
+				<CModalHeader>
+					<CModalTitle>Add New Image</CModalTitle>
+				</CModalHeader>
+				<CModalBody>
+					<ImageNameInput
+						value={localValue}
+						onChange={handleValueChange}
+						disabled={isCreating}
+						errorMessage={errorMessage}
+						helpText={helpText}
+					/>
+				</CModalBody>
+				<CModalFooter>
+					<CButton color="secondary" onClick={handleCancel} disabled={isCreating}>
+						Cancel
+					</CButton>
+					<CButton color="primary" onClick={handleCreate} disabled={!canCreate || isCreating}>
+						{isCreating ? 'Creating...' : 'Create'}
+					</CButton>
+				</CModalFooter>
+			</CModal>
+		)
+	})
+)

--- a/webui/src/ImageLibrary/ImageLibraryCollectionsApi.ts
+++ b/webui/src/ImageLibrary/ImageLibraryCollectionsApi.ts
@@ -1,0 +1,57 @@
+import { useMemo } from 'react'
+import type { NestingCollectionsApi } from '~/Components/CollectionsNestingTable/Types.js'
+import type { GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
+import { trpc, useMutationExt } from '~/Resources/TRPC'
+
+export type ImageLibraryCollectionsApi = NestingCollectionsApi
+
+export function useImageLibraryCollectionsApi(
+	confirmModalRef: React.RefObject<GenericConfirmModalRef>
+): ImageLibraryCollectionsApi {
+	const setNameCollectionMutation = useMutationExt(trpc.imageLibrary.collections.setName.mutationOptions())
+	const removeCollectionMutation = useMutationExt(trpc.imageLibrary.collections.remove.mutationOptions())
+	const reorderCollectionMutation = useMutationExt(trpc.imageLibrary.collections.reorder.mutationOptions())
+	const reorderItemMutation = useMutationExt(trpc.imageLibrary.reorder.mutationOptions())
+
+	return useMemo(
+		() =>
+			({
+				renameCollection: (collectionId: string, newName: string) => {
+					setNameCollectionMutation.mutateAsync({ collectionId, collectionName: newName }).catch((e) => {
+						console.error('Failed to rename collection', e)
+					})
+				},
+
+				deleteCollection: (collectionId: string) => {
+					confirmModalRef.current?.show(
+						'Delete Collection',
+						'Are you sure you want to delete this collection? All images in this collection will be moved to Ungrouped Images.',
+						'Delete',
+						() => {
+							removeCollectionMutation.mutateAsync({ collectionId }).catch((e) => {
+								console.error('Failed to delete collection', e)
+							})
+						}
+					)
+				},
+
+				moveCollection: (collectionId: string, parentId: string | null, dropIndex: number) => {
+					reorderCollectionMutation.mutateAsync({ collectionId, parentId, dropIndex }).catch((e) => {
+						console.error('Failed to reorder collection', e)
+					})
+				},
+				moveItemToCollection: (itemId: string, collectionId: string | null, dropIndex: number) => {
+					reorderItemMutation.mutateAsync({ imageName: itemId, collectionId, dropIndex }).catch((e) => {
+						console.error('Reorder failed', e)
+					})
+				},
+			}) satisfies ImageLibraryCollectionsApi,
+		[
+			reorderItemMutation,
+			removeCollectionMutation,
+			reorderCollectionMutation,
+			setNameCollectionMutation,
+			confirmModalRef,
+		]
+	)
+}

--- a/webui/src/ImageLibrary/ImageLibraryDropzone.tsx
+++ b/webui/src/ImageLibrary/ImageLibraryDropzone.tsx
@@ -1,0 +1,133 @@
+import { faFileUpload } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { nanoid } from 'nanoid'
+import React, { useCallback, useContext, useEffect, useState } from 'react'
+import { trpc, useMutationExt } from '~/Resources/TRPC'
+import { RootAppStoreContext } from '~/Stores/RootAppStore.js'
+import { useImageLibraryUpload } from './useImageLibraryUpload'
+
+export function ImageLibraryDropzone(): React.ReactElement | null {
+	const { notifier } = useContext(RootAppStoreContext)
+	const [isDragOver, setIsDragOver] = useState(false)
+	const [isUploading, setIsUploading] = useState(false)
+
+	const createMutation = useMutationExt(trpc.imageLibrary.create.mutationOptions())
+	const { uploadImageFile } = useImageLibraryUpload()
+
+	const handleDrop = useCallback(
+		(e: React.DragEvent) => {
+			e.preventDefault()
+			e.stopPropagation()
+			setIsDragOver(false)
+
+			const files = e.dataTransfer?.files
+			if (!files || files.length === 0) return
+
+			// Filter for image files only
+			const imageFiles = Array.from(files).filter((file) => file.type.startsWith('image/'))
+
+			if (imageFiles.length === 0) {
+				notifier.show('Invalid Files', 'Please drop image files only', 5000)
+				return
+			}
+
+			setIsUploading(true)
+
+			void (async () => {
+				try {
+					for (const file of imageFiles) {
+						// Generate a random ID for the image
+						const imageName = nanoid()
+
+						// Create the image placeholder first
+						const fileName = file.name.replace(/\.[^/.]+$/, '') // Remove extension
+						await createMutation.mutateAsync({
+							name: imageName,
+							description: fileName || imageName,
+						})
+
+						// Then upload the file
+						await uploadImageFile(file, imageName)
+					}
+
+					notifier.show(
+						'Upload Complete',
+						`Successfully uploaded ${imageFiles.length} image${imageFiles.length > 1 ? 's' : ''}`,
+						5000
+					)
+				} catch (err) {
+					console.error('Failed to import images:', err)
+					notifier.show('Upload Failed', 'Failed to upload one or more images', 5000)
+				} finally {
+					setIsUploading(false)
+				}
+			})()
+		},
+		[createMutation, uploadImageFile, notifier]
+	)
+
+	// Detect drags at window level to show overlay
+	useEffect(() => {
+		let dragCounter = 0
+
+		const handleWindowDragEnter = (e: DragEvent) => {
+			const items = e.dataTransfer?.items
+			if (items && Array.from(items).some((item) => item.kind === 'file')) {
+				dragCounter++
+				setIsDragOver(true)
+			}
+		}
+
+		const handleWindowDragLeave = () => {
+			dragCounter--
+			if (dragCounter === 0) {
+				setIsDragOver(false)
+			}
+		}
+
+		const handleWindowDragOver = (e: DragEvent) => {
+			e.preventDefault()
+		}
+
+		const handleWindowDrop = (e: DragEvent) => {
+			e.preventDefault()
+			dragCounter = 0
+			setIsDragOver(false)
+		}
+
+		const handleDragEnd = () => {
+			// Drag operation ended (cancelled or completed outside window)
+			dragCounter = 0
+			setIsDragOver(false)
+		}
+
+		window.addEventListener('dragenter', handleWindowDragEnter)
+		window.addEventListener('dragleave', handleWindowDragLeave)
+		window.addEventListener('dragover', handleWindowDragOver)
+		window.addEventListener('drop', handleWindowDrop)
+		window.addEventListener('dragend', handleDragEnd)
+
+		return () => {
+			window.removeEventListener('dragenter', handleWindowDragEnter)
+			window.removeEventListener('dragleave', handleWindowDragLeave)
+			window.removeEventListener('dragover', handleWindowDragOver)
+			window.removeEventListener('drop', handleWindowDrop)
+			window.removeEventListener('dragend', handleDragEnd)
+		}
+	}, [])
+
+	if (!isDragOver && !isUploading) return null
+
+	return (
+		<div
+			className={`image-library-dropzone ${isDragOver ? 'active' : ''} ${isUploading ? 'uploading' : ''}`}
+			onDrop={handleDrop}
+			onDragOver={(e) => e.preventDefault()}
+		>
+			<div className="dropzone-content">
+				<FontAwesomeIcon icon={faFileUpload} size="2x" />
+				<span>{isUploading ? 'Uploading...' : 'Upload as new images'}</span>
+			</div>
+		</div>
+	)
+}

--- a/webui/src/ImageLibrary/ImageLibraryDropzone.tsx
+++ b/webui/src/ImageLibrary/ImageLibraryDropzone.tsx
@@ -78,8 +78,10 @@ export function ImageLibraryDropzone(): React.ReactElement | null {
 			}
 		}
 
-		const handleWindowDragLeave = () => {
-			dragCounter--
+		const handleWindowDragLeave = (e: DragEvent) => {
+			const items = e.dataTransfer?.items
+			if (!items || !Array.from(items).some((item) => item.kind === 'file')) return
+			dragCounter = Math.max(0, dragCounter - 1)
 			if (dragCounter === 0) {
 				setIsDragOver(false)
 			}

--- a/webui/src/ImageLibrary/ImageLibraryDropzone.tsx
+++ b/webui/src/ImageLibrary/ImageLibraryDropzone.tsx
@@ -71,6 +71,8 @@ export function ImageLibraryDropzone(): React.ReactElement | null {
 		let dragCounter = 0
 
 		const handleWindowDragEnter = (e: DragEvent) => {
+			e.preventDefault()
+
 			const items = e.dataTransfer?.items
 			if (items && Array.from(items).some((item) => item.kind === 'file')) {
 				dragCounter++
@@ -79,6 +81,8 @@ export function ImageLibraryDropzone(): React.ReactElement | null {
 		}
 
 		const handleWindowDragLeave = (e: DragEvent) => {
+			e.preventDefault()
+
 			const items = e.dataTransfer?.items
 			if (!items || !Array.from(items).some((item) => item.kind === 'file')) return
 			dragCounter = Math.max(0, dragCounter - 1)

--- a/webui/src/ImageLibrary/ImageLibraryEditor.tsx
+++ b/webui/src/ImageLibrary/ImageLibraryEditor.tsx
@@ -1,0 +1,276 @@
+import { CAlert, CButton, CCol, CForm, CFormLabel } from '@coreui/react'
+import { faCopy, faDownload, faEdit, faTrashAlt, faUpload } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { observer } from 'mobx-react-lite'
+import React, { useCallback, useContext, useRef, useState } from 'react'
+import { CopyToClipboard } from 'react-copy-to-clipboard'
+import { GenericConfirmModal, type GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
+import { trpc, trpcClient, useMutationExt } from '~/Resources/TRPC.js'
+import { RootAppStoreContext } from '~/Stores/RootAppStore.js'
+import { ImageDescriptionEditor } from './imageDescriptionEditor.js'
+import { ImageLibraryImagePreview } from './ImageLibraryImagePreview.js'
+import { ImageNameEditModal } from './ImageNameEditModal.js'
+import { useImageLibraryUpload } from './useImageLibraryUpload'
+
+interface ImageLibraryEditorProps {
+	selectedImageName: string | null
+	onDeleteImage: (imageName: string) => void
+	onImageNameChanged?: (oldName: string, newName: string) => void
+}
+
+export const ImageLibraryEditor = observer(function ImageLibraryEditor({
+	selectedImageName,
+	onDeleteImage,
+	onImageNameChanged,
+}: ImageLibraryEditorProps) {
+	const { imageLibrary, notifier } = useContext(RootAppStoreContext)
+	const [uploading, setUploading] = useState(false)
+	const [showNameEditModal, setShowNameEditModal] = useState(false)
+	const [isDragOver, setIsDragOver] = useState(false)
+	const fileInputRef = useRef<HTMLInputElement>(null)
+	const confirmModalRef = useRef<GenericConfirmModalRef>(null)
+
+	// Get image info from the store
+	const imageInfo = selectedImageName ? imageLibrary.getImage(selectedImageName) : null
+
+	const deleteMutation = useMutationExt(trpc.imageLibrary.delete.mutationOptions())
+	const { uploadImageFile } = useImageLibraryUpload()
+
+	const handleDelete = useCallback(() => {
+		if (!selectedImageName) return
+
+		confirmModalRef.current?.show(
+			'Delete Image',
+			'Are you sure you want to delete this image? This action cannot be undone.',
+			'Delete',
+			() => {
+				deleteMutation
+					.mutateAsync({ imageName: selectedImageName })
+					.then(() => {
+						onDeleteImage(selectedImageName)
+					})
+					.catch((err) => {
+						console.error('Failed to delete image:', err)
+					})
+			}
+		)
+	}, [deleteMutation, selectedImageName, onDeleteImage])
+
+	const handleDownload = useCallback(() => {
+		if (!selectedImageName || !imageInfo) return
+
+		// Get image data and download
+		trpcClient.imageLibrary.getData
+			.query({
+				imageName: selectedImageName,
+				type: 'original',
+			})
+			.then((imageData) => {
+				if (imageData?.image) {
+					// Create download link
+					const link = document.createElement('a')
+					link.href = imageData.image
+					link.download = `${imageInfo.name}.${imageInfo.mimeType.split('/')[1] || 'png'}`
+					document.body.appendChild(link)
+					link.click()
+					document.body.removeChild(link)
+				}
+			})
+			.catch((err) => {
+				console.error('Failed to download image:', err)
+			})
+	}, [selectedImageName, imageInfo])
+
+	const uploadFile = useCallback(
+		async (file: File) => {
+			if (!selectedImageName) return
+
+			setUploading(true)
+
+			try {
+				await uploadImageFile(file, selectedImageName)
+			} catch (err) {
+				console.error('Failed to replace image:', err)
+			} finally {
+				setUploading(false)
+			}
+		},
+		[uploadImageFile, selectedImageName]
+	)
+
+	const handleReplaceImage = useCallback(
+		(event: React.ChangeEvent<HTMLInputElement>) => {
+			const file = event.currentTarget.files?.[0]
+			event.currentTarget.value = '' // Reset file input
+
+			if (!file) return
+
+			void uploadFile(file)
+		},
+		[uploadFile]
+	)
+
+	const handleImageNameChanged = useCallback(
+		(oldName: string, newName: string) => {
+			setShowNameEditModal(false)
+			if (onImageNameChanged) {
+				onImageNameChanged(oldName, newName)
+			}
+		},
+		[onImageNameChanged]
+	)
+
+	const handleCopyVariableValue = useCallback(() => {
+		notifier.show('Copied', 'Copied to clipboard', 5000)
+	}, [notifier])
+
+	const handleDragOver = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+		event.preventDefault()
+		event.stopPropagation()
+		setIsDragOver(true)
+	}, [])
+
+	const handleDragLeave = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+		event.preventDefault()
+		event.stopPropagation()
+		setIsDragOver(false)
+	}, [])
+
+	const handleDrop = useCallback(
+		(event: React.DragEvent<HTMLDivElement>) => {
+			event.preventDefault()
+			event.stopPropagation()
+			setIsDragOver(false)
+
+			const files = event.dataTransfer.files
+			if (files && files.length > 0) {
+				const file = files[0]
+				// Check if it's an image file
+				if (file.type.startsWith('image/')) {
+					void uploadFile(file)
+				} else {
+					notifier.show('Invalid File', 'Please drop an image file', 5000)
+				}
+			}
+		},
+		[uploadFile, notifier]
+	)
+
+	const formatDate = (timestamp: number) => {
+		return new Date(timestamp).toLocaleString()
+	}
+
+	if (!selectedImageName) {
+		return (
+			<div className="image-library-editor">
+				<CAlert color="info">Select an image from the library to view and edit its properties.</CAlert>
+			</div>
+		)
+	}
+
+	if (!imageInfo) {
+		return (
+			<div className="image-library-editor">
+				<CAlert color="danger">Failed to load image data.</CAlert>
+			</div>
+		)
+	}
+
+	return (
+		<div className="image-library-editor">
+			<GenericConfirmModal ref={confirmModalRef} />
+
+			<ImageNameEditModal
+				visible={showNameEditModal}
+				onClose={() => setShowNameEditModal(false)}
+				imageName={selectedImageName}
+				currentName={imageInfo.name}
+				onNameChanged={handleImageNameChanged}
+			/>
+
+			<div className="mb-3">
+				<div className="d-flex flex-wrap gap-2">
+					<CButton color="danger" onClick={handleDelete} title="Delete Image">
+						<FontAwesomeIcon icon={faTrashAlt} />
+					</CButton>
+
+					<CButton color="secondary" onClick={handleDownload}>
+						<FontAwesomeIcon icon={faDownload} /> Download
+					</CButton>
+
+					<CButton color="warning" onClick={() => fileInputRef.current?.click()} disabled={uploading}>
+						<FontAwesomeIcon icon={faUpload} />
+						{uploading ? ' Replacing...' : ' Replace'}
+					</CButton>
+				</div>
+
+				<input
+					ref={fileInputRef}
+					type="file"
+					accept="image/*"
+					onChange={handleReplaceImage}
+					style={{ display: 'none' }}
+				/>
+			</div>
+
+			<CForm className="row mb-3">
+				<CFormLabel htmlFor="inputName" className="col-sm-4 col-form-label col-form-label-sm">
+					Name
+				</CFormLabel>
+				<CCol sm={8} className="d-flex align-items-center justify-content-between">
+					<div className="d-flex align-items-center">
+						<span className="font-monospace">{imageInfo.name}</span>
+						<CopyToClipboard text={`$(image:${imageInfo.name})`} onCopy={handleCopyVariableValue}>
+							<CButton size="sm" title="Copy variable name">
+								<FontAwesomeIcon icon={faCopy} />
+							</CButton>
+						</CopyToClipboard>
+					</div>
+					<CButton color="secondary" size="sm" onClick={() => setShowNameEditModal(true)} title="Edit Image name">
+						<FontAwesomeIcon icon={faEdit} />
+					</CButton>
+				</CCol>
+			</CForm>
+			<CForm className="row mb-3">
+				<CFormLabel htmlFor="inputName" className="col-sm-4 col-form-label col-form-label-sm">
+					Description
+				</CFormLabel>
+				<CCol sm={8}>
+					<ImageDescriptionEditor imageName={selectedImageName} currentName={imageInfo.description} />
+				</CCol>
+			</CForm>
+
+			<div
+				className={`image-preview-full ${isDragOver ? 'drag-over' : ''}`}
+				onDragOver={handleDragOver}
+				onDragLeave={handleDragLeave}
+				onDrop={handleDrop}
+			>
+				<ImageLibraryImagePreview
+					imageName={selectedImageName}
+					type="original"
+					checksum={imageInfo.checksum}
+					alt={imageInfo.name}
+				/>
+				{isDragOver && (
+					<div className="drag-overlay">
+						<div className="drag-overlay-message">Drop image to replace</div>
+					</div>
+				)}
+			</div>
+
+			<div className="image-properties">
+				<div className="image-metadata">
+					<div className="metadata-row">
+						<span className="metadata-label">Type:</span>
+						<span>{imageInfo.mimeType}</span>
+					</div>
+					<div className="metadata-row">
+						<span className="metadata-label">Modified:</span>
+						<span>{formatDate(imageInfo.modifiedAt)}</span>
+					</div>
+				</div>
+			</div>
+		</div>
+	)
+})

--- a/webui/src/ImageLibrary/ImageLibraryEditor.tsx
+++ b/webui/src/ImageLibrary/ImageLibraryEditor.tsx
@@ -67,10 +67,13 @@ export const ImageLibraryEditor = observer(function ImageLibraryEditor({
 			})
 			.then((imageData) => {
 				if (imageData?.image) {
+					const subtype = imageInfo.mimeType.split('/')[1]?.split('+')[0] // e.g. 'svg+xml' -> 'svg'
+					const ext = subtype === 'jpeg' ? 'jpg' : subtype || 'png'
+
 					// Create download link
 					const link = document.createElement('a')
 					link.href = imageData.image
-					link.download = `${imageInfo.name}.${imageInfo.mimeType.split('/')[1] || 'png'}`
+					link.download = `${imageInfo.name}.${ext}`
 					document.body.appendChild(link)
 					link.click()
 					document.body.removeChild(link)

--- a/webui/src/ImageLibrary/ImageLibraryEditor.tsx
+++ b/webui/src/ImageLibrary/ImageLibraryEditor.tsx
@@ -2,7 +2,7 @@ import { CAlert, CButton, CCol, CForm, CFormLabel } from '@coreui/react'
 import { faCopy, faDownload, faEdit, faTrashAlt, faUpload } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
-import React, { useCallback, useContext, useRef, useState } from 'react'
+import React, { useCallback, useContext, useId, useRef, useState } from 'react'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
 import { GenericConfirmModal, type GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
 import { trpc, trpcClient, useMutationExt } from '~/Resources/TRPC.js'
@@ -163,6 +163,8 @@ export const ImageLibraryEditor = observer(function ImageLibraryEditor({
 		return new Date(timestamp).toLocaleString()
 	}
 
+	const descriptionFieldId = useId()
+
 	if (!selectedImageName) {
 		return (
 			<div className="image-library-editor">
@@ -217,9 +219,7 @@ export const ImageLibraryEditor = observer(function ImageLibraryEditor({
 			</div>
 
 			<CForm className="row mb-3">
-				<CFormLabel htmlFor="inputName" className="col-sm-4 col-form-label col-form-label-sm">
-					Name
-				</CFormLabel>
+				<CFormLabel className="col-sm-4 col-form-label col-form-label-sm">Name</CFormLabel>
 				<CCol sm={8} className="d-flex align-items-center justify-content-between">
 					<div className="d-flex align-items-center">
 						<span className="font-monospace">{imageInfo.name}</span>
@@ -235,11 +235,15 @@ export const ImageLibraryEditor = observer(function ImageLibraryEditor({
 				</CCol>
 			</CForm>
 			<CForm className="row mb-3">
-				<CFormLabel htmlFor="inputName" className="col-sm-4 col-form-label col-form-label-sm">
+				<CFormLabel htmlFor={descriptionFieldId} className="col-sm-4 col-form-label col-form-label-sm">
 					Description
 				</CFormLabel>
 				<CCol sm={8}>
-					<ImageDescriptionEditor imageName={selectedImageName} currentName={imageInfo.description} />
+					<ImageDescriptionEditor
+						id={descriptionFieldId}
+						imageName={selectedImageName}
+						currentName={imageInfo.description}
+					/>
 				</CCol>
 			</CForm>
 

--- a/webui/src/ImageLibrary/ImageLibraryGrid.tsx
+++ b/webui/src/ImageLibrary/ImageLibraryGrid.tsx
@@ -1,6 +1,7 @@
 import { CButton, CButtonGroup, CFormInput } from '@coreui/react'
 import { faImage, faLayerGroup, faPlus } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import fuzzysort from 'fuzzysort'
 import { humanId } from 'human-id'
 import { observer } from 'mobx-react-lite'
 import { useCallback, useContext, useMemo, useRef, useState } from 'react'
@@ -32,6 +33,7 @@ interface ImageCollection extends Omit<CollectionsNestingTableCollection, 'child
 interface ImageItem extends CollectionsNestingTableItem {
 	// Additional image info
 	imageInfo: ImageLibraryInfo
+	fuzzy: Fuzzysort.Prepared
 }
 
 interface ImageLibraryGridProps {
@@ -114,6 +116,7 @@ export const ImageLibraryGrid = observer(function ImageLibraryGridInner({
 				collectionId: image.collectionId ?? null,
 				sortOrder: image.sortOrder,
 				imageInfo: image,
+				fuzzy: fuzzysort.prepare(`${image.name} ${image.description}`),
 			})),
 		[images]
 	)
@@ -128,7 +131,7 @@ export const ImageLibraryGrid = observer(function ImageLibraryGridInner({
 	// ItemRow component for rendering individual images
 	const ItemRow = useCallback(
 		(item: ImageItem) => {
-			if (!item.imageInfo.name.toLowerCase().includes(searchQuery.toLowerCase())) return null
+			if (searchQuery && fuzzysort.single(searchQuery, item.fuzzy) === null) return null
 
 			return (
 				<ImageThumbnail

--- a/webui/src/ImageLibrary/ImageLibraryGrid.tsx
+++ b/webui/src/ImageLibrary/ImageLibraryGrid.tsx
@@ -1,0 +1,217 @@
+import { CButton, CButtonGroup, CFormInput } from '@coreui/react'
+import { faImage, faLayerGroup, faPlus } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { humanId } from 'human-id'
+import { observer } from 'mobx-react-lite'
+import { useCallback, useContext, useMemo, useRef, useState } from 'react'
+import type { ImageLibraryInfo } from '@companion-app/shared/Model/ImageLibraryModel.js'
+import { CollectionsNestingTable } from '~/Components/CollectionsNestingTable/CollectionsNestingTable.js'
+import type {
+	CollectionsNestingTableCollection,
+	CollectionsNestingTableItem,
+} from '~/Components/CollectionsNestingTable/Types.js'
+import { GenericConfirmModal, type GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
+import { NonIdealState } from '~/Components/NonIdealState.js'
+import { PanelCollapseHelperProvider } from '~/Helpers/CollapseHelper.js'
+import { trpc, useMutationExt } from '~/Resources/TRPC'
+import { useComputed } from '~/Resources/util'
+import { RootAppStoreContext } from '~/Stores/RootAppStore.js'
+import { ImageAddModal, type ImageAddModalRef } from './ImageAddModal'
+import { useImageLibraryCollectionsApi } from './ImageLibraryCollectionsApi.js'
+import { ImageLibraryDropzone } from './ImageLibraryDropzone'
+import { ImageThumbnail } from './ImageThumbnail'
+import { useImageLibraryUpload } from './useImageLibraryUpload'
+
+// Adapters for CollectionsNestingTable
+interface ImageCollection extends Omit<CollectionsNestingTableCollection, 'children'> {
+	label: string
+	sortOrder: number
+	children: ImageCollection[]
+}
+
+interface ImageItem extends CollectionsNestingTableItem {
+	// Additional image info
+	imageInfo: ImageLibraryInfo
+}
+
+interface ImageLibraryGridProps {
+	selectedImageName: string | null
+	onSelectImage: (imageName: string | null) => void
+}
+
+export const ImageLibraryGrid = observer(function ImageLibraryGridInner({
+	selectedImageName,
+	onSelectImage,
+}: ImageLibraryGridProps) {
+	const { imageLibrary, notifier } = useContext(RootAppStoreContext)
+	const [searchQuery, setSearchQuery] = useState('')
+	const addModalRef = useRef<ImageAddModalRef>(null)
+	const confirmModalRef = useRef<GenericConfirmModalRef>(null)
+	const gridContentRef = useRef<HTMLDivElement>(null)
+
+	const createMutation = useMutationExt(trpc.imageLibrary.create.mutationOptions())
+	const { uploadImageFile } = useImageLibraryUpload()
+
+	const handleImportFiles = useCallback(() => {
+		const input = document.createElement('input')
+		input.type = 'file'
+		input.accept = 'image/*'
+		input.multiple = true
+
+		input.onchange = () => {
+			const files = input.files
+			if (!files || files.length === 0) return
+
+			// Filter for image files only
+			const imageFiles = Array.from(files).filter((file) => file.type.startsWith('image/'))
+
+			if (imageFiles.length === 0) {
+				notifier.show('Invalid Files', 'Please select image files only', 5000)
+				return
+			}
+
+			void (async () => {
+				try {
+					for (const file of imageFiles) {
+						// Generate a random ID for the image
+						const imageName = humanId({ separator: '-', capitalize: false })
+
+						// Create the image placeholder first
+						const fileName = file.name.replace(/\.[^/.]+$/, '') // Remove extension
+						await createMutation.mutateAsync({
+							name: imageName,
+							description: fileName || imageName,
+						})
+
+						// Then upload the file
+						await uploadImageFile(file, imageName)
+					}
+
+					notifier.show(
+						'Upload Complete',
+						`Successfully uploaded ${imageFiles.length} image${imageFiles.length > 1 ? 's' : ''}`,
+						5000
+					)
+				} catch (err) {
+					console.error('Failed to import images:', err)
+					notifier.show('Upload Failed', 'Failed to upload one or more images', 5000)
+				}
+			})()
+		}
+
+		input.click()
+	}, [createMutation, uploadImageFile, notifier])
+
+	const handleCreateNew = useCallback(() => addModalRef.current?.show(), [])
+
+	const images = imageLibrary.getAllImages()
+
+	// Convert images to items format for CollectionsNestingTable
+	const imageItems: ImageItem[] = useComputed(
+		() =>
+			images.map((image) => ({
+				id: image.name,
+				collectionId: image.collectionId ?? null,
+				sortOrder: image.sortOrder,
+				imageInfo: image,
+			})),
+		[images]
+	)
+
+	const collections: ImageCollection[] = imageLibrary.rootCollections()
+
+	const collectionsApi = useImageLibraryCollectionsApi(confirmModalRef)
+
+	// Get all collection IDs for the collapse helper
+	const allCollectionIds = useMemo(() => collections.map((collection) => collection.id), [collections])
+
+	// ItemRow component for rendering individual images
+	const ItemRow = useCallback(
+		(item: ImageItem) => {
+			if (!item.imageInfo.name.toLowerCase().includes(searchQuery.toLowerCase())) return null
+
+			return (
+				<ImageThumbnail
+					image={item.imageInfo}
+					selected={selectedImageName === item.id}
+					onClick={() => onSelectImage(item.id)}
+				/>
+			)
+		},
+		[selectedImageName, onSelectImage, searchQuery]
+	)
+
+	return (
+		<div className="image-library-grid">
+			<GenericConfirmModal ref={confirmModalRef} />
+			<ImageAddModal ref={addModalRef} onImageCreated={onSelectImage} />
+
+			<div className="image-library-header">
+				<h4>Image Library</h4>
+				<p>
+					Here you can store images to be reused in your buttons. They get exposed as variables, and can be used
+					anywhere variables usually can.
+				</p>
+
+				<div className="image-library-controls">
+					<div className="d-flex gap-2 mb-3">
+						<CButtonGroup>
+							<CButton color="primary" size="sm" onClick={handleImportFiles}>
+								<FontAwesomeIcon icon={faPlus} /> Import Images
+							</CButton>
+							<CButton color="primary" size="sm" onClick={handleCreateNew}>
+								<FontAwesomeIcon icon={faPlus} /> Add Placeholder
+							</CButton>
+							<CreateCollectionButton />
+						</CButtonGroup>
+					</div>
+
+					<CFormInput
+						type="text"
+						placeholder="Search images..."
+						value={searchQuery}
+						onChange={(e) => setSearchQuery(e.target.value)}
+					/>
+				</div>
+			</div>
+
+			<ImageLibraryDropzone />
+
+			<div className="image-library-grid-content" ref={gridContentRef}>
+				<PanelCollapseHelperProvider storageId="image_library" knownPanelIds={allCollectionIds}>
+					<CollectionsNestingTable
+						ItemRow={ItemRow}
+						itemName="image"
+						dragId="image-library"
+						collectionsApi={collectionsApi}
+						selectedItemId={selectedImageName}
+						gridLayout={true}
+						collections={collections}
+						items={imageItems}
+						NoContent={NoContent}
+					/>
+				</PanelCollapseHelperProvider>
+			</div>
+		</div>
+	)
+})
+
+function NoContent() {
+	return <NonIdealState icon={faImage} text="No images in library" />
+}
+
+function CreateCollectionButton() {
+	const createMutation = useMutationExt(trpc.imageLibrary.collections.add.mutationOptions())
+
+	const doCreateCollection = useCallback(() => {
+		createMutation.mutateAsync({ collectionName: 'New Collection' }).catch((e) => {
+			console.error('Failed to add collection', e)
+		})
+	}, [createMutation])
+
+	return (
+		<CButton color="info" size="sm" onClick={doCreateCollection}>
+			<FontAwesomeIcon icon={faLayerGroup} /> Create Collection
+		</CButton>
+	)
+}

--- a/webui/src/ImageLibrary/ImageLibraryGrid.tsx
+++ b/webui/src/ImageLibrary/ImageLibraryGrid.tsx
@@ -1,4 +1,4 @@
-import { CButton, CButtonGroup, CFormInput } from '@coreui/react'
+import { CAlert, CButton, CButtonGroup, CFormInput } from '@coreui/react'
 import { faImage, faLayerGroup, faPlus } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import fuzzysort from 'fuzzysort'
@@ -155,6 +155,8 @@ export const ImageLibraryGrid = observer(function ImageLibraryGridInner({
 					Here you can store images to be reused in your buttons. They get exposed as variables, and can be used
 					anywhere variables usually can.
 				</p>
+
+				<CAlert color="danger">This is in progress, and is not yet fully functional</CAlert>
 
 				<div className="image-library-controls">
 					<div className="d-flex gap-2 mb-3">

--- a/webui/src/ImageLibrary/ImageLibraryGrid.tsx
+++ b/webui/src/ImageLibrary/ImageLibraryGrid.tsx
@@ -158,6 +158,7 @@ export const ImageLibraryGrid = observer(function ImageLibraryGridInner({
 
 					<CFormInput
 						type="text"
+						aria-label="Search images"
 						placeholder="Search images..."
 						value={searchQuery}
 						onChange={(e) => setSearchQuery(e.target.value)}

--- a/webui/src/ImageLibrary/ImageLibraryGrid.tsx
+++ b/webui/src/ImageLibrary/ImageLibraryGrid.tsx
@@ -4,13 +4,10 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import fuzzysort from 'fuzzysort'
 import { humanId } from 'human-id'
 import { observer } from 'mobx-react-lite'
-import { useCallback, useContext, useMemo, useRef, useState } from 'react'
+import { useCallback, useContext, useRef, useState } from 'react'
 import type { ImageLibraryInfo } from '@companion-app/shared/Model/ImageLibraryModel.js'
 import { CollectionsNestingTable } from '~/Components/CollectionsNestingTable/CollectionsNestingTable.js'
-import type {
-	CollectionsNestingTableCollection,
-	CollectionsNestingTableItem,
-} from '~/Components/CollectionsNestingTable/Types.js'
+import type { CollectionsNestingTableItem } from '~/Components/CollectionsNestingTable/Types.js'
 import { GenericConfirmModal, type GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
 import { NonIdealState } from '~/Components/NonIdealState.js'
 import { PanelCollapseHelperProvider } from '~/Helpers/CollapseHelper.js'
@@ -22,13 +19,6 @@ import { useImageLibraryCollectionsApi } from './ImageLibraryCollectionsApi.js'
 import { ImageLibraryDropzone } from './ImageLibraryDropzone'
 import { ImageThumbnail } from './ImageThumbnail'
 import { useImageLibraryUpload } from './useImageLibraryUpload'
-
-// Adapters for CollectionsNestingTable
-interface ImageCollection extends Omit<CollectionsNestingTableCollection, 'children'> {
-	label: string
-	sortOrder: number
-	children: ImageCollection[]
-}
 
 interface ImageItem extends CollectionsNestingTableItem {
 	// Additional image info
@@ -121,12 +111,7 @@ export const ImageLibraryGrid = observer(function ImageLibraryGridInner({
 		[images]
 	)
 
-	const collections: ImageCollection[] = imageLibrary.rootCollections()
-
 	const collectionsApi = useImageLibraryCollectionsApi(confirmModalRef)
-
-	// Get all collection IDs for the collapse helper
-	const allCollectionIds = useMemo(() => collections.map((collection) => collection.id), [collections])
 
 	// ItemRow component for rendering individual images
 	const ItemRow = useCallback(
@@ -183,7 +168,7 @@ export const ImageLibraryGrid = observer(function ImageLibraryGridInner({
 			<ImageLibraryDropzone />
 
 			<div className="image-library-grid-content" ref={gridContentRef}>
-				<PanelCollapseHelperProvider storageId="image_library" knownPanelIds={allCollectionIds}>
+				<PanelCollapseHelperProvider storageId="image_library" knownPanelIds={imageLibrary.allCollectionIds}>
 					<CollectionsNestingTable
 						ItemRow={ItemRow}
 						itemName="image"
@@ -191,7 +176,7 @@ export const ImageLibraryGrid = observer(function ImageLibraryGridInner({
 						collectionsApi={collectionsApi}
 						selectedItemId={selectedImageName}
 						gridLayout={true}
-						collections={collections}
+						collections={imageLibrary.rootCollections()}
 						items={imageItems}
 						NoContent={NoContent}
 					/>

--- a/webui/src/ImageLibrary/ImageLibraryImagePreview.tsx
+++ b/webui/src/ImageLibrary/ImageLibraryImagePreview.tsx
@@ -1,0 +1,84 @@
+import { faImage } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { useQuery } from '@tanstack/react-query'
+import classNames from 'classnames'
+import { useEffect } from 'react'
+import { MoonLoader } from 'react-spinners'
+import { trpc } from '~/Resources/TRPC'
+
+interface ImageLibraryImagePreviewProps {
+	imageName: string
+	type: 'original' | 'preview'
+	checksum: string
+	className?: string
+	alt?: string
+	onLoad?: () => void
+	onError?: (error: string) => void
+}
+
+// interface LoadState {
+// 	loading: boolean
+// 	imageUrl: string | null
+// 	error: string | null
+// }
+
+export function ImageLibraryImagePreview({
+	imageName,
+	type,
+	checksum,
+	className,
+	alt,
+}: ImageLibraryImagePreviewProps): JSX.Element {
+	const {
+		data: queryData,
+		isLoading: queryLoading,
+		error: queryError,
+		refetch: queryRefetch,
+	} = useQuery(
+		trpc.imageLibrary.getData.queryOptions({
+			imageName,
+			type,
+		})
+	)
+
+	useEffect(() => {
+		queryRefetch().catch((err) => {
+			console.error('Failed to refetch image data:', err)
+		})
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [imageName, type, checksum])
+
+	const checksumMatches = !queryData || queryData.checksum === checksum
+
+	if (queryLoading || !checksumMatches) {
+		return (
+			<div className={classNames('image-library-preview-loading', className)}>
+				<MoonLoader />
+			</div>
+		)
+	}
+
+	if (queryError) {
+		return (
+			<div className={classNames('image-library-preview-error', className)}>
+				<span>{queryError.message}</span>
+			</div>
+		)
+	}
+
+	if (!queryData?.image) {
+		return (
+			<div className={classNames('image-library-preview-empty', className)}>
+				<FontAwesomeIcon icon={faImage} title="No image data" />
+			</div>
+		)
+	}
+
+	return (
+		<img
+			src={queryData.image}
+			alt={alt || 'Image preview'}
+			className={classNames('image-library-preview', className)}
+		/>
+	)
+}

--- a/webui/src/ImageLibrary/ImageNameEditModal.tsx
+++ b/webui/src/ImageLibrary/ImageNameEditModal.tsx
@@ -1,0 +1,124 @@
+import { CButton, CModal, CModalBody, CModalFooter, CModalHeader, CModalTitle } from '@coreui/react'
+import { observer } from 'mobx-react-lite'
+import { useCallback, useEffect, useState } from 'react'
+import { isLabelValid } from '@companion-app/shared/Label.js'
+import { trpc, useMutationExt } from '~/Resources/TRPC'
+import { ImageNameInput } from './ImageNameInput'
+
+interface ImageNameEditModalProps {
+	visible: boolean
+	onClose: () => void
+	imageName: string
+	currentName: string
+	onNameChanged?: (oldName: string, newName: string) => void
+}
+
+export const ImageNameEditModal = observer(function ImageNameEditModal({
+	visible,
+	onClose,
+	imageName,
+	currentName,
+	onNameChanged,
+}: ImageNameEditModalProps) {
+	const [localValue, setLocalValue] = useState(currentName)
+	const [isSaving, setIsSaving] = useState(false)
+	const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+	// Reset state when modal opens
+	useEffect(() => {
+		if (visible) {
+			setLocalValue(currentName)
+			setErrorMessage(null)
+		}
+	}, [visible, currentName])
+
+	const setNameMutation = useMutationExt(trpc.imageLibrary.setName.mutationOptions())
+
+	const handleSave = useCallback(() => {
+		if (!isLabelValid(localValue)) {
+			// The label is already shown as invalid, no need to tell them again
+			return
+		}
+
+		if (localValue === currentName) {
+			// No change, just close
+			onClose()
+			return
+		}
+
+		setIsSaving(true)
+		setErrorMessage(null)
+
+		setNameMutation
+			.mutateAsync({ imageName, newName: localValue })
+			.then((result) => {
+				// Server returns the sanitized name on success
+				if (typeof result === 'string') {
+					const newName = result
+					// Notify parent of the name change
+					if (onNameChanged && newName !== currentName) {
+						onNameChanged(currentName, newName)
+					}
+					onClose()
+				}
+			})
+			.catch((err) => {
+				console.error('Failed to save image name:', err)
+				// Provide more specific error messages
+				if (err.message || err) {
+					setErrorMessage(err.message || err)
+				} else {
+					setErrorMessage('Failed to save image name. Check it is valid and try again.')
+				}
+			})
+			.finally(() => {
+				setIsSaving(false)
+			})
+	}, [setNameMutation, imageName, currentName, localValue, onNameChanged, onClose])
+
+	const handleCancel = useCallback(() => {
+		setLocalValue(currentName)
+		setErrorMessage(null)
+		onClose()
+	}, [currentName, onClose])
+
+	const handleValueChange = useCallback((newValue: string) => {
+		setLocalValue(newValue)
+		setErrorMessage(null)
+	}, [])
+
+	const canSave = isLabelValid(localValue) && localValue !== currentName
+
+	const warningText = (
+		<>
+			<strong>Warning:</strong> Changing the image name will break any existing references to this image in button
+			configurations, actions, or other places where this name is currently used.
+		</>
+	)
+
+	return (
+		<CModal visible={visible} onClose={handleCancel} backdrop="static">
+			<CModalHeader>
+				<CModalTitle>Edit Image name</CModalTitle>
+			</CModalHeader>
+			<CModalBody>
+				<ImageNameInput
+					value={localValue}
+					onChange={handleValueChange}
+					disabled={isSaving}
+					errorMessage={errorMessage}
+					showWarning={true}
+					warningText={warningText}
+				/>
+			</CModalBody>
+			<CModalFooter>
+				<CButton color="secondary" onClick={handleCancel} disabled={isSaving}>
+					Cancel
+				</CButton>
+				<CButton color="primary" onClick={handleSave} disabled={!canSave || isSaving}>
+					{isSaving ? 'Saving...' : 'Save'}
+				</CButton>
+			</CModalFooter>
+		</CModal>
+	)
+})

--- a/webui/src/ImageLibrary/ImageNameEditModal.tsx
+++ b/webui/src/ImageLibrary/ImageNameEditModal.tsx
@@ -2,6 +2,7 @@ import { CButton, CModal, CModalBody, CModalFooter, CModalHeader, CModalTitle } 
 import { observer } from 'mobx-react-lite'
 import { useCallback, useEffect, useState } from 'react'
 import { isLabelValid } from '@companion-app/shared/Label.js'
+import { stringifyError } from '@companion-app/shared/Stringify.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC'
 import { ImageNameInput } from './ImageNameInput'
 
@@ -65,8 +66,8 @@ export const ImageNameEditModal = observer(function ImageNameEditModal({
 			.catch((err) => {
 				console.error('Failed to save image name:', err)
 				// Provide more specific error messages
-				if (err.message || err) {
-					setErrorMessage(err.message || err)
+				if (err) {
+					setErrorMessage(stringifyError(err))
 				} else {
 					setErrorMessage('Failed to save image name. Check it is valid and try again.')
 				}

--- a/webui/src/ImageLibrary/ImageNameInput.tsx
+++ b/webui/src/ImageLibrary/ImageNameInput.tsx
@@ -1,5 +1,5 @@
 import { CAlert, CFormLabel } from '@coreui/react'
-import React from 'react'
+import React, { useId } from 'react'
 import { isLabelValid } from '@companion-app/shared/Label.js'
 import { TextInputField } from '~/Components/TextInputField.js'
 
@@ -35,6 +35,8 @@ export function ImageNameInput({
 		</>
 	)
 
+	const labelInputId = useId()
+
 	return (
 		<>
 			{errorMessage && (
@@ -50,11 +52,12 @@ export function ImageNameInput({
 			)}
 
 			<div className="mb-3 row">
-				<CFormLabel htmlFor="imageNameInput" className="col-sm-3 col-form-label">
+				<CFormLabel htmlFor={labelInputId} className="col-sm-3 col-form-label">
 					Image name
 				</CFormLabel>
 				<div className="col-sm-9">
 					<TextInputField
+						// id={labelInputId}
 						value={value}
 						setValue={onChange}
 						placeholder={placeholder}

--- a/webui/src/ImageLibrary/ImageNameInput.tsx
+++ b/webui/src/ImageLibrary/ImageNameInput.tsx
@@ -1,0 +1,70 @@
+import { CAlert, CFormLabel } from '@coreui/react'
+import React from 'react'
+import { isLabelValid } from '@companion-app/shared/Label.js'
+import { TextInputField } from '~/Components/TextInputField.js'
+
+interface ImageNameInputProps {
+	value: string
+	onChange: (value: string) => void
+	disabled?: boolean
+	placeholder?: string
+	helpText?: string | React.ReactNode
+	showWarning?: boolean
+	warningText?: string | React.ReactNode
+	errorMessage?: string | null
+}
+
+export function ImageNameInput({
+	value,
+	onChange,
+	disabled = false,
+	placeholder = 'Enter image name...',
+	helpText,
+	showWarning = false,
+	warningText,
+	errorMessage,
+}: ImageNameInputProps): JSX.Element {
+	// Generate tooltip based on validation state
+	const tooltip = !isLabelValid(value) ? 'Invalid name: Use only letters, numbers, hyphens, and underscores' : undefined
+
+	const defaultHelpText = (
+		<>
+			The image name is used to reference this image in button configurations and other places.
+			<br />
+			It must contain only letters, numbers, hyphens, and underscores.
+		</>
+	)
+
+	return (
+		<>
+			{errorMessage && (
+				<CAlert color="danger" className="mb-3">
+					{errorMessage}
+				</CAlert>
+			)}
+
+			{showWarning && warningText && (
+				<CAlert color="warning" className="mb-3">
+					{warningText}
+				</CAlert>
+			)}
+
+			<div className="mb-3 row">
+				<CFormLabel htmlFor="imageNameInput" className="col-sm-3 col-form-label">
+					Image name
+				</CFormLabel>
+				<div className="col-sm-9">
+					<TextInputField
+						value={value}
+						setValue={onChange}
+						placeholder={placeholder}
+						tooltip={tooltip}
+						checkValid={isLabelValid}
+						disabled={disabled}
+					/>
+				</div>
+			</div>
+			<div className="text-muted small">{helpText || defaultHelpText}</div>
+		</>
+	)
+}

--- a/webui/src/ImageLibrary/ImageThumbnail.tsx
+++ b/webui/src/ImageLibrary/ImageThumbnail.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames'
+import { useCallback } from 'react'
 import type { ImageLibraryInfo } from '@companion-app/shared/Model/ImageLibraryModel.js'
 import { ImageLibraryImagePreview } from './ImageLibraryImagePreview.js'
 
@@ -9,8 +10,24 @@ interface ImageThumbnailProps {
 }
 
 export function ImageThumbnail({ image, selected, onClick }: ImageThumbnailProps): JSX.Element {
+	const onKeyDown = useCallback(
+		(e: React.KeyboardEvent) => {
+			if (e.key === 'Enter' || e.key === ' ') {
+				e.preventDefault()
+				onClick()
+			}
+		},
+		[onClick]
+	)
+
 	return (
-		<div className={classNames('image-thumbnail', { selected })} onClick={onClick}>
+		<div
+			className={classNames('image-thumbnail', { selected })}
+			role="button"
+			tabIndex={0}
+			onClick={onClick}
+			onKeyDown={onKeyDown}
+		>
 			<div className="image-preview">
 				<ImageLibraryImagePreview
 					imageName={image.name}

--- a/webui/src/ImageLibrary/ImageThumbnail.tsx
+++ b/webui/src/ImageLibrary/ImageThumbnail.tsx
@@ -1,0 +1,32 @@
+import classNames from 'classnames'
+import type { ImageLibraryInfo } from '@companion-app/shared/Model/ImageLibraryModel.js'
+import { ImageLibraryImagePreview } from './ImageLibraryImagePreview.js'
+
+interface ImageThumbnailProps {
+	image: ImageLibraryInfo
+	selected: boolean
+	onClick: () => void
+}
+
+export function ImageThumbnail({ image, selected, onClick }: ImageThumbnailProps): JSX.Element {
+	return (
+		<div className={classNames('image-thumbnail', { selected })} onClick={onClick}>
+			<div className="image-preview">
+				<ImageLibraryImagePreview
+					imageName={image.name}
+					type="preview"
+					checksum={image.checksum}
+					alt={image.description}
+				/>
+			</div>
+			<div className="p-2">
+				<div className="image-name" title={image.description}>
+					{image.description}
+				</div>
+				<div className="image-id" title={image.name}>
+					{image.name}
+				</div>
+			</div>
+		</div>
+	)
+}

--- a/webui/src/ImageLibrary/imageDescriptionEditor.tsx
+++ b/webui/src/ImageLibrary/imageDescriptionEditor.tsx
@@ -4,11 +4,13 @@ import React, { useCallback } from 'react'
 import { trpc, useMutationExt } from '~/Resources/TRPC'
 
 interface ImageDescriptionEditorProps {
+	id: string
 	imageName: string
 	currentName: string
 }
 
 export const ImageDescriptionEditor = observer(function ImageDescriptionEditor({
+	id,
 	imageName,
 	currentName,
 }: ImageDescriptionEditorProps) {
@@ -24,6 +26,12 @@ export const ImageDescriptionEditor = observer(function ImageDescriptionEditor({
 	)
 
 	return (
-		<CFormInput type="text" value={currentName} onChange={handleNameChange} placeholder="Enter image description..." />
+		<CFormInput
+			type="text"
+			id={id}
+			value={currentName}
+			onChange={handleNameChange}
+			placeholder="Enter image description..."
+		/>
 	)
 })

--- a/webui/src/ImageLibrary/imageDescriptionEditor.tsx
+++ b/webui/src/ImageLibrary/imageDescriptionEditor.tsx
@@ -1,6 +1,6 @@
-import { CFormInput } from '@coreui/react'
 import { observer } from 'mobx-react-lite'
-import React, { useCallback } from 'react'
+import { useCallback, useEffect, useState } from 'react'
+import { TextInputField } from '~/Components/TextInputField.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC'
 
 interface ImageDescriptionEditorProps {
@@ -10,27 +10,30 @@ interface ImageDescriptionEditorProps {
 }
 
 export const ImageDescriptionEditor = observer(function ImageDescriptionEditor({
-	id,
 	imageName,
 	currentName,
 }: ImageDescriptionEditorProps) {
 	const setDescriptionMutation = useMutationExt(trpc.imageLibrary.setDescription.mutationOptions())
 
-	const handleNameChange = useCallback(
-		(e: React.ChangeEvent<HTMLInputElement>) => {
-			setDescriptionMutation.mutateAsync({ imageName, description: e.target.value }).catch((err) => {
-				console.error('Failed to save image description:', err)
-			})
-		},
-		[setDescriptionMutation, imageName]
-	)
+	const [localValue, setLocalValue] = useState(currentName)
+
+	// Sync when the server value changes (e.g. switching images)
+	useEffect(() => {
+		setLocalValue(currentName)
+	}, [currentName])
+
+	const commitToServer = useCallback(() => {
+		setDescriptionMutation.mutateAsync({ imageName, description: localValue }).catch((err) => {
+			console.error('Failed to save image description:', err)
+		})
+	}, [setDescriptionMutation, imageName, localValue])
 
 	return (
-		<CFormInput
-			type="text"
-			id={id}
-			value={currentName}
-			onChange={handleNameChange}
+		<TextInputField
+			// id={id}
+			value={localValue}
+			setValue={setLocalValue}
+			onBlur={commitToServer}
 			placeholder="Enter image description..."
 		/>
 	)

--- a/webui/src/ImageLibrary/imageDescriptionEditor.tsx
+++ b/webui/src/ImageLibrary/imageDescriptionEditor.tsx
@@ -1,0 +1,29 @@
+import { CFormInput } from '@coreui/react'
+import { observer } from 'mobx-react-lite'
+import React, { useCallback } from 'react'
+import { trpc, useMutationExt } from '~/Resources/TRPC'
+
+interface ImageDescriptionEditorProps {
+	imageName: string
+	currentName: string
+}
+
+export const ImageDescriptionEditor = observer(function ImageDescriptionEditor({
+	imageName,
+	currentName,
+}: ImageDescriptionEditorProps) {
+	const setDescriptionMutation = useMutationExt(trpc.imageLibrary.setDescription.mutationOptions())
+
+	const handleNameChange = useCallback(
+		(e: React.ChangeEvent<HTMLInputElement>) => {
+			setDescriptionMutation.mutateAsync({ imageName, description: e.target.value }).catch((err) => {
+				console.error('Failed to save image description:', err)
+			})
+		},
+		[setDescriptionMutation, imageName]
+	)
+
+	return (
+		<CFormInput type="text" value={currentName} onChange={handleNameChange} placeholder="Enter image description..." />
+	)
+})

--- a/webui/src/ImageLibrary/index.tsx
+++ b/webui/src/ImageLibrary/index.tsx
@@ -1,0 +1,49 @@
+import { CCol, CRow } from '@coreui/react'
+import { Outlet, useMatchRoute, useNavigate } from '@tanstack/react-router'
+import { observer } from 'mobx-react-lite'
+import { useCallback } from 'react'
+import { MyErrorBoundary } from '~/Resources/Error'
+import { ImageLibraryGrid } from './ImageLibraryGrid'
+
+export const ImageLibraryPage = observer(function ImageLibraryPage() {
+	const matchRoute = useMatchRoute()
+	const routeMatch = matchRoute({ to: '/image-library/$imageName' })
+
+	const navigate = useNavigate({ from: '/image-library' })
+
+	const selectedImageName = routeMatch ? routeMatch.imageName : null
+
+	const handleSelectImage = useCallback(
+		(imageName: string | null) => {
+			if (imageName === null) {
+				void navigate({ to: '/image-library' })
+			} else {
+				void navigate({
+					to: `/image-library/$imageName`,
+					params: {
+						imageName,
+					},
+				})
+			}
+		},
+		[navigate]
+	)
+
+	return (
+		<CRow className="image-library-page split-panels">
+			<CCol xs={12} xl={6} className="primary-panel">
+				<MyErrorBoundary>
+					<ImageLibraryGrid selectedImageName={selectedImageName} onSelectImage={handleSelectImage} />
+				</MyErrorBoundary>
+			</CCol>
+
+			<CCol xs={12} xl={6} className="secondary-panel">
+				<div className="secondary-panel-inner">
+					<MyErrorBoundary>
+						<Outlet />
+					</MyErrorBoundary>
+				</div>
+			</CCol>
+		</CRow>
+	)
+})

--- a/webui/src/ImageLibrary/useImageLibraryUpload.ts
+++ b/webui/src/ImageLibrary/useImageLibraryUpload.ts
@@ -1,0 +1,59 @@
+import CryptoJS from 'crypto-js'
+import { useCallback } from 'react'
+import { blobToDataURL } from '~/Helpers/FileUpload.js'
+import { trpc, useMutationExt } from '~/Resources/TRPC.js'
+import { base64EncodeUint8Array } from '~/Resources/util.js'
+
+/**
+ * Hook for uploading image files to the image library
+ */
+export function useImageLibraryUpload(): { uploadImageFile: (file: File, imageName: string) => Promise<void> } {
+	const startUploadMutation = useMutationExt(trpc.imageLibrary.upload.start.mutationOptions())
+	const uploadChunkMutation = useMutationExt(trpc.imageLibrary.upload.uploadChunk.mutationOptions())
+	const completeUploadMutation = useMutationExt(trpc.imageLibrary.upload.complete.mutationOptions())
+
+	const uploadImageFile = useCallback(
+		async (file: File, imageName: string) => {
+			// Convert file to data URL and upload
+			const dataUrl = await blobToDataURL(file)
+			const data = new TextEncoder().encode(dataUrl)
+
+			const hasher = CryptoJS.algo.SHA1.create()
+			hasher.update(CryptoJS.lib.WordArray.create(data))
+			const checksum = hasher.finalize().toString(CryptoJS.enc.Hex)
+
+			// Start upload
+			const sessionId = await startUploadMutation.mutateAsync({
+				name: file.name,
+				size: data.byteLength,
+			})
+			if (!sessionId) throw new Error('Failed to start upload')
+
+			// Upload the file in 1MB chunks
+			const CHUNK_SIZE = 1024 * 1024 // 1MB
+			const totalChunks = Math.ceil(data.length / CHUNK_SIZE)
+
+			for (let chunkIndex = 0; chunkIndex < totalChunks; chunkIndex++) {
+				const start = chunkIndex * CHUNK_SIZE
+				const end = Math.min(start + CHUNK_SIZE, data.length)
+				const chunk = data.slice(start, end)
+
+				await uploadChunkMutation.mutateAsync({
+					sessionId,
+					offset: start,
+					data: base64EncodeUint8Array(chunk),
+				})
+			}
+
+			// Complete upload
+			await completeUploadMutation.mutateAsync({
+				sessionId,
+				expectedChecksum: checksum,
+				userData: { imageName },
+			})
+		},
+		[startUploadMutation, uploadChunkMutation, completeUploadMutation]
+	)
+
+	return { uploadImageFile }
+}

--- a/webui/src/ImportExport/Export.tsx
+++ b/webui/src/ImportExport/Export.tsx
@@ -290,7 +290,7 @@ export const ExportWizardModal = observer(
 									/>
 								</div>
 
-								{/* <div className="indent3">
+								<div className="indent3">
 									<form.Field
 										name="imageLibrary"
 										children={(field) => (
@@ -302,7 +302,7 @@ export const ExportWizardModal = observer(
 											/>
 										)}
 									/>
-								</div> */}
+								</div>
 
 								<div style={{ paddingTop: '1em' }}>
 									<CFormLabel>File format</CFormLabel>

--- a/webui/src/ImportExport/Export.tsx
+++ b/webui/src/ImportExport/Export.tsx
@@ -36,6 +36,7 @@ export const ExportWizardModal = observer(
 			customVariables: true,
 			expressionVariables: true,
 			includeSecrets: true,
+			imageLibrary: true,
 			// userconfig: true,
 			format: ExportFormatDefault,
 			filename: userConfig.properties?.default_export_filename ?? '',
@@ -288,6 +289,20 @@ export const ExportWizardModal = observer(
 										)}
 									/>
 								</div>
+
+								{/* <div className="indent3">
+									<form.Field
+										name="imageLibrary"
+										children={(field) => (
+											<CFormCheck
+												checked={field.state.value}
+												onChange={(e) => field.handleChange(e.currentTarget.checked)}
+												onBlur={field.handleBlur}
+												label="Image Library"
+											/>
+										)}
+									/>
+								</div> */}
 
 								<div style={{ paddingTop: '1em' }}>
 									<CFormLabel>File format</CFormLabel>

--- a/webui/src/ImportExport/Import/Full.tsx
+++ b/webui/src/ImportExport/Import/Full.tsx
@@ -358,6 +358,12 @@ function FullImportTab({ snapshot }: FullImportTabProps) {
 					</div>
 
 					{/* <div className="ms-2">
+						<form.AppField name="imageLibrary">
+							{(field) => <field.ImportToggleField label="Image Library" disabled={!snapshot.imageLibrary} />}
+						</form.AppField>
+					</div> */}
+
+					{/* <div className="ms-2">
 								<form.AppField name="userconfig">
 									{(field) => <field.ImportToggleField label="Settings" disabled={!snapshot.userconfig} />}
 								</form.AppField>
@@ -514,10 +520,10 @@ function sanitiseSelection(
 		triggers: processValue(!!snapshot.triggers, values.triggers),
 		customVariables: processValue(snapshot.customVariables, values.customVariables),
 		expressionVariables: processValue(snapshot.expressionVariables, values.expressionVariables),
+		imageLibrary: processValue(snapshot.imageLibrary, values.imageLibrary),
 
 		// These are not user selectable, so simply vary depending on whether this is a full reset or not
 		connections: defaultBehaviour,
 		userconfig: defaultBehaviour,
-		imageLibrary: defaultBehaviour,
 	}
 }

--- a/webui/src/ImportExport/Import/Full.tsx
+++ b/webui/src/ImportExport/Import/Full.tsx
@@ -357,11 +357,11 @@ function FullImportTab({ snapshot }: FullImportTabProps) {
 						</form.AppField>
 					</div>
 
-					{/* <div className="ms-2">
+					<div className="ms-2">
 						<form.AppField name="imageLibrary">
 							{(field) => <field.ImportToggleField label="Image Library" disabled={!snapshot.imageLibrary} />}
 						</form.AppField>
-					</div> */}
+					</div>
 
 					{/* <div className="ms-2">
 								<form.AppField name="userconfig">

--- a/webui/src/ImportExport/Import/Full.tsx
+++ b/webui/src/ImportExport/Import/Full.tsx
@@ -147,6 +147,7 @@ const defaultFullImportConfig: ClientImportSelection = {
 	triggers: 'reset-and-import',
 	customVariables: 'reset-and-import',
 	expressionVariables: 'reset-and-import',
+	imageLibrary: 'reset-and-import',
 }
 
 const { fieldContext, useFieldContext, formContext } = createFormHookContexts()
@@ -517,5 +518,6 @@ function sanitiseSelection(
 		// These are not user selectable, so simply vary depending on whether this is a full reset or not
 		connections: defaultBehaviour,
 		userconfig: defaultBehaviour,
+		imageLibrary: defaultBehaviour,
 	}
 }

--- a/webui/src/ImportExport/Reset.tsx
+++ b/webui/src/ImportExport/Reset.tsx
@@ -449,6 +449,10 @@ const ResetApplyStep = withForm({
 						changes.push(<li key="expression-variables">All expression variables.</li>)
 					}
 
+					if (config.imageLibrary !== 'unchanged') {
+						changes.push(<li key="image-library">All images and image collections.</li>)
+					}
+
 					if (config.userconfig !== 'unchanged') {
 						changes.push(<li key="userconfig">All settings, including enabled remote control services.</li>)
 					}

--- a/webui/src/ImportExport/Reset.tsx
+++ b/webui/src/ImportExport/Reset.tsx
@@ -354,11 +354,11 @@ const ResetOptionsStep = withForm({
 					</form.AppField>
 				</div>
 
-				{/* <div className="indent3">
+				<div className="indent3">
 					<form.AppField name="imageLibrary">
 						{(field) => <field.ResetToggleField label="Image Library" />}
 					</form.AppField>
-				</div> */}
+				</div>
 
 				<div className="indent3">
 					<form.AppField name="userconfig">{(field) => <field.ResetToggleField label="Settings" />}</form.AppField>

--- a/webui/src/ImportExport/Reset.tsx
+++ b/webui/src/ImportExport/Reset.tsx
@@ -27,6 +27,7 @@ const defaultFullResetConfig: ClientImportOrResetSelection = {
 	customVariables: 'reset',
 	expressionVariables: 'reset',
 	userconfig: 'reset',
+	imageLibrary: 'reset',
 }
 
 const { fieldContext, useFieldContext, formContext } = createFormHookContexts()
@@ -352,6 +353,12 @@ const ResetOptionsStep = withForm({
 						)}
 					</form.AppField>
 				</div>
+
+				{/* <div className="indent3">
+					<form.AppField name="imageLibrary">
+						{(field) => <field.ResetToggleField label="Image Library" />}
+					</form.AppField>
+				</div> */}
 
 				<div className="indent3">
 					<form.AppField name="userconfig">{(field) => <field.ResetToggleField label="Settings" />}</form.AppField>

--- a/webui/src/ImportExport/index.tsx
+++ b/webui/src/ImportExport/index.tsx
@@ -94,6 +94,7 @@ export const ImportExportPage = observer(function ImportExport() {
 										const [err, config] = await completePrepareImportMutation.mutateAsync({
 											sessionId,
 											expectedChecksum: hashText,
+											userData: null,
 										})
 
 										if (err || !config) {

--- a/webui/src/Layout/Sidebar.tsx
+++ b/webui/src/Layout/Sidebar.tsx
@@ -16,6 +16,7 @@ import {
 	faHammer,
 	faHatWizard,
 	faHeadset,
+	faImages,
 	faInfo,
 	faNetworkWired,
 	faPeopleArrows,
@@ -397,7 +398,7 @@ export const MySidebar = memo(function MySidebar() {
 						path="/connections"
 					/>
 					<SidebarMenuItem name="Buttons" icon={faTableCells} path="/buttons" />
-					{/* <SidebarMenuItem name="Image Library" icon={faImages} path="/image-library" /> */}
+					<SidebarMenuItem name="Image Library" icon={faImages} path="/image-library" />
 					<SidebarMenuItemGroup
 						name="Surfaces"
 						icon={faGamepad}

--- a/webui/src/Layout/Sidebar.tsx
+++ b/webui/src/Layout/Sidebar.tsx
@@ -397,6 +397,7 @@ export const MySidebar = memo(function MySidebar() {
 						path="/connections"
 					/>
 					<SidebarMenuItem name="Buttons" icon={faTableCells} path="/buttons" />
+					{/* <SidebarMenuItem name="Image Library" icon={faImages} path="/image-library" /> */}
 					<SidebarMenuItemGroup
 						name="Surfaces"
 						icon={faGamepad}

--- a/webui/src/Modules/ImportCustomModule.tsx
+++ b/webui/src/Modules/ImportCustomModule.tsx
@@ -155,6 +155,7 @@ export function ImportModules(): React.JSX.Element {
 										const success = await completeBundleImportMutation.mutateAsync({
 											sessionId,
 											expectedChecksum: hashText,
+											userData: null,
 										})
 										if (!success) throw new Error(`Failed to import`)
 

--- a/webui/src/Stores/ImageLibraryStore.tsx
+++ b/webui/src/Stores/ImageLibraryStore.tsx
@@ -1,0 +1,65 @@
+import { action, observable } from 'mobx'
+import type {
+	ImageLibraryCollection,
+	ImageLibraryInfo,
+	ImageLibraryUpdate,
+} from '@companion-app/shared/Model/ImageLibraryModel.js'
+import { assertNever } from '~/Resources/util'
+import type { GenericCollectionsStore } from './GenericCollectionsStore'
+
+export class ImageLibraryStore implements GenericCollectionsStore<null> {
+	readonly store = observable.map<string, ImageLibraryInfo>()
+	readonly collections = observable.map<string, ImageLibraryCollection>()
+
+	public resetCollections = action((newData: ImageLibraryCollection[] | null): void => {
+		this.collections.clear()
+
+		if (newData) {
+			for (const collection of newData) {
+				this.collections.set(collection.id, collection)
+			}
+		}
+	})
+
+	public updateStore = action((changes: ImageLibraryUpdate[] | null): void => {
+		if (!changes) {
+			this.store.clear()
+			return
+		}
+
+		for (const change of changes) {
+			switch (change.type) {
+				case 'init':
+					this.store.clear()
+					for (const image of change.images) {
+						this.store.set(image.name, image)
+					}
+					break
+				case 'update':
+					this.store.set(change.itemName, change.info)
+					break
+				case 'remove':
+					this.store.delete(change.itemName)
+					break
+				default:
+					assertNever(change)
+			}
+		}
+	})
+
+	public getImage(imageId: string): ImageLibraryInfo | undefined {
+		return this.store.get(imageId)
+	}
+
+	public getAllImages(): ImageLibraryInfo[] {
+		return Array.from(this.store.values()).sort((a, b) => b.modifiedAt - a.modifiedAt)
+	}
+
+	public get count(): number {
+		return this.store.size
+	}
+
+	public rootCollections(): ImageLibraryCollection[] {
+		return Array.from(this.collections.values()).sort((a, b) => a.sortOrder - b.sortOrder)
+	}
+}

--- a/webui/src/Stores/ImageLibraryStore.tsx
+++ b/webui/src/Stores/ImageLibraryStore.tsx
@@ -59,6 +59,21 @@ export class ImageLibraryStore implements GenericCollectionsStore<null> {
 		return this.store.size
 	}
 
+	public get allCollectionIds(): string[] {
+		const collectionIds: string[] = []
+
+		const collectCollectionIds = (collections: Iterable<ImageLibraryCollection>): void => {
+			for (const collection of collections || []) {
+				collectionIds.push(collection.id)
+				collectCollectionIds(collection.children)
+			}
+		}
+
+		collectCollectionIds(this.collections.values())
+
+		return collectionIds
+	}
+
 	public rootCollections(): ImageLibraryCollection[] {
 		return Array.from(this.collections.values()).sort((a, b) => a.sortOrder - b.sortOrder)
 	}

--- a/webui/src/Stores/RootAppStore.tsx
+++ b/webui/src/Stores/RootAppStore.tsx
@@ -7,6 +7,7 @@ import type { ConnectionsStore } from './ConnectionsStore.js'
 import type { EntityDefinitionsStore } from './EntityDefinitionsStore.js'
 import type { EventDefinitionsStore } from './EventDefinitionsStore.js'
 import type { ExpressionVariablesListStore } from './ExpressionVariablesListStore.js'
+import type { ImageLibraryStore } from './ImageLibraryStore.js'
 import type { InstanceStatusesStore } from './InstanceStatusesStore.js'
 import type { ModuleInfoStore } from './ModuleInfoStore.js'
 import type { PagesStore } from './PagesStore.js'
@@ -44,6 +45,8 @@ export interface RootAppStore {
 	readonly triggersList: TriggersListStore
 
 	readonly userConfig: UserConfigStore
+
+	readonly imageLibrary: ImageLibraryStore
 
 	readonly moduleStoreRefreshProgress: ObservableMap<string | null, number>
 

--- a/webui/src/routeTree.gen.ts
+++ b/webui/src/routeTree.gen.ts
@@ -27,6 +27,7 @@ import { Route as AppTriggersRouteImport } from './routes/_app/triggers.tsx'
 import { Route as AppModulesRouteImport } from './routes/_app/modules.tsx'
 import { Route as AppLogRouteImport } from './routes/_app/log.tsx'
 import { Route as AppImportExportRouteImport } from './routes/_app/import-export.tsx'
+import { Route as AppImageLibraryRouteImport } from './routes/_app/image-library.tsx'
 import { Route as AppConnectionsRouteImport } from './routes/_app/connections.tsx'
 import { Route as AppCloudRouteImport } from './routes/_app/cloud.tsx'
 import { Route as AppButtonsRouteImport } from './routes/_app/buttons.tsx'
@@ -36,6 +37,7 @@ import { Route as AppVariablesIndexRouteImport } from './routes/_app/variables/i
 import { Route as AppTriggersIndexRouteImport } from './routes/_app/triggers/index.tsx'
 import { Route as AppSettingsIndexRouteImport } from './routes/_app/settings/index.tsx'
 import { Route as AppModulesIndexRouteImport } from './routes/_app/modules/index.tsx'
+import { Route as AppImageLibraryIndexRouteImport } from './routes/_app/image-library/index.tsx'
 import { Route as AppConnectionsIndexRouteImport } from './routes/_app/connections/index.tsx'
 import { Route as StandaloneConnectionDebugDotconnectionIdRouteImport } from './routes/_standalone/connection-debug.$connectionId.tsx'
 import { Route as AppVariablesExpressionRouteImport } from './routes/_app/variables/expression.tsx'
@@ -52,6 +54,7 @@ import { Route as AppSettingsGeneralRouteImport } from './routes/_app/settings/g
 import { Route as AppSettingsButtonsRouteImport } from './routes/_app/settings/buttons.tsx'
 import { Route as AppSettingsBackupsRouteImport } from './routes/_app/settings/backups.tsx'
 import { Route as AppSettingsAdvancedRouteImport } from './routes/_app/settings/advanced.tsx'
+import { Route as AppImageLibraryImageNameRouteImport } from './routes/_app/image-library/$imageName.tsx'
 import { Route as AppConnectionsAddRouteImport } from './routes/_app/connections/add.tsx'
 import { Route as AppConnectionsConnectionIdRouteImport } from './routes/_app/connections/$connectionId.tsx'
 import { Route as AppButtonsPageRouteImport } from './routes/_app/buttons/$page.tsx'
@@ -164,6 +167,11 @@ const AppImportExportRoute = AppImportExportRouteImport.update({
   path: '/import-export',
   getParentRoute: () => AppRoute,
 } as any)
+const AppImageLibraryRoute = AppImageLibraryRouteImport.update({
+  id: '/image-library',
+  path: '/image-library',
+  getParentRoute: () => AppRoute,
+} as any)
 const AppConnectionsRoute = AppConnectionsRouteImport.update({
   id: '/connections',
   path: '/connections',
@@ -208,6 +216,11 @@ const AppModulesIndexRoute = AppModulesIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => AppModulesRoute,
+} as any)
+const AppImageLibraryIndexRoute = AppImageLibraryIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => AppImageLibraryRoute,
 } as any)
 const AppConnectionsIndexRoute = AppConnectionsIndexRouteImport.update({
   id: '/',
@@ -300,6 +313,12 @@ const AppSettingsAdvancedRoute = AppSettingsAdvancedRouteImport.update({
   path: '/settings/advanced',
   getParentRoute: () => AppRoute,
 } as any)
+const AppImageLibraryImageNameRoute =
+  AppImageLibraryImageNameRouteImport.update({
+    id: '/$imageName',
+    path: '/$imageName',
+    getParentRoute: () => AppImageLibraryRoute,
+  } as any)
 const AppConnectionsAddRoute = AppConnectionsAddRouteImport.update({
   id: '/add',
   path: '/add',
@@ -420,6 +439,7 @@ export interface FileRoutesByFullPath {
   '/buttons': typeof AppButtonsRouteWithChildren
   '/cloud': typeof AppCloudRoute
   '/connections': typeof AppConnectionsRouteWithChildren
+  '/image-library': typeof AppImageLibraryRouteWithChildren
   '/import-export': typeof AppImportExportRoute
   '/log': typeof AppLogRoute
   '/modules': typeof AppModulesRouteWithChildren
@@ -429,6 +449,7 @@ export interface FileRoutesByFullPath {
   '/buttons/$page': typeof AppButtonsPageRoute
   '/connections/$connectionId': typeof AppConnectionsConnectionIdRoute
   '/connections/add': typeof AppConnectionsAddRoute
+  '/image-library/$imageName': typeof AppImageLibraryImageNameRoute
   '/settings/advanced': typeof AppSettingsAdvancedRoute
   '/settings/backups': typeof AppSettingsBackupsRouteWithChildren
   '/settings/buttons': typeof AppSettingsButtonsRoute
@@ -446,6 +467,7 @@ export interface FileRoutesByFullPath {
   '/connection-debug/$connectionId': typeof StandaloneConnectionDebugDotconnectionIdRoute
   '/emulator/$emulatorId': typeof StandaloneEmulatorEmulatorIdDotlazyRoute
   '/connections/': typeof AppConnectionsIndexRoute
+  '/image-library/': typeof AppImageLibraryIndexRoute
   '/modules/': typeof AppModulesIndexRoute
   '/settings/': typeof AppSettingsIndexRoute
   '/triggers/': typeof AppTriggersIndexRoute
@@ -487,6 +509,7 @@ export interface FileRoutesByTo {
   '/buttons/$page': typeof AppButtonsPageRoute
   '/connections/$connectionId': typeof AppConnectionsConnectionIdRoute
   '/connections/add': typeof AppConnectionsAddRoute
+  '/image-library/$imageName': typeof AppImageLibraryImageNameRoute
   '/settings/advanced': typeof AppSettingsAdvancedRoute
   '/settings/buttons': typeof AppSettingsButtonsRoute
   '/settings/general': typeof AppSettingsGeneralRoute
@@ -500,6 +523,7 @@ export interface FileRoutesByTo {
   '/connection-debug/$connectionId': typeof StandaloneConnectionDebugDotconnectionIdRoute
   '/emulator/$emulatorId': typeof StandaloneEmulatorEmulatorIdDotlazyRoute
   '/connections': typeof AppConnectionsIndexRoute
+  '/image-library': typeof AppImageLibraryIndexRoute
   '/modules': typeof AppModulesIndexRoute
   '/settings': typeof AppSettingsIndexRoute
   '/triggers': typeof AppTriggersIndexRoute
@@ -537,6 +561,7 @@ export interface FileRoutesById {
   '/_app/buttons': typeof AppButtonsRouteWithChildren
   '/_app/cloud': typeof AppCloudRoute
   '/_app/connections': typeof AppConnectionsRouteWithChildren
+  '/_app/image-library': typeof AppImageLibraryRouteWithChildren
   '/_app/import-export': typeof AppImportExportRoute
   '/_app/log': typeof AppLogRoute
   '/_app/modules': typeof AppModulesRouteWithChildren
@@ -547,6 +572,7 @@ export interface FileRoutesById {
   '/_app/buttons/$page': typeof AppButtonsPageRoute
   '/_app/connections/$connectionId': typeof AppConnectionsConnectionIdRoute
   '/_app/connections/add': typeof AppConnectionsAddRoute
+  '/_app/image-library/$imageName': typeof AppImageLibraryImageNameRoute
   '/_app/settings/advanced': typeof AppSettingsAdvancedRoute
   '/_app/settings/backups': typeof AppSettingsBackupsRouteWithChildren
   '/_app/settings/buttons': typeof AppSettingsButtonsRoute
@@ -564,6 +590,7 @@ export interface FileRoutesById {
   '/_standalone/connection-debug/$connectionId': typeof StandaloneConnectionDebugDotconnectionIdRoute
   '/_standalone/emulator/$emulatorId': typeof StandaloneEmulatorEmulatorIdDotlazyRoute
   '/_app/connections/': typeof AppConnectionsIndexRoute
+  '/_app/image-library/': typeof AppImageLibraryIndexRoute
   '/_app/modules/': typeof AppModulesIndexRoute
   '/_app/settings/': typeof AppSettingsIndexRoute
   '/_app/triggers/': typeof AppTriggersIndexRoute
@@ -602,6 +629,7 @@ export interface FileRouteTypes {
     | '/buttons'
     | '/cloud'
     | '/connections'
+    | '/image-library'
     | '/import-export'
     | '/log'
     | '/modules'
@@ -611,6 +639,7 @@ export interface FileRouteTypes {
     | '/buttons/$page'
     | '/connections/$connectionId'
     | '/connections/add'
+    | '/image-library/$imageName'
     | '/settings/advanced'
     | '/settings/backups'
     | '/settings/buttons'
@@ -628,6 +657,7 @@ export interface FileRouteTypes {
     | '/connection-debug/$connectionId'
     | '/emulator/$emulatorId'
     | '/connections/'
+    | '/image-library/'
     | '/modules/'
     | '/settings/'
     | '/triggers/'
@@ -669,6 +699,7 @@ export interface FileRouteTypes {
     | '/buttons/$page'
     | '/connections/$connectionId'
     | '/connections/add'
+    | '/image-library/$imageName'
     | '/settings/advanced'
     | '/settings/buttons'
     | '/settings/general'
@@ -682,6 +713,7 @@ export interface FileRouteTypes {
     | '/connection-debug/$connectionId'
     | '/emulator/$emulatorId'
     | '/connections'
+    | '/image-library'
     | '/modules'
     | '/settings'
     | '/triggers'
@@ -718,6 +750,7 @@ export interface FileRouteTypes {
     | '/_app/buttons'
     | '/_app/cloud'
     | '/_app/connections'
+    | '/_app/image-library'
     | '/_app/import-export'
     | '/_app/log'
     | '/_app/modules'
@@ -728,6 +761,7 @@ export interface FileRouteTypes {
     | '/_app/buttons/$page'
     | '/_app/connections/$connectionId'
     | '/_app/connections/add'
+    | '/_app/image-library/$imageName'
     | '/_app/settings/advanced'
     | '/_app/settings/backups'
     | '/_app/settings/buttons'
@@ -745,6 +779,7 @@ export interface FileRouteTypes {
     | '/_standalone/connection-debug/$connectionId'
     | '/_standalone/emulator/$emulatorId'
     | '/_app/connections/'
+    | '/_app/image-library/'
     | '/_app/modules/'
     | '/_app/settings/'
     | '/_app/triggers/'
@@ -905,6 +940,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppImportExportRouteImport
       parentRoute: typeof AppRoute
     }
+    '/_app/image-library': {
+      id: '/_app/image-library'
+      path: '/image-library'
+      fullPath: '/image-library'
+      preLoaderRoute: typeof AppImageLibraryRouteImport
+      parentRoute: typeof AppRoute
+    }
     '/_app/connections': {
       id: '/_app/connections'
       path: '/connections'
@@ -967,6 +1009,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/modules/'
       preLoaderRoute: typeof AppModulesIndexRouteImport
       parentRoute: typeof AppModulesRoute
+    }
+    '/_app/image-library/': {
+      id: '/_app/image-library/'
+      path: '/'
+      fullPath: '/image-library/'
+      preLoaderRoute: typeof AppImageLibraryIndexRouteImport
+      parentRoute: typeof AppImageLibraryRoute
     }
     '/_app/connections/': {
       id: '/_app/connections/'
@@ -1086,6 +1135,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/settings/advanced'
       preLoaderRoute: typeof AppSettingsAdvancedRouteImport
       parentRoute: typeof AppRoute
+    }
+    '/_app/image-library/$imageName': {
+      id: '/_app/image-library/$imageName'
+      path: '/$imageName'
+      fullPath: '/image-library/$imageName'
+      preLoaderRoute: typeof AppImageLibraryImageNameRouteImport
+      parentRoute: typeof AppImageLibraryRoute
     }
     '/_app/connections/add': {
       id: '/_app/connections/add'
@@ -1244,6 +1300,20 @@ const AppConnectionsRouteWithChildren = AppConnectionsRoute._addFileChildren(
   AppConnectionsRouteChildren,
 )
 
+interface AppImageLibraryRouteChildren {
+  AppImageLibraryImageNameRoute: typeof AppImageLibraryImageNameRoute
+  AppImageLibraryIndexRoute: typeof AppImageLibraryIndexRoute
+}
+
+const AppImageLibraryRouteChildren: AppImageLibraryRouteChildren = {
+  AppImageLibraryImageNameRoute: AppImageLibraryImageNameRoute,
+  AppImageLibraryIndexRoute: AppImageLibraryIndexRoute,
+}
+
+const AppImageLibraryRouteWithChildren = AppImageLibraryRoute._addFileChildren(
+  AppImageLibraryRouteChildren,
+)
+
 interface AppModulesRouteChildren {
   AppModulesIndexRoute: typeof AppModulesIndexRoute
   AppModulesModuleTypeDotmoduleIdRoute: typeof AppModulesModuleTypeDotmoduleIdRoute
@@ -1345,6 +1415,7 @@ interface AppRouteChildren {
   AppButtonsRoute: typeof AppButtonsRouteWithChildren
   AppCloudRoute: typeof AppCloudRoute
   AppConnectionsRoute: typeof AppConnectionsRouteWithChildren
+  AppImageLibraryRoute: typeof AppImageLibraryRouteWithChildren
   AppImportExportRoute: typeof AppImportExportRoute
   AppLogRoute: typeof AppLogRoute
   AppModulesRoute: typeof AppModulesRouteWithChildren
@@ -1373,6 +1444,7 @@ const AppRouteChildren: AppRouteChildren = {
   AppButtonsRoute: AppButtonsRouteWithChildren,
   AppCloudRoute: AppCloudRoute,
   AppConnectionsRoute: AppConnectionsRouteWithChildren,
+  AppImageLibraryRoute: AppImageLibraryRouteWithChildren,
   AppImportExportRoute: AppImportExportRoute,
   AppLogRoute: AppLogRoute,
   AppModulesRoute: AppModulesRouteWithChildren,

--- a/webui/src/routes/_app/image-library.tsx
+++ b/webui/src/routes/_app/image-library.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { ImageLibraryPage } from '~/ImageLibrary/index.js'
+
+export const Route = createFileRoute('/_app/image-library')({
+	component: ImageLibraryPage,
+})

--- a/webui/src/routes/_app/image-library/$imageName.tsx
+++ b/webui/src/routes/_app/image-library/$imageName.tsx
@@ -1,0 +1,64 @@
+import { CNav, CNavItem, CNavLink, CTabContent, CTabPane } from '@coreui/react'
+import { faImage } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { observer } from 'mobx-react-lite'
+import { useContext } from 'react'
+import { ImageLibraryEditor } from '~/ImageLibrary/ImageLibraryEditor.js'
+import { MyErrorBoundary } from '~/Resources/Error'
+import { useComputed } from '~/Resources/util'
+import { RootAppStoreContext } from '~/Stores/RootAppStore.js'
+
+const RouteComponent = observer(function RouteComponent() {
+	const { imageName } = Route.useParams()
+
+	const navigate = useNavigate({ from: '/image-library/$imageName' })
+	const { imageLibrary } = useContext(RootAppStoreContext)
+
+	// Ensure the selected image is valid
+	useComputed(() => {
+		if (imageName && !imageLibrary.getImage(imageName)) {
+			void navigate({ to: `/image-library` })
+		}
+	}, [navigate, imageLibrary, imageName])
+
+	const handleDeleteImage = (deletedImageName: string) => {
+		if (deletedImageName === imageName) {
+			void navigate({ to: `/image-library` })
+		}
+	}
+
+	const handleImageNameChanged = (oldName: string, newName: string) => {
+		if (oldName === imageName) {
+			void navigate({ to: `/image-library/${newName}` })
+		}
+	}
+
+	return (
+		<>
+			<CNav variant="tabs" role="tablist">
+				<CNavItem>
+					<CNavLink active>
+						<FontAwesomeIcon icon={faImage} /> Edit Image
+					</CNavLink>
+				</CNavItem>
+			</CNav>
+			<CTabContent>
+				<CTabPane data-tab="edit" visible>
+					<MyErrorBoundary>
+						<ImageLibraryEditor
+							key={imageName}
+							selectedImageName={imageName}
+							onDeleteImage={handleDeleteImage}
+							onImageNameChanged={handleImageNameChanged}
+						/>
+					</MyErrorBoundary>
+				</CTabPane>
+			</CTabContent>
+		</>
+	)
+})
+
+export const Route = createFileRoute('/_app/image-library/$imageName')({
+	component: RouteComponent,
+})

--- a/webui/src/routes/_app/image-library/index.tsx
+++ b/webui/src/routes/_app/image-library/index.tsx
@@ -1,0 +1,25 @@
+import { CNav, CNavItem, CNavLink, CTabContent, CTabPane } from '@coreui/react'
+import { faImage } from '@fortawesome/free-solid-svg-icons'
+import { createFileRoute } from '@tanstack/react-router'
+import { NonIdealState } from '~/Components/NonIdealState.js'
+
+export const Route = createFileRoute('/_app/image-library/')({
+	component: RouteComponent,
+})
+
+function RouteComponent() {
+	return (
+		<>
+			<CNav variant="tabs" role="tablist">
+				<CNavItem>
+					<CNavLink active>Select an image</CNavLink>
+				</CNavItem>
+			</CNav>
+			<CTabContent>
+				<CTabPane data-tab="placeholder" visible>
+					<NonIdealState text="Select an image to edit" icon={faImage} />
+				</CTabPane>
+			</CTabContent>
+		</>
+	)
+}

--- a/webui/src/scss/_image-library.scss
+++ b/webui/src/scss/_image-library.scss
@@ -1,0 +1,255 @@
+.image-library-page {
+	.image-library-grid {
+		height: 100%;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.image-library-header {
+		padding-bottom: 1rem;
+		border-bottom: 1px solid #dee2e6;
+	}
+
+	.image-library-controls {
+		.d-flex {
+			gap: 0.5rem;
+		}
+	}
+
+	.image-library-dropzone {
+		margin: 1rem 0;
+		padding: 1.5rem 2rem;
+		border: 2px dashed #dee2e6;
+		border-radius: 6px;
+		background-color: #f8f9fa;
+		transition: all 0.2s ease;
+
+		&.active {
+			border-color: #0d6efd;
+			background-color: rgba(13, 110, 253, 0.05);
+		}
+
+		&.uploading {
+			border-color: #198754;
+			background-color: rgba(25, 135, 84, 0.05);
+		}
+
+		.dropzone-content {
+			display: flex;
+			flex-direction: row;
+			align-items: center;
+			justify-content: center;
+			gap: 0.75rem;
+			color: #6c757d;
+
+			svg {
+				color: #0d6efd;
+			}
+
+			span {
+				font-weight: 500;
+				color: #495057;
+			}
+		}
+
+		&.uploading .dropzone-content {
+			svg {
+				color: #198754;
+			}
+		}
+	}
+
+	.image-library-grid-content {
+		flex: 1;
+		overflow-y: auto;
+		padding: 1rem;
+	}
+
+	// Override CollectionsNestingTable grid dimensions for image thumbnails
+	.collections-nesting-table-grid-container {
+		--collection-nesting-table-grid-tile-min-width: 150px;
+	}
+
+	.image-thumbnail {
+		overflow: hidden;
+		cursor: pointer;
+	}
+
+	.image-preview {
+		aspect-ratio: 1;
+		background: #f8f9fa;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		overflow: hidden;
+		border-bottom: 1px solid #dee2e6;
+		position: relative;
+
+		img {
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
+		}
+	}
+
+	.image-library-preview {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		pointer-events: none;
+	}
+
+	.image-library-preview-loading,
+	.image-library-preview-error,
+	.image-library-preview-empty {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: #f8f9fa;
+		color: #6c757d;
+		text-align: center;
+		padding: 1rem;
+		min-height: 100px;
+		width: 100%;
+
+		span {
+			font-size: 0.875rem;
+		}
+	}
+
+	.image-library-preview-empty {
+		color: #a8b2b8;
+
+		svg {
+			max-width: none !important;
+			max-height: none !important;
+			font-size: inherit !important;
+		}
+	}
+
+	.image-preview .image-library-preview-empty {
+		padding: 0;
+		min-height: auto;
+		background: transparent;
+
+		svg {
+			width: 50% !important;
+			height: 50% !important;
+		}
+	}
+
+	.image-preview-full .image-library-preview-empty {
+		svg,
+		.fa,
+		.fas,
+		.far,
+		.fal,
+		.fab {
+			width: 150px !important;
+			height: 150px !important;
+			font-size: 150px !important;
+		}
+	}
+
+	.image-library-preview-error {
+		background: #f8d7da;
+		color: #721c24;
+	}
+
+	.image-name {
+		font-weight: 600;
+		margin-bottom: 0.125rem;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		font-size: 0.875rem;
+	}
+
+	.image-id {
+		font-size: 0.75rem;
+		color: #6c757d;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.image-library-editor {
+		height: 100%;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.image-preview-full {
+		flex: 0 0 300px;
+		margin-bottom: 1.5rem;
+		border: 1px solid #dee2e6;
+		border-radius: 8px;
+		overflow: hidden;
+		background: #f8f9fa;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		position: relative;
+		transition: border-color 0.2s ease;
+
+		&.drag-over {
+			border: 2px dashed #0d6efd;
+		}
+
+		img {
+			max-width: 100%;
+			max-height: 100%;
+			object-fit: contain;
+		}
+	}
+
+	.drag-overlay {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		background-color: rgba(13, 110, 253, 0.1);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		pointer-events: none;
+		border-radius: 8px;
+	}
+
+	.drag-overlay-message {
+		background-color: rgba(255, 255, 255, 0.95);
+		padding: 20px;
+		border-radius: 8px;
+		font-weight: bold;
+		color: #0d6efd;
+	}
+
+	.image-properties {
+		flex: 1;
+		overflow-y: auto;
+
+		.image-metadata {
+			border: 1px solid #dee2e6;
+			border-radius: 6px;
+			padding: 1rem;
+			margin-bottom: 1rem;
+			background: #f8f9fa;
+		}
+
+		.metadata-row {
+			display: flex;
+			justify-content: space-between;
+			margin-bottom: 0.5rem;
+
+			&:last-child {
+				margin-bottom: 0;
+			}
+		}
+
+		.metadata-label {
+			font-weight: 600;
+			color: #495057;
+		}
+	}
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1785,6 +1785,7 @@ __metadata:
     fast-json-patch: "patch:fast-json-patch@npm%3A3.1.1#~/.yarn/patches/fast-json-patch-npm-3.1.1-7e8bb70a45.patch"
     fuzzysort: "npm:^3.1.0"
     html-entities: "npm:^2.6.0"
+    human-id: "npm:^4.1.3"
     intersection-observer: "npm:^0.12.2"
     jsdom: "npm:^29.0.2"
     json5: "npm:^2.2.3"
@@ -14970,6 +14971,15 @@ __metadata:
     agent-base: "npm:^7.1.2"
     debug: "npm:4"
   checksum: 10c0/f729219bc735edb621fa30e6e84e60ee5d00802b8247aac0d7b79b0bd6d4b3294737a337b93b86a0bd9e68099d031858a39260c976dc14cdbba238ba1f8779ac
+  languageName: node
+  linkType: hard
+
+"human-id@npm:^4.1.3":
+  version: 4.1.3
+  resolution: "human-id@npm:4.1.3"
+  bin:
+    human-id: dist/cli.js
+  checksum: 10c0/c0e6aacfa71adff6e9783fc209493a7f8de92da041bea32deb3a9cd1244a4d2b89f32d5e90130e8e22da4e6fe15b61cf4e533f114927384de1418460c92b5a7a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Pulling a chunk out of https://github.com/bitfocus/companion/pull/4098 to make for easier reviewing and merging

This is functional (from a light test), but is not added to the sidebar yet

Essentially a rebase of #3493

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full Image Library: upload, organize into collections, import/export, bulk reset, collection export filtering, and real‑time sync.
  * Automatic optimized preview generation with retry-backed processing and checksum-validated retrieval.
  * Web UI: Image Library page, grid/search, add/rename/delete/replace/download, copy image variable, collections management, image editor, and drag‑and‑drop uploader with chunked uploads and notifications.
* **Chores**
  * Added runtime helper dependency for UI identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->