### PR TITLE
feat: let user choose what right-click does on sidebar

### DIFF
--- a/webui/src/Components/useContextMenuProps.tsx
+++ b/webui/src/Components/useContextMenuProps.tsx
@@ -21,6 +21,9 @@ export interface ContextMenuProps {
 	It also manages positioning and visibility, and must be passed to the ContextMenu component.
 
 	* menuItems: the menu description
+	* preferSystemMenu: default, false: right-click brings up the context-menu; holding down a modifier key on click brings up the system menu
+	* 							if true, the behavior is reversed. (modifier = ctl, cmd, alt, shift, or meta)
+
 	Note that menuItems is supplied as a pass-through purely to simplify the client syntax:
 
 	const contextMenuItems = useMemo(() => [ ...menu items... ])
@@ -29,7 +32,7 @@ export interface ContextMenuProps {
 		<ContextMenu { ...contextMenuProps}/>
 	</div>
 */
-export function useContextMenuState(menuItems: MenuItemProps[]): ContextMenuProps {
+export function useContextMenuState(menuItems: MenuItemProps[], preferSystemMenu = false): ContextMenuProps {
 	const [visible, setVisible] = useState(false)
 	const [position, setPosition] = useState({ x: 200, y: 200 })
 	const menuRef = useRef<HTMLDivElement>(null) // to get the ContextMenu's ref for event handling here
@@ -83,17 +86,20 @@ export function useContextMenuState(menuItems: MenuItemProps[]): ContextMenuProp
 		(e) => {
 			// allow modifiers to suppress the context menu so we can inspect things in the browser
 			// Also, doing it this way avoids worrying about mac command key vs. windows' windows key, etc.
-			if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) {
-				setVisible(false) // in case menu was open at the time
-			} else {
+			// Finally, we let the user choose what an unadorned click does
+			const showOnClick = preferSystemMenu === (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey)
+
+			if (showOnClick) {
 				e.preventDefault()
 				e.stopPropagation()
 
 				setPosition({ x: e.clientX, y: e.clientY })
 				setVisible(true)
+			} else {
+				setVisible(false) // in case menu was open at the time
 			}
 		},
-		[setPosition, setVisible]
+		[preferSystemMenu]
 	)
 
 	return { visible, position, onContextMenu, menuItems, menuRef }

--- a/webui/src/Layout/Sidebar.tsx
+++ b/webui/src/Layout/Sidebar.tsx
@@ -353,7 +353,7 @@ export const MySidebar = memo(function MySidebar() {
 			MenuSeparator,
 			{
 				id: 'prefer-system-menu',
-				label: 'Prefer System Context-Menu',
+				label: 'Prefer System Menu',
 				icon: preferSystemMenu ? faCheck : undefined,
 				do: () => setPreferSystemMenu((value) => !value),
 				tooltip:

--- a/webui/src/Layout/Sidebar.tsx
+++ b/webui/src/Layout/Sidebar.tsx
@@ -247,6 +247,8 @@ export const MySidebar = memo(function MySidebar() {
 	const [ibuttonsGroupVis, setIbuttonsGroupVis] = useLocalStorage('ibuttons_group_vis', false)
 	const [supportGroupVis, setSupportGroupVis] = useLocalStorage('support_group_vis', false)
 
+	const [preferSystemMenu, setPreferSystemMenu] = useLocalStorage('sidebar_prefer_system_menu', false)
+
 	const toggleUnfoldable = useCallback(() => {
 		setUnfoldable((val) => {
 			if (!val) setTempNarrow(true) // if new value is true, make sidebar narrow so it folds now
@@ -348,25 +350,35 @@ export const MySidebar = memo(function MySidebar() {
 				do: toggleNarrowMode,
 				tooltip: 'When active, the sidebar remains narrow.',
 			},
+			MenuSeparator,
+			{
+				id: 'prefer-system-menu',
+				label: 'Prefer System Context-Menu',
+				icon: preferSystemMenu ? faCheck : undefined,
+				do: () => setPreferSystemMenu((value) => !value),
+				tooltip:
+					'If set, right-click brings up the system menu and ctrl-right-click brings up this menu. Default is the opposite.',
+			},
 		],
 		[
 			accordionMode,
+			hideModuleVars,
+			hideHelp,
 			mobileMode,
 			narrowMode,
 			unfoldable,
 			toggleUnfoldable,
 			toggleNarrowMode,
-			hideModuleVars,
-			hideHelp,
+			preferSystemMenu,
 			expandAllGroups,
 			setAccordionMode,
 			setHideModuleVars,
 			setHideHelp,
+			setPreferSystemMenu,
 		]
 	)
-
-	// we need the following primarily to provide the onContextMenu callback, which resides in the parent, not the component.
-	const contextState = useContextMenuState(contextMenuItems)
+	//useContextMenuState provides the onContextMenu callback, which resides in the parent, not the component.
+	const contextState = useContextMenuState(contextMenuItems, preferSystemMenu)
 	const DontSetOrUnset: React.Dispatch<React.SetStateAction<boolean>> = () => {}
 
 	return (


### PR DESCRIPTION
https://github.com/bitfocus/companion/discussions/4122

Default is current behavior: right-click gets the context-menu and modifier-right-click gets the system menu. This option allows the user to reverse that behavior by activating "Prefer System Menu".

<img width="219" height="321" alt="image" src="https://github.com/user-attachments/assets/00479a05-4bb3-4d8e-9d87-3b070a9546eb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Prefer System Menu" preference option. Users can now toggle between using the custom context menu and the system context menu, with their choice persisted across sessions. The toggle is accessible from the sidebar settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->