### PR TITLE
chore: fix usage comment on `ContextHelpButton`

### DIFF
--- a/webui/src/Layout/PanelIcons.tsx
+++ b/webui/src/Layout/PanelIcons.tsx
@@ -36,10 +36,8 @@ export function CloseButton({ closeFn, visibilityClass }: CloseButtonProps): Rea
 /*
  ContextHelpButton - a generic inline-help icon, 
  particularly handy for panels and other headers such as in Connections and Surfaces.
- - tooltip: what to show on hover or focus. Can be plain-text or a React fragment.
- - action: Caller can supply a link to the user guide or a custom function (or leave it out).
- - size: a FontAwesome size class such as lg or 2xl. The default size is intended for panel headers.
- The button is given a class with the size appended, such as context-help-button-2xl
+ - children: what to show on hover or focus. Can be plain-text or a React fragment.
+ - action: optional, either a link to the user guide or a custom function (to open a modal dialog, for example).
 */
 export function ContextHelpButton({ children, action }: ContextHelpButtonProps): React.JSX.Element {
 	// First, a little trick to handle both keyboard navigation, in which the "hover help" should show up on focus,


### PR DESCRIPTION
The comment did not reflect the current props and behavior.

Note: FWIW, `ContextHelpButton` is essentially a superset of the new `InlineHelpIcon` (f868f609) -- it may be worth considering merging the two to avoid confusion.  (`ContextHelpButton` w/o the optional action prop is essentially `InlineHelpIcon`, but a little better-behaved -- they both use `children` as the source of the popover text; `ContextHelpButton` allows children to be empty if a clickable link is preferred). The only "conflict" I see is how they handle className -- `ContextHelpButton` expects CSS to handle formatting whereas `InlineHelpIcon` allows classname-based formatting as well. This is easily resolved, of course.