### PR TITLE
Fix: Limit scope of sidebar context menu

### DIFF
--- a/webui/src/Components/useContextMenuProps.tsx
+++ b/webui/src/Components/useContextMenuProps.tsx
@@ -48,7 +48,9 @@ export function useContextMenuState(menuItems: MenuItemProps[]): ContextMenuProp
 			setVisible(false)
 		}
 
-		const handleInsideClick = (e?: Event) => {
+		const handleInsideClick = (e: MouseEvent) => {
+			if (e.button === 2) return // Ignore right click, to avoid the trigger click closing itself
+
 			if (e && menuRef.current && menuRef.current.contains(e.target as Node)) {
 				// allow propagation just to be safe so actions will trigger regardless of calling order.
 				setVisible(false)

--- a/webui/src/Layout/Sidebar.tsx
+++ b/webui/src/Layout/Sidebar.tsx
@@ -608,7 +608,11 @@ const UnfoldTogglerAndVersion = observer(function UnfoldTogglerAndVersion({
 
 	return (
 		<div className="nav-link sidebar-header-toggler2">
-			<span className={classNames('nav-icon-wrapper', mobileMode ? 'd-none' : 'd-flex')} onClick={toggleUnfoldable} onContextMenu={onContextMenu}>
+			<span
+				className={classNames('nav-icon-wrapper', mobileMode ? 'd-none' : 'd-flex')}
+				onClick={toggleUnfoldable}
+				onContextMenu={onContextMenu}
+			>
 				<span className="nav-icon sidebar-toggler"></span>
 			</span>
 

--- a/webui/src/Layout/Sidebar.tsx
+++ b/webui/src/Layout/Sidebar.tsx
@@ -374,7 +374,6 @@ export const MySidebar = memo(function MySidebar() {
 				unfoldable={unfoldable}
 				narrow={tempNarrow || narrowMode}
 				setNarrow={narrowMode ? DontSetOrUnset : setTempNarrow}
-				onContextMenu={contextState.onContextMenu}
 			>
 				<ContextMenu {...contextState} />
 				<CSidebarHeader className="brand">
@@ -504,7 +503,7 @@ export const MySidebar = memo(function MySidebar() {
 				)}
 				{!narrowMode && (
 					<CSidebarHeader className="border-top d-flex sidebar-header-toggler">
-						<UnfoldTogglerAndVersion toggleUnfoldable={toggleUnfoldable} />
+						<UnfoldTogglerAndVersion toggleUnfoldable={toggleUnfoldable} onContextMenu={contextState.onContextMenu} />
 					</CSidebarHeader>
 				)}
 			</CSidebar>
@@ -599,8 +598,10 @@ const SidebarMenuItemSubGroup = observer(function SidebarMenuItemSubGroup(props:
 
 const UnfoldTogglerAndVersion = observer(function UnfoldTogglerAndVersion({
 	toggleUnfoldable,
+	onContextMenu,
 }: {
 	toggleUnfoldable: () => void
+	onContextMenu?: MouseEventHandler<HTMLDivElement>
 }) {
 	const { versionName, versionBuild: versionSubheading } = useCompanionVersion()
 	const { mobileMode } = useSidebarState()
@@ -608,7 +609,7 @@ const UnfoldTogglerAndVersion = observer(function UnfoldTogglerAndVersion({
 	return (
 		<div className="nav-link sidebar-header-toggler2">
 			<span className={classNames('nav-icon-wrapper', mobileMode ? 'd-none' : 'd-flex')} onClick={toggleUnfoldable}>
-				<span className="nav-icon sidebar-toggler"></span>
+				<span className="nav-icon sidebar-toggler" onContextMenu={onContextMenu}></span>
 			</span>
 
 			<span className="flex-fill text-truncate">
@@ -633,9 +634,8 @@ interface CSidebarProps {
 	unfoldable?: boolean
 	narrow: boolean
 	setNarrow: React.Dispatch<React.SetStateAction<boolean>>
-	onContextMenu?: MouseEventHandler<HTMLDivElement>
 }
-function CSidebar({ children, unfoldable, narrow, setNarrow, onContextMenu }: React.PropsWithChildren<CSidebarProps>) {
+function CSidebar({ children, unfoldable, narrow, setNarrow }: React.PropsWithChildren<CSidebarProps>) {
 	const sidebarRef = useRef<HTMLDivElement>(null)
 
 	const [visibleMobile, setVisibleMobile] = useState<boolean>(false)
@@ -744,7 +744,6 @@ function CSidebar({ children, unfoldable, narrow, setNarrow, onContextMenu }: Re
 					// hide: visibleDesktop === false && !showToggle && !overlaid,
 				})}
 				ref={sidebarRef}
-				onContextMenu={onContextMenu}
 				onMouseLeave={handleMouseLeave}
 			>
 				{children}

--- a/webui/src/Layout/Sidebar.tsx
+++ b/webui/src/Layout/Sidebar.tsx
@@ -612,6 +612,7 @@ const UnfoldTogglerAndVersion = observer(function UnfoldTogglerAndVersion({
 				className={classNames('nav-icon-wrapper', mobileMode ? 'd-none' : 'd-flex')}
 				onClick={toggleUnfoldable}
 				onContextMenu={onContextMenu}
+				title="Right click for more sidebar options"
 			>
 				<span className="nav-icon sidebar-toggler"></span>
 			</span>

--- a/webui/src/Layout/Sidebar.tsx
+++ b/webui/src/Layout/Sidebar.tsx
@@ -608,8 +608,8 @@ const UnfoldTogglerAndVersion = observer(function UnfoldTogglerAndVersion({
 
 	return (
 		<div className="nav-link sidebar-header-toggler2">
-			<span className={classNames('nav-icon-wrapper', mobileMode ? 'd-none' : 'd-flex')} onClick={toggleUnfoldable}>
-				<span className="nav-icon sidebar-toggler" onContextMenu={onContextMenu}></span>
+			<span className={classNames('nav-icon-wrapper', mobileMode ? 'd-none' : 'd-flex')} onClick={toggleUnfoldable} onContextMenu={onContextMenu}>
+				<span className="nav-icon sidebar-toggler"></span>
 			</span>
 
 			<span className="flex-fill text-truncate">


### PR DESCRIPTION
This PR adjusts the new context menu added in #3938 by limiting the scope of the custom context menu to only appear when right-clicking the sidebar-toggler element.

Right-clicks anywhere else in the UI now return to the default browser context menu which has been the well-established behaviour for all versions prior to 4.3. With the vast majority of the Companion userbase (~85% at the time of writing this) still on versions <4.3 this fix will allow to maintain a consistent experience with this when they upgrade.

This addresses the some of usability concerns raised in discussion #4122 and gives us time to consider more suitable solutions such as if we want to includes the context menu on other elements, have settings options to control right click behaviour and if so where is appropriate for those settings to be, and any other discussion that may need to be had.
