### PR TITLE
feat: replace some coreui with base-ui

### DIFF
--- a/companion/lib/Instance/Connection/ConfigFieldsLegacy.ts
+++ b/companion/lib/Instance/Connection/ConfigFieldsLegacy.ts
@@ -245,7 +245,6 @@ function translateMultiDropdownField(
 		choices: field.choices,
 		allowCustom: false, // Not supported from modules
 		regex: undefined, // Not supported from modules
-		minChoicesForSearch: field.minChoicesForSearch,
 		minSelection: field.minSelection,
 		maxSelection: field.maxSelection,
 		sortSelection: undefined, // Not supported from old modules

--- a/companion/lib/Instance/Connection/ConfigFieldsLegacy.ts
+++ b/companion/lib/Instance/Connection/ConfigFieldsLegacy.ts
@@ -230,7 +230,6 @@ function translateDropdownField(
 		choices: field.choices,
 		allowCustom: field.allowCustom,
 		regex: field.regex,
-		minChoicesForSearch: field.minChoicesForSearch,
 	}
 }
 function translateMultiDropdownField(

--- a/companion/lib/Instance/Connection/Thread/ConfigFields.ts
+++ b/companion/lib/Instance/Connection/Thread/ConfigFields.ts
@@ -230,7 +230,6 @@ function translateMultiDropdownField(
 		choices: field.choices,
 		allowCustom: false, // Not supported from modules
 		regex: undefined, // Not supported from modules
-		minChoicesForSearch: field.minChoicesForSearch,
 		minSelection: field.minSelection,
 		maxSelection: field.maxSelection,
 		sortSelection: field.sortSelection,

--- a/companion/lib/Instance/Connection/Thread/ConfigFields.ts
+++ b/companion/lib/Instance/Connection/Thread/ConfigFields.ts
@@ -215,7 +215,6 @@ function translateDropdownField(
 		choices: field.choices,
 		allowCustom: field.allowCustom,
 		regex: field.regex,
-		minChoicesForSearch: field.minChoicesForSearch,
 	}
 }
 function translateMultiDropdownField(

--- a/companion/lib/Instance/Surface/Thread/ConfigFields.ts
+++ b/companion/lib/Instance/Surface/Thread/ConfigFields.ts
@@ -110,7 +110,6 @@ function translateDropdownField(field: CompanionInputFieldDropdown): Complete<Co
 		choices: field.choices,
 		allowCustom: undefined,
 		regex: undefined,
-		minChoicesForSearch: undefined,
 	}
 }
 

--- a/companion/lib/Resources/EventDefinitions.ts
+++ b/companion/lib/Resources/EventDefinitions.ts
@@ -72,7 +72,6 @@ export const EventDefinitions: Record<string, EventDefinition> = {
 				id: 'days',
 				label: 'Days',
 				type: 'multidropdown',
-				minChoicesForSearch: 10,
 				minSelection: 1,
 				choices: Array(7)
 					.keys()

--- a/companion/lib/Service/Satellite/SatelliteConfigFields.ts
+++ b/companion/lib/Service/Satellite/SatelliteConfigFields.ts
@@ -109,7 +109,6 @@ function translateDropdownField(field: DropdownField): Complete<CompanionInputFi
 		choices: field.choices,
 		allowCustom: field.allowCustom,
 		regex: undefined,
-		minChoicesForSearch: undefined,
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "dev:webui": "yarn workspace @companion-app/webui dev",
     "dev:webui:docs": "tsx ./tools/webui-dev-docs.mts",
     "dev:docs": "yarn workspace @companion-app/docs start",
+    "dev:storybook": "yarn workspace @companion-app/webui storybook",
     "build:ts": "tsc --build --force",
     "build:whatsnew": "tsx ./tools/build_whatsnew.mts",
     "dist:webui": "run build:ts && run build:whatsnew && yarn workspace @companion-app/webui build",

--- a/shared-lib/lib/Model/Options.ts
+++ b/shared-lib/lib/Model/Options.ts
@@ -230,7 +230,6 @@ export interface CompanionInputFieldDropdownExtended extends CompanionInputField
 	default: DropdownChoiceId
 	allowCustom?: boolean
 	regex?: string
-	minChoicesForSearch?: number
 }
 export interface CompanionInputFieldMultiDropdownExtended extends CompanionInputFieldBaseExtended {
 	type: 'multidropdown'

--- a/shared-lib/lib/Model/Options.ts
+++ b/shared-lib/lib/Model/Options.ts
@@ -238,8 +238,6 @@ export interface CompanionInputFieldMultiDropdownExtended extends CompanionInput
 	choices: DropdownChoice[]
 	/** The default selected values */
 	default: DropdownChoiceId[]
-	/** The minimum number of entries the dropdown must have before it allows searching */
-	minChoicesForSearch?: number
 	/** The minimum number of selected values */
 	minSelection?: number
 	/** The maximum number of selected values */

--- a/shared-lib/lib/ValidateInputValue.ts
+++ b/shared-lib/lib/ValidateInputValue.ts
@@ -322,7 +322,7 @@ export function validateInputValue(
 	}
 }
 
-function compileRegex(regex: string | undefined): RegExp | null {
+export function compileRegex(regex: string | undefined): RegExp | null {
 	if (!regex) return null
 
 	try {

--- a/webui/.storybook/main.ts
+++ b/webui/.storybook/main.ts
@@ -1,0 +1,31 @@
+import path from 'path'
+import type { StorybookConfig } from '@storybook/react-vite'
+import { mergeConfig } from 'vite'
+
+const config: StorybookConfig = {
+	stories: ['../src/**/*.stories.tsx'],
+	framework: {
+		name: '@storybook/react-vite',
+		options: {},
+	},
+	typescript: {
+		// react-docgen-typescript crawls ALL TypeScript source files to extract prop types.
+		// In this large monorepo that exhausts the heap. Disable it.
+		reactDocgen: false,
+	},
+	viteFinal: async (cfg) => {
+		return mergeConfig(cfg, {
+			resolve: {
+				alias: {
+					// Don't use the auto tsconfig paths, it causes vite to explore too much and run out of memory
+					'~': path.resolve(import.meta.dirname, '../src'),
+				},
+			},
+			build: {
+				sourcemap: false,
+			},
+		})
+	},
+}
+
+export default config

--- a/webui/.storybook/mockRootAppStore.tsx
+++ b/webui/.storybook/mockRootAppStore.tsx
@@ -1,0 +1,29 @@
+import type { Decorator } from '@storybook/react'
+import { RootAppStoreContext, type RootAppStore } from '../src/Stores/RootAppStore'
+
+export const mockRootAppStore: Partial<RootAppStore> = {
+	notifier: {
+		show: (_title, _message, _duration, _stickyId) => 'mock-notification-id',
+		close: () => {},
+	},
+	activeLearns: new Set<string>() as unknown as RootAppStore['activeLearns'],
+	userConfig: {
+		properties: {
+			default_export_filename: 'companion-export',
+		},
+	} as unknown as RootAppStore['userConfig'],
+	variablesStore: {
+		allVariableDefinitions: {
+			get: () => [
+				{ connectionLabel: 'internal', name: 'time_hms', description: 'internal:time_hms — Current time (HH:MM:SS)' },
+				{ connectionLabel: 'internal', name: 'date_y', description: 'internal:date_y — Current year' },
+			],
+		},
+	} as unknown as RootAppStore['variablesStore'],
+}
+
+export const withMockStore: Decorator = (Story) => (
+	<RootAppStoreContext.Provider value={mockRootAppStore as RootAppStore}>
+		<Story />
+	</RootAppStoreContext.Provider>
+)

--- a/webui/.storybook/preview.css
+++ b/webui/.storybook/preview.css
@@ -1,0 +1,3 @@
+body {
+	background-color: #fff !important;
+}

--- a/webui/.storybook/preview.ts
+++ b/webui/.storybook/preview.ts
@@ -1,0 +1,27 @@
+import type { Preview } from '@storybook/react'
+import '../src/App.scss'
+import './preview.css'
+import alignmentImg from '../src/scss/img/alignment.png'
+import checkImg from '../src/scss/img/check.svg?no-inline'
+import indeterminateImg from '../src/scss/img/indeterminate.svg?no-inline'
+
+document.body.style.setProperty('--companion-img-alignment', `url(${alignmentImg})`)
+document.body.style.setProperty('--companion-img-check', `url(${checkImg})`)
+document.body.style.setProperty('--companion-img-indeterminate', `url(${indeterminateImg})`)
+
+const preview: Preview = {
+	parameters: {
+		backgrounds: {
+			default: 'light',
+			values: [{ name: 'light', value: '#fff' }],
+		},
+		controls: {
+			matchers: {
+				color: /(background|color)$/i,
+				date: /Date$/i,
+			},
+		},
+	},
+}
+
+export default preview

--- a/webui/package.json
+++ b/webui/package.json
@@ -94,13 +94,16 @@
     "dev": "run start",
     "dev:docs": "yarn workspace @companion-app/workspace dev:webui:docs",
     "test": "vitest",
+    "storybook": "storybook dev -p 6006",
     "build": "NODE_OPTIONS=--max-old-space-size=4096 vite build --base=/ROOT_URL_HERE",
     "serve": "vite preview"
   },
   "devDependencies": {
+    "@storybook/react-vite": "^10.3.6",
     "@types/react-transition-group": "^4",
     "jsdom": "^29.1.1",
     "monaco-editor": "^0.55.1",
+    "storybook": "^10.3.6",
     "vitest": "^4.1.5"
   }
 }

--- a/webui/package.json
+++ b/webui/package.json
@@ -100,6 +100,10 @@
   },
   "devDependencies": {
     "@storybook/react-vite": "^10.3.6",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react-transition-group": "^4",
     "jsdom": "^29.1.1",
     "monaco-editor": "^0.55.1",

--- a/webui/src/Buttons/ButtonGridHeader.stories.tsx
+++ b/webui/src/Buttons/ButtonGridHeader.stories.tsx
@@ -1,0 +1,142 @@
+import type { Decorator, Meta, StoryObj } from '@storybook/react'
+import { useArgs } from 'storybook/preview-api'
+import { mockRootAppStore } from '../../.storybook/mockRootAppStore'
+import { RootAppStoreContext, type RootAppStore } from '../Stores/RootAppStore'
+import { ButtonGridHeader, PageNumberPicker, type PageNumberOption } from './ButtonGridHeader'
+
+const samplePages: PageNumberOption[] = [
+	{ value: 1, label: '1 (Main)' },
+	{ value: 2, label: '2 (Cameras)' },
+	{ value: 3, label: '3 (Audio)' },
+	{ value: 4, label: '4 (Graphics)' },
+	{ value: 5, label: '5' },
+]
+
+const meta = {
+	component: PageNumberPicker,
+	args: {
+		pageNumber: 1,
+		pageOptions: samplePages,
+		changePage: undefined,
+		setPage: undefined,
+	},
+	render: function Render(args) {
+		const [, setArgs] = useArgs<{ pageNumber: number }>()
+		return (
+			<PageNumberPicker
+				{...args}
+				changePage={
+					args.changePage ? (delta) => setArgs({ pageNumber: Math.max(1, args.pageNumber + delta) }) : undefined
+				}
+				setPage={args.setPage ? (page) => setArgs({ pageNumber: page }) : undefined}
+			/>
+		)
+	},
+} satisfies Meta<typeof PageNumberPicker>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Read-only — no changePage or setPage, just displays current page */
+export const ReadOnly: Story = {}
+
+/** Interactive — prev/next buttons + dropdown navigation both work */
+export const Interactive: Story = {
+	args: {
+		changePage: () => {},
+		setPage: () => {},
+	},
+}
+
+/** DropdownOnly — setPage only, no prev/next arrow buttons */
+export const DropdownOnly: Story = {
+	args: {
+		setPage: () => {},
+	},
+}
+
+/** ManyPages — shows the searchable dropdown is useful with many pages */
+export const ManyPages: Story = {
+	args: {
+		pageNumber: 5,
+		pageOptions: Array.from({ length: 20 }, (_, i) => ({ value: i + 1, label: `${i + 1}` })),
+		changePage: () => {},
+		setPage: () => {},
+	},
+}
+
+/** WithChildren — the children slot renders in the right-buttons area */
+export const WithChildren: Story = {
+	args: {
+		changePage: () => {},
+		setPage: () => {},
+	},
+	render: function Render(args) {
+		const [, setArgs] = useArgs<{ pageNumber: number }>()
+		return (
+			<PageNumberPicker
+				{...args}
+				changePage={(delta) => setArgs({ pageNumber: Math.max(1, args.pageNumber + delta) })}
+				setPage={(page) => setArgs({ pageNumber: page })}
+			>
+				<button>Edit</button>
+				<button>Copy</button>
+			</PageNumberPicker>
+		)
+	},
+}
+
+const withStorePagesDecorator: Decorator = (Story) => (
+	<RootAppStoreContext.Provider
+		value={
+			{
+				...mockRootAppStore,
+				pages: {
+					data: [{ name: 'Main' }, { name: 'Cameras' }, { name: '' }, { name: 'Audio' }, { name: '' }],
+				},
+			} as unknown as RootAppStore
+		}
+	>
+		<Story />
+	</RootAppStoreContext.Provider>
+)
+
+/** ButtonGridHeader — wraps PageNumberPicker and loads page list from the store */
+export const WithStore: StoryObj<typeof ButtonGridHeader> = {
+	name: 'ButtonGridHeader (with store)',
+	decorators: [withStorePagesDecorator],
+	render: function Render() {
+		const [page, setPage] = useArgs<{ pageNumber: number }>()
+		return (
+			<ButtonGridHeader
+				pageNumber={page.pageNumber ?? 1}
+				changePage={(delta) => setPage({ pageNumber: Math.max(1, (page.pageNumber ?? 1) + delta) })}
+				setPage={(p) => setPage({ pageNumber: p })}
+			/>
+		)
+	},
+}
+
+const withNewPageAtEndDecorator: Decorator = (Story) => (
+	<RootAppStoreContext.Provider
+		value={
+			{
+				...mockRootAppStore,
+				pages: {
+					data: [{ name: 'Main' }, { name: 'Cameras' }],
+				},
+			} as unknown as RootAppStore
+		}
+	>
+		<Story />
+	</RootAppStoreContext.Provider>
+)
+
+/** NewPageAtEnd — ButtonGridHeader with an "Insert new page" option at the bottom of the dropdown */
+export const NewPageAtEnd: StoryObj<typeof ButtonGridHeader> = {
+	name: 'ButtonGridHeader (newPageAtEnd)',
+	decorators: [withNewPageAtEndDecorator],
+	render: function Render() {
+		return <ButtonGridHeader pageNumber={1} changePage={() => {}} setPage={() => {}} newPageAtEnd />
+	},
+}

--- a/webui/src/Buttons/ButtonGridHeader.tsx
+++ b/webui/src/Buttons/ButtonGridHeader.tsx
@@ -115,7 +115,7 @@ export const PageNumberPicker = observer(function ButtonGridHeader({
 						onInputValueChange={setInputValue}
 						itemToStringLabel={() => ''}
 					>
-						<Combobox.InputGroup className="dropdown-field-input-group button-page-input-group">
+						<Combobox.InputGroup className="dropdown-field-input-group rounded-start-0 rounded-end-0">
 							<Combobox.Input
 								className="dropdown-field-input"
 								placeholder={choiceOptions.find((o) => o.id === pageNumber)?.label ?? String(pageNumber ?? '')}

--- a/webui/src/Buttons/ButtonGridHeader.tsx
+++ b/webui/src/Buttons/ButtonGridHeader.tsx
@@ -1,9 +1,14 @@
+import { Combobox } from '@base-ui/react/combobox'
 import { CButton, CInputGroup } from '@coreui/react'
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { prepare as fuzzyPrepare, single as fuzzySingle } from 'fuzzysort'
+import { ChevronDownIcon } from 'lucide-react'
 import { observer } from 'mobx-react-lite'
-import { useCallback, useContext, useMemo } from 'react'
-import Select from 'react-select'
+import { useCallback, useContext, useState } from 'react'
+import type { DropdownChoice } from '@companion-app/shared/Model/Common.js'
+import { DropdownInputPopup } from '~/Components/DropdownInputField/Popup.js'
+import { MenuPortalContext } from '~/Components/MenuPortalContext.js'
 import { useComputed } from '~/Resources/util.js'
 import { RootAppStoreContext } from '~/Stores/RootAppStore.js'
 
@@ -63,31 +68,35 @@ export const PageNumberPicker = observer(function ButtonGridHeader({
 	pageOptions,
 	children,
 }: React.PropsWithChildren<PageNumberPickerProps>) {
+	const menuPortal = useContext(MenuPortalContext)
+
 	const inputChange = useCallback(
-		(val: PageNumberOption | null) => {
-			const val2 = val?.value
-			if (val2 !== undefined && setPage && !isNaN(val2)) {
-				setPage(val2)
+		(val: number | null) => {
+			if (val !== null && setPage && !isNaN(val)) {
+				setPage(val)
 			}
 		},
 		[setPage]
 	)
 
-	const nextPage = useCallback(() => {
-		changePage?.(1)
-	}, [changePage])
-	const prevPage = useCallback(() => {
-		changePage?.(-1)
-	}, [changePage])
+	const nextPage = useCallback(() => changePage?.(1), [changePage])
+	const prevPage = useCallback(() => changePage?.(-1), [changePage])
 
-	const currentValue: PageNumberOption | undefined = useMemo(() => {
-		return (
-			pageOptions.find((o) => o.value == pageNumber) ?? {
-				value: pageNumber,
-				label: pageNumber + '',
-			}
-		)
+	const choiceOptions = useComputed<Array<DropdownChoice & { fuzzy: ReturnType<typeof fuzzyPrepare> }>>(() => {
+		const options = pageOptions.map((o) => ({ id: o.value, label: o.label, fuzzy: fuzzyPrepare(o.label) }))
+		if (!options.some((o) => o.id === pageNumber)) {
+			const label = String(pageNumber)
+			options.push({ id: pageNumber, label, fuzzy: fuzzyPrepare(label) })
+		}
+		return options
 	}, [pageOptions, pageNumber])
+
+	const [inputValue, setInputValue] = useState('')
+
+	const filteredItems = useComputed<DropdownChoice[]>(() => {
+		if (!inputValue) return choiceOptions
+		return choiceOptions.filter((o) => (fuzzySingle(inputValue, o.fuzzy)?.score ?? 0) >= 0.5)
+	}, [choiceOptions, inputValue])
 
 	return (
 		<div className="button-grid-header">
@@ -95,18 +104,29 @@ export const PageNumberPicker = observer(function ButtonGridHeader({
 				<CButton color="dark" hidden={!changePage} onClick={prevPage}>
 					<FontAwesomeIcon icon={faChevronLeft} />
 				</CButton>
-				<Select<PageNumberOption>
-					className="button-page-input"
-					isDisabled={!setPage}
-					placeholder={pageNumber}
-					classNamePrefix={'select-control'}
-					isClearable={false}
-					isSearchable={true}
-					isMulti={false}
-					options={pageOptions}
-					value={currentValue}
-					onChange={inputChange}
-				/>
+				<div className="dropdown-field button-page-input">
+					<Combobox.Root<number | null>
+						autoHighlight
+						value={pageNumber}
+						items={choiceOptions}
+						filteredItems={filteredItems}
+						disabled={!setPage}
+						onValueChange={inputChange}
+						onInputValueChange={setInputValue}
+						itemToStringLabel={() => ''}
+					>
+						<Combobox.InputGroup className="dropdown-field-input-group button-page-input-group">
+							<Combobox.Input
+								className="dropdown-field-input"
+								placeholder={choiceOptions.find((o) => o.id === pageNumber)?.label ?? String(pageNumber ?? '')}
+							/>
+							<Combobox.Trigger className="dropdown-field-trigger">
+								<ChevronDownIcon className="dropdown-field-icon" />
+							</Combobox.Trigger>
+						</Combobox.InputGroup>
+						<DropdownInputPopup menuPortal={menuPortal ?? undefined} />
+					</Combobox.Root>
+				</div>
 				<CButton color="dark" hidden={!changePage} onClick={nextPage}>
 					<FontAwesomeIcon icon={faChevronRight} />
 				</CButton>

--- a/webui/src/Buttons/ButtonGridResizePrompt.stories.tsx
+++ b/webui/src/Buttons/ButtonGridResizePrompt.stories.tsx
@@ -1,0 +1,80 @@
+import type { Decorator, Meta, StoryObj } from '@storybook/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { mockRootAppStore } from '../../.storybook/mockRootAppStore'
+import { RootAppStoreContext, type RootAppStore } from '../Stores/RootAppStore'
+import { ButtonGridResizePrompt } from './ButtonGridResizePrompt'
+
+const queryClient = new QueryClient()
+
+const withQueryClient: Decorator = (Story) => (
+	<QueryClientProvider client={queryClient}>
+		<Story />
+	</QueryClientProvider>
+)
+
+const gridSize = { minColumn: 0, maxColumn: 7, minRow: 0, maxRow: 3 }
+
+const withOverflowStore: Partial<RootAppStore> = {
+	...mockRootAppStore,
+	userConfig: {
+		properties: {
+			...mockRootAppStore.userConfig?.properties,
+			gridSize,
+		},
+	} as unknown as RootAppStore['userConfig'],
+	surfaces: {
+		getSurfacesOverflowingBounds: () => ({
+			neededBounds: { minColumn: 0, maxColumn: 11, minRow: 0, maxRow: 5 },
+			surfaces: [
+				{ id: 'surface-1', displayName: 'Stream Deck XL (desk)' },
+				{ id: 'surface-2', displayName: 'Loupedeck Live (rack)' },
+			],
+		}),
+	} as unknown as RootAppStore['surfaces'],
+}
+
+const withNoOverflowStore: Partial<RootAppStore> = {
+	...mockRootAppStore,
+	userConfig: {
+		properties: {
+			...mockRootAppStore.userConfig?.properties,
+			gridSize,
+		},
+	} as unknown as RootAppStore['userConfig'],
+	surfaces: {
+		getSurfacesOverflowingBounds: () => ({
+			neededBounds: gridSize,
+			surfaces: [],
+		}),
+	} as unknown as RootAppStore['surfaces'],
+}
+
+const withOverflowDecorator: Decorator = (Story) => (
+	<RootAppStoreContext.Provider value={withOverflowStore as RootAppStore}>
+		<Story />
+	</RootAppStoreContext.Provider>
+)
+
+const withNoOverflowDecorator: Decorator = (Story) => (
+	<RootAppStoreContext.Provider value={withNoOverflowStore as RootAppStore}>
+		<Story />
+	</RootAppStoreContext.Provider>
+)
+
+const meta = {
+	component: ButtonGridResizePrompt,
+	decorators: [withQueryClient],
+} satisfies Meta<typeof ButtonGridResizePrompt>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Surfaces overflow the grid — shows the resize prompt with affected surface names */
+export const WithOverflowingSurfaces: Story = {
+	decorators: [withOverflowDecorator],
+}
+
+/** No surfaces overflow the grid — component renders nothing */
+export const NoOverflowingSurfaces: Story = {
+	decorators: [withNoOverflowDecorator],
+}

--- a/webui/src/Buttons/ButtonGridZoomControl.stories.tsx
+++ b/webui/src/Buttons/ButtonGridZoomControl.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { useArgs } from 'storybook/preview-api'
+import { ButtonGridZoomControl } from './ButtonGridZoomControl'
+import { ZOOM_MAX, ZOOM_MIN, ZOOM_STEP, type GridZoomController } from './GridZoom'
+
+function makeController(setZoom: (v: number) => void, zoom: number): GridZoomController {
+	return {
+		zoomIn: () => setZoom(Math.min(zoom + ZOOM_STEP, ZOOM_MAX)),
+		zoomOut: () => setZoom(Math.max(zoom - ZOOM_STEP, ZOOM_MIN)),
+		zoomReset: () => setZoom(100),
+		setZoom,
+	}
+}
+
+const meta = {
+	component: ButtonGridZoomControl,
+	args: {
+		useCompactButtons: false,
+		gridZoomValue: 100,
+	},
+	render: function Render(args) {
+		const [, setArgs] = useArgs<{ gridZoomValue: number }>()
+		const controller = makeController((v) => setArgs({ gridZoomValue: v }), args.gridZoomValue)
+		return <ButtonGridZoomControl {...args} gridZoomController={controller} />
+	},
+	argTypes: {
+		useCompactButtons: { control: 'boolean' },
+		gridZoomValue: { control: { type: 'range', min: ZOOM_MIN, max: ZOOM_MAX, step: ZOOM_STEP } },
+	},
+} satisfies Meta<typeof ButtonGridZoomControl>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Full-size button showing the zoom percentage label */
+export const Default: Story = {
+	args: {
+		gridZoomController: makeController(() => {}, 100),
+	},
+}
+
+/** Compact button — icon only, no percentage label */
+export const Compact: Story = {
+	args: { useCompactButtons: true, gridZoomController: makeController(() => {}, 100) },
+}
+
+/** Zoomed in to 150% */
+export const ZoomedIn: Story = {
+	args: { gridZoomValue: 150, gridZoomController: makeController(() => {}, 150) },
+}
+
+/** Zoomed out to 50% */
+export const ZoomedOut: Story = {
+	args: { gridZoomValue: 50, gridZoomController: makeController(() => {}, 50) },
+}

--- a/webui/src/Components/ActionMenu.stories.tsx
+++ b/webui/src/Components/ActionMenu.stories.tsx
@@ -1,0 +1,55 @@
+import { faCopy, faDownload, faEdit, faTrash } from '@fortawesome/free-solid-svg-icons'
+import type { Meta, StoryObj } from '@storybook/react'
+import { ActionMenu } from './ActionMenu'
+
+const meta = {
+	component: ActionMenu,
+	args: {
+		menuItems: [],
+	},
+} satisfies Meta<typeof ActionMenu>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Typical menu with icons, separators and group headings */
+export const Default: Story = {
+	args: {
+		menuItems: [
+			{ label: 'Edit', icon: faEdit, do: () => console.log('edit'), tooltip: 'Edit this item' },
+			{ label: 'Duplicate', icon: faCopy, do: () => console.log('duplicate') },
+			{ label: 'Danger Zone', isSeparator: true },
+			{ label: 'Delete', icon: faTrash, do: () => console.log('delete') },
+		],
+	},
+}
+
+/** Demonstrates copy-to-clipboard and external-link (inNewTab) item variants */
+export const SpecialItems: Story = {
+	args: {
+		menuItems: [
+			{
+				label: 'Copy ID to clipboard',
+				icon: faCopy,
+				do: (): void => {},
+				copyToClipboard: { text: 'item-abc-123' },
+			},
+			{
+				label: 'Open documentation',
+				icon: faDownload,
+				do: () => window.open('https://companion.bitfocus.io'),
+				inNewTab: true,
+			},
+		],
+	},
+}
+
+/** Items without icons */
+export const NoIcons: Story = {
+	args: {
+		menuItems: [
+			{ label: 'Edit', icon: 'none', do: () => console.log('edit') },
+			{ label: 'Delete', icon: 'none', do: () => console.log('delete') },
+		],
+	},
+}

--- a/webui/src/Components/Alert.stories.tsx
+++ b/webui/src/Components/Alert.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { useState } from 'react'
+import { DismissableAlert, StaticAlert } from './Alert'
+
+const meta = {
+	component: StaticAlert,
+	args: {
+		children: 'This is an alert message.',
+		color: 'info',
+	},
+} satisfies Meta<typeof StaticAlert>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Info: Story = { args: { color: 'info' } }
+export const Success: Story = { args: { color: 'success', children: 'Operation completed successfully.' } }
+export const Warning: Story = { args: { color: 'warning', children: 'Proceed with caution.' } }
+export const Danger: Story = { args: { color: 'danger', children: 'Something went wrong.' } }
+export const Solid: Story = { args: { color: 'primary', variant: 'solid', children: 'Solid style alert.' } }
+
+export const Dismissable: Story = {
+	render: function Render() {
+		const [visible, setVisible] = useState(true)
+		return (
+			<div>
+				<DismissableAlert color="warning" visible={visible} onClose={() => setVisible(false)}>
+					Dismiss me with the × button.
+				</DismissableAlert>
+				{!visible && (
+					<button onClick={() => setVisible(true)} style={{ marginTop: 8 }}>
+						Show again
+					</button>
+				)}
+			</div>
+		)
+	},
+}

--- a/webui/src/Components/AlignmentInputField.stories.tsx
+++ b/webui/src/Components/AlignmentInputField.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { useState } from 'react'
+import { useArgs } from 'storybook/preview-api'
+import type { CompanionAlignment } from '@companion-module/base'
+import { AlignmentInputField, HorizontalAlignmentInputField, VerticalAlignmentInputField } from './AlignmentInputField'
+
+const meta = {
+	component: AlignmentInputField,
+	args: {
+		value: 'center:center' as CompanionAlignment,
+		setValue: () => {},
+	},
+	render: function Render(args) {
+		const [, setArgs] = useArgs<{ value: CompanionAlignment }>()
+		return <AlignmentInputField {...args} setValue={(v) => setArgs({ value: v })} />
+	},
+} satisfies Meta<typeof AlignmentInputField>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+export const TopLeft: Story = { args: { value: 'left:top' as CompanionAlignment } }
+export const BottomRight: Story = { args: { value: 'right:bottom' as CompanionAlignment } }
+
+export const HorizontalAlignment: Story = {
+	render: function Render() {
+		const [value, setValue] = useState('center')
+		return <HorizontalAlignmentInputField value={value} setValue={setValue} />
+	},
+}
+
+export const HorizontalAlignmentDisabled: Story = {
+	render: function Render() {
+		const [value, setValue] = useState('center')
+		return <HorizontalAlignmentInputField value={value} setValue={setValue} disabled />
+	},
+}
+
+export const VerticalAlignment: Story = {
+	render: function Render() {
+		const [value, setValue] = useState('center')
+		return <VerticalAlignmentInputField value={value} setValue={setValue} />
+	},
+}
+
+export const VerticalAlignmentDisabled: Story = {
+	render: function Render() {
+		const [value, setValue] = useState('center')
+		return <VerticalAlignmentInputField value={value} setValue={setValue} disabled />
+	},
+}

--- a/webui/src/Components/ButtonPreview.stories.tsx
+++ b/webui/src/Components/ButtonPreview.stories.tsx
@@ -1,0 +1,68 @@
+import type { Decorator, Meta, StoryObj } from '@storybook/react'
+import { ButtonPreviewBase, RedImage } from './ButtonPreview'
+
+const withSize: Decorator = (Story) => (
+	<div style={{ width: 72, height: 72 }}>
+		<Story />
+	</div>
+)
+
+const meta = {
+	component: ButtonPreviewBase,
+	decorators: [withSize],
+	args: {
+		preview: null,
+		style: { width: '100%', height: '100%' },
+		canDrop: false,
+		dropHover: false,
+		right: false,
+		title: '',
+	},
+} satisfies Meta<typeof ButtonPreviewBase>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Empty: Story = {}
+
+export const WithPlaceholder: Story = {
+	args: { placeholder: '1/2', preview: null },
+}
+
+export const WithImage: Story = {
+	args: { preview: RedImage },
+}
+
+export const Selected: Story = {
+	args: { preview: RedImage, selected: true },
+}
+
+export const Clickable: Story = {
+	args: {
+		preview: RedImage,
+		onClick: (pressed) => console.log('clicked', pressed),
+	},
+}
+
+export const FixedSize: Story = {
+	args: { preview: RedImage, fixedSize: true },
+}
+
+/** canDrop highlights the button as a valid drop target */
+export const CanDrop: Story = {
+	args: { preview: RedImage, canDrop: true },
+}
+
+/** dropHover shows the button is being hovered while dragging */
+export const DropHover: Story = {
+	args: { preview: RedImage, canDrop: true, dropHover: true },
+}
+
+/** right-aligned layout variant */
+export const RightLayout: Story = {
+	args: { preview: RedImage, right: true },
+}
+
+export const WithTitle: Story = {
+	args: { preview: RedImage, title: 'My Button' },
+}

--- a/webui/src/Components/CModalExt.stories.tsx
+++ b/webui/src/Components/CModalExt.stories.tsx
@@ -1,0 +1,68 @@
+import { CModalBody, CModalFooter, CModalHeader, CModalTitle } from '@coreui/react'
+import type { Meta, StoryObj } from '@storybook/react'
+import { useState } from 'react'
+import { CModalExt } from './CModalExt'
+
+const meta = {
+	component: CModalExt,
+	args: {
+		visible: false,
+		children: null,
+	},
+} satisfies Meta<typeof CModalExt>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+	render: function Render(args) {
+		const [visible, setVisible] = useState(false)
+		return (
+			<>
+				<button onClick={() => setVisible(true)}>Open Modal</button>
+				<CModalExt {...args} visible={visible} onClose={() => setVisible(false)}>
+					<CModalHeader>
+						<CModalTitle>Example Modal</CModalTitle>
+					</CModalHeader>
+					<CModalBody>This is the modal body content.</CModalBody>
+					<CModalFooter>
+						<button onClick={() => setVisible(false)}>Close</button>
+					</CModalFooter>
+				</CModalExt>
+			</>
+		)
+	},
+}
+
+export const WithCallbacks: Story = {
+	render: function Render(args) {
+		const [visible, setVisible] = useState(false)
+		const [log, setLog] = useState<string[]>([])
+		const addLog = (msg: string) => setLog((prev) => [...prev, msg])
+		return (
+			<>
+				<button onClick={() => setVisible(true)}>Open Modal</button>
+				<ul>
+					{log.map((entry, i) => (
+						<li key={i}>{entry}</li>
+					))}
+				</ul>
+				<CModalExt
+					{...args}
+					visible={visible}
+					onClose={() => setVisible(false)}
+					onOpened={() => addLog('onOpened fired')}
+					onClosed={() => addLog('onClosed fired')}
+				>
+					<CModalHeader>
+						<CModalTitle>With Callbacks</CModalTitle>
+					</CModalHeader>
+					<CModalBody>Open/close and watch the log below.</CModalBody>
+					<CModalFooter>
+						<button onClick={() => setVisible(false)}>Close</button>
+					</CModalFooter>
+				</CModalExt>
+			</>
+		)
+	},
+}

--- a/webui/src/Components/CheckboxInputField.stories.tsx
+++ b/webui/src/Components/CheckboxInputField.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { useArgs } from 'storybook/preview-api'
+import { CheckboxInputField, CheckboxInputFieldWithLabel } from './CheckboxInputField'
+
+const meta = {
+	component: CheckboxInputField,
+	args: {
+		value: false,
+		setValue: () => {},
+		tooltip: '',
+		disabled: false,
+	},
+	render: function Render(args) {
+		const [, setArgs] = useArgs<{ value: boolean }>()
+		return <CheckboxInputField {...args} setValue={(v) => setArgs({ value: v })} />
+	},
+} satisfies Meta<typeof CheckboxInputField>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+export const Indeterminate: Story = { args: { indeterminate: true } }
+export const Disabled: Story = { args: { disabled: true, value: true } }
+
+export const WithLabel: Story = {
+	render: function Render(args) {
+		const [, setArgs] = useArgs<{ value: boolean }>()
+		return <CheckboxInputFieldWithLabel {...args} label="Enable feature" setValue={(v) => setArgs({ value: v })} />
+	},
+}
+
+export const DisabledWithLabel: Story = {
+	args: { value: true, disabled: true },
+	render: function Render(args) {
+		const [, setArgs] = useArgs<{ value: boolean }>()
+		return <CheckboxInputFieldWithLabel {...args} label="Enable feature" setValue={(v) => setArgs({ value: v })} />
+	},
+}

--- a/webui/src/Components/ColorInputField.stories.tsx
+++ b/webui/src/Components/ColorInputField.stories.tsx
@@ -1,0 +1,45 @@
+import type { Decorator, Meta, StoryObj } from '@storybook/react'
+import { useArgs } from 'storybook/preview-api'
+import { ColorInputField } from './ColorInputField'
+import { MenuPortalContext } from './MenuPortalContext'
+
+const withPortal: Decorator = (Story) => (
+	<MenuPortalContext.Provider value={document.body}>
+		<Story />
+	</MenuPortalContext.Provider>
+)
+
+const meta = {
+	component: ColorInputField<'number'>,
+	decorators: [withPortal],
+	args: {
+		value: 0x000000,
+		returnType: 'number',
+		setValue: () => {},
+		enableAlpha: false,
+		disabled: false,
+	},
+	render: function Render(args) {
+		const [, setArgs] = useArgs<{ value: number }>()
+		return <ColorInputField<'number'> {...args} setValue={(v) => setArgs({ value: v })} />
+	},
+} satisfies Meta<typeof ColorInputField<'number'>>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Black: Story = {}
+
+export const Red: Story = {
+	args: { value: 0xff0000 },
+}
+
+export const WithAlpha: Story = {
+	args: { value: 0x800000ff, enableAlpha: true },
+}
+
+export const WithPresetColors: Story = {
+	args: {
+		presetColors: ['#ff0000', '#00ff00', '#0000ff', '#ffff00', '#ff00ff', '#00ffff'],
+	},
+}

--- a/webui/src/Components/ColorInputField.tsx
+++ b/webui/src/Components/ColorInputField.tsx
@@ -51,7 +51,7 @@ const toReturnType = <T extends 'string' | 'number'>(
 	enableAlpha: boolean | undefined
 ): AsType<T> => {
 	if (returnType === 'string') {
-		return `rgba(${value.rgb.r}, ${value.rgb.g}, ${value.rgb.b}, ${value.rgb.a})` as any // TODO - typings
+		return `rgba(${value.rgb.r}, ${value.rgb.g}, ${value.rgb.b}, ${value.rgb.a ?? 1})` as any // TODO - typings
 	} else {
 		let colorNumber = parseInt(value.hex.slice(1, 7), 16)
 		if (enableAlpha && value.rgb.a !== undefined && value.rgb.a !== 1) {

--- a/webui/src/Components/ConfirmExportModal.stories.tsx
+++ b/webui/src/Components/ConfirmExportModal.stories.tsx
@@ -1,0 +1,44 @@
+import type { Decorator, Meta, StoryObj } from '@storybook/react'
+import { useRef } from 'react'
+import { withMockStore } from '../../.storybook/mockRootAppStore'
+import { ConfirmExportModal, type ConfirmExportModalRef } from './ConfirmExportModal'
+import { MenuPortalContext } from './MenuPortalContext'
+
+const withPortal: Decorator = (Story) => (
+	<MenuPortalContext.Provider value={document.body}>
+		<Story />
+	</MenuPortalContext.Provider>
+)
+
+const meta = {
+	component: ConfirmExportModal,
+	decorators: [withMockStore, withPortal],
+} satisfies Meta<typeof ConfirmExportModal>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+	render: function Render(args) {
+		const ref = useRef<ConfirmExportModalRef | null>(null)
+		return (
+			<>
+				<button onClick={() => ref.current?.show('/api/export/config')}>Open Export Modal</button>
+				<ConfirmExportModal {...args} ref={ref} />
+			</>
+		)
+	},
+}
+
+export const WithTitle: Story = {
+	args: { title: 'Export Page Configuration' },
+	render: function Render(args) {
+		const ref = useRef<ConfirmExportModalRef | null>(null)
+		return (
+			<>
+				<button onClick={() => ref.current?.show('/api/export/page/1')}>Open Export Modal</button>
+				<ConfirmExportModal {...args} ref={ref} />
+			</>
+		)
+	},
+}

--- a/webui/src/Components/ContextMenu.stories.tsx
+++ b/webui/src/Components/ContextMenu.stories.tsx
@@ -1,0 +1,54 @@
+import { faEdit, faTrash } from '@fortawesome/free-solid-svg-icons'
+import type { Meta, StoryObj } from '@storybook/react'
+import { useRef } from 'react'
+import { ContextMenu } from './ContextMenu'
+
+const meta = {
+	component: ContextMenu,
+	args: {
+		visible: true,
+		position: { x: 20, y: 20 },
+		onContextMenu: (e: React.MouseEvent<HTMLDivElement>) => e.preventDefault(),
+		menuItems: [],
+		menuRef: { current: null },
+	},
+} satisfies Meta<typeof ContextMenu>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+	render: function Render(args) {
+		const menuRef = useRef<HTMLDivElement>(null)
+		return (
+			<ContextMenu
+				{...args}
+				visible={true}
+				position={{ x: 20, y: 20 }}
+				menuRef={menuRef}
+				onContextMenu={(e) => e.preventDefault()}
+				menuItems={[
+					{ label: 'Edit', icon: faEdit, do: () => console.log('edit') },
+					{ isSeparator: true },
+					{ label: 'Delete', icon: faTrash, do: () => console.log('delete') },
+				]}
+			/>
+		)
+	},
+}
+
+export const Hidden: Story = {
+	render: function Render(args) {
+		const menuRef = useRef<HTMLDivElement>(null)
+		return (
+			<ContextMenu
+				{...args}
+				visible={false}
+				position={{ x: 20, y: 20 }}
+				menuRef={menuRef}
+				onContextMenu={(e) => e.preventDefault()}
+				menuItems={[{ label: 'Edit', icon: faEdit, do: () => console.log('edit') }]}
+			/>
+		)
+	},
+}

--- a/webui/src/Components/DropdownInputField.stories.tsx
+++ b/webui/src/Components/DropdownInputField.stories.tsx
@@ -40,7 +40,10 @@ type Story = StoryObj<typeof meta>
 export const Default: Story = {}
 
 export const WithAllowCustom: Story = {
-	args: { allowCustom: true, value: 'my-custom-value' },
+	args: { allowCustom: true, value: 'my-custom-value', disableEditingCustom: false },
+	argTypes: {
+		disableEditingCustom: { control: 'boolean' },
+	},
 }
 
 export const WithValidation: Story = {
@@ -49,6 +52,28 @@ export const WithValidation: Story = {
 
 export const Disabled: Story = {
 	args: { disabled: true },
+}
+
+export const GroupedChoices: Story = {
+	args: {
+		choices: [
+			{
+				label: 'Fruits',
+				options: [
+					{ id: 'apple', label: 'Apple' },
+					{ id: 'banana', label: 'Banana' },
+				],
+			},
+			{
+				label: 'Veggies',
+				options: [
+					{ id: 'carrot', label: 'Carrot' },
+					{ id: 'potato', label: 'Potato' },
+				],
+			},
+		],
+		value: 'apple',
+	},
 }
 
 /** FancyFormat uses a custom option renderer that shows the variable name and description on two lines */
@@ -61,5 +86,6 @@ export const FancyFormat: Story = {
 			{ id: 'internal:uptime', label: 'Time since last restart' },
 		],
 		value: 'internal:time_hms',
+		allowCustom: false,
 	},
 }

--- a/webui/src/Components/DropdownInputField.stories.tsx
+++ b/webui/src/Components/DropdownInputField.stories.tsx
@@ -27,7 +27,6 @@ const meta = {
 		tooltip: '',
 		disabled: false,
 		searchLabelsOnly: true,
-		minChoicesForSearch: 0,
 	},
 	render: function Render(args) {
 		const [, setArgs] = useArgs<{ value: string }>()

--- a/webui/src/Components/DropdownInputField.stories.tsx
+++ b/webui/src/Components/DropdownInputField.stories.tsx
@@ -1,0 +1,66 @@
+import type { Decorator, Meta, StoryObj } from '@storybook/react'
+import { useArgs } from 'storybook/preview-api'
+import { DropdownInputField } from './DropdownInputField'
+import { MenuPortalContext } from './MenuPortalContext'
+
+const withPortal: Decorator = (Story) => (
+	<MenuPortalContext.Provider value={document.body}>
+		<Story />
+	</MenuPortalContext.Provider>
+)
+
+const choices = [
+	{ id: 'apple', label: 'Apple' },
+	{ id: 'banana', label: 'Banana' },
+	{ id: 'cherry', label: 'Cherry' },
+	{ id: 'date', label: 'Date' },
+	{ id: 'elderberry', label: 'Elderberry' },
+]
+
+const meta = {
+	component: DropdownInputField,
+	decorators: [withPortal],
+	args: {
+		choices,
+		value: 'apple',
+		setValue: () => {},
+		tooltip: '',
+		disabled: false,
+		searchLabelsOnly: true,
+		minChoicesForSearch: 0,
+	},
+	render: function Render(args) {
+		const [, setArgs] = useArgs<{ value: string }>()
+		return <DropdownInputField {...args} setValue={(v) => setArgs({ value: String(v) })} />
+	},
+} satisfies Meta<typeof DropdownInputField>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const WithAllowCustom: Story = {
+	args: { allowCustom: true, value: 'my-custom-value' },
+}
+
+export const WithValidation: Story = {
+	args: { checkValid: (v) => v !== 'banana' },
+}
+
+export const Disabled: Story = {
+	args: { disabled: true },
+}
+
+/** FancyFormat uses a custom option renderer that shows the variable name and description on two lines */
+export const FancyFormat: Story = {
+	args: {
+		fancyFormat: true,
+		choices: [
+			{ id: 'internal:time_hms', label: 'Current time (HH:MM:SS)' },
+			{ id: 'internal:date_y', label: 'Current year' },
+			{ id: 'internal:uptime', label: 'Time since last restart' },
+		],
+		value: 'internal:time_hms',
+	},
+}

--- a/webui/src/Components/DropdownInputField.stories.tsx
+++ b/webui/src/Components/DropdownInputField.stories.tsx
@@ -75,17 +75,3 @@ export const GroupedChoices: Story = {
 		value: 'apple',
 	},
 }
-
-/** FancyFormat uses a custom option renderer that shows the variable name and description on two lines */
-export const FancyFormat: Story = {
-	args: {
-		fancyFormat: true,
-		choices: [
-			{ id: 'internal:time_hms', label: 'Current time (HH:MM:SS)' },
-			{ id: 'internal:date_y', label: 'Current year' },
-			{ id: 'internal:uptime', label: 'Time since last restart' },
-		],
-		value: 'internal:time_hms',
-		allowCustom: false,
-	},
-}

--- a/webui/src/Components/DropdownInputField.tsx
+++ b/webui/src/Components/DropdownInputField.tsx
@@ -1,6 +1,7 @@
 import { Combobox } from '@base-ui/react/combobox'
 import classNames from 'classnames'
 import { ChevronDownIcon } from 'lucide-react'
+import { observable, runInAction } from 'mobx'
 import { observer } from 'mobx-react-lite'
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import type { DropdownChoiceId } from '@companion-app/shared/Model/Common.js'
@@ -9,6 +10,7 @@ import { DropdownInputPopup } from './DropdownInputField/Popup.js'
 import { useDropdownComboboxItems } from './DropdownInputField/useDropdownComboboxItems.js'
 import { useFuzzyChoices } from './DropdownInputField/useFuzzyChoices.js'
 import { MenuPortalContext } from './MenuPortalContext.js'
+import { useRegex } from './useRegex.js'
 
 interface DropdownInputFieldProps {
 	htmlName?: string
@@ -45,17 +47,11 @@ export const DropdownInputField = observer(function DropdownInputField({
 
 	const { allItems, flatItems } = useFuzzyChoices(choices, searchLabelsOnly)
 
-	// The popup doesn't handle groups whwn virtualised, so detect if there are any groups
+	// The popup doesn't handle groups when virtualised, so detect if there are any groups
 	const hasGroups = allItems.some((item) => 'items' in item)
 
 	// Compile the regex for custom value validation
-	const compiledRegex = useMemo(() => {
-		if (regex) {
-			const match = regex.match(/^\/(.*)\/(.*)$/)
-			if (match) return new RegExp(match[1], match[2])
-		}
-		return null
-	}, [regex])
+	const compiledRegex = useRegex(regex)
 
 	const isValidCustom = useCallback((input: string) => !compiledRegex || !!input.match(compiledRegex), [compiledRegex])
 
@@ -64,14 +60,8 @@ export const DropdownInputField = observer(function DropdownInputField({
 
 	// In editing mode the Combobox.Input is controlled so the user can edit the raw value.
 	// undefined = not in editing mode (input is uncontrolled / driven by the Combobox).
-	// string   = focused in editing mode; the ref mirrors it for stale-closure-free reads.
-	const [controlledInputValue, setControlledInputValue] = useState<string | undefined>(undefined)
-	const controlledInputValueRef = useRef<string | undefined>(undefined)
-
-	const setControlledInput = useCallback((v: string | undefined) => {
-		controlledInputValueRef.current = v
-		setControlledInputValue(v)
-	}, [])
+	// string   = focused in editing mode.
+	const controlledInput = useRef(observable.box<string | undefined>(undefined)).current
 
 	const triggerRef = useRef<HTMLButtonElement>(null)
 
@@ -79,14 +69,17 @@ export const DropdownInputField = observer(function DropdownInputField({
 	// pre-fills the input with the raw value so it can be edited directly like a text field.
 	const isEditingMode = !disableEditingCustom && !!allowCustom
 
-	// localDisplayValue mirrors the committed value but is updated synchronously on selection,
+	// localDisplay mirrors the committed value but is updated synchronously on selection,
 	// staying one render ahead of the parent prop. Without this, selecting "Use XX" clears
 	// inputValue immediately while the parent's MobX value hasn't propagated yet, causing a
 	// flash of the old label.
-	// prevValueProp is not a real value — it is only used to detect when the parent prop
-	// changes so we can reset localDisplayValue (standard React derived-state pattern).
-	const [localDisplayValue, setLocalDisplayValue] = useState<DropdownChoiceId>(value)
-	useEffect(() => setLocalDisplayValue(value), [value])
+	const localDisplay = useRef(observable.box<DropdownChoiceId>(value)).current
+	useEffect(() => runInAction(() => localDisplay.set(value)), [localDisplay, value])
+
+	// Derive plain values for this render; observer() tracks the box reads and re-renders
+	// the component whenever either box changes.
+	const localDisplayValue = localDisplay.get()
+	const controlledInputValue = controlledInput.get()
 
 	const isKnownValue = !!allowCustom || flatItems.length === 0 || flatItems.some((o) => o.id == localDisplayValue)
 
@@ -104,16 +97,18 @@ export const DropdownInputField = observer(function DropdownInputField({
 	const onValueChange = useCallback(
 		(newId: DropdownChoiceId | null) => {
 			if (newId !== null) {
-				setLocalDisplayValue(newId)
+				runInAction(() => {
+					localDisplay.set(newId)
+					controlledInput.set(undefined)
+				})
 				setValue(newId)
-				setControlledInput(undefined)
 				setInputValue('')
 
 				// Shift focus to the trigger
 				triggerRef.current?.focus()
 			}
 		},
-		[setValue, setControlledInput]
+		[localDisplay, controlledInput, setValue]
 	)
 
 	const onInputValueChange = useCallback(
@@ -123,11 +118,11 @@ export const DropdownInputField = observer(function DropdownInputField({
 			// When base-ui resets the input (e.g. popup close, item selection), the reason
 			// is 'none' or 'item-press' — in those cases we must NOT overwrite the raw id
 			// that was pre-filled on focus.
-			if (controlledInputValueRef.current !== undefined && eventDetails.reason === 'input-change') {
-				setControlledInput(v)
+			if (controlledInput.get() !== undefined && eventDetails.reason === 'input-change') {
+				runInAction(() => controlledInput.set(v))
 			}
 		},
-		[setControlledInput]
+		[controlledInput]
 	)
 
 	// On focus in editing mode: pre-fill the controlled input value with the raw id so it can be
@@ -135,22 +130,27 @@ export const DropdownInputField = observer(function DropdownInputField({
 	// itemToStringLabel-based display.
 	const onInputFocus = useCallback(() => {
 		if (!isEditingMode) return
-		setControlledInput(String(localDisplayValue))
-	}, [isEditingMode, localDisplayValue, setControlledInput])
+		runInAction(() => controlledInput.set(String(localDisplay.get())))
+	}, [isEditingMode, localDisplay, controlledInput])
 
 	// On blur: if in editing mode and no item was selected via onValueChange, commit the
 	// current input text as the new value. In search-only mode (disableEditingCustom=true),
 	// just reset the filter and focus state.
 	const onInputBlur = useCallback(() => {
-		if (isEditingMode && controlledInputValueRef.current !== undefined) {
-			setValue(controlledInputValueRef.current)
-			setControlledInput(undefined)
+		const currentControlled = controlledInput.get()
+		if (isEditingMode && currentControlled !== undefined) {
+			const currentLocal = localDisplay.get()
+			// Preserve the original value type when the text hasn't changed (e.g. focus + blur
+			// with no edits). Without this, a numeric DropdownChoiceId becomes a string silently.
+			const next = currentControlled === String(currentLocal) ? currentLocal : currentControlled
+			setValue(next)
+			runInAction(() => controlledInput.set(undefined))
 			setInputValue('')
 		} else if (!isEditingMode && allowCustom) {
 			setInputValue('')
 		}
 		onBlur?.()
-	}, [isEditingMode, allowCustom, setValue, setControlledInput, onBlur])
+	}, [isEditingMode, allowCustom, localDisplay, controlledInput, setValue, onBlur])
 
 	// In disableEditingCustom mode, when focused the input is cleared for searching but the
 	// current value is shown as a placeholder so the user knows what's selected.

--- a/webui/src/Components/DropdownInputField.tsx
+++ b/webui/src/Components/DropdownInputField.tsx
@@ -88,7 +88,9 @@ export const DropdownInputField = observer(function DropdownInputField({
 	const [localDisplayValue, setLocalDisplayValue] = useState<DropdownChoiceId>(value)
 	useEffect(() => setLocalDisplayValue(value), [value])
 
-	const { currentItem, effectiveItems, filteredItems } = useDropdownComboboxItems({
+	const isKnownValue = !!allowCustom || flatItems.length === 0 || flatItems.some((o) => o.id == localDisplayValue)
+
+	const { effectiveItems, filteredItems } = useDropdownComboboxItems({
 		allItems,
 		flatItems,
 		localDisplayValue,
@@ -161,7 +163,7 @@ export const DropdownInputField = observer(function DropdownInputField({
 		<div
 			className={classNames(
 				'dropdown-field',
-				{ 'dropdown-field-invalid': !!checkValid && !checkValid(currentItem.id) },
+				{ 'dropdown-field-invalid': !isKnownValue || (!!checkValid && !checkValid(localDisplayValue)) },
 				className
 			)}
 			title={tooltip}
@@ -180,7 +182,9 @@ export const DropdownInputField = observer(function DropdownInputField({
 						? (controlledInputValue ??
 							flatItems.find((o) => o.id == localDisplayValue)?.label ??
 							String(localDisplayValue))
-						: undefined
+						: disableEditingCustom && allowCustom
+							? inputValue
+							: undefined
 				}
 				itemToStringLabel={(id: DropdownChoiceId) => {
 					if (disableEditingCustom && allowCustom) return ''

--- a/webui/src/Components/DropdownInputField.tsx
+++ b/webui/src/Components/DropdownInputField.tsx
@@ -7,7 +7,6 @@ import type { DropdownChoiceId } from '@companion-app/shared/Model/Common.js'
 import { stringifyVariableValue } from '@companion-app/shared/Model/Variables.js'
 import { useDropdownChoicesForSelect, type DropdownChoiceInt, type DropdownChoicesOrGroups } from './DropdownChoices.js'
 import { CustomOption, CustomSingleValue } from './DropDownInputFancy.js'
-// import { WindowedMenuList } from '~/Components/WindowedSelect/MenuList.js'
 import { MenuPortalContext } from './MenuPortalContext.js'
 
 interface DropdownInputFieldProps {
@@ -16,7 +15,6 @@ interface DropdownInputFieldProps {
 	choices: DropdownChoicesOrGroups
 	allowCustom?: boolean
 	disableEditingCustom?: boolean
-	minChoicesForSearch?: number
 	tooltip?: string
 	regex?: string
 	value: DropdownChoiceId
@@ -35,7 +33,6 @@ export const DropdownInputField = observer(function DropdownInputField({
 	choices,
 	allowCustom,
 	disableEditingCustom,
-	minChoicesForSearch,
 	tooltip,
 	regex,
 	value,
@@ -120,8 +117,6 @@ export const DropdownInputField = observer(function DropdownInputField({
 		)
 	}, [onPasteIntercept, fancyFormat])
 
-	const minChoicesForSearchNumber = typeof minChoicesForSearch === 'number' ? minChoicesForSearch : 10
-
 	// const selectRef = useRef<any>(null)
 
 	const selectProps: Partial<CreatableProps<any, any, any>> = {
@@ -134,7 +129,7 @@ export const DropdownInputField = observer(function DropdownInputField({
 		menuPosition: 'fixed',
 		menuPlacement: 'auto',
 		isClearable: false,
-		isSearchable: minChoicesForSearchNumber <= flatOptions.length,
+		isSearchable: true,
 		isMulti: false,
 		options: options,
 		value: currentValue,

--- a/webui/src/Components/DropdownInputField.tsx
+++ b/webui/src/Components/DropdownInputField.tsx
@@ -1,13 +1,17 @@
+import { Combobox } from '@base-ui/react/combobox'
 import classNames from 'classnames'
+import { prepare as fuzzyPrepare, single as fuzzySingle } from 'fuzzysort'
+import { ChevronDownIcon } from 'lucide-react'
 import { observer } from 'mobx-react-lite'
-import { useCallback, useContext, useMemo, useState } from 'react'
-import Select, { components, createFilter, type InputActionMeta } from 'react-select'
-import CreatableSelect, { type CreatableProps } from 'react-select/creatable'
-import type { DropdownChoiceId } from '@companion-app/shared/Model/Common.js'
-import { stringifyVariableValue } from '@companion-app/shared/Model/Variables.js'
-import { useDropdownChoicesForSelect, type DropdownChoiceInt, type DropdownChoicesOrGroups } from './DropdownChoices.js'
-import { CustomOption, CustomSingleValue } from './DropDownInputFancy.js'
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
+import type { DropdownChoice, DropdownChoiceId } from '@companion-app/shared/Model/Common.js'
+import { useComputed } from '~/Resources/util.js'
+import { type DropdownChoicesOrGroups } from './DropdownChoices.js'
+import { DropdownInputPopup, type DropdownChoiceWithMeta, type DropdownGroupBase } from './DropdownInputField/Popup.js'
 import { MenuPortalContext } from './MenuPortalContext.js'
+
+type FuzzyChoice = DropdownChoiceWithMeta & { fuzzy: ReturnType<typeof fuzzyPrepare> }
+type FuzzyGroup = DropdownGroupBase & { items: FuzzyChoice[] }
 
 interface DropdownInputFieldProps {
 	htmlName?: string
@@ -46,49 +50,218 @@ export const DropdownInputField = observer(function DropdownInputField({
 }: DropdownInputFieldProps): React.JSX.Element {
 	const menuPortal = useContext(MenuPortalContext)
 
-	// If fancy format is enabled, always search full option
+	// fancyFormat always searches both label and id
 	if (fancyFormat) searchLabelsOnly = false
 
-	const { options, flatOptions } = useDropdownChoicesForSelect(choices)
+	// Build fuzzy-prepared item lists from choices (choices may be MobX observables)
+	const { allItems, flatItems } = useComputed(() => {
+		const flatItems: FuzzyChoice[] = []
+		const allItems: Array<FuzzyChoice | FuzzyGroup> = []
 
-	const currentValue = useMemo(() => {
-		const entry = flatOptions.find((o) => stringifyVariableValue(o.value) === stringifyVariableValue(value)) // Intentionally loose for compatibility
-		if (entry) {
-			return entry
-		} else if (allowCustom) {
-			return { value: value, label: value }
-		} else if (value === '' || value === undefined || value === null) {
-			return null
-		} else {
-			return { value: value, label: `?? (${value})` }
+		const toFuzzy = (c: DropdownChoice): FuzzyChoice => ({
+			id: c.id,
+			label: String(c.label),
+			fuzzy: fuzzyPrepare(searchLabelsOnly ? String(c.label) : `${String(c.label)} ${String(c.id)}`),
+		})
+
+		if (Array.isArray(choices)) {
+			for (const item of choices) {
+				if ('options' in item) {
+					const opts = item.options.map(toFuzzy)
+					allItems.push({ id: String(item.label), label: String(item.label), items: opts })
+					flatItems.push(...opts)
+				} else {
+					const f = toFuzzy(item)
+					allItems.push(f)
+					flatItems.push(f)
+				}
+			}
+		} else if (typeof choices === 'object') {
+			for (const choice of Object.values(choices)) {
+				const f = toFuzzy(choice)
+				allItems.push(f)
+				flatItems.push(f)
+			}
 		}
-	}, [value, flatOptions, allowCustom])
 
-	// Compile the regex (and cache)
+		return { allItems, flatItems }
+	}, [choices, searchLabelsOnly])
+
+	// The popup doesn't handle groups whwn virtualised, so detect if there are any groups
+	const hasGroups = allItems.some((item) => 'items' in item)
+
+	// Compile the regex for custom value validation
 	const compiledRegex = useMemo(() => {
 		if (regex) {
-			// Compile the regex string
 			const match = regex.match(/^\/(.*)\/(.*)$/)
-			if (match) {
-				return new RegExp(match[1], match[2])
-			}
+			if (match) return new RegExp(match[1], match[2])
 		}
 		return null
 	}, [regex])
 
-	const onChange = useCallback(
-		(e: DropdownChoiceInt) => {
-			const newValue = e?.value
+	const isValidCustom = useCallback((input: string) => !compiledRegex || !!input.match(compiledRegex), [compiledRegex])
 
-			setValue(newValue)
+	// Input value for fuzzy filtering
+	const [inputValue, setInputValue] = useState('')
+
+	// In editing mode the Combobox.Input is controlled so the user can edit the raw value.
+	// undefined = not in editing mode (input is uncontrolled / driven by the Combobox).
+	// string   = focused in editing mode; the ref mirrors it for stale-closure-free reads.
+	const [controlledInputValue, setControlledInputValue] = useState<string | undefined>(undefined)
+	const controlledInputValueRef = useRef<string | undefined>(undefined)
+
+	const setControlledInput = useCallback((v: string | undefined) => {
+		controlledInputValueRef.current = v
+		setControlledInputValue(v)
+	}, [])
+
+	const triggerRef = useRef<HTMLButtonElement>(null)
+
+	// Editing mode: when allowCustom=true and disableEditingCustom=false, focusing the field
+	// pre-fills the input with the raw value so it can be edited directly like a text field.
+	const isEditingMode = !disableEditingCustom && !!allowCustom
+
+	// localDisplayValue mirrors the committed value but is updated synchronously on selection,
+	// staying one render ahead of the parent prop. Without this, selecting "Use XX" clears
+	// inputValue immediately while the parent's MobX value hasn't propagated yet, causing a
+	// flash of the old label.
+	// prevValueProp is not a real value — it is only used to detect when the parent prop
+	// changes so we can reset localDisplayValue (standard React derived-state pattern).
+	const [localDisplayValue, setLocalDisplayValue] = useState<DropdownChoiceId>(value)
+	useEffect(() => setLocalDisplayValue(value), [value])
+
+	// Resolve the current value to a display item
+	const currentItem = useComputed((): FuzzyChoice => {
+		const entry = flatItems.find((o) => o.id == localDisplayValue) // Intentionally loose for compatibility
+		if (entry) return entry
+		const strValue = String(localDisplayValue)
+		if (allowCustom) return { id: localDisplayValue, label: strValue, fuzzy: fuzzyPrepare(strValue) }
+		if (localDisplayValue === '' || localDisplayValue === undefined || localDisplayValue === null)
+			return { id: localDisplayValue, label: '', fuzzy: fuzzyPrepare('') }
+		const unknownLabel = `?? (${strValue})`
+		return { id: localDisplayValue, label: unknownLabel, fuzzy: fuzzyPrepare(unknownLabel) }
+	}, [localDisplayValue, flatItems, allowCustom])
+
+	// Synthetic "Use X" item — appears when the user has typed a value that passes regex
+	// and doesn't exactly match any existing option.
+	const syntheticItem = useComputed((): FuzzyChoice | null => {
+		if (!allowCustom || !inputValue || !isValidCustom(inputValue)) return null
+		if (flatItems.some((o) => o.id == inputValue)) return null
+		return {
+			id: inputValue,
+			label: `Use "${inputValue}"`,
+			fuzzy: fuzzyPrepare(inputValue),
+			plusIndicator: true,
+		}
+	}, [allowCustom, inputValue, isValidCustom, flatItems])
+
+	// Items for base-ui value resolution. Includes the synthetic item and, when the current
+	// value is a custom/unknown entry, the current item itself so itemToStringLabel can find it.
+	const effectiveItems = useComputed((): Array<FuzzyChoice | FuzzyGroup> => {
+		const isCurrentKnown = flatItems.some((o) => o.id == localDisplayValue)
+		const isSyntheticMatchesCurrent = syntheticItem != null && syntheticItem.id == localDisplayValue
+
+		const prefixed: FuzzyChoice[] = []
+		if (syntheticItem) prefixed.push(syntheticItem)
+		// Ensure the current value is resolvable even when it's not in the choices list
+		if (!isCurrentKnown && !isSyntheticMatchesCurrent) {
+			prefixed.push(currentItem)
+		}
+
+		return [...prefixed, ...allItems]
+	}, [syntheticItem, allItems, flatItems, value, currentItem])
+
+	// Items displayed in the popup (excluding the hidden resolution entry for the current custom value)
+	const filteredItems = useComputed((): Array<FuzzyChoice | FuzzyGroup> => {
+		// In editing mode, when the input still shows the pre-filled raw value (user hasn't typed
+		// anything different), show all options rather than filtering.
+		const fuzzyInput =
+			isEditingMode && controlledInputValue !== undefined && inputValue === String(localDisplayValue) ? '' : inputValue
+
+		if (!fuzzyInput) return allItems
+
+		const filterFlat = (items: FuzzyChoice[]): FuzzyChoice[] =>
+			items.filter((o) => (fuzzySingle(fuzzyInput, o.fuzzy)?.score ?? 0) >= 0.5)
+
+		const result: Array<FuzzyChoice | FuzzyGroup> = []
+		for (const item of allItems) {
+			if ('items' in item) {
+				const filtered = filterFlat(item.items)
+				if (filtered.length > 0) result.push({ ...item, items: filtered })
+			} else {
+				if ((fuzzySingle(fuzzyInput, item.fuzzy)?.score ?? 0) >= 0.5) result.push(item)
+			}
+		}
+
+		if (syntheticItem) result.unshift(syntheticItem)
+		return result
+	}, [allItems, syntheticItem, inputValue, isEditingMode, controlledInputValue, value])
+
+	const onValueChange = useCallback(
+		(newId: DropdownChoiceId | null) => {
+			if (newId !== null) {
+				setLocalDisplayValue(newId)
+				setValue(newId)
+				setControlledInput(undefined)
+				setInputValue('')
+
+				// Shift focus to the trigger
+				triggerRef.current?.focus()
+			}
 		},
-		[setValue]
+		[setValue, setControlledInput]
 	)
 
-	const inputComponent = useMemo(() => {
-		const onPaste = (e: React.ClipboardEvent) => {
-			if (!e.clipboardData || !onPasteIntercept) return
+	const onInputValueChange = useCallback(
+		(v: string, eventDetails: Combobox.Root.ChangeEventDetails) => {
+			setInputValue(v)
+			// Only mirror into the controlled value when the user is actually typing.
+			// When base-ui resets the input (e.g. popup close, item selection), the reason
+			// is 'none' or 'item-press' — in those cases we must NOT overwrite the raw id
+			// that was pre-filled on focus.
+			if (controlledInputValueRef.current !== undefined && eventDetails.reason === 'input-change') {
+				setControlledInput(v)
+			}
+		},
+		[setControlledInput]
+	)
 
+	// On focus in editing mode: pre-fill the controlled input value with the raw id so it can be
+	// edited directly. The controlled inputValue prop on Combobox.Root takes over from base-ui's
+	// itemToStringLabel-based display.
+	const onInputFocus = useCallback(() => {
+		if (!isEditingMode) return
+		setControlledInput(String(localDisplayValue))
+	}, [isEditingMode, localDisplayValue, setControlledInput])
+
+	// On blur: if in editing mode and no item was selected via onValueChange, commit the
+	// current input text as the new value. In search-only mode (disableEditingCustom=true),
+	// just reset the filter and focus state.
+	const onInputBlur = useCallback(() => {
+		if (isEditingMode && controlledInputValueRef.current !== undefined) {
+			setValue(controlledInputValueRef.current)
+			setControlledInput(undefined)
+			setInputValue('')
+		} else if (!isEditingMode && allowCustom) {
+			setInputValue('')
+		}
+		onBlur?.()
+	}, [isEditingMode, allowCustom, setValue, setControlledInput, onBlur])
+
+	// In disableEditingCustom mode, when focused the input is cleared for searching but the
+	// current value is shown as a placeholder so the user knows what's selected.
+	const inputPlaceholder = useMemo(() => {
+		if (!disableEditingCustom || !allowCustom) return undefined
+		if (fancyFormat) return String(localDisplayValue)
+		return flatItems.find((o) => o.id == localDisplayValue)?.label ?? String(localDisplayValue)
+	}, [disableEditingCustom, allowCustom, fancyFormat, localDisplayValue, flatItems])
+
+	// Paste interception: transforms the pasted value and dispatches a native input event so
+	// base-ui picks up the change via onInputValueChange.
+	const onPaste = useMemo(() => {
+		if (!onPasteIntercept) return undefined
+		return (e: React.ClipboardEvent<HTMLInputElement>) => {
+			if (!e.clipboardData) return
 			const rawValue = e.clipboardData.getData('text')
 			const newValue = onPasteIntercept(rawValue)
 
@@ -96,10 +269,9 @@ export const DropdownInputField = observer(function DropdownInputField({
 			if (newValue === rawValue) return
 
 			e.preventDefault()
-			// console.log('Intercept paste', rawValue, 'to', newValue)
 
 			// Set the value of the input, using the native setter
-			const target = e.currentTarget as HTMLInputElement
+			const target = e.currentTarget
 			// eslint-disable-next-line @typescript-eslint/unbound-method
 			const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!
 			nativeInputValueSetter.call(target, newValue)
@@ -107,150 +279,78 @@ export const DropdownInputField = observer(function DropdownInputField({
 			// Dispatch a change event
 			target.dispatchEvent(new Event('input', { bubbles: true }))
 		}
-
-		return (props: any) => (
-			<components.Input
-				{...props}
-				onPaste={onPaste}
-				className={fancyFormat && (props.className ?? '') + 'variable-dropdown-edit'}
-			/>
-		)
-	}, [onPasteIntercept, fancyFormat])
-
-	// const selectRef = useRef<any>(null)
-
-	const selectProps: Partial<CreatableProps<any, any, any>> = {
-		name: htmlName,
-		isDisabled: disabled,
-		classNamePrefix: 'select-control',
-		className: 'select-control',
-		menuPortalTarget: menuPortal || document.body,
-		menuShouldBlockScroll: !!menuPortal, // The dropdown doesn't follow scroll when in a modal
-		menuPosition: 'fixed',
-		menuPlacement: 'auto',
-		isClearable: false,
-		isSearchable: true,
-		isMulti: false,
-		options: options,
-		value: currentValue,
-		onChange: onChange,
-		filterOption: createFilter({
-			ignoreAccents: false,
-			stringify: searchLabelsOnly ? (option) => option.label : (option) => `${option.label} ${option.value}`,
-		}),
-		components: {
-			// MenuList: WindowedMenuList,
-			Input: inputComponent,
-			// couldn't find a cleaner way to do this: otherwise TypeScript complains about Singlevalue...
-			...((fancyFormat ? { Option: CustomOption, SingleValue: CustomSingleValue } : {}) as Partial<
-				CreatableProps<any, any, any>
-			>),
-		},
-		onBlur: onBlur,
-	}
-
-	const isValidNewOption = useCallback(
-		(newValue: string | number) => typeof newValue === 'string' && (!compiledRegex || !!newValue.match(compiledRegex)),
-		[compiledRegex]
-	)
-	const noOptionsMessage = useCallback(
-		({ inputValue }: { inputValue: string | number }) => {
-			if (!isValidNewOption(inputValue)) {
-				return 'Input is not a valid value'
-			} else {
-				return 'Begin typing to use a custom value'
-			}
-		},
-		[isValidNewOption]
-	)
-	const isValidNewOptionIgnoreCurrent = useCallback(
-		(newValue: string | number) => !flatOptions.find((opt) => opt.value == newValue) && isValidNewOption(newValue),
-		[isValidNewOption, flatOptions]
-	)
-	const formatCreateLabel = useCallback((v: string | number) => `Use "${v}"`, [])
-
-	/**
-	 * Do some mangling with the input value to make custom values flow a bit better
-	 */
-	const [customInputValue, setCustomInputValue] = useState<string | undefined>(undefined)
-	const onFocus = () => setCustomInputValue(value + '')
-	const onBlurEditingCustom = useCallback(() => {
-		setCustomInputValue(undefined)
-
-		onBlur?.()
-	}, [onBlur])
-
-	const onChangeEditingCustom = useCallback(
-		(e: DropdownChoiceInt) => {
-			setCustomInputValue(e.value as any)
-			onChange(e)
-		},
-		[onChange]
-	)
-	const onInputChange = useCallback(
-		(v: string, a: InputActionMeta) => {
-			if (!allowCustom) return
-
-			if (a.action === 'input-blur') {
-				onChange({ value: a.prevInputValue, label: a.prevInputValue })
-			} else if (a.action === 'input-change') {
-				setCustomInputValue(v)
-			}
-		},
-		[onChange, allowCustom]
-	)
-
-	const onCreateOption = useCallback(
-		(inputValue: string) => {
-			setCustomInputValue(inputValue)
-			onChange({ value: inputValue, label: inputValue })
-		},
-		[onChange]
-	)
-
-	if (allowCustom && customInputValue === value) {
-		// If the custom input value has not changed, then don't use it as a filter
-		selectProps.filterOption = null
-	}
+	}, [onPasteIntercept])
 
 	return (
 		<div
 			className={classNames(
-				{
-					'select-tooltip': true,
-					'select-invalid': !!checkValid && !checkValid(currentValue?.value as any),
-				},
+				'dropdown-field',
+				{ 'dropdown-field-invalid': !!checkValid && !checkValid(currentItem.id) },
 				className
 			)}
 			title={tooltip}
 		>
-			{allowCustom ? (
-				<CreatableSelect
-					{...selectProps}
-					className={!disableEditingCustom ? `${selectProps.className} select-control-editable` : selectProps.className}
-					isSearchable={true}
-					noOptionsMessage={noOptionsMessage}
-					createOptionPosition="first"
-					formatCreateLabel={formatCreateLabel}
-					isValidNewOption={isValidNewOptionIgnoreCurrent}
-					onFocus={!disableEditingCustom ? onFocus : undefined}
-					onBlur={!disableEditingCustom ? onBlurEditingCustom : onBlur}
-					onCreateOption={onCreateOption}
-					inputValue={allowCustom && !disableEditingCustom ? customInputValue : undefined}
-					value={
-						!allowCustom ||
-						disableEditingCustom ||
-						customInputValue === undefined ||
-						customInputValue === currentValue?.value
-							? currentValue
-							: ''
-					}
-					onInputChange={!disableEditingCustom ? onInputChange : undefined}
-					onChange={!disableEditingCustom ? onChangeEditingCustom : onChange}
+			<Combobox.Root<DropdownChoiceId>
+				virtualized={!hasGroups}
+				autoHighlight
+				value={localDisplayValue}
+				items={effectiveItems}
+				filteredItems={filteredItems}
+				disabled={disabled}
+				onValueChange={onValueChange}
+				onInputValueChange={onInputValueChange}
+				inputValue={
+					isEditingMode
+						? (controlledInputValue ??
+							(fancyFormat
+								? String(localDisplayValue)
+								: (flatItems.find((o) => o.id == localDisplayValue)?.label ?? String(localDisplayValue))))
+						: undefined
+				}
+				itemToStringLabel={(id: DropdownChoiceId) => {
+					if (disableEditingCustom && allowCustom) return ''
+					if (fancyFormat) return String(id)
+					const item = flatItems.find((o) => o.id == id)
+					if (item) return item.label
+					const strId = String(id)
+					if (!allowCustom && strId) return `?? (${strId})`
+					return strId
+				}}
+			>
+				<Combobox.InputGroup className="dropdown-field-input-group">
+					{' '}
+					{fancyFormat && (
+						<div className="dropdown-field-fancy-display" aria-hidden="true">
+							<div className="var-name">{String(localDisplayValue) || '\u00A0'}</div>
+							<div className="var-label">
+								{(flatItems.find((o) => o.id == localDisplayValue)?.label ?? String(localDisplayValue)) || '\u00A0'}
+							</div>
+						</div>
+					)}{' '}
+					<Combobox.Input
+						className={classNames('dropdown-field-input', {
+							'variable-dropdown-edit': fancyFormat,
+							'dropdown-field-input-value-placeholder': !fancyFormat && inputPlaceholder !== undefined,
+						})}
+						name={htmlName}
+						placeholder={inputPlaceholder}
+						onFocus={onInputFocus}
+						onBlur={onInputBlur}
+						onPaste={onPaste}
+					/>
+					<Combobox.Trigger className="dropdown-field-trigger" ref={triggerRef}>
+						<ChevronDownIcon className="dropdown-field-icon" />
+					</Combobox.Trigger>
+				</Combobox.InputGroup>
+
+				<DropdownInputPopup
+					menuPortal={menuPortal ?? undefined}
+					noOptionsMessage={allowCustom ? 'Begin typing to use a custom value' : undefined}
+					showIndicator={!!allowCustom}
+					fancyFormat={fancyFormat}
+					virtualized={!hasGroups}
 				/>
-			) : (
-				<Select {...selectProps} />
-			)}
+			</Combobox.Root>
 		</div>
 	)
-}) as (props: DropdownInputFieldProps) => JSX.Element
+})

--- a/webui/src/Components/DropdownInputField/Popup.tsx
+++ b/webui/src/Components/DropdownInputField/Popup.tsx
@@ -7,7 +7,7 @@ import type { DropdownChoice } from '@companion-app/shared/Model/Common.js'
 export interface DropdownGroupBase {
 	id: string
 	label: string
-	options: DropdownChoice[]
+	items: DropdownChoice[]
 }
 
 /** Extended choice that can carry a display hint for the indicator slot. */
@@ -63,10 +63,12 @@ export function DropdownInputPopup({
 							className={`dropdown-field-list${disableUnselected ? ' dropdown-field-list--max-reached' : ''}`}
 						>
 							{(item: DropdownChoiceWithMeta | DropdownGroupBase) => {
-								if ('options' in item) {
+								if ('items' in item) {
 									return (
-										<Combobox.Group key={item.id} items={item.options} className="dropdown-field-group">
-											<Combobox.GroupLabel className="dropdown-field-group-label">{item.label}</Combobox.GroupLabel>
+										<Combobox.Group key={item.id} items={item.items} className="dropdown-field-group">
+											{item.label && (
+												<Combobox.GroupLabel className="dropdown-field-group-label">{item.label}</Combobox.GroupLabel>
+											)}
 											<Combobox.Collection>{renderItem}</Combobox.Collection>
 										</Combobox.Group>
 									)

--- a/webui/src/Components/DropdownInputField/Popup.tsx
+++ b/webui/src/Components/DropdownInputField/Popup.tsx
@@ -21,6 +21,8 @@ export interface DropdownInputPopupProps {
 	disableUnselected?: boolean
 	/** When true, renders the list using @tanstack/react-virtual for large datasets. Only supports flat (non-grouped) item lists. */
 	virtualized?: boolean
+	/** When true, each item renders two lines: the id (top) and the label (bottom), matching the variable dropdown style. */
+	fancyFormat?: boolean
 }
 
 export function DropdownInputPopup({
@@ -29,9 +31,14 @@ export function DropdownInputPopup({
 	showIndicator,
 	disableUnselected,
 	virtualized,
+	fancyFormat,
 }: DropdownInputPopupProps): React.JSX.Element {
 	const renderItem = (item: DropdownChoiceWithMeta) => (
-		<Combobox.Item key={item.id} value={item.id} className="dropdown-field-item">
+		<Combobox.Item
+			key={item.id}
+			value={item.id}
+			className={fancyFormat ? 'dropdown-field-item variable-dropdown-option' : 'dropdown-field-item'}
+		>
 			{showIndicator && (
 				<span className="dropdown-field-item-indicator">
 					{item.plusIndicator ? (
@@ -41,7 +48,14 @@ export function DropdownInputPopup({
 					)}
 				</span>
 			)}
-			{item.label}
+			{fancyFormat ? (
+				<div className="dropdown-field-item-content">
+					<span className="var-name">{String(item.id)}</span>
+					<span className="var-label">{item.label}</span>
+				</div>
+			) : (
+				item.label
+			)}
 		</Combobox.Item>
 	)
 
@@ -56,7 +70,7 @@ export function DropdownInputPopup({
 						<Combobox.List
 							className={`dropdown-field-list dropdown-field-list--virtualized${disableUnselected ? ' dropdown-field-list--max-reached' : ''}`}
 						>
-							<VirtualizedComboboxList showIndicator={showIndicator} />
+							<VirtualizedComboboxList showIndicator={showIndicator} fancyFormat={fancyFormat} />
 						</Combobox.List>
 					) : (
 						<Combobox.List
@@ -86,21 +100,21 @@ export function DropdownInputPopup({
 interface VirtualComboboxItemProps {
 	item: DropdownChoiceWithMeta
 	index: number
-	size: number
 	start: number
 	totalCount: number
 	measureElement: (el: Element | null) => void
 	showIndicator?: boolean
+	fancyFormat?: boolean
 }
 
 const VirtualComboboxItem = React.memo(function VirtualComboboxItem({
 	item,
 	index,
-	size,
 	start,
 	totalCount,
 	measureElement,
 	showIndicator,
+	fancyFormat,
 }: VirtualComboboxItemProps): React.JSX.Element {
 	return (
 		<Combobox.Item
@@ -110,13 +124,12 @@ const VirtualComboboxItem = React.memo(function VirtualComboboxItem({
 			ref={measureElement}
 			aria-setsize={totalCount}
 			aria-posinset={index + 1}
-			className="dropdown-field-item"
+			className={fancyFormat ? 'dropdown-field-item variable-dropdown-option' : 'dropdown-field-item'}
 			style={{
 				position: 'absolute',
 				top: 0,
 				left: 0,
 				width: '100%',
-				height: size,
 				transform: `translateY(${start}px)`,
 			}}
 		>
@@ -129,12 +142,25 @@ const VirtualComboboxItem = React.memo(function VirtualComboboxItem({
 					)}
 				</span>
 			)}
-			{item.label}
+			{fancyFormat ? (
+				<div className="dropdown-field-item-content">
+					<span className="var-name">{String(item.id)}</span>
+					<span className="var-label">{item.label}</span>
+				</div>
+			) : (
+				item.label
+			)}
 		</Combobox.Item>
 	)
 })
 
-function VirtualizedComboboxList({ showIndicator }: { showIndicator?: boolean }): React.JSX.Element | null {
+function VirtualizedComboboxList({
+	showIndicator,
+	fancyFormat,
+}: {
+	showIndicator?: boolean
+	fancyFormat?: boolean
+}): React.JSX.Element | null {
 	const filteredItems = Combobox.useFilteredItems<DropdownChoiceWithMeta>()
 	const scrollElementRef = useRef<HTMLDivElement | null>(null)
 
@@ -181,11 +207,11 @@ function VirtualizedComboboxList({ showIndicator }: { showIndicator?: boolean })
 							key={virtualRow.key}
 							item={item}
 							index={virtualRow.index}
-							size={virtualRow.size}
 							start={virtualRow.start}
 							totalCount={filteredItems.length}
 							measureElement={virtualizer.measureElement}
 							showIndicator={showIndicator}
+							fancyFormat={fancyFormat}
 						/>
 					)
 				})}

--- a/webui/src/Components/DropdownInputField/Popup.tsx
+++ b/webui/src/Components/DropdownInputField/Popup.tsx
@@ -1,5 +1,7 @@
 import { Combobox } from '@base-ui/react/combobox'
-import React from 'react'
+import { useVirtualizer } from '@tanstack/react-virtual'
+import { CheckIcon, PlusIcon } from 'lucide-react'
+import React, { useCallback, useRef, type Ref } from 'react'
 import type { DropdownChoice } from '@companion-app/shared/Model/Common.js'
 
 export interface DropdownGroupBase {
@@ -8,12 +10,41 @@ export interface DropdownGroupBase {
 	options: DropdownChoice[]
 }
 
+/** Extended choice that can carry a display hint for the indicator slot. */
+export type DropdownChoiceWithMeta = DropdownChoice & { plusIndicator?: boolean }
+
 export interface DropdownInputPopupProps {
 	menuPortal: HTMLElement | undefined
 	noOptionsMessage?: string
+	showIndicator?: boolean
+	/** When true, unselected items show a not-allowed cursor (selection is rejected by onValueChange). */
+	disableUnselected?: boolean
+	/** When true, renders the list using @tanstack/react-virtual for large datasets. Only supports flat (non-grouped) item lists. */
+	virtualized?: boolean
 }
 
-export function DropdownInputPopup({ menuPortal, noOptionsMessage }: DropdownInputPopupProps): React.JSX.Element {
+export function DropdownInputPopup({
+	menuPortal,
+	noOptionsMessage,
+	showIndicator,
+	disableUnselected,
+	virtualized,
+}: DropdownInputPopupProps): React.JSX.Element {
+	const renderItem = (item: DropdownChoiceWithMeta) => (
+		<Combobox.Item key={item.id} value={item.id} className="dropdown-field-item">
+			{showIndicator && (
+				<span className="dropdown-field-item-indicator">
+					{item.plusIndicator ? (
+						<PlusIcon className="dropdown-field-item-indicator-icon dropdown-field-item-indicator-icon--always" />
+					) : (
+						<CheckIcon className="dropdown-field-item-indicator-icon" />
+					)}
+				</span>
+			)}
+			{item.label}
+		</Combobox.Item>
+	)
+
 	return (
 		<Combobox.Portal container={menuPortal}>
 			<Combobox.Positioner className="dropdown-field-positioner" sideOffset={8}>
@@ -21,32 +52,142 @@ export function DropdownInputPopup({ menuPortal, noOptionsMessage }: DropdownInp
 					<Combobox.Empty>
 						<div className="dropdown-field-empty">{noOptionsMessage || 'No options found.'}</div>
 					</Combobox.Empty>
-					<Combobox.List className="dropdown-field-list">
-						{(item: DropdownChoice | DropdownGroupBase) => {
-							if ('options' in item) {
-								return (
-									<Combobox.Group key={item.id} items={item.options} className="dropdown-field-group">
-										<Combobox.GroupLabel className="dropdown-field-group-label">{item.label}</Combobox.GroupLabel>
-										<Combobox.Collection>
-											{(item: DropdownChoice) => (
-												<Combobox.Item key={item.id} value={item.id} className="dropdown-field-item">
-													{item.label}
-												</Combobox.Item>
-											)}
-										</Combobox.Collection>
-									</Combobox.Group>
-								)
-							}
-
-							return (
-								<Combobox.Item key={item.id} value={item.id} className="dropdown-field-item">
-									{item.label}
-								</Combobox.Item>
-							)
-						}}
-					</Combobox.List>
+					{virtualized ? (
+						<Combobox.List
+							className={`dropdown-field-list dropdown-field-list--virtualized${disableUnselected ? ' dropdown-field-list--max-reached' : ''}`}
+						>
+							<VirtualizedComboboxList showIndicator={showIndicator} />
+						</Combobox.List>
+					) : (
+						<Combobox.List
+							className={`dropdown-field-list${disableUnselected ? ' dropdown-field-list--max-reached' : ''}`}
+						>
+							{(item: DropdownChoiceWithMeta | DropdownGroupBase) => {
+								if ('options' in item) {
+									return (
+										<Combobox.Group key={item.id} items={item.options} className="dropdown-field-group">
+											<Combobox.GroupLabel className="dropdown-field-group-label">{item.label}</Combobox.GroupLabel>
+											<Combobox.Collection>{renderItem}</Combobox.Collection>
+										</Combobox.Group>
+									)
+								}
+								return renderItem(item)
+							}}
+						</Combobox.List>
+					)}
 				</Combobox.Popup>
 			</Combobox.Positioner>
 		</Combobox.Portal>
+	)
+}
+
+interface VirtualComboboxItemProps {
+	item: DropdownChoiceWithMeta
+	index: number
+	size: number
+	start: number
+	totalCount: number
+	measureElement: (el: Element | null) => void
+	showIndicator?: boolean
+}
+
+const VirtualComboboxItem = React.memo(function VirtualComboboxItem({
+	item,
+	index,
+	size,
+	start,
+	totalCount,
+	measureElement,
+	showIndicator,
+}: VirtualComboboxItemProps): React.JSX.Element {
+	return (
+		<Combobox.Item
+			value={item.id}
+			index={index}
+			data-index={index}
+			ref={measureElement}
+			aria-setsize={totalCount}
+			aria-posinset={index + 1}
+			className="dropdown-field-item"
+			style={{
+				position: 'absolute',
+				top: 0,
+				left: 0,
+				width: '100%',
+				height: size,
+				transform: `translateY(${start}px)`,
+			}}
+		>
+			{showIndicator && (
+				<span className="dropdown-field-item-indicator">
+					{item.plusIndicator ? (
+						<PlusIcon className="dropdown-field-item-indicator-icon dropdown-field-item-indicator-icon--always" />
+					) : (
+						<CheckIcon className="dropdown-field-item-indicator-icon" />
+					)}
+				</span>
+			)}
+			{item.label}
+		</Combobox.Item>
+	)
+})
+
+function VirtualizedComboboxList({ showIndicator }: { showIndicator?: boolean }): React.JSX.Element | null {
+	const filteredItems = Combobox.useFilteredItems<DropdownChoiceWithMeta>()
+	const scrollElementRef = useRef<HTMLDivElement | null>(null)
+
+	const getScrollElement = useCallback(() => scrollElementRef.current, [])
+	const estimateSize = useCallback(() => 37.6, [])
+
+	// eslint-disable-next-line react-hooks/incompatible-library
+	const virtualizer = useVirtualizer({
+		count: filteredItems.length,
+		getScrollElement,
+		estimateSize,
+		overscan: 20,
+		paddingStart: 4,
+		paddingEnd: 4,
+		scrollPaddingStart: 4,
+		scrollPaddingEnd: 4,
+	})
+
+	const scrollerRef: Ref<HTMLDivElement> = useCallback(
+		(element: HTMLDivElement | null) => {
+			scrollElementRef.current = element
+			if (element) virtualizer.measure()
+		},
+		[virtualizer]
+	)
+
+	const totalSize = virtualizer.getTotalSize()
+
+	if (!filteredItems.length) return null
+
+	return (
+		<div
+			role="presentation"
+			ref={scrollerRef}
+			className="dropdown-field-list-scroller"
+			style={{ '--total-size': `${totalSize}px` } as React.CSSProperties}
+		>
+			<div role="presentation" style={{ height: totalSize, width: '100%', position: 'relative' }}>
+				{virtualizer.getVirtualItems().map((virtualRow) => {
+					const item = filteredItems[virtualRow.index]
+					if (!item) return null
+					return (
+						<VirtualComboboxItem
+							key={virtualRow.key}
+							item={item}
+							index={virtualRow.index}
+							size={virtualRow.size}
+							start={virtualRow.start}
+							totalCount={filteredItems.length}
+							measureElement={virtualizer.measureElement}
+							showIndicator={showIndicator}
+						/>
+					)
+				})}
+			</div>
+		</div>
 	)
 }

--- a/webui/src/Components/DropdownInputField/useDropdownComboboxItems.ts
+++ b/webui/src/Components/DropdownInputField/useDropdownComboboxItems.ts
@@ -1,0 +1,102 @@
+import { prepare as fuzzyPrepare, single as fuzzySingle } from 'fuzzysort'
+import type { DropdownChoiceId } from '@companion-app/shared/Model/Common.js'
+import { useComputed } from '~/Resources/util.js'
+import type { FuzzyChoice, FuzzyGroup } from './useFuzzyChoices.js'
+
+interface UseDropdownComboboxItemsParams {
+	allItems: Array<FuzzyChoice | FuzzyGroup>
+	flatItems: FuzzyChoice[]
+	localDisplayValue: DropdownChoiceId
+	inputValue: string
+	controlledInputValue: string | undefined
+	allowCustom: boolean | undefined
+	isValidCustom: (input: string) => boolean
+	isEditingMode: boolean
+}
+
+interface UseDropdownComboboxItemsResult {
+	currentItem: FuzzyChoice
+	syntheticItem: FuzzyChoice | null
+	effectiveItems: Array<FuzzyChoice | FuzzyGroup>
+	filteredItems: Array<FuzzyChoice | FuzzyGroup>
+}
+
+export function useDropdownComboboxItems({
+	allItems,
+	flatItems,
+	localDisplayValue,
+	inputValue,
+	controlledInputValue,
+	allowCustom,
+	isValidCustom,
+	isEditingMode,
+}: UseDropdownComboboxItemsParams): UseDropdownComboboxItemsResult {
+	// Resolve the current value to a display item
+	const currentItem = useComputed((): FuzzyChoice => {
+		const entry = flatItems.find((o) => o.id == localDisplayValue) // Intentionally loose for compatibility
+		if (entry) return entry
+		const strValue = String(localDisplayValue)
+		if (allowCustom) return { id: localDisplayValue, label: strValue, fuzzy: fuzzyPrepare(strValue) }
+		if (localDisplayValue === '' || localDisplayValue === undefined || localDisplayValue === null)
+			return { id: localDisplayValue, label: '', fuzzy: fuzzyPrepare('') }
+		const unknownLabel = `?? (${strValue})`
+		return { id: localDisplayValue, label: unknownLabel, fuzzy: fuzzyPrepare(unknownLabel) }
+	}, [localDisplayValue, flatItems, allowCustom])
+
+	// Synthetic "Use X" item — appears when the user has typed a value that passes regex
+	// and doesn't exactly match any existing option.
+	const syntheticItem = useComputed((): FuzzyChoice | null => {
+		if (!allowCustom || !inputValue || !isValidCustom(inputValue)) return null
+		if (flatItems.some((o) => o.id == inputValue)) return null
+		return {
+			id: inputValue,
+			label: `Use "${inputValue}"`,
+			fuzzy: fuzzyPrepare(inputValue),
+			plusIndicator: true,
+		}
+	}, [allowCustom, inputValue, isValidCustom, flatItems])
+
+	// Items for base-ui value resolution. Includes the synthetic item and, when the current
+	// value is a custom/unknown entry, the current item itself so itemToStringLabel can find it.
+	const effectiveItems = useComputed((): Array<FuzzyChoice | FuzzyGroup> => {
+		const isCurrentKnown = flatItems.some((o) => o.id == localDisplayValue)
+		const isSyntheticMatchesCurrent = syntheticItem != null && syntheticItem.id == localDisplayValue
+
+		const prefixed: FuzzyChoice[] = []
+		if (syntheticItem) prefixed.push(syntheticItem)
+		// Ensure the current value is resolvable even when it's not in the choices list
+		if (!isCurrentKnown && !isSyntheticMatchesCurrent) {
+			prefixed.push(currentItem)
+		}
+
+		return [...prefixed, ...allItems]
+	}, [syntheticItem, allItems, flatItems, localDisplayValue, currentItem])
+
+	// Items displayed in the popup (excluding the hidden resolution entry for the current custom value)
+	const filteredItems = useComputed((): Array<FuzzyChoice | FuzzyGroup> => {
+		// In editing mode, when the input still shows the pre-filled raw value (user hasn't typed
+		// anything different), show all options rather than filtering.
+		const fuzzyInput =
+			isEditingMode && controlledInputValue !== undefined && inputValue === String(localDisplayValue) ? '' : inputValue
+
+		if (!fuzzyInput) return allItems
+
+		const filterFlat = (items: FuzzyChoice[]): FuzzyChoice[] =>
+			items.filter((o) => (fuzzySingle(fuzzyInput, o.fuzzy)?.score ?? 0) >= 0.5)
+
+		const result: Array<FuzzyChoice | FuzzyGroup> = []
+		for (const item of allItems) {
+			if ('items' in item) {
+				const filtered = filterFlat(item.items)
+				if (filtered.length > 0) result.push({ ...item, items: filtered })
+			} else {
+				if ((fuzzySingle(fuzzyInput, item.fuzzy)?.score ?? 0) >= 0.5) result.push(item)
+			}
+		}
+
+		if (syntheticItem) result.unshift(syntheticItem)
+		return result
+	}, [allItems, syntheticItem, inputValue, isEditingMode, controlledInputValue, localDisplayValue])
+
+	return { currentItem, syntheticItem, effectiveItems, filteredItems }
+}

--- a/webui/src/Components/DropdownInputField/useFuzzyChoices.ts
+++ b/webui/src/Components/DropdownInputField/useFuzzyChoices.ts
@@ -1,0 +1,54 @@
+import { prepare as fuzzyPrepare } from 'fuzzysort'
+import type { DropdownChoice } from '@companion-app/shared/Model/Common.js'
+import { useComputed } from '~/Resources/util.js'
+import type { DropdownChoicesOrGroups } from '../DropdownChoices.js'
+import type { DropdownChoiceWithMeta, DropdownGroupBase } from './Popup.js'
+
+type FuzzyChoice = DropdownChoiceWithMeta & { fuzzy: ReturnType<typeof fuzzyPrepare> }
+type FuzzyGroup = DropdownGroupBase & { items: FuzzyChoice[] }
+
+export type { FuzzyChoice, FuzzyGroup }
+
+/**
+ * Converts raw choices into fuzzysort-prepared items.
+ * @param choices - The choices to prepare, may be a flat array, grouped array, or record.
+ * @param searchLabelsOnly - When true, only the label is indexed for fuzzy search.
+ *   When false, both label and id are concatenated so the id is also searchable.
+ */
+export function useFuzzyChoices(
+	choices: DropdownChoicesOrGroups,
+	searchLabelsOnly: boolean
+): { allItems: Array<FuzzyChoice | FuzzyGroup>; flatItems: FuzzyChoice[] } {
+	return useComputed(() => {
+		const flatItems: FuzzyChoice[] = []
+		const allItems: Array<FuzzyChoice | FuzzyGroup> = []
+
+		const toFuzzy = (c: DropdownChoice): FuzzyChoice => ({
+			id: c.id,
+			label: String(c.label),
+			fuzzy: fuzzyPrepare(searchLabelsOnly ? String(c.label) : `${String(c.label)} ${String(c.id)}`),
+		})
+
+		if (Array.isArray(choices)) {
+			for (const item of choices) {
+				if ('options' in item) {
+					const opts = item.options.map(toFuzzy)
+					allItems.push({ id: String(item.label), label: String(item.label), items: opts })
+					flatItems.push(...opts)
+				} else {
+					const f = toFuzzy(item)
+					allItems.push(f)
+					flatItems.push(f)
+				}
+			}
+		} else if (typeof choices === 'object') {
+			for (const choice of Object.values(choices)) {
+				const f = toFuzzy(choice)
+				allItems.push(f)
+				flatItems.push(f)
+			}
+		}
+
+		return { allItems, flatItems }
+	}, [choices, searchLabelsOnly])
+}

--- a/webui/src/Components/DropdownInputFieldSimple.stories.tsx
+++ b/webui/src/Components/DropdownInputFieldSimple.stories.tsx
@@ -1,0 +1,56 @@
+import type { Decorator, Meta, StoryObj } from '@storybook/react'
+import { useArgs } from 'storybook/preview-api'
+import { SimpleDropdownInputField } from './DropdownInputFieldSimple'
+import { MenuPortalContext } from './MenuPortalContext'
+
+const withPortal: Decorator = (Story) => (
+	<MenuPortalContext.Provider value={document.body}>
+		<Story />
+	</MenuPortalContext.Provider>
+)
+
+const choices = [
+	{ id: 'red', label: 'Red' },
+	{ id: 'green', label: 'Green' },
+	{ id: 'blue', label: 'Blue' },
+	{ id: 'yellow', label: 'Yellow' },
+]
+
+const meta = {
+	component: SimpleDropdownInputField,
+	decorators: [withPortal],
+	args: {
+		choices,
+		value: 'red',
+		setValue: () => {},
+		tooltip: '',
+		badOptionPrefix: '⚠ Unknown: ',
+	},
+	render: function Render(args) {
+		const [, setArgs] = useArgs<{ value: string }>()
+		return <SimpleDropdownInputField {...args} setValue={(v) => setArgs({ value: String(v) })} />
+	},
+} satisfies Meta<typeof SimpleDropdownInputField>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const Disabled: Story = {
+	args: { disabled: true },
+}
+
+export const WithValidation: Story = {
+	args: { checkValid: (v) => v !== 'red' },
+}
+
+/** noOptionsMessage — shown when choices list is empty */
+export const NoOptions: Story = {
+	args: { choices: [], value: '' as never, noOptionsMessage: 'No colours available' },
+}
+
+/** badOptionPrefix — shown before value when the current value is not in choices */
+export const BadOption: Story = {
+	args: { value: 'purple' as never },
+}

--- a/webui/src/Components/DropdownInputFieldSimple.stories.tsx
+++ b/webui/src/Components/DropdownInputFieldSimple.stories.tsx
@@ -1,5 +1,6 @@
 import type { Decorator, Meta, StoryObj } from '@storybook/react'
 import { useArgs } from 'storybook/preview-api'
+import type { DropdownChoiceId } from '@companion-app/shared/Model/Common.js'
 import { SimpleDropdownInputField } from './DropdownInputFieldSimple'
 import { MenuPortalContext } from './MenuPortalContext'
 
@@ -27,8 +28,8 @@ const meta = {
 		badOptionPrefix: '⚠ Unknown: ',
 	},
 	render: function Render(args) {
-		const [, setArgs] = useArgs<{ value: string }>()
-		return <SimpleDropdownInputField {...args} setValue={(v) => setArgs({ value: String(v) })} />
+		const [, setArgs] = useArgs<{ value: DropdownChoiceId }>()
+		return <SimpleDropdownInputField {...args} setValue={(v) => setArgs({ value: v })} />
 	},
 } satisfies Meta<typeof SimpleDropdownInputField>
 

--- a/webui/src/Components/DropdownInputFieldSimple.tsx
+++ b/webui/src/Components/DropdownInputFieldSimple.tsx
@@ -42,6 +42,8 @@ export const SimpleDropdownInputField = observer(function SimpleDropdownInputFie
 	const menuPortal = useContext(MenuPortalContext)
 	const { options, flatOptions } = useDropdownChoicesForSelect(choices as DropdownChoicesOrGroups)
 
+	const flatItems = useMemo(() => flatOptions.map((o) => ({ value: o.value, label: o.label })), [flatOptions])
+
 	const onChange = useCallback(
 		(v: DropdownChoiceId | null) => {
 			setValue(v as DropdownChoiceId)
@@ -49,24 +51,19 @@ export const SimpleDropdownInputField = observer(function SimpleDropdownInputFie
 		[setValue]
 	)
 
-	const stringValue = String(value)
-	const stringFlatOptions = useMemo(
-		() => flatOptions.map((o) => ({ value: String(o.value), label: o.label })),
-		[flatOptions]
-	)
-	const isKnownValue = stringFlatOptions.some((o) => o.value === stringValue) || options.length === 0
+	const isKnownValue = flatItems.some((o) => o.value === value) || options.length === 0
 	const itemsForLookup = useMemo(
 		() =>
 			isKnownValue
-				? stringFlatOptions
+				? flatItems
 				: [
-						...stringFlatOptions,
+						...flatItems,
 						{
-							value: stringValue,
-							label: badOptionPrefix ? `${badOptionPrefix}: ${stringValue}` : `?? (${stringValue})`,
+							value,
+							label: badOptionPrefix ? `${badOptionPrefix}: ${value}` : `?? (${value})`,
 						},
 					],
-		[isKnownValue, stringFlatOptions, stringValue, badOptionPrefix]
+		[isKnownValue, flatItems, value, badOptionPrefix]
 	)
 
 	const noOptionsMessageFull = noOptionsMessage || 'No options available'
@@ -84,7 +81,7 @@ export const SimpleDropdownInputField = observer(function SimpleDropdownInputFie
 		>
 			<Select.Root<DropdownChoiceId>
 				id={id}
-				value={options.length === 0 ? '' : stringValue}
+				value={options.length === 0 ? null : value}
 				onValueChange={onChange}
 				items={itemsForLookup}
 				disabled={disabled}
@@ -107,6 +104,13 @@ export const SimpleDropdownInputField = observer(function SimpleDropdownInputFie
 										<Select.ItemText>{noOptionsMessageFull}</Select.ItemText>
 									</Select.Item>
 								)}
+								{!isKnownValue && (
+									<Select.Item key={`bad-option-${String(value)}`} value={value} className="dropdown-field-item">
+										<Select.ItemText>
+											{badOptionPrefix ? `${badOptionPrefix}: ${value}` : `?? (${value})`}
+										</Select.ItemText>
+									</Select.Item>
+								)}
 								{options.map((item) => {
 									if ('options' in item) {
 										return (
@@ -114,8 +118,8 @@ export const SimpleDropdownInputField = observer(function SimpleDropdownInputFie
 												<Select.GroupLabel className="dropdown-field-group-label">{item.label}</Select.GroupLabel>
 												{item.options.map((opt) => (
 													<Select.Item
-														key={String(opt.value)}
-														value={String(opt.value)}
+														key={JSON.stringify(opt.value)}
+														value={opt.value}
 														className="dropdown-field-item"
 													>
 														<Select.ItemText>{opt.label}</Select.ItemText>
@@ -125,7 +129,7 @@ export const SimpleDropdownInputField = observer(function SimpleDropdownInputFie
 										)
 									}
 									return (
-										<Select.Item key={String(item.value)} value={String(item.value)} className="dropdown-field-item">
+										<Select.Item key={JSON.stringify(item.value)} value={item.value} className="dropdown-field-item">
 											<Select.ItemText>{item.label}</Select.ItemText>
 										</Select.Item>
 									)

--- a/webui/src/Components/ExpressionInputField.stories.tsx
+++ b/webui/src/Components/ExpressionInputField.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { useArgs } from 'storybook/preview-api'
+import { withMockStore } from '../../.storybook/mockRootAppStore'
+import { ExpressionInputField } from './ExpressionInputField'
+
+const meta = {
+	component: ExpressionInputField,
+	decorators: [withMockStore],
+	args: {
+		value: '',
+		setValue: () => {},
+	},
+	render: function Render(args) {
+		const [, setArgs] = useArgs<{ value: string }>()
+		return (
+			<div style={{ height: 80 }}>
+				<ExpressionInputField {...args} setValue={(v) => setArgs({ value: v })} />
+			</div>
+		)
+	},
+} satisfies Meta<typeof ExpressionInputField>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Empty: Story = {}
+
+export const WithExpression: Story = {
+	args: { value: '$(internal:time_hms) + 1' },
+}
+
+export const InvalidExpression: Story = {
+	args: { value: '$(foo:bar +' },
+}
+
+export const Disabled: Story = {
+	args: { value: '$(internal:time_hms)', disabled: true },
+}
+
+export const WithLocalVariables: Story = {
+	args: {
+		value: '$(local:pressed)',
+		localVariables: [
+			{ value: 'local:pressed', label: 'pressed — Whether the button is pressed' },
+			{ value: 'local:surface_id', label: 'surface_id — ID of the triggering surface' },
+		],
+	},
+}

--- a/webui/src/Components/FieldOrExpression.stories.tsx
+++ b/webui/src/Components/FieldOrExpression.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { useArgs } from 'storybook/preview-api'
+import type { JsonValue } from 'type-fest'
+import type { ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
+import { stringifyVariableValue } from '@companion-app/shared/Model/Variables.js'
+import { withMockStore } from '../../.storybook/mockRootAppStore'
+import { FieldOrExpression } from './FieldOrExpression'
+import { TextInputField } from './TextInputField'
+
+const meta = {
+	component: FieldOrExpression,
+	decorators: [withMockStore],
+	args: {
+		localVariablesStore: null,
+		value: { isExpression: false, value: 'hello' } satisfies ExpressionOrValue<JsonValue | undefined>,
+		setValue: () => {},
+		disabled: false,
+		entityType: null,
+		isLocatedInGrid: false,
+		children: null,
+	},
+	render: function Render(args) {
+		const [, setArgs] = useArgs<{ value: ExpressionOrValue<JsonValue | undefined> }>()
+		return (
+			<FieldOrExpression {...args} setValue={(v) => setArgs({ value: v })}>
+				<TextInputField
+					value={stringifyVariableValue(args.value.value) ?? ''}
+					setValue={() => {}}
+					disabled={args.disabled}
+				/>
+			</FieldOrExpression>
+		)
+	},
+} satisfies Meta<typeof FieldOrExpression>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const PlainValue: Story = {}
+
+export const AsExpression: Story = {
+	args: { value: { isExpression: true, value: '$(internal:time_hms)' } },
+}
+
+export const Disabled: Story = {
+	args: { disabled: true },
+}

--- a/webui/src/Components/GenericConfirmModal.stories.tsx
+++ b/webui/src/Components/GenericConfirmModal.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { useRef } from 'react'
+import { GenericConfirmModal, type GenericConfirmModalRef } from './GenericConfirmModal'
+
+const meta = {
+	component: GenericConfirmModal,
+} satisfies Meta<typeof GenericConfirmModal>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+	render: function Render(args) {
+		const ref = useRef<GenericConfirmModalRef | null>(null)
+		return (
+			<>
+				<button
+					onClick={() =>
+						ref.current?.show('Confirm Action', 'Are you sure you want to proceed?', 'Confirm', () =>
+							console.log('confirmed')
+						)
+					}
+				>
+					Open Confirm Modal
+				</button>
+				<GenericConfirmModal {...args} ref={ref} />
+			</>
+		)
+	},
+}
+
+export const MultiLineMessage: Story = {
+	render: function Render(args) {
+		const ref = useRef<GenericConfirmModalRef | null>(null)
+		return (
+			<>
+				<button
+					onClick={() =>
+						ref.current?.show(
+							'Delete Page',
+							['This will permanently delete the page.', 'All buttons on this page will be lost.'],
+							'Delete',
+							() => console.log('deleted')
+						)
+					}
+				>
+					Open Multi-line Modal
+				</button>
+				<GenericConfirmModal {...args} ref={ref} />
+			</>
+		)
+	},
+}
+
+export const WithCustomContent: Story = {
+	args: { content: <em>Custom content rendered via props.</em> },
+	render: function Render(args) {
+		const ref = useRef<GenericConfirmModalRef | null>(null)
+		return (
+			<>
+				<button onClick={() => ref.current?.show('Custom', null, 'OK', () => console.log('ok'))}>
+					Open Custom Modal
+				</button>
+				<GenericConfirmModal {...args} ref={ref} />
+			</>
+		)
+	},
+}

--- a/webui/src/Components/InlineHelp.stories.tsx
+++ b/webui/src/Components/InlineHelp.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { InlineHelpCustom, InlineHelpIcon } from './InlineHelp'
+
+const meta = {
+	component: InlineHelpIcon,
+} satisfies Meta<typeof InlineHelpIcon>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Icon: Story = {
+	args: {
+		children: 'This is the help text shown in a popover when you hover the question mark icon.',
+	},
+}
+
+export const Custom: Story = {
+	args: { children: '' },
+	render: () => (
+		<InlineHelpCustom help="This help text appears when you hover the custom trigger element.">
+			<span style={{ textDecoration: 'underline dotted', cursor: 'help' }}>hover me</span>
+		</InlineHelpCustom>
+	),
+}
+
+export const RichContent: Story = {
+	args: { children: '' },
+	render: () => (
+		<InlineHelpIcon>
+			<div>
+				<strong>Rich help content</strong>
+				<ul>
+					<li>First item</li>
+					<li>Second item</li>
+				</ul>
+			</div>
+		</InlineHelpIcon>
+	),
+}

--- a/webui/src/Components/LearnButton.stories.tsx
+++ b/webui/src/Components/LearnButton.stories.tsx
@@ -1,0 +1,32 @@
+import type { Decorator, Meta, StoryObj } from '@storybook/react'
+import { mockRootAppStore, withMockStore } from '../../.storybook/mockRootAppStore'
+import { RootAppStoreContext, type RootAppStore } from '../Stores/RootAppStore'
+import { LearnButton } from './LearnButton'
+
+const meta = {
+	component: LearnButton,
+	decorators: [withMockStore],
+	args: {
+		id: 'my-learn-id',
+		doLearn: () => console.log('learn triggered'),
+	},
+} satisfies Meta<typeof LearnButton>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Idle: Story = {}
+
+const withActiveLearnDecorator: Decorator = (Story) => (
+	<RootAppStoreContext.Provider value={{ ...mockRootAppStore, activeLearns: new Set(['my-learn-id']) } as RootAppStore}>
+		<Story />
+	</RootAppStoreContext.Provider>
+)
+
+export const Active: Story = {
+	decorators: [withActiveLearnDecorator],
+}
+
+export const Disabled: Story = {
+	args: { disabled: true },
+}

--- a/webui/src/Components/MultiDropdownInputField.stories.tsx
+++ b/webui/src/Components/MultiDropdownInputField.stories.tsx
@@ -1,5 +1,6 @@
 import type { Decorator, Meta, StoryObj } from '@storybook/react'
 import { useArgs } from 'storybook/preview-api'
+import type { DropdownChoiceId } from '@companion-app/shared/Model/Common.js'
 import { MenuPortalContext } from './MenuPortalContext'
 import { MultiDropdownInputField } from './MultiDropdownInputField'
 
@@ -30,8 +31,8 @@ const meta = {
 		sortSelection: false,
 	},
 	render: function Render(args) {
-		const [, setArgs] = useArgs<{ value: string[] }>()
-		return <MultiDropdownInputField {...args} setValue={(v) => setArgs({ value: v.map(String) })} />
+		const [, setArgs] = useArgs<{ value: DropdownChoiceId[] }>()
+		return <MultiDropdownInputField {...args} setValue={(v) => setArgs({ value: v })} />
 	},
 } satisfies Meta<typeof MultiDropdownInputField>
 

--- a/webui/src/Components/MultiDropdownInputField.stories.tsx
+++ b/webui/src/Components/MultiDropdownInputField.stories.tsx
@@ -65,3 +65,10 @@ export const WithValidation: Story = {
 export const Disabled: Story = {
 	args: { disabled: true, value: ['mon', 'wed'] },
 }
+
+const tenThousandChoices = Array.from({ length: 10000 }, (_, i) => ({ id: `item-${i}`, label: `Item ${i}` }))
+
+/** 10 000 items — tests windowed / virtualised menu list performance */
+export const TenThousandItems: Story = {
+	args: { choices: tenThousandChoices, value: ['item-0', 'item-42'] },
+}

--- a/webui/src/Components/MultiDropdownInputField.stories.tsx
+++ b/webui/src/Components/MultiDropdownInputField.stories.tsx
@@ -1,0 +1,67 @@
+import type { Decorator, Meta, StoryObj } from '@storybook/react'
+import { useArgs } from 'storybook/preview-api'
+import { MenuPortalContext } from './MenuPortalContext'
+import { MultiDropdownInputField } from './MultiDropdownInputField'
+
+const withPortal: Decorator = (Story) => (
+	<MenuPortalContext.Provider value={document.body}>
+		<Story />
+	</MenuPortalContext.Provider>
+)
+
+const choices = [
+	{ id: 'mon', label: 'Monday' },
+	{ id: 'tue', label: 'Tuesday' },
+	{ id: 'wed', label: 'Wednesday' },
+	{ id: 'thu', label: 'Thursday' },
+	{ id: 'fri', label: 'Friday' },
+]
+
+const meta = {
+	component: MultiDropdownInputField,
+	decorators: [withPortal],
+	args: {
+		choices,
+		value: ['mon'],
+		setValue: () => {},
+		tooltip: '',
+		disabled: false,
+		allowCustom: false,
+		sortSelection: false,
+	},
+	render: function Render(args) {
+		const [, setArgs] = useArgs<{ value: string[] }>()
+		return <MultiDropdownInputField {...args} setValue={(v) => setArgs({ value: v.map(String) })} />
+	},
+} satisfies Meta<typeof MultiDropdownInputField>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const MultipleSelected: Story = {
+	args: { value: ['mon', 'wed', 'fri'] },
+}
+
+export const WithMinMax: Story = {
+	args: { value: ['mon', 'tue'], minSelection: 1, maxSelection: 3 },
+}
+
+/** sortSelection — selected tags are kept alphabetically sorted */
+export const SortedSelection: Story = {
+	args: { value: ['fri', 'mon', 'wed'], sortSelection: true },
+}
+
+/** allowCustom — user can type and add values not in the choices list */
+export const WithCustomValues: Story = {
+	args: { allowCustom: true, value: ['mon', 'my-custom-day'] },
+}
+
+export const WithValidation: Story = {
+	args: { value: ['mon', 'tue'], checkValid: (v) => !v.includes('fri') },
+}
+
+export const Disabled: Story = {
+	args: { disabled: true, value: ['mon', 'wed'] },
+}

--- a/webui/src/Components/MultiDropdownInputField.tsx
+++ b/webui/src/Components/MultiDropdownInputField.tsx
@@ -3,13 +3,14 @@ import classNames from 'classnames'
 import { prepare as fuzzyPrepare, single as fuzzySingle } from 'fuzzysort'
 import { ChevronDownIcon, XIcon } from 'lucide-react'
 import { observer } from 'mobx-react-lite'
-import { useCallback, useContext, useMemo, useState } from 'react'
+import { useCallback, useContext, useState } from 'react'
 import type { DropdownChoice, DropdownChoiceId } from '@companion-app/shared/Model/Common.js'
 import { DropdownInputPopup } from '~/Components/DropdownInputField/Popup.js'
 import { useFuzzyChoices, type FuzzyChoice, type FuzzyGroup } from '~/Components/DropdownInputField/useFuzzyChoices.js'
 import { useComputed } from '~/Resources/util.js'
 import type { DropdownChoicesOrGroups } from './DropdownChoices.js'
 import { MenuPortalContext } from './MenuPortalContext.js'
+import { useRegex } from './useRegex.js'
 
 interface MultiDropdownInputFieldProps {
 	htmlName?: string
@@ -52,19 +53,11 @@ export const MultiDropdownInputField = observer(function MultiDropdownInputField
 	// Always search labels only for multi-dropdown (no id-based search needed)
 	const { allItems, flatItems } = useFuzzyChoices(choices, true)
 
-	// The popup doesn't handle groups whwn virtualised, so detect if there are any groups
+	// The popup doesn't handle groups when virtualised, so detect if there are any groups
 	const hasGroups = allItems.some((item) => 'items' in item)
 
 	// Compile the regex (and cache)
-	const compiledRegex = useMemo(() => {
-		if (regex) {
-			const match = regex.match(/^\/(.*)\/(.*)$/)
-			if (match) {
-				return new RegExp(match[1], match[2])
-			}
-		}
-		return null
-	}, [regex])
+	const compiledRegex = useRegex(regex)
 
 	const currentValue = useComputed(() => {
 		const selectedValue = Array.isArray(value) ? value : [value]
@@ -152,7 +145,7 @@ export const MultiDropdownInputField = observer(function MultiDropdownInputField
 		(id: DropdownChoiceId) => {
 			const isAtMinimum = typeof minSelection === 'number' && value.length <= minSelection
 			if (isAtMinimum) return
-			setValue(value.filter((v) => v !== id))
+			setValue(value.filter((v) => v != id)) // Intentionally loose for compatibility
 		},
 		[setValue, value, minSelection]
 	)

--- a/webui/src/Components/MultiDropdownInputField.tsx
+++ b/webui/src/Components/MultiDropdownInputField.tsx
@@ -88,6 +88,9 @@ export const MultiDropdownInputField = observer(function MultiDropdownInputField
 		return { allItems, flatItems }
 	}, [choices])
 
+	// The popup doesn't handle groups whwn virtualised, so detect if there are any groups
+	const hasGroups = allItems.some((item) => 'items' in item)
+
 	// Compile the regex (and cache)
 	const compiledRegex = useMemo(() => {
 		if (regex) {
@@ -204,7 +207,7 @@ export const MultiDropdownInputField = observer(function MultiDropdownInputField
 		>
 			<Combobox.Root<DropdownChoiceId, true>
 				multiple={true}
-				virtualized
+				virtualized={!hasGroups}
 				autoHighlight
 				value={value}
 				items={effectiveItems}
@@ -243,7 +246,7 @@ export const MultiDropdownInputField = observer(function MultiDropdownInputField
 					noOptionsMessage={allowCustom ? 'Begin typing to use a custom value' : undefined}
 					showIndicator
 					disableUnselected={isMaxReached}
-					virtualized
+					virtualized={!hasGroups}
 				/>
 			</Combobox.Root>
 		</div>

--- a/webui/src/Components/MultiDropdownInputField.tsx
+++ b/webui/src/Components/MultiDropdownInputField.tsx
@@ -15,7 +15,7 @@ import type { DropdownChoicesOrGroups } from './DropdownChoices.js'
 import { MenuPortalContext } from './MenuPortalContext.js'
 
 type FuzzyChoice = DropdownChoiceWithMeta & { fuzzy: ReturnType<typeof fuzzyPrepare> }
-type FuzzyGroup = DropdownGroupBase & { options: FuzzyChoice[] }
+type FuzzyGroup = DropdownGroupBase & { items: FuzzyChoice[] }
 
 interface MultiDropdownInputFieldProps {
 	htmlName?: string
@@ -69,7 +69,7 @@ export const MultiDropdownInputField = observer(function MultiDropdownInputField
 			for (const item of choices) {
 				if ('options' in item) {
 					const opts = item.options.map(toFuzzy)
-					allItems.push({ id: String(item.label), label: String(item.label), options: opts })
+					allItems.push({ id: String(item.label), label: String(item.label), items: opts })
 					flatItems.push(...opts)
 				} else {
 					const f = toFuzzy(item)
@@ -155,9 +155,9 @@ export const MultiDropdownInputField = observer(function MultiDropdownInputField
 		const result: Array<FuzzyChoice | FuzzyGroup> = []
 
 		for (const item of allItems) {
-			if ('options' in item) {
-				const filtered = filterFlat(item.options)
-				if (filtered.length > 0) result.push({ ...item, options: filtered })
+			if ('items' in item) {
+				const filtered = filterFlat(item.items)
+				if (filtered.length > 0) result.push({ ...item, items: filtered })
 			} else {
 				if ((fuzzySingle(inputValue, item.fuzzy)?.score ?? 0) >= 0.5) result.push(item)
 			}

--- a/webui/src/Components/MultiDropdownInputField.tsx
+++ b/webui/src/Components/MultiDropdownInputField.tsx
@@ -5,17 +5,11 @@ import { ChevronDownIcon, XIcon } from 'lucide-react'
 import { observer } from 'mobx-react-lite'
 import { useCallback, useContext, useMemo, useState } from 'react'
 import type { DropdownChoice, DropdownChoiceId } from '@companion-app/shared/Model/Common.js'
-import {
-	DropdownInputPopup,
-	type DropdownChoiceWithMeta,
-	type DropdownGroupBase,
-} from '~/Components/DropdownInputField/Popup.js'
+import { DropdownInputPopup } from '~/Components/DropdownInputField/Popup.js'
+import { useFuzzyChoices, type FuzzyChoice, type FuzzyGroup } from '~/Components/DropdownInputField/useFuzzyChoices.js'
 import { useComputed } from '~/Resources/util.js'
 import type { DropdownChoicesOrGroups } from './DropdownChoices.js'
 import { MenuPortalContext } from './MenuPortalContext.js'
-
-type FuzzyChoice = DropdownChoiceWithMeta & { fuzzy: ReturnType<typeof fuzzyPrepare> }
-type FuzzyGroup = DropdownGroupBase & { items: FuzzyChoice[] }
 
 interface MultiDropdownInputFieldProps {
 	htmlName?: string
@@ -55,38 +49,8 @@ export const MultiDropdownInputField = observer(function MultiDropdownInputField
 	if (value === undefined) value = []
 
 	// Convert DropdownChoicesOrGroups -> base-ui Combobox format (choices may be mobx proxies)
-	const { allItems, flatItems } = useComputed(() => {
-		const flatItems: FuzzyChoice[] = []
-		const allItems: Array<FuzzyChoice | FuzzyGroup> = []
-
-		const toFuzzy = (c: DropdownChoice): FuzzyChoice => ({
-			id: c.id,
-			label: String(c.label),
-			fuzzy: fuzzyPrepare(String(c.label)),
-		})
-
-		if (Array.isArray(choices)) {
-			for (const item of choices) {
-				if ('options' in item) {
-					const opts = item.options.map(toFuzzy)
-					allItems.push({ id: String(item.label), label: String(item.label), items: opts })
-					flatItems.push(...opts)
-				} else {
-					const f = toFuzzy(item)
-					allItems.push(f)
-					flatItems.push(f)
-				}
-			}
-		} else if (typeof choices === 'object') {
-			for (const choice of Object.values(choices)) {
-				const f = toFuzzy(choice)
-				allItems.push(f)
-				flatItems.push(f)
-			}
-		}
-
-		return { allItems, flatItems }
-	}, [choices])
+	// Always search labels only for multi-dropdown (no id-based search needed)
+	const { allItems, flatItems } = useFuzzyChoices(choices, true)
 
 	// The popup doesn't handle groups whwn virtualised, so detect if there are any groups
 	const hasGroups = allItems.some((item) => 'items' in item)

--- a/webui/src/Components/MultiDropdownInputField.tsx
+++ b/webui/src/Components/MultiDropdownInputField.tsx
@@ -23,7 +23,6 @@ interface MultiDropdownInputFieldProps {
 	choices: DropdownChoicesOrGroups
 	allowCustom?: boolean
 	minSelection?: number
-	minChoicesForSearch?: number // nocommit - remove this
 	maxSelection?: number
 	sortSelection?: boolean
 	tooltip?: string

--- a/webui/src/Components/MultiDropdownInputField.tsx
+++ b/webui/src/Components/MultiDropdownInputField.tsx
@@ -1,15 +1,21 @@
+import { Combobox } from '@base-ui/react/combobox'
 import classNames from 'classnames'
+import { prepare as fuzzyPrepare, single as fuzzySingle } from 'fuzzysort'
+import { ChevronDownIcon, XIcon } from 'lucide-react'
 import { observer } from 'mobx-react-lite'
-import { createContext, useCallback, useContext, useMemo } from 'react'
-import Select, { createFilter, components as SelectComponents, type MultiValueRemoveProps } from 'react-select'
-import CreatableSelect, { type CreatableProps } from 'react-select/creatable'
-import type { DropdownChoiceId } from '@companion-app/shared/Model/Common.js'
-import { WindowedMenuList } from '~/Components/WindowedSelect/MenuList.js'
+import { useCallback, useContext, useMemo, useState } from 'react'
+import type { DropdownChoice, DropdownChoiceId } from '@companion-app/shared/Model/Common.js'
+import {
+	DropdownInputPopup,
+	type DropdownChoiceWithMeta,
+	type DropdownGroupBase,
+} from '~/Components/DropdownInputField/Popup.js'
 import { useComputed } from '~/Resources/util.js'
-import { useDropdownChoicesForSelect, type DropdownChoiceInt, type DropdownChoicesOrGroups } from './DropdownChoices.js'
+import type { DropdownChoicesOrGroups } from './DropdownChoices.js'
 import { MenuPortalContext } from './MenuPortalContext.js'
 
-const IsAtMinimumContext = createContext(false)
+type FuzzyChoice = DropdownChoiceWithMeta & { fuzzy: ReturnType<typeof fuzzyPrepare> }
+type FuzzyGroup = DropdownGroupBase & { options: FuzzyChoice[] }
 
 interface MultiDropdownInputFieldProps {
 	htmlName?: string
@@ -17,7 +23,7 @@ interface MultiDropdownInputFieldProps {
 	choices: DropdownChoicesOrGroups
 	allowCustom?: boolean
 	minSelection?: number
-	minChoicesForSearch?: number
+	minChoicesForSearch?: number // nocommit - remove this
 	maxSelection?: number
 	sortSelection?: boolean
 	tooltip?: string
@@ -35,7 +41,6 @@ export const MultiDropdownInputField = observer(function MultiDropdownInputField
 	choices,
 	allowCustom,
 	minSelection,
-	minChoicesForSearch,
 	maxSelection,
 	sortSelection,
 	tooltip,
@@ -48,40 +53,45 @@ export const MultiDropdownInputField = observer(function MultiDropdownInputField
 }: MultiDropdownInputFieldProps) {
 	const menuPortal = useContext(MenuPortalContext)
 
-	const { options, flatOptions } = useDropdownChoicesForSelect(choices)
-
 	if (value === undefined) value = []
 
-	const currentValue = useComputed(() => {
-		const selectedValue = Array.isArray(value) ? value : [value]
-		const res: DropdownChoiceInt[] = []
-		for (const val of selectedValue) {
-			const entry = flatOptions.find((o) => o.value == val) // Intentionally loose for compatibility
-			if (entry) {
-				res.push(entry)
-			} else if (allowCustom) {
-				res.push({ value: val, label: String(val) })
-			} else {
-				res.push({ value: val, label: allowCustom ? String(val) : `?? (${val})` })
+	// Convert DropdownChoicesOrGroups -> base-ui Combobox format (choices may be mobx proxies)
+	const { allItems, flatItems } = useComputed(() => {
+		const flatItems: FuzzyChoice[] = []
+		const allItems: Array<FuzzyChoice | FuzzyGroup> = []
+
+		const toFuzzy = (c: DropdownChoice): FuzzyChoice => ({
+			id: c.id,
+			label: String(c.label),
+			fuzzy: fuzzyPrepare(String(c.label)),
+		})
+
+		if (Array.isArray(choices)) {
+			for (const item of choices) {
+				if ('options' in item) {
+					const opts = item.options.map(toFuzzy)
+					allItems.push({ id: String(item.label), label: String(item.label), options: opts })
+					flatItems.push(...opts)
+				} else {
+					const f = toFuzzy(item)
+					allItems.push(f)
+					flatItems.push(f)
+				}
+			}
+		} else if (typeof choices === 'object') {
+			for (const choice of Object.values(choices)) {
+				const f = toFuzzy(choice)
+				allItems.push(f)
+				flatItems.push(f)
 			}
 		}
-		if (sortSelection) {
-			res.sort((a, b) => {
-				const aIndex = flatOptions.findIndex((o) => o.value == a.value)
-				const bIndex = flatOptions.findIndex((o) => o.value == b.value)
-				if (aIndex !== -1 && bIndex !== -1) return aIndex - bIndex
-				if (aIndex !== -1) return -1
-				if (bIndex !== -1) return 1
-				return String(a.label).localeCompare(String(b.label))
-			})
-		}
-		return res
-	}, [value, flatOptions, allowCustom, sortSelection])
+
+		return { allItems, flatItems }
+	}, [choices])
 
 	// Compile the regex (and cache)
 	const compiledRegex = useMemo(() => {
 		if (regex) {
-			// Compile the regex string
 			const match = regex.match(/^\/(.*)\/(.*)$/)
 			if (match) {
 				return new RegExp(match[1], match[2])
@@ -90,119 +100,153 @@ export const MultiDropdownInputField = observer(function MultiDropdownInputField
 		return null
 	}, [regex])
 
-	const onChange = useCallback(
-		(e: DropdownChoiceInt[]) => {
-			const newValue = e?.map((v) => v.value) ?? []
+	const currentValue = useComputed(() => {
+		const selectedValue = Array.isArray(value) ? value : [value]
+		const res: DropdownChoice[] = []
+		for (const val of selectedValue) {
+			const entry = flatItems.find((o) => o.id == val) // Intentionally loose for compatibility
+			if (entry) {
+				res.push(entry)
+			} else if (allowCustom) {
+				res.push({ id: val, label: String(val) })
+			} else {
+				res.push({ id: val, label: `?? (${val})` })
+			}
+		}
+		if (sortSelection) {
+			res.sort((a, b) => {
+				const aIndex = flatItems.findIndex((o) => o.id == a.id)
+				const bIndex = flatItems.findIndex((o) => o.id == b.id)
+				if (aIndex !== -1 && bIndex !== -1) return aIndex - bIndex
+				if (aIndex !== -1) return -1
+				if (bIndex !== -1) return 1
+				return String(a.label).localeCompare(String(b.label))
+			})
+		}
+		return res
+	}, [value, flatItems, allowCustom, sortSelection])
 
-			const valueArr = value as DropdownChoiceId[] | undefined
-			if (
-				typeof minSelection === 'number' &&
-				newValue.length < minSelection &&
-				newValue.length <= (valueArr || []).length
-			) {
-				// Block change if too few are selected
+	const [inputValue, setInputValue] = useState('')
+
+	const isValidCustom = useCallback((input: string) => !compiledRegex || !!input.match(compiledRegex), [compiledRegex])
+
+	const syntheticItem = useComputed((): FuzzyChoice | null => {
+		if (!allowCustom || !inputValue || !isValidCustom(inputValue)) return null
+		if (flatItems.some((o) => o.id == inputValue)) return null
+		return {
+			id: inputValue,
+			label: `Create "${inputValue}"`,
+			fuzzy: fuzzyPrepare(inputValue),
+			plusIndicator: true,
+		}
+	}, [allowCustom, inputValue, isValidCustom, flatItems])
+
+	// Items master list — must include the synthetic item so base-ui can resolve it on selection
+	const effectiveItems = useComputed(
+		(): Array<FuzzyChoice | FuzzyGroup> => (syntheticItem ? [syntheticItem, ...allItems] : allItems),
+		[syntheticItem, allItems]
+	)
+
+	const filteredItems = useComputed((): Array<FuzzyChoice | FuzzyGroup> => {
+		if (!inputValue) return allItems
+
+		const filterFlat = (items: FuzzyChoice[]): FuzzyChoice[] =>
+			items.filter((o) => (fuzzySingle(inputValue, o.fuzzy)?.score ?? 0) >= 0.5)
+
+		const result: Array<FuzzyChoice | FuzzyGroup> = []
+
+		for (const item of allItems) {
+			if ('options' in item) {
+				const filtered = filterFlat(item.options)
+				if (filtered.length > 0) result.push({ ...item, options: filtered })
+			} else {
+				if ((fuzzySingle(inputValue, item.fuzzy)?.score ?? 0) >= 0.5) result.push(item)
+			}
+		}
+
+		if (syntheticItem) result.unshift(syntheticItem)
+
+		return result
+	}, [allItems, syntheticItem, inputValue])
+
+	const onValueChange = useCallback(
+		(newIds: DropdownChoiceId[]) => {
+			if (typeof minSelection === 'number' && newIds.length < minSelection && newIds.length <= value.length) {
 				return
 			}
-
-			if (
-				typeof maxSelection === 'number' &&
-				newValue.length > maxSelection &&
-				newValue.length >= (valueArr || []).length
-			) {
-				// Block change if too many are selected
+			if (typeof maxSelection === 'number' && newIds.length > maxSelection && newIds.length >= value.length) {
 				return
 			}
-
-			setValue(newValue)
+			setValue(newIds)
 		},
 		[setValue, value, minSelection, maxSelection]
 	)
 
-	const isAtMinimum = typeof minSelection === 'number' && currentValue.length <= minSelection
-	const minChoicesForSearch2 = typeof minChoicesForSearch === 'number' ? minChoicesForSearch : 10
-
-	// const selectRef = useRef<any>(null)
-
-	const selectProps: Partial<CreatableProps<any, any, any>> = {
-		name: htmlName,
-		isDisabled: disabled,
-		classNamePrefix: 'select-control',
-		className: 'select-control',
-		menuPortalTarget: menuPortal || document.body,
-		menuShouldBlockScroll: !!menuPortal, // The dropdown doesn't follow scroll when in a modal
-		menuPosition: 'fixed',
-		menuPlacement: 'auto',
-		isClearable: false,
-		isSearchable: minChoicesForSearch2 <= flatOptions.length,
-		isMulti: true,
-		options: options,
-		value: currentValue,
-		onChange: onChange,
-		filterOption: createFilter({ ignoreAccents: false }),
-		components: { MenuList: WindowedMenuList, MultiValueRemove: MinAwareMultiValueRemove },
-		onBlur: onBlur,
-	}
-
-	const isValidNewOption = useCallback(
-		(newValue: string | number) => typeof newValue === 'string' && (!compiledRegex || !!newValue.match(compiledRegex)),
-		[compiledRegex]
-	)
-	const noOptionsMessage = useCallback(
-		({ inputValue }: { inputValue: string | number }) => {
-			if (!isValidNewOption(inputValue)) {
-				return 'Input is not a valid value'
-			} else {
-				return 'Begin typing to use a custom value'
-			}
+	const removeValue = useCallback(
+		(id: DropdownChoiceId) => {
+			const isAtMinimum = typeof minSelection === 'number' && value.length <= minSelection
+			if (isAtMinimum) return
+			setValue(value.filter((v) => v !== id))
 		},
-		[isValidNewOption]
+		[setValue, value, minSelection]
 	)
-	const formatCreateLabel = useCallback((v: string | number) => `Use "${v}"`, [])
+
+	const isAtMinimum = typeof minSelection === 'number' && currentValue.length <= minSelection
+	const isMaxReached = typeof maxSelection === 'number' && value.length >= maxSelection
 
 	return (
-		<IsAtMinimumContext.Provider value={isAtMinimum}>
-			<div
-				className={classNames(
-					{
-						'select-tooltip': true,
-						'select-invalid': !!checkValid && !checkValid(currentValue.map((v) => v.value) ?? []),
-					},
-					className
-				)}
-				title={tooltip}
+		<div
+			className={classNames(
+				'dropdown-field',
+				{ 'dropdown-field-invalid': !!checkValid && !checkValid(currentValue.map((v) => v.id)) },
+				className
+			)}
+			title={tooltip}
+		>
+			<Combobox.Root<DropdownChoiceId, true>
+				multiple={true}
+				virtualized
+				autoHighlight
+				value={value}
+				items={effectiveItems}
+				filteredItems={filteredItems}
+				disabled={disabled}
+				onValueChange={onValueChange}
+				onInputValueChange={setInputValue}
 			>
-				{allowCustom ? (
-					<CreatableSelect
-						{...selectProps}
-						// ref={selectRef}
-						className={`${selectProps.className} select-control-editable`}
-						isSearchable={true}
-						noOptionsMessage={noOptionsMessage}
-						createOptionPosition="first"
-						formatCreateLabel={formatCreateLabel}
-						isValidNewOption={isValidNewOption}
-					/>
-				) : (
-					<Select {...selectProps} />
-				)}
-			</div>
-		</IsAtMinimumContext.Provider>
-	)
-}) as (props: MultiDropdownInputFieldProps) => JSX.Element
+				<Combobox.InputGroup className="dropdown-field-input-group dropdown-field-multi-input-group">
+					{currentValue.map((item) => (
+						<span className="dropdown-field-pill" key={String(item.id)}>
+							<span className="dropdown-field-pill-label">{item.label}</span>
+							<button
+								type="button"
+								className="dropdown-field-pill-remove"
+								disabled={isAtMinimum || disabled}
+								onClick={(e) => {
+									e.stopPropagation()
+									removeValue(item.id)
+								}}
+								tabIndex={-1}
+								aria-label={`Remove ${item.label}`}
+							>
+								<XIcon className="dropdown-field-pill-remove-icon" />
+							</button>
+						</span>
+					))}
+					<Combobox.Input className="dropdown-field-input" name={htmlName} onBlur={onBlur} />
+					<Combobox.Trigger className="dropdown-field-trigger">
+						<ChevronDownIcon className="dropdown-field-icon" />
+					</Combobox.Trigger>
+				</Combobox.InputGroup>
 
-function MinAwareMultiValueRemove(props: MultiValueRemoveProps<DropdownChoiceInt, true, never>) {
-	const isAtMinimum = useContext(IsAtMinimumContext)
-	if (isAtMinimum) {
-		const { innerProps, ...rest } = props
-		return (
-			<SelectComponents.MultiValueRemove
-				{...rest}
-				innerProps={{
-					...innerProps,
-					style: { ...innerProps.style, opacity: 0.3, cursor: 'not-allowed' },
-				}}
-			/>
-		)
-	}
-	return <SelectComponents.MultiValueRemove {...props} />
-}
+				<DropdownInputPopup
+					menuPortal={menuPortal ?? undefined}
+					noOptionsMessage={allowCustom ? 'Begin typing to use a custom value' : undefined}
+					showIndicator
+					disableUnselected={isMaxReached}
+					virtualized
+				/>
+			</Combobox.Root>
+		</div>
+	)
+})

--- a/webui/src/Components/NonIdealState.stories.tsx
+++ b/webui/src/Components/NonIdealState.stories.tsx
@@ -1,0 +1,39 @@
+import { faExclamationTriangle, faSearch, faTrash, faWifi } from '@fortawesome/free-solid-svg-icons'
+import type { Meta, StoryObj } from '@storybook/react'
+import { NonIdealState } from './NonIdealState'
+
+const meta = {
+	component: NonIdealState,
+	args: {
+		icon: faTrash,
+	},
+} satisfies Meta<typeof NonIdealState>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const WithText: Story = {
+	args: { text: 'Nothing to show here.' },
+}
+
+export const NoResults: Story = {
+	args: { icon: faSearch, text: 'No results found.' },
+}
+
+export const Warning: Story = {
+	args: { icon: faExclamationTriangle, text: 'Something went wrong.' },
+}
+
+export const WithChildren: Story = {
+	args: {
+		icon: faWifi,
+		children: (
+			<>
+				Not connected.{' '}
+				<a href="#" onClick={(e) => e.preventDefault()}>
+					Retry
+				</a>
+			</>
+		),
+	},
+}

--- a/webui/src/Components/NumberInputField.stories.tsx
+++ b/webui/src/Components/NumberInputField.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { useArgs } from 'storybook/preview-api'
+import { NumberInputField } from './NumberInputField'
+
+const meta = {
+	component: NumberInputField,
+	args: {
+		value: 0,
+		setValue: () => {},
+		tooltip: '',
+		disabled: false,
+	},
+	render: function Render(args) {
+		const [, setArgs] = useArgs<{ value: number }>()
+		return <NumberInputField {...args} setValue={(v) => setArgs({ value: v })} />
+	},
+} satisfies Meta<typeof NumberInputField>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Basic: Story = { args: { value: 42 } }
+
+export const WithMinMax: Story = {
+	args: { value: 50, min: 0, max: 100 },
+}
+
+export const WithStep: Story = {
+	args: { value: 5, min: 0, max: 20, step: 5 },
+}
+
+export const WithRange: Story = {
+	args: { value: 30, min: 0, max: 100, range: true },
+}
+
+export const WithValidation: Story = {
+	args: {
+		value: 3,
+		min: 1,
+		max: 10,
+		checkValid: (v: number) => v >= 1 && v <= 10,
+	},
+}
+
+export const InfinityOverlays: Story = {
+	args: {
+		value: 0,
+		min: 0,
+		max: 100,
+		showMinAsNegativeInfinity: true,
+		showMaxAsPositiveInfinity: true,
+	},
+}
+
+export const Disabled: Story = {
+	args: { value: 7, disabled: true },
+}

--- a/webui/src/Components/NumberInputField.tsx
+++ b/webui/src/Components/NumberInputField.tsx
@@ -51,8 +51,11 @@ export function NumberInputField({
 
 	// Compute whether we should visually show -∞ or ∞.
 	const numericEffective = Number(tmpValue ?? value ?? 0)
+	// Only show infinity overlays when the user has explicitly set a value.
+	const hasExplicitValue = tmpValue !== null || value !== undefined
 	let showOverlayValue: string | null = null
 	if (
+		hasExplicitValue &&
 		!!showMinAsNegativeInfinity &&
 		typeof min !== 'undefined' &&
 		!isNaN(numericEffective) &&
@@ -60,6 +63,7 @@ export function NumberInputField({
 	) {
 		showOverlayValue = '-∞'
 	} else if (
+		hasExplicitValue &&
 		!!showMaxAsPositiveInfinity &&
 		typeof max !== 'undefined' &&
 		!isNaN(numericEffective) &&
@@ -68,8 +72,7 @@ export function NumberInputField({
 		showOverlayValue = '∞'
 	}
 
-	const valueIsInvalid =
-		typeof checkValid === 'boolean' ? !checkValid : !!checkValid && !checkValid(Number(tmpValue ?? value))
+	const valueIsInvalid = typeof checkValid === 'boolean' ? !checkValid : !!checkValid && !checkValid(numericEffective)
 
 	const input = (
 		<NumberField.Root

--- a/webui/src/Components/PNGInputField.tsx
+++ b/webui/src/Components/PNGInputField.tsx
@@ -18,9 +18,17 @@ interface PNGInputFieldProps {
 	onSelect: (png64Str: string, name: string) => void
 	onError: (err: string | null) => void
 	allowNonPng?: boolean
+	disabled?: boolean
 }
 
-export function PNGInputField({ min, max, onSelect, onError, allowNonPng }: PNGInputFieldProps): React.JSX.Element {
+export function PNGInputField({
+	min,
+	max,
+	onSelect,
+	onError,
+	allowNonPng,
+	disabled,
+}: PNGInputFieldProps): React.JSX.Element {
 	const inputRef = useRef<HTMLInputElement>(null)
 
 	const apiIsSupported = !!(window.File && window.FileReader && window.FileList && window.Blob)
@@ -116,11 +124,11 @@ export function PNGInputField({ min, max, onSelect, onError, allowNonPng }: PNGI
 			color="primary"
 			className="pnginputfield"
 			onClick={onClick}
-			disabled={!apiIsSupported}
+			disabled={!apiIsSupported || disabled}
 			title={apiIsSupported ? undefined : 'Not supported in your browser'}
 		>
 			<FontAwesomeIcon icon={faFolderOpen} />
-			<CFormInput type="file" ref={inputRef} onChange={onChange} disabled={!apiIsSupported} />
+			<CFormInput type="file" ref={inputRef} onChange={onChange} disabled={!apiIsSupported || disabled} />
 		</CButton>
 	)
 }

--- a/webui/src/Components/PngImageInputField.stories.tsx
+++ b/webui/src/Components/PngImageInputField.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { useArgs } from 'storybook/preview-api'
+import { PngImageInputField } from './PngImageInputField'
+
+// Minimal 1×1 red PNG as a data URL for demo purposes
+const SAMPLE_PNG =
+	'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg=='
+
+const meta = {
+	component: PngImageInputField,
+	args: {
+		value: null,
+		setValue: () => {},
+		allowNonPng: true,
+	},
+	render: function Render(args) {
+		const [, setArgs] = useArgs<{ value: string | null }>()
+		return <PngImageInputField {...args} setValue={(v) => setArgs({ value: v })} />
+	},
+} satisfies Meta<typeof PngImageInputField>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Empty: Story = {}
+
+export const WithImage: Story = {
+	args: { value: SAMPLE_PNG },
+}
+
+/** allowNonPng: false — only PNG files accepted */
+export const PngOnly: Story = {
+	args: { allowNonPng: false, value: SAMPLE_PNG },
+}
+
+/** Constrained dimensions — min 32×32, max 128×128 */
+export const WithSizeConstraints: Story = {
+	args: {
+		value: SAMPLE_PNG,
+		min: { width: 32, height: 32 },
+		max: { width: 128, height: 128 },
+	},
+}
+
+export const Disabled: Story = {
+	args: { disabled: true, value: SAMPLE_PNG },
+}

--- a/webui/src/Components/PngImageInputField.tsx
+++ b/webui/src/Components/PngImageInputField.tsx
@@ -46,6 +46,7 @@ export function PngImageInputField({
 					min={min}
 					max={max}
 					allowNonPng={allowNonPng}
+					disabled={disabled}
 				/>
 				<CButton color="danger" disabled={disabled || !value} onClick={clearImage}>
 					<FontAwesomeIcon icon={faTrash} />

--- a/webui/src/Components/Popover.stories.tsx
+++ b/webui/src/Components/Popover.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Popover } from './Popover'
+
+const meta = {
+	component: Popover,
+	args: {
+		content: 'This is the popover content.',
+		children: <span style={{ textDecoration: 'underline', cursor: 'default' }}>hover me</span>,
+	},
+} satisfies Meta<typeof Popover>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const Immediate: Story = {
+	args: { hoverWait: 0 },
+}
+
+export const LongWait: Story = {
+	args: { hoverWait: 1500, content: 'This popover takes 1.5s to appear.' },
+}

--- a/webui/src/Components/SearchBox.stories.tsx
+++ b/webui/src/Components/SearchBox.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { useArgs } from 'storybook/preview-api'
+import { SearchBox } from './SearchBox'
+
+const meta = {
+	component: SearchBox,
+	args: {
+		filter: '',
+		setFilter: () => {},
+	},
+	render: function Render(args) {
+		const [, setArgs] = useArgs()
+		return <SearchBox {...args} setFilter={(value) => setArgs({ filter: value })} />
+	},
+} satisfies Meta<typeof SearchBox>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Empty: Story = {
+	args: {
+		filter: '',
+	},
+}
+
+export const WithValue: Story = {
+	args: {
+		filter: 'my search',
+	},
+}

--- a/webui/src/Components/SecretTextInputField.stories.tsx
+++ b/webui/src/Components/SecretTextInputField.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { useArgs } from 'storybook/preview-api'
+import { SecretTextInputField } from './SecretTextInputField'
+
+const meta = {
+	component: SecretTextInputField,
+	args: {
+		value: '',
+		setValue: () => {},
+		tooltip: '',
+	},
+	render: function Render(args) {
+		const [, setArgs] = useArgs()
+		return <SecretTextInputField {...args} setValue={(value) => setArgs({ value })} />
+	},
+} satisfies Meta<typeof SecretTextInputField>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Empty: Story = {}
+
+export const WithValue: Story = {
+	args: {
+		value: 'super-secret-password',
+	},
+}
+
+export const WithValidation: Story = {
+	args: {
+		value: 'short',
+		checkValid: (v) => v.length >= 8,
+	},
+}

--- a/webui/src/Components/SwitchInputField.stories.tsx
+++ b/webui/src/Components/SwitchInputField.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { useArgs } from 'storybook/preview-api'
+import { SwitchInputField, SwitchInputFieldWithLabel } from './SwitchInputField'
+
+const meta = {
+	component: SwitchInputField,
+	args: {
+		value: false,
+		setValue: () => {},
+		tooltip: '',
+		disabled: false,
+		small: false,
+	},
+	render: function Render(args) {
+		const [, setArgs] = useArgs()
+		return <SwitchInputField {...args} setValue={(value) => setArgs({ value })} />
+	},
+} satisfies Meta<typeof SwitchInputField>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const Small: Story = {
+	args: { small: true },
+}
+
+export const Disabled: Story = {
+	args: { disabled: true, value: true },
+}
+
+export const WithLabel: Story = {
+	render: function Render(args) {
+		const [, setArgs] = useArgs()
+		return <SwitchInputFieldWithLabel {...args} label="Enable feature" setValue={(value) => setArgs({ value })} />
+	},
+}
+
+export const DisabledWithLabel: Story = {
+	args: { value: true, disabled: true },
+	render: function Render(args) {
+		const [, setArgs] = useArgs()
+		return <SwitchInputFieldWithLabel {...args} label="Enable feature" setValue={(value) => setArgs({ value })} />
+	},
+}

--- a/webui/src/Components/TabArea.stories.tsx
+++ b/webui/src/Components/TabArea.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { TabArea } from './TabArea'
+
+const meta = {
+	component: TabArea.Root,
+	render: (args) => (
+		<TabArea.Root {...args}>
+			<TabArea.List>
+				<TabArea.Tab value="tab1">First</TabArea.Tab>
+				<TabArea.Tab value="tab2">Second</TabArea.Tab>
+				<TabArea.Tab value="tab3">Third</TabArea.Tab>
+				<TabArea.Indicator />
+			</TabArea.List>
+			<TabArea.Panel value="tab1">Content of the first tab</TabArea.Panel>
+			<TabArea.Panel value="tab2">Content of the second tab</TabArea.Panel>
+			<TabArea.Panel value="tab3">Content of the third tab</TabArea.Panel>
+		</TabArea.Root>
+	),
+} satisfies Meta<typeof TabArea.Root>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+	args: {
+		defaultValue: 'tab1',
+	},
+}
+
+export const SecondTabActive: Story = {
+	args: {
+		defaultValue: 'tab2',
+	},
+}

--- a/webui/src/Components/TableVisibility.stories.tsx
+++ b/webui/src/Components/TableVisibility.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { useArgs } from 'storybook/preview-api'
+import { VisibilityButton } from './TableVisibility'
+
+type Columns = { name: boolean; status: boolean; actions: boolean }
+
+const defaultVisibility: Columns = { name: true, status: true, actions: false }
+
+const meta = {
+	component: VisibilityButton<Columns>,
+	args: {
+		keyId: 'name',
+		color: 'primary',
+		label: 'Name',
+		visibility: defaultVisibility,
+		toggleVisibility: () => {},
+	},
+	render: function Render(args) {
+		const [, setArgs] = useArgs<{ visibility: Columns }>()
+		const toggleVisibility = (key: keyof Columns) => {
+			const next = { ...args.visibility, [key]: !args.visibility[key] }
+			setArgs({ visibility: next })
+		}
+		return <VisibilityButton {...args} toggleVisibility={toggleVisibility} />
+	},
+} satisfies Meta<typeof VisibilityButton<Columns>>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const ActiveByDefault: Story = {}
+
+export const InactiveByDefault: Story = {
+	args: {
+		keyId: 'actions',
+		label: 'Actions',
+	},
+}
+
+export const MultipleButtons: Story = {
+	render: function Render(args) {
+		const [, setArgs] = useArgs<{ visibility: Columns }>()
+		const toggleVisibility = (key: keyof Columns) => {
+			const next = { ...args.visibility, [key]: !args.visibility[key] }
+			setArgs({ visibility: next })
+		}
+		return (
+			<div style={{ display: 'flex', gap: '4px' }}>
+				<VisibilityButton {...args} keyId="name" label="Name" color="primary" toggleVisibility={toggleVisibility} />
+				<VisibilityButton {...args} keyId="status" label="Status" color="success" toggleVisibility={toggleVisibility} />
+				<VisibilityButton
+					{...args}
+					keyId="actions"
+					label="Actions"
+					color="warning"
+					toggleVisibility={toggleVisibility}
+				/>
+			</div>
+		)
+	},
+}
+
+const allColors = ['primary', 'secondary', 'success', 'danger', 'warning', 'info', 'light', 'dark'] as const
+
+export const AllColors: Story = {
+	render: function Render(args) {
+		const [, setArgs] = useArgs<{ visibility: Columns }>()
+		const toggleVisibility = (key: keyof Columns) => {
+			const next = { ...args.visibility, [key]: !args.visibility[key] }
+			setArgs({ visibility: next })
+		}
+		return (
+			<div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px' }}>
+				{allColors.map((color) => (
+					<VisibilityButton
+						key={color}
+						{...args}
+						keyId="name"
+						label={color}
+						color={color}
+						toggleVisibility={toggleVisibility}
+					/>
+				))}
+			</div>
+		)
+	},
+}

--- a/webui/src/Components/TextInputField.stories.tsx
+++ b/webui/src/Components/TextInputField.stories.tsx
@@ -1,0 +1,68 @@
+import type { Decorator, Meta, StoryObj } from '@storybook/react'
+import { useArgs } from 'storybook/preview-api'
+import { withMockStore } from '../../.storybook/mockRootAppStore'
+import { MenuPortalContext } from './MenuPortalContext'
+import { TextInputField } from './TextInputField'
+
+const meta = {
+	component: TextInputField,
+	args: {
+		value: '',
+		setValue: () => {},
+		tooltip: '',
+		disabled: false,
+	},
+	render: function Render(args) {
+		const [, setArgs] = useArgs<{ value: string }>()
+		return <TextInputField {...args} setValue={(v) => setArgs({ value: v })} />
+	},
+} satisfies Meta<typeof TextInputField>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const WithPlaceholder: Story = {
+	args: { placeholder: 'Type something…' },
+}
+
+export const Multiline: Story = {
+	args: { multiline: true, value: 'Line one\nLine two' },
+}
+
+export const WithValidation: Story = {
+	args: {
+		value: 'hi',
+		checkValid: (v) => v.length >= 5,
+	},
+}
+
+export const Disabled: Story = {
+	args: { value: 'Read-only text', disabled: true },
+}
+
+const withMenuPortalDecorator: Decorator = (Story) => (
+	<MenuPortalContext.Provider value={document.body}>
+		<Story />
+	</MenuPortalContext.Provider>
+)
+
+const withVariablesDecorators: Decorator[] = [withMockStore, withMenuPortalDecorator]
+
+export const WithVariables: Story = {
+	decorators: withVariablesDecorators,
+	args: { useVariables: true, value: '$(internal:time_hms)' },
+}
+
+export const WithVariablesAndLocalVars: Story = {
+	decorators: withVariablesDecorators,
+	args: {
+		useVariables: true,
+		value: '$(local:pressed)',
+		localVariables: [
+			{ value: 'local:pressed', label: 'pressed — Whether the button is pressed' },
+			{ value: 'local:surface_id', label: 'surface_id — ID of the triggering surface' },
+		],
+	},
+}

--- a/webui/src/Components/Tuck.stories.tsx
+++ b/webui/src/Components/Tuck.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Tuck } from './Tuck'
+
+const meta = {
+	component: Tuck,
+} satisfies Meta<typeof Tuck>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Number: Story = { args: { children: '1' } }
+export const Letter: Story = { args: { children: 'A' } }
+export const Symbol: Story = { args: { children: '★' } }
+export const InContext: Story = {
+	args: { children: '' },
+	render: () => (
+		<div>
+			<Tuck>1</Tuck> First item
+			<br />
+			<Tuck>2</Tuck> Second item
+			<br />
+			<Tuck>3</Tuck> Third item
+		</div>
+	),
+}

--- a/webui/src/Components/VariablePickerField.stories.tsx
+++ b/webui/src/Components/VariablePickerField.stories.tsx
@@ -1,0 +1,67 @@
+import type { Decorator, Meta, StoryObj } from '@storybook/react'
+import { useArgs } from 'storybook/preview-api'
+import { MenuPortalContext } from './MenuPortalContext'
+import { VariablePickerField } from './VariablePickerField'
+
+const withPortal: Decorator = (Story) => (
+	<MenuPortalContext.Provider value={document.body}>
+		<Story />
+	</MenuPortalContext.Provider>
+)
+
+const choices = [
+	{ id: 'internal:time_hms', label: 'Current time (HH:MM:SS)' },
+	{ id: 'internal:date_y', label: 'Current year' },
+	{ id: 'internal:uptime', label: 'Time since last restart' },
+	{ id: 'custom:var1', label: 'My Custom Variable' },
+]
+
+const meta = {
+	component: VariablePickerField,
+	decorators: [withPortal],
+	args: {
+		choices,
+		value: 'internal:time_hms',
+		setValue: () => {},
+		disabled: false,
+	},
+	render: function Render(args) {
+		const [, setArgs] = useArgs<{ value: string }>()
+		return <VariablePickerField {...args} setValue={(v) => setArgs({ value: String(v) })} />
+	},
+} satisfies Meta<typeof VariablePickerField>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const WithAllowCustom: Story = {
+	args: { allowCustom: true, value: 'my-custom:value' },
+}
+
+export const Disabled: Story = {
+	args: { disabled: true },
+}
+
+export const GroupedChoices: Story = {
+	args: {
+		choices: [
+			{
+				label: 'Date & Time',
+				options: [
+					{ id: 'internal:time_hms', label: 'Current time (HH:MM:SS)' },
+					{ id: 'internal:date_y', label: 'Current year' },
+				],
+			},
+			{
+				label: 'System',
+				options: [
+					{ id: 'internal:uptime', label: 'Time since last restart' },
+					{ id: 'internal:hostname', label: 'Hostname' },
+				],
+			},
+		],
+		value: 'internal:time_hms',
+	},
+}

--- a/webui/src/Components/VariablePickerField.tsx
+++ b/webui/src/Components/VariablePickerField.tsx
@@ -10,42 +10,36 @@ import { useDropdownComboboxItems } from './DropdownInputField/useDropdownCombob
 import { useFuzzyChoices } from './DropdownInputField/useFuzzyChoices.js'
 import { MenuPortalContext } from './MenuPortalContext.js'
 
-interface DropdownInputFieldProps {
-	htmlName?: string
+interface VariablePickerFieldProps {
 	className?: string
 	choices: DropdownChoicesOrGroups
 	allowCustom?: boolean
-	disableEditingCustom?: boolean
-	tooltip?: string
 	regex?: string
 	value: DropdownChoiceId
 	setValue: (value: DropdownChoiceId) => void
 	disabled?: boolean
-	onBlur?: () => void
-	checkValid?: (value: DropdownChoiceId) => boolean
-	searchLabelsOnly?: boolean
+	onPasteIntercept?: (value: string) => string
 }
 
-export const DropdownInputField = observer(function DropdownInputField({
-	htmlName,
+/**
+ * A specialised dropdown field component, intended for picking variables
+ * This means it displays in a "fancy" way with both variable id and label, and searches both fields as well.
+ */
+export const VariablePickerField = observer(function VariablePickerField({
 	className,
 	choices,
 	allowCustom,
-	disableEditingCustom,
-	tooltip,
 	regex,
 	value,
 	setValue,
 	disabled,
-	onBlur,
-	checkValid,
-	searchLabelsOnly = true,
-}: DropdownInputFieldProps): React.JSX.Element {
+	onPasteIntercept,
+}: VariablePickerFieldProps): React.JSX.Element {
 	const menuPortal = useContext(MenuPortalContext)
 
-	const { allItems, flatItems } = useFuzzyChoices(choices, searchLabelsOnly)
+	// Always search both label and id for variable pickers
+	const { allItems, flatItems } = useFuzzyChoices(choices, false)
 
-	// The popup doesn't handle groups whwn virtualised, so detect if there are any groups
 	const hasGroups = allItems.some((item) => 'items' in item)
 
 	// Compile the regex for custom value validation
@@ -59,12 +53,8 @@ export const DropdownInputField = observer(function DropdownInputField({
 
 	const isValidCustom = useCallback((input: string) => !compiledRegex || !!input.match(compiledRegex), [compiledRegex])
 
-	// Input value for fuzzy filtering
 	const [inputValue, setInputValue] = useState('')
 
-	// In editing mode the Combobox.Input is controlled so the user can edit the raw value.
-	// undefined = not in editing mode (input is uncontrolled / driven by the Combobox).
-	// string   = focused in editing mode; the ref mirrors it for stale-closure-free reads.
 	const [controlledInputValue, setControlledInputValue] = useState<string | undefined>(undefined)
 	const controlledInputValueRef = useRef<string | undefined>(undefined)
 
@@ -75,20 +65,13 @@ export const DropdownInputField = observer(function DropdownInputField({
 
 	const triggerRef = useRef<HTMLButtonElement>(null)
 
-	// Editing mode: when allowCustom=true and disableEditingCustom=false, focusing the field
-	// pre-fills the input with the raw value so it can be edited directly like a text field.
-	const isEditingMode = !disableEditingCustom && !!allowCustom
+	// isEditingMode: always true when allowCustom (no disableEditingCustom concept here)
+	const isEditingMode = !!allowCustom
 
-	// localDisplayValue mirrors the committed value but is updated synchronously on selection,
-	// staying one render ahead of the parent prop. Without this, selecting "Use XX" clears
-	// inputValue immediately while the parent's MobX value hasn't propagated yet, causing a
-	// flash of the old label.
-	// prevValueProp is not a real value — it is only used to detect when the parent prop
-	// changes so we can reset localDisplayValue (standard React derived-state pattern).
 	const [localDisplayValue, setLocalDisplayValue] = useState<DropdownChoiceId>(value)
 	useEffect(() => setLocalDisplayValue(value), [value])
 
-	const { currentItem, effectiveItems, filteredItems } = useDropdownComboboxItems({
+	const { effectiveItems, filteredItems } = useDropdownComboboxItems({
 		allItems,
 		flatItems,
 		localDisplayValue,
@@ -106,8 +89,6 @@ export const DropdownInputField = observer(function DropdownInputField({
 				setValue(newId)
 				setControlledInput(undefined)
 				setInputValue('')
-
-				// Shift focus to the trigger
 				triggerRef.current?.focus()
 			}
 		},
@@ -117,10 +98,6 @@ export const DropdownInputField = observer(function DropdownInputField({
 	const onInputValueChange = useCallback(
 		(v: string, eventDetails: Combobox.Root.ChangeEventDetails) => {
 			setInputValue(v)
-			// Only mirror into the controlled value when the user is actually typing.
-			// When base-ui resets the input (e.g. popup close, item selection), the reason
-			// is 'none' or 'item-press' — in those cases we must NOT overwrite the raw id
-			// that was pre-filled on focus.
 			if (controlledInputValueRef.current !== undefined && eventDetails.reason === 'input-change') {
 				setControlledInput(v)
 			}
@@ -128,44 +105,44 @@ export const DropdownInputField = observer(function DropdownInputField({
 		[setControlledInput]
 	)
 
-	// On focus in editing mode: pre-fill the controlled input value with the raw id so it can be
-	// edited directly. The controlled inputValue prop on Combobox.Root takes over from base-ui's
-	// itemToStringLabel-based display.
 	const onInputFocus = useCallback(() => {
 		if (!isEditingMode) return
 		setControlledInput(String(localDisplayValue))
 	}, [isEditingMode, localDisplayValue, setControlledInput])
 
-	// On blur: if in editing mode and no item was selected via onValueChange, commit the
-	// current input text as the new value. In search-only mode (disableEditingCustom=true),
-	// just reset the filter and focus state.
 	const onInputBlur = useCallback(() => {
 		if (isEditingMode && controlledInputValueRef.current !== undefined) {
 			setValue(controlledInputValueRef.current)
 			setControlledInput(undefined)
 			setInputValue('')
-		} else if (!isEditingMode && allowCustom) {
-			setInputValue('')
 		}
-		onBlur?.()
-	}, [isEditingMode, allowCustom, setValue, setControlledInput, onBlur])
+	}, [isEditingMode, setValue, setControlledInput])
 
-	// In disableEditingCustom mode, when focused the input is cleared for searching but the
-	// current value is shown as a placeholder so the user knows what's selected.
-	const inputPlaceholder = useMemo(() => {
-		if (!disableEditingCustom || !allowCustom) return undefined
-		return flatItems.find((o) => o.id == localDisplayValue)?.label ?? String(localDisplayValue)
-	}, [disableEditingCustom, allowCustom, localDisplayValue, flatItems])
+	// Paste interception: transforms the pasted value and dispatches a native input event so
+	// base-ui picks up the change via onInputValueChange.
+	const onPaste = useCallback(
+		(e: React.ClipboardEvent<HTMLInputElement>) => {
+			if (!onPasteIntercept || !e.clipboardData) return
+			const rawValue = e.clipboardData.getData('text')
+			const newValue = onPasteIntercept(rawValue)
+
+			// Nothing changed, let default behaviour happen
+			if (newValue === rawValue) return
+
+			e.preventDefault()
+
+			const target = e.currentTarget
+			// eslint-disable-next-line @typescript-eslint/unbound-method
+			const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!
+			nativeInputValueSetter.call(target, newValue)
+
+			target.dispatchEvent(new Event('input', { bubbles: true }))
+		},
+		[onPasteIntercept]
+	)
 
 	return (
-		<div
-			className={classNames(
-				'dropdown-field',
-				{ 'dropdown-field-invalid': !!checkValid && !checkValid(currentItem.id) },
-				className
-			)}
-			title={tooltip}
-		>
+		<div className={classNames('dropdown-field', className)}>
 			<Combobox.Root<DropdownChoiceId>
 				virtualized={!hasGroups}
 				autoHighlight
@@ -175,31 +152,22 @@ export const DropdownInputField = observer(function DropdownInputField({
 				disabled={disabled}
 				onValueChange={onValueChange}
 				onInputValueChange={onInputValueChange}
-				inputValue={
-					isEditingMode
-						? (controlledInputValue ??
-							flatItems.find((o) => o.id == localDisplayValue)?.label ??
-							String(localDisplayValue))
-						: undefined
-				}
-				itemToStringLabel={(id: DropdownChoiceId) => {
-					if (disableEditingCustom && allowCustom) return ''
-					const item = flatItems.find((o) => o.id == id)
-					if (item) return item.label
-					const strId = String(id)
-					if (!allowCustom && strId) return `?? (${strId})`
-					return strId
-				}}
+				inputValue={isEditingMode ? (controlledInputValue ?? String(localDisplayValue)) : undefined}
+				itemToStringLabel={(id: DropdownChoiceId) => String(id)}
 			>
 				<Combobox.InputGroup className="dropdown-field-input-group">
+					{' '}
+					<div className="dropdown-field-fancy-display" aria-hidden="true">
+						<div className="var-name">{String(localDisplayValue) || '\u00A0'}</div>
+						<div className="var-label">
+							{(flatItems.find((o) => o.id == localDisplayValue)?.label ?? String(localDisplayValue)) || '\u00A0'}
+						</div>
+					</div>{' '}
 					<Combobox.Input
-						className={classNames('dropdown-field-input', {
-							'dropdown-field-input-value-placeholder': inputPlaceholder !== undefined,
-						})}
-						name={htmlName}
-						placeholder={inputPlaceholder}
+						className="dropdown-field-input variable-dropdown-edit"
 						onFocus={onInputFocus}
 						onBlur={onInputBlur}
+						onPaste={onPaste}
 					/>
 					<Combobox.Trigger className="dropdown-field-trigger" ref={triggerRef}>
 						<ChevronDownIcon className="dropdown-field-icon" />
@@ -210,6 +178,7 @@ export const DropdownInputField = observer(function DropdownInputField({
 					menuPortal={menuPortal ?? undefined}
 					noOptionsMessage={allowCustom ? 'Begin typing to use a custom value' : undefined}
 					showIndicator={!!allowCustom}
+					fancyFormat={true}
 					virtualized={!hasGroups}
 				/>
 			</Combobox.Root>

--- a/webui/src/Components/VariablePickerField.tsx
+++ b/webui/src/Components/VariablePickerField.tsx
@@ -71,6 +71,8 @@ export const VariablePickerField = observer(function VariablePickerField({
 	const [localDisplayValue, setLocalDisplayValue] = useState<DropdownChoiceId>(value)
 	useEffect(() => setLocalDisplayValue(value), [value])
 
+	const isKnownValue = flatItems.length === 0 || flatItems.some((o) => o.id == localDisplayValue)
+
 	const { effectiveItems, filteredItems } = useDropdownComboboxItems({
 		allItems,
 		flatItems,
@@ -142,7 +144,9 @@ export const VariablePickerField = observer(function VariablePickerField({
 	)
 
 	return (
-		<div className={classNames('dropdown-field', className)}>
+		<div
+			className={classNames('dropdown-field', { 'dropdown-field-warning': !!allowCustom && !isKnownValue }, className)}
+		>
 			<Combobox.Root<DropdownChoiceId>
 				virtualized={!hasGroups}
 				autoHighlight

--- a/webui/src/Components/VariablePickerField.tsx
+++ b/webui/src/Components/VariablePickerField.tsx
@@ -2,13 +2,14 @@ import { Combobox } from '@base-ui/react/combobox'
 import classNames from 'classnames'
 import { ChevronDownIcon } from 'lucide-react'
 import { observer } from 'mobx-react-lite'
-import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useContext, useEffect, useRef, useState } from 'react'
 import type { DropdownChoiceId } from '@companion-app/shared/Model/Common.js'
 import { type DropdownChoicesOrGroups } from './DropdownChoices.js'
 import { DropdownInputPopup } from './DropdownInputField/Popup.js'
 import { useDropdownComboboxItems } from './DropdownInputField/useDropdownComboboxItems.js'
 import { useFuzzyChoices } from './DropdownInputField/useFuzzyChoices.js'
 import { MenuPortalContext } from './MenuPortalContext.js'
+import { useRegex } from './useRegex.js'
 
 interface VariablePickerFieldProps {
 	className?: string
@@ -43,13 +44,7 @@ export const VariablePickerField = observer(function VariablePickerField({
 	const hasGroups = allItems.some((item) => 'items' in item)
 
 	// Compile the regex for custom value validation
-	const compiledRegex = useMemo(() => {
-		if (regex) {
-			const match = regex.match(/^\/(.*)\/(.*)$/)
-			if (match) return new RegExp(match[1], match[2])
-		}
-		return null
-	}, [regex])
+	const compiledRegex = useRegex(regex)
 
 	const isValidCustom = useCallback((input: string) => !compiledRegex || !!input.match(compiledRegex), [compiledRegex])
 

--- a/webui/src/Components/VariableTypeIcon.stories.tsx
+++ b/webui/src/Components/VariableTypeIcon.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { VariableTypeIcon, type VariableTypeIconType } from './VariableTypeIcon'
+
+const meta = {
+	component: VariableTypeIcon,
+	args: {
+		width: 32,
+		height: 32,
+		fill: '#333',
+	},
+} satisfies Meta<typeof VariableTypeIcon>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const StringType: Story = { args: { icon: 'string' } }
+export const NumberType: Story = { args: { icon: 'number' } }
+export const BooleanType: Story = { args: { icon: 'boolean' } }
+export const ObjectType: Story = { args: { icon: 'object' } }
+export const NullType: Story = { args: { icon: 'null' } }
+export const UndefinedType: Story = { args: { icon: 'undefined' } }
+export const UnknownType: Story = { args: { icon: 'unknown' } }
+
+const allIcons: VariableTypeIconType[] = [
+	'string',
+	'number',
+	'boolean',
+	'object',
+	'undefined',
+	'null',
+	'NaN',
+	'regex',
+	'asterisk',
+	'A',
+	'$',
+	'unknown',
+]
+
+export const AllTypes: Story = {
+	render: (args) => (
+		<div style={{ display: 'flex', flexWrap: 'wrap', gap: '12px', alignItems: 'center' }}>
+			{allIcons.map((icon) => (
+				<div key={icon} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4 }}>
+					<VariableTypeIcon {...args} icon={icon} />
+					<span style={{ fontSize: 11, color: '#555' }}>{icon}</span>
+				</div>
+			))}
+		</div>
+	),
+}

--- a/webui/src/Components/VariableValueDisplay.stories.tsx
+++ b/webui/src/Components/VariableValueDisplay.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { VariableValueDisplay } from './VariableValueDisplay'
+
+// All toggleable props are exposed as controls — use the Controls panel to
+// interactively toggle showIcon, showCopy, compact, forceExpanded, maxLines, icon.
+const meta = {
+	component: VariableValueDisplay,
+	args: {
+		value: 'Hello, World!',
+		onCopied: () => {},
+		showIcon: true,
+		showCopy: true,
+		compact: false,
+		forceExpanded: false,
+	},
+} satisfies Meta<typeof VariableValueDisplay>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** String value — all props tweakable via the Controls panel */
+export const Default: Story = {}
+
+/** Multi-line value — shows the collapse/expand affordance */
+export const Multiline: Story = {
+	args: {
+		value: 'Line one\nLine two\nLine three\nLine four\nLine five\nLine six',
+	},
+}
+
+/** Numeric value — shows the number type icon */
+export const NumberValue: Story = {
+	args: { value: 42 },
+}
+
+/** JSON object value — shows the object type icon and JSON formatting */
+export const ObjectValue: Story = {
+	args: { value: { name: 'Companion', version: 3, active: true } },
+}
+
+/** Error state — shown when a variable cannot be resolved */
+export const Invalid: Story = {
+	args: { value: undefined, invalidReason: 'Variable not found' },
+}

--- a/webui/src/Components/__tests__/ColorInputField.test.tsx
+++ b/webui/src/Components/__tests__/ColorInputField.test.tsx
@@ -1,0 +1,294 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { ColorInputField } from '../ColorInputField.js'
+import { MenuPortalContext } from '../MenuPortalContext.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Pack r, g, b into a 24-bit integer (matching the component's encoding).
+function packRgb(r: number, g: number, b: number): number {
+	return (r << 16) | (g << 8) | b
+}
+
+// Pack r, g, b, a into the component's 32-bit format.
+// Alpha is stored in the high byte as 255*(1-a) (inverted).
+function packRgba(r: number, g: number, b: number, a: number): number {
+	return packRgb(r, g, b) + 0x1000000 * Math.round(255 * (1 - a))
+}
+
+interface RenderOptions {
+	value?: number | string
+	enableAlpha?: boolean
+	returnType?: 'number' | 'string'
+	setValue?: (v: number | string) => void
+}
+
+function renderField(opts: RenderOptions = {}) {
+	const setValue = opts.setValue ?? vi.fn()
+	const user = userEvent.setup()
+	const utils = render(
+		<MenuPortalContext.Provider value={document.body}>
+			<ColorInputField
+				returnType={opts.returnType ?? 'number'}
+				value={(opts.value ?? 0xff0000) as never}
+				setValue={setValue as never}
+				enableAlpha={opts.enableAlpha}
+			/>
+		</MenuPortalContext.Provider>
+	)
+	// The swatch is the first div that contains the colour preview.
+	// Structure: container > div[lineHeight:0] > div[swatch, cursor:pointer] > div[color, background:rgba]
+	const swatchDiv = utils.container.querySelector<HTMLDivElement>('[style*="cursor: pointer"]')!
+	// colorDiv is the direct child of swatchDiv (querySelector('[style*="background: rgba"]') is
+	// unreliable because jsdom serialises the background shorthand as background-color in the attribute)
+	const colorDiv = swatchDiv.querySelector<HTMLDivElement>(':scope > div')!
+	return { ...utils, setValue, user, swatchDiv, colorDiv }
+}
+
+async function openPicker(swatchDiv: HTMLDivElement) {
+	await userEvent.click(swatchDiv)
+}
+
+function getHexInput() {
+	return screen.getByLabelText('hex')
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+describe('Rendering (swatch)', () => {
+	it('renders a colour swatch', () => {
+		const { swatchDiv } = renderField()
+		expect(swatchDiv).toBeInTheDocument()
+	})
+
+	it('swatch inner div background reflects the numeric value (pure red = 0xFF0000)', () => {
+		const { colorDiv } = renderField({ value: 0xff0000 })
+		// splitColor(0xFF0000, false) → {r:255, g:0, b:0, a:1}
+		// jsdom normalises rgba(r,g,b,1) → rgb(r,g,b) when alpha=1
+		expect(colorDiv.style.background).toContain('rgb(255, 0, 0)')
+	})
+
+	it('swatch shows pure green for 0x00FF00', () => {
+		const { colorDiv } = renderField({ value: 0x00ff00 })
+		expect(colorDiv.style.background).toContain('rgb(0, 255, 0)')
+	})
+
+	it('swatch shows pure blue for 0x0000FF', () => {
+		const { colorDiv } = renderField({ value: 0x0000ff })
+		expect(colorDiv.style.background).toContain('rgb(0, 0, 255)')
+	})
+
+	it('swatch shows black for value 0', () => {
+		const { colorDiv } = renderField({ value: 0 })
+		expect(colorDiv.style.background).toContain('rgb(0, 0, 0)')
+	})
+
+	it('swatch shows white for value 0xFFFFFF', () => {
+		const { colorDiv } = renderField({ value: 0xffffff })
+		expect(colorDiv.style.background).toContain('rgb(255, 255, 255)')
+	})
+
+	it('accepts a CSS string value and shows the correct colour', () => {
+		const { colorDiv } = renderField({ value: 'rgb(128, 64, 32)' })
+		expect(colorDiv.style.background).toContain('rgb(128, 64, 32)')
+	})
+
+	it('shows colour with alpha when enableAlpha=true and packed number has alpha byte', () => {
+		// 50 % opacity red: high byte = Math.round(255 * 0.5) = 128 → 0x80000000 + 0xFF0000
+		const halfOpacityRed = packRgba(255, 0, 0, 0.5)
+		const { colorDiv } = renderField({ value: halfOpacityRed, enableAlpha: true })
+		// (255 - 128) / 255 ≈ 0.498 due to integer rounding
+		expect(colorDiv.style.background).toMatch(/rgba\(255, 0, 0, 0\.\d+\)/)
+	})
+
+	it('ignores alpha byte in swatch when enableAlpha=false', () => {
+		// Pack a value that has a non-zero alpha byte
+		const halfOpacityRed = packRgba(255, 0, 0, 0.5)
+		const { colorDiv } = renderField({ value: halfOpacityRed, enableAlpha: false })
+		// enableAlpha=false → a is always treated as 1.0
+		expect(colorDiv.style.background).toContain('rgb(255, 0, 0)')
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Picker open / close
+// ---------------------------------------------------------------------------
+
+describe('Picker open / close', () => {
+	it('picker is hidden by default', () => {
+		renderField()
+		expect(screen.queryByLabelText('hex')).toBeNull()
+	})
+
+	it('picker opens when swatch is clicked', async () => {
+		const { swatchDiv } = renderField()
+		await openPicker(swatchDiv)
+		expect(getHexInput()).toBeInTheDocument()
+	})
+
+	it('picker closes when swatch is clicked a second time', async () => {
+		const { swatchDiv, user } = renderField()
+		await user.click(swatchDiv)
+		await user.click(swatchDiv)
+		expect(screen.queryByLabelText('hex')).toBeNull()
+	})
+
+	it('picker closes when clicking outside', async () => {
+		const { swatchDiv } = renderField()
+		await openPicker(swatchDiv)
+		expect(getHexInput()).toBeInTheDocument()
+		// Click somewhere outside both the swatch and the picker
+		await userEvent.click(document.body)
+		expect(screen.queryByLabelText('hex')).toBeNull()
+	})
+})
+
+// ---------------------------------------------------------------------------
+// returnType='number'
+// ---------------------------------------------------------------------------
+
+describe("returnType='number'", () => {
+	it('calls setValue with a packed RGB integer when hex changes (pure green)', async () => {
+		const setValue = vi.fn()
+		const { swatchDiv } = renderField({ value: 0xff0000, returnType: 'number', setValue })
+		await openPicker(swatchDiv)
+		// 0x00FF00 = 65280
+		fireEvent.change(getHexInput(), { target: { value: '00FF00' } })
+		expect(setValue).toHaveBeenLastCalledWith(0x00ff00)
+	})
+
+	it('calls setValue with a packed RGB integer for pure red', async () => {
+		const setValue = vi.fn()
+		const { swatchDiv } = renderField({ value: 0x000000, returnType: 'number', setValue })
+		await openPicker(swatchDiv)
+		fireEvent.change(getHexInput(), { target: { value: 'FF0000' } })
+		expect(setValue).toHaveBeenLastCalledWith(0xff0000)
+	})
+
+	it('does NOT include an alpha byte when enableAlpha=false, even if alpha is dragged', async () => {
+		const setValue = vi.fn()
+		// Use 0x000000 as initial value so changing hex to FF0000 is a real change
+		const { swatchDiv } = renderField({ value: 0x000000, returnType: 'number', enableAlpha: false, setValue })
+		await openPicker(swatchDiv)
+		fireEvent.change(getHexInput(), { target: { value: 'FF0000' } })
+		// With enableAlpha=false the high 8 bits must be 0
+		const lastCall = setValue.mock.calls.at(-1)![0] as number
+		expect(lastCall & 0xff000000).toBe(0)
+		expect(lastCall).toBe(0xff0000)
+	})
+
+	it('includes alpha byte in return value when enableAlpha=true and alpha < 1', async () => {
+		const setValue = vi.fn()
+		// Start with a fully-opaque red
+		const { swatchDiv } = renderField({ value: 0xff0000, returnType: 'number', enableAlpha: true, setValue })
+		await openPicker(swatchDiv)
+
+		// Decrease alpha via the alpha input to 50 (as a percentage integer, 0-100)
+		const alphaInput = screen.getByLabelText('a')
+		fireEvent.change(alphaInput, { target: { value: '50' } })
+
+		const lastCall = setValue.mock.calls.at(-1)![0] as number
+		// The high byte should be non-zero when alpha < 1.
+		// Use unsigned right shift (>>>) to extract the high byte as an unsigned value;
+		// bitwise & on its own yields a signed 32-bit integer (0x80000000 = -2147483648).
+		expect(lastCall >>> 24).toBeGreaterThan(0)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// returnType='string'
+// ---------------------------------------------------------------------------
+
+describe("returnType='string'", () => {
+	it('calls setValue with an rgba() string when hex changes', async () => {
+		const setValue = vi.fn()
+		const { swatchDiv } = renderField({ value: 0x000000, returnType: 'string', setValue })
+		await openPicker(swatchDiv)
+		fireEvent.change(getHexInput(), { target: { value: 'FF0000' } })
+		expect(setValue).toHaveBeenLastCalledWith('rgba(255, 0, 0, 1)')
+	})
+
+	it('returned string includes alpha when enableAlpha=true', async () => {
+		const setValue = vi.fn()
+		const { swatchDiv } = renderField({
+			value: 'rgba(255, 0, 0, 1)',
+			returnType: 'string',
+			enableAlpha: true,
+			setValue,
+		})
+		await openPicker(swatchDiv)
+		const alphaInput = screen.getByLabelText('a')
+		fireEvent.change(alphaInput, { target: { value: '50' } })
+
+		const lastCall = setValue.mock.calls.at(-1)![0] as string
+		// Should contain rgba(…) with alpha ≈ 0.5
+		expect(lastCall).toMatch(/^rgba\(255, 0, 0, 0\.\d+\)$/)
+	})
+
+	it('alpha field is hidden from the picker when enableAlpha=false', async () => {
+		const { swatchDiv } = renderField({ returnType: 'string', enableAlpha: false })
+		await openPicker(swatchDiv)
+		expect(screen.queryByLabelText('a')).toBeNull()
+	})
+
+	it('alpha field is visible in the picker when enableAlpha=true', async () => {
+		const { swatchDiv } = renderField({ returnType: 'string', enableAlpha: true })
+		await openPicker(swatchDiv)
+		expect(screen.getByLabelText('a')).toBeInTheDocument()
+	})
+
+	it('rgba string always includes a numeric alpha value (guarded by ?? 1)', async () => {
+		const setValue = vi.fn()
+		const { swatchDiv } = renderField({ value: 0x000000, returnType: 'string', setValue })
+		await openPicker(swatchDiv)
+		fireEvent.change(getHexInput(), { target: { value: 'FF0000' } })
+		const result = setValue.mock.calls.at(-1)![0] as string
+		expect(result).not.toContain('undefined')
+		expect(result).toMatch(/^rgba\(\d+, \d+, \d+, [\d.]+\)$/)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Alpha encoding / round-trip
+// ---------------------------------------------------------------------------
+
+describe('Alpha round-trip (number encoding)', () => {
+	it('packs and unpacks pure red with full opacity', () => {
+		const packed = packRgb(255, 0, 0)
+		const { colorDiv } = renderField({ value: packed, enableAlpha: true })
+		expect(colorDiv.style.background).toContain('rgb(255, 0, 0)')
+	})
+
+	it('packs and unpacks with 0% opacity (fully transparent)', () => {
+		// alpha=0 → high byte = 255 → Math.round(255*(1-0)) = 255
+		const packed = packRgba(255, 0, 0, 0)
+		const { colorDiv } = renderField({ value: packed, enableAlpha: true })
+		expect(colorDiv.style.background).toContain('rgba(255, 0, 0, 0)')
+	})
+
+	// NOTE: alpha=0.5 → stored as byte 128 → decoded as (255-128)/255 = 127/255 ≈ 0.498.
+	// There is inherent precision loss in the round-trip due to integer rounding.
+	it('alpha 0.5 round-trip has slight precision loss (byte-rounding artefact)', () => {
+		const packed = packRgba(255, 0, 0, 0.5)
+		const { colorDiv } = renderField({ value: packed, enableAlpha: true })
+		// Should NOT be exactly 0.5 due to rounding
+		expect(colorDiv.style.background).not.toContain('rgba(255, 0, 0, 0.5)')
+		expect(colorDiv.style.background).toMatch(/rgba\(255, 0, 0, 0\.4\d+\)/)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+describe('Edge cases', () => {
+	it('empty-string value is treated as 0 (black) — acceptable fallback', () => {
+		const { colorDiv } = renderField({ value: '' })
+		expect(colorDiv.style.background).toContain('rgb(0, 0, 0)')
+	})
+})

--- a/webui/src/Components/__tests__/DropdownInputField.test.tsx
+++ b/webui/src/Components/__tests__/DropdownInputField.test.tsx
@@ -27,9 +27,7 @@ interface RenderOptions {
 	regex?: string
 	disabled?: boolean
 	onBlur?: () => void
-	onPasteIntercept?: (v: string) => string
 	checkValid?: (v: DropdownChoiceId) => boolean
-	fancyFormat?: boolean
 	searchLabelsOnly?: boolean
 }
 
@@ -231,6 +229,7 @@ describe('Fuzzy filtering', () => {
 	it('shows empty message when no options match', async () => {
 		const { user, input } = renderField()
 		await user.click(input)
+		await user.clear(input)
 		await user.type(input, 'zzzzz')
 		expect(screen.getByText('No options found.')).toBeInTheDocument()
 	})
@@ -239,6 +238,7 @@ describe('Fuzzy filtering', () => {
 		// regex ensures 'zzzzz' fails validation → no synthetic item → filteredItems empty → Empty renders
 		const { user, input } = renderField({ allowCustom: true, regex: '/^\\d+$/' })
 		await user.click(input)
+		await user.clear(input)
 		await user.type(input, 'zzzzz')
 		expect(screen.getAllByText('Begin typing to use a custom value').length).toBeGreaterThan(0)
 	})
@@ -246,6 +246,7 @@ describe('Fuzzy filtering', () => {
 	it('matches by id when searchLabelsOnly=false', async () => {
 		const { user, input } = renderField({ searchLabelsOnly: false })
 		await user.click(input)
+		await user.clear(input)
 		await user.type(input, 'apple')
 		const list = getListbox()
 		expect(within(list).getByText('Apple')).toBeInTheDocument()
@@ -392,75 +393,69 @@ describe('onBlur callback', () => {
 })
 
 // ---------------------------------------------------------------------------
-// onPasteIntercept
+// Grouped choices — interactions
 // ---------------------------------------------------------------------------
 
-describe('onPasteIntercept', () => {
-	it('transforms pasted text using onPasteIntercept', async () => {
-		const setValue = vi.fn()
-		const { user, input } = renderField({
-			allowCustom: true,
-			disableEditingCustom: false,
-			setValue,
-			onPasteIntercept: (v) => v.toUpperCase(),
-		})
-		await user.click(input)
-		await user.clear(input)
-		await user.paste('hello')
-		// The intercept uppercases the value, so the synthetic item should show the transformed string
-		expect(screen.getByText(/Use "HELLO"/)).toBeInTheDocument()
-	})
-
-	it('does not double-fire when onPasteIntercept returns unchanged value', async () => {
-		const onPasteIntercept = vi.fn((v: string) => v)
-		const { user, input } = renderField({
-			allowCustom: true,
-			disableEditingCustom: false,
-			onPasteIntercept,
-		})
-		await user.click(input)
-		await user.clear(input)
-		await user.paste('apple')
-		expect(onPasteIntercept).toHaveBeenCalledTimes(1)
-	})
-})
-
-// ---------------------------------------------------------------------------
-// fancyFormat
-// ---------------------------------------------------------------------------
-
-describe('fancyFormat=true', () => {
-	const fancyChoices = [
-		{ id: 'internal:time_hms', label: 'Current time (HH:MM:SS)' },
-		{ id: 'internal:date_y', label: 'Current year' },
+describe('Grouped choices — interactions', () => {
+	const GROUPED = [
+		{
+			label: 'Fruits',
+			options: [
+				{ id: 'apple', label: 'Apple' },
+				{ id: 'apricot', label: 'Apricot' },
+			],
+		},
+		{
+			label: 'Veggies',
+			options: [
+				{ id: 'carrot', label: 'Carrot' },
+				{ id: 'celery', label: 'Celery' },
+			],
+		},
 	]
 
-	it('renders two lines per item: var-name (id) and var-label (label)', async () => {
-		const user = userEvent.setup()
-		render(
-			<MenuPortalContext.Provider value={document.body}>
-				<DropdownInputField choices={fancyChoices} value="internal:time_hms" setValue={vi.fn()} fancyFormat />
-			</MenuPortalContext.Provider>
-		)
+	it('calls setValue with the correct id when selecting an item from inside a group', async () => {
+		const setValue = vi.fn()
+		const { user } = renderField({ choices: GROUPED, setValue, initialValue: 'apple' })
 		await user.click(screen.getByRole('button'))
-		const list = getListbox()
-		expect(list.querySelector('.var-name')).toBeInTheDocument()
-		expect(list.querySelector('.var-label')).toBeInTheDocument()
+		await user.click(within(getListbox()).getByText('Carrot'))
+		expect(setValue).toHaveBeenCalledWith('carrot')
 	})
 
-	it('searches both id and label (searchLabelsOnly forced false)', async () => {
-		const user = userEvent.setup()
-		render(
-			<MenuPortalContext.Provider value={document.body}>
-				<DropdownInputField choices={fancyChoices} value="internal:time_hms" setValue={vi.fn()} fancyFormat />
-			</MenuPortalContext.Provider>
-		)
-		const input = screen.getByRole('combobox')
+	it('displays the label of a value that lives inside a group', () => {
+		const { input } = renderField({ choices: GROUPED, initialValue: 'carrot' })
+		expect(input).toHaveValue('Carrot')
+	})
+
+	it('removes an entire group from the popup when none of its items match the filter', async () => {
+		const { user, input } = renderField({ choices: GROUPED, initialValue: 'apple' })
 		await user.click(input)
 		await user.clear(input)
-		await user.type(input, 'internal:date')
+		await user.type(input, 'appl')
 		const list = getListbox()
-		expect(within(list).getByText('Current year')).toBeInTheDocument()
-		expect(within(list).queryByText('Current time (HH:MM:SS)')).toBeNull()
+		expect(within(list).queryByText('Veggies')).toBeNull()
+	})
+
+	it('keeps a group in the popup but hides non-matching items within it', async () => {
+		const { user, input } = renderField({ choices: GROUPED, initialValue: 'apple' })
+		await user.click(input)
+		await user.clear(input)
+		await user.type(input, 'cel')
+		const list = getListbox()
+		expect(within(list).getByText('Celery')).toBeInTheDocument()
+		expect(within(list).queryByText('Carrot')).toBeNull()
+	})
+
+	it('still shows the synthetic "Use X" item when allowCustom=true and choices are all grouped', async () => {
+		const { user, input } = renderField({
+			choices: GROUPED,
+			allowCustom: true,
+			disableEditingCustom: false,
+			initialValue: 'apple',
+		})
+		await user.click(input)
+		await user.clear(input)
+		await user.type(input, 'custom-grouped')
+		expect(screen.getByText(/Use "custom-grouped"/)).toBeInTheDocument()
 	})
 })

--- a/webui/src/Components/__tests__/DropdownInputField.test.tsx
+++ b/webui/src/Components/__tests__/DropdownInputField.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 import type { DropdownChoiceId } from '@companion-app/shared/Model/Common.js'
 import type { DropdownChoicesOrGroups } from '../DropdownChoices.js'
@@ -108,6 +108,35 @@ describe('Rendering (static)', () => {
 
 	it('does not apply dropdown-field-invalid class when no checkValid is provided', () => {
 		const { container } = renderField()
+		expect(container.querySelector('.dropdown-field-invalid')).toBeNull()
+	})
+
+	it('applies dropdown-field-invalid when value is not in choices and no checkValid', () => {
+		const { container } = renderField({ initialValue: 'unknown-id' as DropdownChoiceId })
+		expect(container.querySelector('.dropdown-field-invalid')).toBeTruthy()
+	})
+
+	it('applies dropdown-field-invalid for unknown value even when checkValid returns true', () => {
+		const { container } = renderField({
+			initialValue: 'unknown-id' as DropdownChoiceId,
+			checkValid: () => true,
+		})
+		expect(container.querySelector('.dropdown-field-invalid')).toBeTruthy()
+	})
+
+	it('does not apply dropdown-field-invalid for unknown value when there are no options', () => {
+		const { container } = renderField({
+			choices: [],
+			initialValue: 'unknown-id' as DropdownChoiceId,
+		})
+		expect(container.querySelector('.dropdown-field-invalid')).toBeNull()
+	})
+
+	it('does not apply dropdown-field-invalid for a custom value not in choices when allowCustom=true', () => {
+		const { container } = renderField({
+			initialValue: 'my-custom' as DropdownChoiceId,
+			allowCustom: true,
+		})
 		expect(container.querySelector('.dropdown-field-invalid')).toBeNull()
 	})
 })

--- a/webui/src/Components/__tests__/DropdownInputField.test.tsx
+++ b/webui/src/Components/__tests__/DropdownInputField.test.tsx
@@ -488,3 +488,76 @@ describe('Grouped choices — interactions', () => {
 		expect(screen.getByText(/Use "custom-grouped"/)).toBeInTheDocument()
 	})
 })
+
+// ---------------------------------------------------------------------------
+// Type preservation (numeric DropdownChoiceId must not become a string)
+// ---------------------------------------------------------------------------
+
+describe('Type preservation on focus/blur (editing mode)', () => {
+	const NUMERIC_CHOICES = [
+		{ id: 1, label: 'One' },
+		{ id: 2, label: 'Two' },
+		{ id: 3, label: 'Three' },
+	]
+
+	it('preserves a numeric id when the user focuses and blurs without typing', async () => {
+		const setValue = vi.fn()
+		const user = userEvent.setup()
+		render(
+			<MenuPortalContext.Provider value={document.body}>
+				<DropdownInputField
+					choices={NUMERIC_CHOICES}
+					allowCustom={true}
+					disableEditingCustom={false}
+					value={1}
+					setValue={setValue}
+				/>
+			</MenuPortalContext.Provider>
+		)
+		const input = screen.getByRole('combobox')
+		await user.click(input)
+		await user.tab()
+		expect(setValue).toHaveBeenCalledTimes(1)
+		const committed = setValue.mock.calls[0][0]
+		expect(committed).toBe(1)
+		expect(typeof committed).toBe('number')
+	})
+
+	it('preserves a string id when the user focuses and blurs without typing', async () => {
+		const setValue = vi.fn()
+		const { user, input } = renderField({
+			allowCustom: true,
+			disableEditingCustom: false,
+			setValue,
+			initialValue: 'apple',
+		})
+		await user.click(input)
+		await user.tab()
+		expect(setValue).toHaveBeenCalledTimes(1)
+		const committed = setValue.mock.calls[0][0]
+		expect(committed).toBe('apple')
+		expect(typeof committed).toBe('string')
+	})
+
+	it('passes a string when the user actually edits the value', async () => {
+		const setValue = vi.fn()
+		const user = userEvent.setup()
+		render(
+			<MenuPortalContext.Provider value={document.body}>
+				<DropdownInputField
+					choices={NUMERIC_CHOICES}
+					allowCustom={true}
+					disableEditingCustom={false}
+					value={1}
+					setValue={setValue}
+				/>
+			</MenuPortalContext.Provider>
+		)
+		const input = screen.getByRole('combobox')
+		await user.click(input)
+		await user.clear(input)
+		await user.type(input, '99')
+		await user.tab()
+		expect(setValue).toHaveBeenCalledWith('99')
+	})
+})

--- a/webui/src/Components/__tests__/DropdownInputField.test.tsx
+++ b/webui/src/Components/__tests__/DropdownInputField.test.tsx
@@ -1,0 +1,466 @@
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React, { useState } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import type { DropdownChoiceId } from '@companion-app/shared/Model/Common.js'
+import type { DropdownChoicesOrGroups } from '../DropdownChoices.js'
+import { DropdownInputField } from '../DropdownInputField.js'
+import { MenuPortalContext } from '../MenuPortalContext.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CHOICES = [
+	{ id: 'apple', label: 'Apple' },
+	{ id: 'banana', label: 'Banana' },
+	{ id: 'cherry', label: 'Cherry' },
+	{ id: 'date', label: 'Date' },
+	{ id: 'elderberry', label: 'Elderberry' },
+]
+
+interface RenderOptions {
+	choices?: DropdownChoicesOrGroups
+	value?: DropdownChoiceId
+	allowCustom?: boolean
+	disableEditingCustom?: boolean
+	regex?: string
+	disabled?: boolean
+	onBlur?: () => void
+	onPasteIntercept?: (v: string) => string
+	checkValid?: (v: DropdownChoiceId) => boolean
+	fancyFormat?: boolean
+	searchLabelsOnly?: boolean
+}
+
+/** Controlled wrapper so the component's value updates on setValue calls */
+function ControlledDropdown({
+	initialValue = 'apple',
+	setValue: externalSetValue,
+	...rest
+}: RenderOptions & { initialValue?: DropdownChoiceId; setValue?: (v: DropdownChoiceId) => void }) {
+	const [value, setValue] = useState<DropdownChoiceId>(initialValue)
+	return (
+		<MenuPortalContext.Provider value={document.body}>
+			<DropdownInputField
+				choices={CHOICES}
+				{...rest}
+				value={value}
+				setValue={(v) => {
+					setValue(v)
+					externalSetValue?.(v)
+				}}
+			/>
+		</MenuPortalContext.Provider>
+	)
+}
+
+function renderField(
+	opts: RenderOptions & { initialValue?: DropdownChoiceId; setValue?: (v: DropdownChoiceId) => void } = {}
+) {
+	const setValue = opts.setValue ?? vi.fn()
+	const user = userEvent.setup()
+	const utils = render(<ControlledDropdown {...opts} setValue={setValue} initialValue={opts.initialValue ?? 'apple'} />)
+	const input = utils.getByRole('combobox')
+	return { ...utils, input, setValue, user }
+}
+
+function getListbox() {
+	return screen.getByRole('listbox')
+}
+
+function queryListbox() {
+	return screen.queryByRole('listbox')
+}
+
+// ---------------------------------------------------------------------------
+// Rendering — static
+// ---------------------------------------------------------------------------
+
+describe('Rendering (static)', () => {
+	it('shows the label of the current value in the input', () => {
+		const { input } = renderField({ initialValue: 'banana' })
+		expect(input).toHaveValue('Banana')
+	})
+
+	it('shows ?? (id) label for a value not in choices list when allowCustom is false', () => {
+		const { input } = renderField({ initialValue: 'unknown-id' as DropdownChoiceId })
+		expect(input).toHaveValue('?? (unknown-id)')
+	})
+
+	it('shows the raw value when allowCustom is true and value is not in choices', () => {
+		const { input } = renderField({ initialValue: 'my-custom' as DropdownChoiceId, allowCustom: true })
+		expect(input).toHaveValue('my-custom')
+	})
+
+	it('has a disabled input when disabled=true', () => {
+		const { input } = renderField({ disabled: true })
+		expect(input).toBeDisabled()
+	})
+
+	it('applies dropdown-field-invalid class when checkValid returns false', () => {
+		const { container } = renderField({ checkValid: () => false })
+		expect(container.querySelector('.dropdown-field-invalid')).toBeTruthy()
+	})
+
+	it('does not apply dropdown-field-invalid class when checkValid returns true', () => {
+		const { container } = renderField({ checkValid: () => true })
+		expect(container.querySelector('.dropdown-field-invalid')).toBeNull()
+	})
+
+	it('does not apply dropdown-field-invalid class when no checkValid is provided', () => {
+		const { container } = renderField()
+		expect(container.querySelector('.dropdown-field-invalid')).toBeNull()
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Popup open / close
+// ---------------------------------------------------------------------------
+
+describe('Popup open / close', () => {
+	it('opens the listbox when clicking the chevron trigger', async () => {
+		const { user } = renderField()
+		const trigger = screen.getByRole('button')
+		await user.click(trigger)
+		expect(getListbox()).toBeInTheDocument()
+	})
+
+	it('closes the listbox when clicking the trigger a second time', async () => {
+		const { user } = renderField()
+		const trigger = screen.getByRole('button')
+		await user.click(trigger)
+		await user.click(trigger)
+		expect(queryListbox()).toBeNull()
+	})
+
+	it('closes the listbox when pressing Escape', async () => {
+		const { user } = renderField()
+		const trigger = screen.getByRole('button')
+		await user.click(trigger)
+		expect(getListbox()).toBeInTheDocument()
+		await user.keyboard('{Escape}')
+		expect(queryListbox()).toBeNull()
+	})
+
+	it('shows all flat choices in the open popup', async () => {
+		const { user } = renderField()
+		await user.click(screen.getByRole('button'))
+		const list = getListbox()
+		for (const c of CHOICES) {
+			expect(within(list).getByText(c.label)).toBeInTheDocument()
+		}
+	})
+
+	it('renders grouped choices with group labels', async () => {
+		const { user } = renderField({
+			choices: [
+				{ label: 'Fruits', options: [{ id: 'apple', label: 'Apple' }] },
+				{ label: 'Veggies', options: [{ id: 'carrot', label: 'Carrot' }] },
+			],
+			initialValue: 'apple',
+		})
+		await user.click(screen.getByRole('button'))
+		const list = getListbox()
+		expect(within(list).getByText('Fruits')).toBeInTheDocument()
+		expect(within(list).getByText('Veggies')).toBeInTheDocument()
+		expect(within(list).getByText('Apple')).toBeInTheDocument()
+		expect(within(list).getByText('Carrot')).toBeInTheDocument()
+	})
+
+	it('renders object-shaped (Record) choices', async () => {
+		const { user } = renderField({
+			choices: {
+				a: { id: 'a', label: 'Alpha' },
+				b: { id: 'b', label: 'Beta' },
+			},
+			initialValue: 'a',
+		})
+		await user.click(screen.getByRole('button'))
+		const list = getListbox()
+		expect(within(list).getByText('Alpha')).toBeInTheDocument()
+		expect(within(list).getByText('Beta')).toBeInTheDocument()
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Selection
+// ---------------------------------------------------------------------------
+
+describe('Selection', () => {
+	it('calls setValue with the item id when clicking an option', async () => {
+		const setValue = vi.fn()
+		const { user } = renderField({ setValue })
+		await user.click(screen.getByRole('button'))
+		await user.click(within(getListbox()).getByText('Banana'))
+		expect(setValue).toHaveBeenCalledWith('banana')
+	})
+
+	it('updates the input display after mouse selection', async () => {
+		const { user, input } = renderField()
+		await user.click(screen.getByRole('button'))
+		await user.click(within(getListbox()).getByText('Cherry'))
+		expect(input).toHaveValue('Cherry')
+	})
+
+	it('selects an item via keyboard Arrow + Enter', async () => {
+		const setValue = vi.fn()
+		const { user, input } = renderField({ setValue })
+		await user.click(input)
+		await user.keyboard('{ArrowDown}')
+		await user.keyboard('{Enter}')
+		expect(setValue).toHaveBeenCalledTimes(1)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Fuzzy filtering
+// ---------------------------------------------------------------------------
+
+describe('Fuzzy filtering', () => {
+	it('hides non-matching options when typing', async () => {
+		const { user, input } = renderField()
+		await user.click(input)
+		await user.clear(input)
+		await user.type(input, 'ban')
+		const list = getListbox()
+		expect(within(list).getByText('Banana')).toBeInTheDocument()
+		expect(within(list).queryByText('Apple')).toBeNull()
+	})
+
+	it('shows empty message when no options match', async () => {
+		const { user, input } = renderField()
+		await user.click(input)
+		await user.type(input, 'zzzzz')
+		expect(screen.getByText('No options found.')).toBeInTheDocument()
+	})
+
+	it('shows custom noOptionsMessage when provided', async () => {
+		// regex ensures 'zzzzz' fails validation → no synthetic item → filteredItems empty → Empty renders
+		const { user, input } = renderField({ allowCustom: true, regex: '/^\\d+$/' })
+		await user.click(input)
+		await user.type(input, 'zzzzz')
+		expect(screen.getAllByText('Begin typing to use a custom value').length).toBeGreaterThan(0)
+	})
+
+	it('matches by id when searchLabelsOnly=false', async () => {
+		const { user, input } = renderField({ searchLabelsOnly: false })
+		await user.click(input)
+		await user.type(input, 'apple')
+		const list = getListbox()
+		expect(within(list).getByText('Apple')).toBeInTheDocument()
+	})
+})
+
+// ---------------------------------------------------------------------------
+// allowCustom=true, disableEditingCustom=false (editing mode)
+// ---------------------------------------------------------------------------
+
+describe('allowCustom=true, disableEditingCustom=false (editing mode)', () => {
+	it('pre-fills the input with the raw value id on focus', async () => {
+		const { user, input } = renderField({
+			allowCustom: true,
+			disableEditingCustom: false,
+			initialValue: 'apple',
+		})
+		await user.click(input)
+		expect(input).toHaveValue('apple')
+	})
+
+	it('shows the Use "X" synthetic item when typing a value not in choices', async () => {
+		const { user, input } = renderField({ allowCustom: true, disableEditingCustom: false })
+		await user.click(input)
+		await user.clear(input)
+		await user.type(input, 'my-custom-val')
+		expect(screen.getByText(/Use "my-custom-val"/)).toBeInTheDocument()
+	})
+
+	it('does not show Use "X" when input exactly matches an existing id', async () => {
+		const { user, input } = renderField({ allowCustom: true, disableEditingCustom: false })
+		await user.click(input)
+		await user.clear(input)
+		await user.type(input, 'apple')
+		expect(screen.queryByText(/Use "apple"/)).toBeNull()
+	})
+
+	it('calls setValue with the typed text when selecting the synthetic item', async () => {
+		const setValue = vi.fn()
+		const { user, input } = renderField({ allowCustom: true, disableEditingCustom: false, setValue })
+		await user.click(input)
+		await user.clear(input)
+		await user.type(input, 'custom-value')
+		await user.click(screen.getByText(/Use "custom-value"/))
+		expect(setValue).toHaveBeenCalledWith('custom-value')
+	})
+
+	it('commits the typed text via setValue on blur (no selection made)', async () => {
+		const setValue = vi.fn()
+		const { user, input } = renderField({ allowCustom: true, disableEditingCustom: false, setValue })
+		await user.click(input)
+		await user.clear(input)
+		await user.type(input, 'blur-value')
+		await user.tab()
+		expect(setValue).toHaveBeenCalledWith('blur-value')
+	})
+
+	it('hides synthetic item when typed value fails regex', async () => {
+		const { user, input } = renderField({
+			allowCustom: true,
+			disableEditingCustom: false,
+			regex: '/^\\d+$/',
+		})
+		await user.click(input)
+		await user.clear(input)
+		await user.type(input, 'notanumber')
+		expect(screen.queryByText(/Use "notanumber"/)).toBeNull()
+	})
+
+	it('shows synthetic item when typed value passes regex', async () => {
+		const { user, input } = renderField({
+			allowCustom: true,
+			disableEditingCustom: false,
+			regex: '/^\\d+$/',
+		})
+		await user.click(input)
+		await user.clear(input)
+		await user.type(input, '12345')
+		expect(screen.getByText(/Use "12345"/)).toBeInTheDocument()
+	})
+})
+
+// ---------------------------------------------------------------------------
+// allowCustom=true, disableEditingCustom=true (search-only custom mode)
+// ---------------------------------------------------------------------------
+
+describe('allowCustom=true, disableEditingCustom=true (search-only custom mode)', () => {
+	it('shows the current label as placeholder when focused', async () => {
+		const { user, input } = renderField({
+			allowCustom: true,
+			disableEditingCustom: true,
+			initialValue: 'banana',
+		})
+		await user.click(input)
+		expect(input).toHaveAttribute('placeholder', 'Banana')
+	})
+
+	it('does not call setValue on blur without a selection', async () => {
+		const setValue = vi.fn()
+		const { user, input } = renderField({
+			allowCustom: true,
+			disableEditingCustom: true,
+			setValue,
+		})
+		await user.click(input)
+		await user.type(input, 'some text')
+		await user.tab()
+		expect(setValue).not.toHaveBeenCalled()
+	})
+
+	it('calls setValue when selecting an option from the list', async () => {
+		const setValue = vi.fn()
+		const { user, input } = renderField({
+			allowCustom: true,
+			disableEditingCustom: true,
+			setValue,
+		})
+		await user.click(input)
+		await user.click(within(getListbox()).getByText('Cherry'))
+		expect(setValue).toHaveBeenCalledWith('cherry')
+	})
+})
+
+// ---------------------------------------------------------------------------
+// onBlur callback
+// ---------------------------------------------------------------------------
+
+describe('onBlur callback', () => {
+	it('calls onBlur when the input loses focus (standard mode)', async () => {
+		const onBlur = vi.fn()
+		const { user, input } = renderField({ onBlur })
+		await user.click(input)
+		await user.tab()
+		expect(onBlur).toHaveBeenCalledTimes(1)
+	})
+
+	it('calls onBlur when the input loses focus (editing mode)', async () => {
+		const onBlur = vi.fn()
+		const { user, input } = renderField({ allowCustom: true, disableEditingCustom: false, onBlur })
+		await user.click(input)
+		await user.tab()
+		expect(onBlur).toHaveBeenCalledTimes(1)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// onPasteIntercept
+// ---------------------------------------------------------------------------
+
+describe('onPasteIntercept', () => {
+	it('transforms pasted text using onPasteIntercept', async () => {
+		const setValue = vi.fn()
+		const { user, input } = renderField({
+			allowCustom: true,
+			disableEditingCustom: false,
+			setValue,
+			onPasteIntercept: (v) => v.toUpperCase(),
+		})
+		await user.click(input)
+		await user.clear(input)
+		await user.paste('hello')
+		// The intercept uppercases the value, so the synthetic item should show the transformed string
+		expect(screen.getByText(/Use "HELLO"/)).toBeInTheDocument()
+	})
+
+	it('does not double-fire when onPasteIntercept returns unchanged value', async () => {
+		const onPasteIntercept = vi.fn((v: string) => v)
+		const { user, input } = renderField({
+			allowCustom: true,
+			disableEditingCustom: false,
+			onPasteIntercept,
+		})
+		await user.click(input)
+		await user.clear(input)
+		await user.paste('apple')
+		expect(onPasteIntercept).toHaveBeenCalledTimes(1)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// fancyFormat
+// ---------------------------------------------------------------------------
+
+describe('fancyFormat=true', () => {
+	const fancyChoices = [
+		{ id: 'internal:time_hms', label: 'Current time (HH:MM:SS)' },
+		{ id: 'internal:date_y', label: 'Current year' },
+	]
+
+	it('renders two lines per item: var-name (id) and var-label (label)', async () => {
+		const user = userEvent.setup()
+		render(
+			<MenuPortalContext.Provider value={document.body}>
+				<DropdownInputField choices={fancyChoices} value="internal:time_hms" setValue={vi.fn()} fancyFormat />
+			</MenuPortalContext.Provider>
+		)
+		await user.click(screen.getByRole('button'))
+		const list = getListbox()
+		expect(list.querySelector('.var-name')).toBeInTheDocument()
+		expect(list.querySelector('.var-label')).toBeInTheDocument()
+	})
+
+	it('searches both id and label (searchLabelsOnly forced false)', async () => {
+		const user = userEvent.setup()
+		render(
+			<MenuPortalContext.Provider value={document.body}>
+				<DropdownInputField choices={fancyChoices} value="internal:time_hms" setValue={vi.fn()} fancyFormat />
+			</MenuPortalContext.Provider>
+		)
+		const input = screen.getByRole('combobox')
+		await user.click(input)
+		await user.clear(input)
+		await user.type(input, 'internal:date')
+		const list = getListbox()
+		expect(within(list).getByText('Current year')).toBeInTheDocument()
+		expect(within(list).queryByText('Current time (HH:MM:SS)')).toBeNull()
+	})
+})

--- a/webui/src/Components/__tests__/DropdownInputFieldSimple.test.tsx
+++ b/webui/src/Components/__tests__/DropdownInputFieldSimple.test.tsx
@@ -1,0 +1,464 @@
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import type { DropdownChoiceId } from '@companion-app/shared/Model/Common.js'
+import type { DropdownChoicesOrGroups } from '../DropdownChoices.js'
+import { SimpleDropdownInputField } from '../DropdownInputFieldSimple.js'
+import { MenuPortalContext } from '../MenuPortalContext.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CHOICES: DropdownChoicesOrGroups = [
+	{ id: 'apple', label: 'Apple' },
+	{ id: 'banana', label: 'Banana' },
+	{ id: 'cherry', label: 'Cherry' },
+	{ id: 'date', label: 'Date' },
+]
+
+const NUMERIC_CHOICES: DropdownChoicesOrGroups = [
+	{ id: 1, label: 'One' },
+	{ id: 2, label: 'Two' },
+	{ id: 3, label: 'Three' },
+]
+
+// Choices that contain both numeric 1 and string '1' as distinct IDs.
+const AMBIGUOUS_CHOICES: DropdownChoicesOrGroups = [
+	{ id: 1, label: 'One (number)' },
+	{ id: '1', label: 'One (string)' },
+	{ id: 2, label: 'Two' },
+]
+
+const GROUPED_CHOICES: DropdownChoicesOrGroups = [
+	{
+		label: 'Fruits',
+		options: [
+			{ id: 'apple', label: 'Apple' },
+			{ id: 'banana', label: 'Banana' },
+		],
+	},
+	{
+		label: 'Veggies',
+		options: [
+			{ id: 'carrot', label: 'Carrot' },
+			{ id: 'daikon', label: 'Daikon' },
+		],
+	},
+]
+
+interface RenderOptions {
+	choices?: DropdownChoicesOrGroups
+	value?: DropdownChoiceId
+	disabled?: boolean
+	checkValid?: (v: DropdownChoiceId) => boolean
+	noOptionsMessage?: string
+	badOptionPrefix?: string
+	onBlur?: () => void
+}
+
+/** Controlled wrapper so the component's value updates on setValue calls. */
+function ControlledSimple({
+	initialValue = 'apple',
+	setValue: externalSetValue,
+	choices = CHOICES,
+	...rest
+}: RenderOptions & { initialValue?: DropdownChoiceId; setValue?: (v: DropdownChoiceId) => void }) {
+	const [value, setValue] = useState<DropdownChoiceId>(initialValue)
+	return (
+		<MenuPortalContext.Provider value={document.body}>
+			<SimpleDropdownInputField
+				choices={choices}
+				{...rest}
+				value={value}
+				setValue={(v) => {
+					setValue(v)
+					externalSetValue?.(v)
+				}}
+			/>
+		</MenuPortalContext.Provider>
+	)
+}
+
+function renderField(
+	opts: RenderOptions & { initialValue?: DropdownChoiceId; setValue?: (v: DropdownChoiceId) => void } = {}
+) {
+	const setValue = opts.setValue ?? vi.fn()
+	const user = userEvent.setup()
+	const utils = render(<ControlledSimple {...opts} setValue={setValue} />)
+	const trigger = utils.container.querySelector<HTMLButtonElement>('.dropdown-field-select-trigger')!
+	return { ...utils, trigger, setValue, user }
+}
+
+function getListbox() {
+	return screen.getByRole('listbox')
+}
+
+function queryListbox() {
+	return screen.queryByRole('listbox')
+}
+
+// ---------------------------------------------------------------------------
+// Rendering — static
+// ---------------------------------------------------------------------------
+
+describe('Rendering (static)', () => {
+	it('renders the trigger button', () => {
+		const { trigger } = renderField()
+		expect(trigger).toBeInTheDocument()
+	})
+
+	it('shows the label for the current value', () => {
+		const { trigger } = renderField({ initialValue: 'banana' })
+		expect(trigger).toHaveTextContent('Banana')
+	})
+
+	it('does not render a listbox initially', () => {
+		renderField()
+		expect(queryListbox()).toBeNull()
+	})
+
+	it('renders a listbox when trigger is clicked', async () => {
+		const { trigger, user } = renderField()
+		await user.click(trigger)
+		expect(getListbox()).toBeInTheDocument()
+	})
+
+	it('listbox contains all choices as options', async () => {
+		const { trigger, user } = renderField()
+		await user.click(trigger)
+		const listbox = getListbox()
+		const options = within(listbox).getAllByRole('option')
+		expect(options).toHaveLength(CHOICES.length)
+	})
+
+	it('labels all options correctly', async () => {
+		const { trigger, user } = renderField()
+		await user.click(trigger)
+		const listbox = getListbox()
+		expect(within(listbox).getByRole('option', { name: 'Apple' })).toBeInTheDocument()
+		expect(within(listbox).getByRole('option', { name: 'Banana' })).toBeInTheDocument()
+		expect(within(listbox).getByRole('option', { name: 'Cherry' })).toBeInTheDocument()
+		expect(within(listbox).getByRole('option', { name: 'Date' })).toBeInTheDocument()
+	})
+
+	it('disables the trigger when disabled=true', () => {
+		const { trigger } = renderField({ disabled: true })
+		expect(trigger).toBeDisabled()
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Selection
+// ---------------------------------------------------------------------------
+
+describe('Selection', () => {
+	it('calls setValue when an option is selected', async () => {
+		const setValue = vi.fn()
+		const { trigger, user } = renderField({ setValue })
+		await user.click(trigger)
+		const listbox = getListbox()
+		await user.click(within(listbox).getByRole('option', { name: 'Cherry' }))
+		expect(setValue).toHaveBeenCalledWith('cherry')
+	})
+
+	it('updates the displayed label after selection', async () => {
+		const { trigger, user } = renderField({ initialValue: 'apple' })
+		await user.click(trigger)
+		const listbox = getListbox()
+		await user.click(within(listbox).getByRole('option', { name: 'Banana' }))
+		// Re-query the trigger because the listbox closed
+		const updatedTrigger = document.querySelector('.dropdown-field-select-trigger')!
+		expect(updatedTrigger).toHaveTextContent('Banana')
+	})
+
+	it('does not call setValue with null (no-op guard in onChange)', async () => {
+		// Base-UI has been observed calling onValueChange(null) in edge cases —
+		// e.g. re-clicking the selected option (deselect) or when the component
+		// receives value={null} after choices become empty. The guard
+		// `if (v !== null) setValue(v)` is the safety net against those paths.
+		const setValue = vi.fn()
+		const { trigger, user, rerender } = renderField({ initialValue: 'apple', setValue })
+
+		// Re-clicking the currently-selected option can produce onValueChange(null)
+		// in some Base-UI versions.
+		await user.click(trigger)
+		const listbox = screen.getByRole('listbox')
+		await user.click(within(listbox).getByRole('option', { name: 'Apple' }))
+		expect(setValue).not.toHaveBeenCalledWith(null)
+
+		// Transitioning to no choices makes Select.Root receive value={null}, which
+		// is another known trigger for the null path.
+		rerender(<ControlledSimple choices={[]} setValue={setValue} />)
+		expect(setValue).not.toHaveBeenCalledWith(null)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Bad option (unknown value)
+// ---------------------------------------------------------------------------
+
+describe('Bad option injection', () => {
+	it('shows default ?? (value) label when value is not in choices', () => {
+		const { trigger } = renderField({ initialValue: 'unknown-id' })
+		expect(trigger).toHaveTextContent('?? (unknown-id)')
+	})
+
+	it('shows badOptionPrefix label when value is unknown and badOptionPrefix is set', () => {
+		const { trigger } = renderField({ initialValue: 'unknown-id', badOptionPrefix: 'Invalid' })
+		expect(trigger).toHaveTextContent('Invalid: unknown-id')
+	})
+
+	it('injects the bad option into the listbox so it is visible as an option', async () => {
+		const { trigger, user } = renderField({ initialValue: 'unknown-id' })
+		await user.click(trigger)
+		const listbox = getListbox()
+		expect(within(listbox).getByRole('option', { name: '?? (unknown-id)' })).toBeInTheDocument()
+	})
+
+	it('does not inject a bad option when value is known', async () => {
+		const { trigger, user } = renderField({ initialValue: 'apple' })
+		await user.click(trigger)
+		const listbox = getListbox()
+		// Only the 4 real choices should be present, no extra ?? option
+		expect(within(listbox).getAllByRole('option')).toHaveLength(CHOICES.length)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Validity (checkValid + isKnownValue)
+// ---------------------------------------------------------------------------
+
+describe('Validity (checkValid and isKnownValue)', () => {
+	it('applies dropdown-field-invalid when value is not in choices', () => {
+		const { container } = renderField({ initialValue: 'unknown-id' })
+		expect(container.querySelector('.dropdown-field')).toHaveClass('dropdown-field-invalid')
+	})
+
+	it('does not apply dropdown-field-invalid when value is in choices', () => {
+		const { container } = renderField({ initialValue: 'apple' })
+		expect(container.querySelector('.dropdown-field')).not.toHaveClass('dropdown-field-invalid')
+	})
+
+	it('applies dropdown-field-invalid when checkValid returns false for a known value', () => {
+		const { container } = renderField({ initialValue: 'apple', checkValid: () => false })
+		expect(container.querySelector('.dropdown-field')).toHaveClass('dropdown-field-invalid')
+	})
+
+	it('does not apply dropdown-field-invalid when checkValid returns true for a known value', () => {
+		const { container } = renderField({ initialValue: 'apple', checkValid: () => true })
+		expect(container.querySelector('.dropdown-field')).not.toHaveClass('dropdown-field-invalid')
+	})
+
+	it('passes the original value to checkValid (not the string-coerced version)', () => {
+		const checkValid = vi.fn(() => true)
+		render(
+			<MenuPortalContext.Provider value={document.body}>
+				<SimpleDropdownInputField choices={NUMERIC_CHOICES} value={1} setValue={vi.fn()} checkValid={checkValid} />
+			</MenuPortalContext.Provider>
+		)
+		// The value prop is the number 1; checkValid should receive 1, not '1'
+		expect(checkValid).toHaveBeenCalledWith(1)
+	})
+
+	it('applies dropdown-field-invalid for unknown value even when checkValid returns true', () => {
+		const { container } = renderField({ initialValue: 'unknown-id', checkValid: () => true })
+		// isKnownValue=false → always invalid, regardless of checkValid
+		expect(container.querySelector('.dropdown-field')).toHaveClass('dropdown-field-invalid')
+	})
+})
+
+// ---------------------------------------------------------------------------
+// No options
+// ---------------------------------------------------------------------------
+
+describe('No options', () => {
+	it('shows the noOptionsMessage inside the listbox', async () => {
+		const user = userEvent.setup()
+		const { container } = render(
+			<MenuPortalContext.Provider value={document.body}>
+				<SimpleDropdownInputField choices={[]} value="" setValue={vi.fn()} noOptionsMessage="Nothing here" />
+			</MenuPortalContext.Provider>
+		)
+		const trigger = container.querySelector<HTMLButtonElement>('.dropdown-field-select-trigger')!
+		await user.click(trigger)
+		const listbox = getListbox()
+		expect(within(listbox).getByText('Nothing here')).toBeInTheDocument()
+	})
+
+	it('shows the default no-options message when noOptionsMessage is omitted', async () => {
+		const user = userEvent.setup()
+		const { container } = render(
+			<MenuPortalContext.Provider value={document.body}>
+				<SimpleDropdownInputField choices={[]} value="" setValue={vi.fn()} />
+			</MenuPortalContext.Provider>
+		)
+		const trigger = container.querySelector<HTMLButtonElement>('.dropdown-field-select-trigger')!
+		await user.click(trigger)
+		const listbox = getListbox()
+		expect(within(listbox).getByText('No options available')).toBeInTheDocument()
+	})
+
+	it('does not apply dropdown-field-invalid for unknown value when there are no options', () => {
+		// isKnownValue = true when options.length === 0 (guard in the source)
+		const { container } = render(
+			<MenuPortalContext.Provider value={document.body}>
+				<SimpleDropdownInputField choices={[]} value="anything" setValue={vi.fn()} />
+			</MenuPortalContext.Provider>
+		)
+		expect(container.querySelector('.dropdown-field')).not.toHaveClass('dropdown-field-invalid')
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Grouped choices
+// ---------------------------------------------------------------------------
+
+describe('Grouped choices', () => {
+	it('renders options from all groups', async () => {
+		const user = userEvent.setup()
+		const { container } = render(
+			<MenuPortalContext.Provider value={document.body}>
+				<ControlledSimple choices={GROUPED_CHOICES} initialValue="apple" />
+			</MenuPortalContext.Provider>
+		)
+		const trigger = container.querySelector<HTMLButtonElement>('.dropdown-field-select-trigger')!
+		await user.click(trigger)
+		const listbox = getListbox()
+		expect(within(listbox).getByRole('option', { name: 'Apple' })).toBeInTheDocument()
+		expect(within(listbox).getByRole('option', { name: 'Carrot' })).toBeInTheDocument()
+	})
+
+	it('calls setValue when a grouped option is selected', async () => {
+		const setValue = vi.fn()
+		const user = userEvent.setup()
+		const { container } = render(
+			<MenuPortalContext.Provider value={document.body}>
+				<ControlledSimple choices={GROUPED_CHOICES} initialValue="apple" setValue={setValue} />
+			</MenuPortalContext.Provider>
+		)
+		const trigger = container.querySelector<HTMLButtonElement>('.dropdown-field-select-trigger')!
+		await user.click(trigger)
+		const listbox = getListbox()
+		await user.click(within(listbox).getByRole('option', { name: 'Daikon' }))
+		expect(setValue).toHaveBeenCalledWith('daikon')
+	})
+})
+
+// ---------------------------------------------------------------------------
+// onBlur
+// ---------------------------------------------------------------------------
+
+describe('onBlur', () => {
+	it('calls onBlur when the trigger loses focus', async () => {
+		const onBlur = vi.fn()
+		const { trigger, user } = renderField({ onBlur })
+		await user.click(trigger)
+		await user.tab()
+		expect(onBlur).toHaveBeenCalled()
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Numeric vs string ID disambiguation
+// ---------------------------------------------------------------------------
+
+describe('Numeric vs string ID disambiguation', () => {
+	// Base UI Select stores values by identity (Object.is), so numeric 1 and
+	// string '1' are kept as separate items with no coercion.
+
+	it('shows the numeric-ID label when value={1}', () => {
+		const { container } = render(
+			<MenuPortalContext.Provider value={document.body}>
+				<SimpleDropdownInputField choices={AMBIGUOUS_CHOICES} value={1} setValue={vi.fn()} />
+			</MenuPortalContext.Provider>
+		)
+		const trigger = container.querySelector('.dropdown-field-select-trigger')!
+		expect(trigger).toHaveTextContent('One (number)')
+	})
+
+	it('shows the string-ID label when value={"1"}', () => {
+		const { container } = render(
+			<MenuPortalContext.Provider value={document.body}>
+				<SimpleDropdownInputField choices={AMBIGUOUS_CHOICES} value="1" setValue={vi.fn()} />
+			</MenuPortalContext.Provider>
+		)
+		const trigger = container.querySelector('.dropdown-field-select-trigger')!
+		expect(trigger).toHaveTextContent('One (string)')
+	})
+
+	it('selecting the numeric-ID option calls setValue with number 1, not string "1"', async () => {
+		const setValue = vi.fn()
+		const user = userEvent.setup()
+		const { container } = render(
+			<MenuPortalContext.Provider value={document.body}>
+				<ControlledSimple choices={AMBIGUOUS_CHOICES} initialValue={1} setValue={setValue} />
+			</MenuPortalContext.Provider>
+		)
+		const trigger = container.querySelector<HTMLButtonElement>('.dropdown-field-select-trigger')!
+		await user.click(trigger)
+		const listbox = getListbox()
+		await user.click(within(listbox).getByRole('option', { name: 'Two' }))
+		await user.click(trigger)
+		await user.click(within(getListbox()).getByRole('option', { name: 'One (number)' }))
+		expect(setValue).toHaveBeenLastCalledWith(1)
+		expect(setValue).not.toHaveBeenLastCalledWith('1')
+	})
+
+	it('selecting the string-ID option calls setValue with string "1", not number 1', async () => {
+		const setValue = vi.fn()
+		const user = userEvent.setup()
+		const { container } = render(
+			<MenuPortalContext.Provider value={document.body}>
+				<ControlledSimple choices={AMBIGUOUS_CHOICES} initialValue={1} setValue={setValue} />
+			</MenuPortalContext.Provider>
+		)
+		const trigger = container.querySelector<HTMLButtonElement>('.dropdown-field-select-trigger')!
+		await user.click(trigger)
+		const listbox = getListbox()
+		await user.click(within(listbox).getByRole('option', { name: 'One (string)' }))
+		expect(setValue).toHaveBeenLastCalledWith('1')
+		expect(setValue).not.toHaveBeenLastCalledWith(1)
+	})
+
+	it('value={1} is known (not treated as unknown just because "1" also exists)', () => {
+		const { container } = render(
+			<MenuPortalContext.Provider value={document.body}>
+				<SimpleDropdownInputField choices={AMBIGUOUS_CHOICES} value={1} setValue={vi.fn()} />
+			</MenuPortalContext.Provider>
+		)
+		expect(container.querySelector('.dropdown-field')).not.toHaveClass('dropdown-field-invalid')
+	})
+
+	it('value={"1"} is known (not treated as unknown just because 1 also exists)', () => {
+		const { container } = render(
+			<MenuPortalContext.Provider value={document.body}>
+				<SimpleDropdownInputField choices={AMBIGUOUS_CHOICES} value="1" setValue={vi.fn()} />
+			</MenuPortalContext.Provider>
+		)
+		expect(container.querySelector('.dropdown-field')).not.toHaveClass('dropdown-field-invalid')
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+describe('Edge cases', () => {
+	it('selecting a numeric-ID choice calls setValue with the original number, not a string', async () => {
+		const setValue = vi.fn()
+		const user = userEvent.setup()
+		const { container } = render(
+			<MenuPortalContext.Provider value={document.body}>
+				<ControlledSimple choices={NUMERIC_CHOICES} initialValue={1} setValue={setValue} />
+			</MenuPortalContext.Provider>
+		)
+		const trigger = container.querySelector<HTMLButtonElement>('.dropdown-field-select-trigger')!
+		await user.click(trigger)
+		const listbox = getListbox()
+		await user.click(within(listbox).getByRole('option', { name: 'Two' }))
+
+		expect(setValue).toHaveBeenLastCalledWith(2)
+	})
+})

--- a/webui/src/Components/__tests__/MultiDropdownInputField.test.tsx
+++ b/webui/src/Components/__tests__/MultiDropdownInputField.test.tsx
@@ -229,6 +229,14 @@ describe('Selection', () => {
 		await user.click(within(getListbox()).getByText('Date'))
 		expect(container.querySelectorAll('.dropdown-field-pill')).toHaveLength(2)
 	})
+
+	it('removes selected value when choice id is number and value id is string-equivalent', async () => {
+		const choices = [{ id: 1, label: 'One' }]
+		const setValue = vi.fn()
+		const { user } = renderField({ choices, initialValue: ['1'], setValue })
+		await user.click(screen.getByRole('button', { name: 'Remove One' }))
+		expect(setValue).toHaveBeenCalledWith([])
+	})
 })
 
 // ---------------------------------------------------------------------------

--- a/webui/src/Components/__tests__/MultiDropdownInputField.test.tsx
+++ b/webui/src/Components/__tests__/MultiDropdownInputField.test.tsx
@@ -1,11 +1,11 @@
 import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 import type { DropdownChoiceId } from '@companion-app/shared/Model/Common.js'
 import type { DropdownChoicesOrGroups } from '../DropdownChoices.js'
-import { MultiDropdownInputField } from '../MultiDropdownInputField.js'
 import { MenuPortalContext } from '../MenuPortalContext.js'
+import { MultiDropdownInputField } from '../MultiDropdownInputField.js'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -105,13 +105,13 @@ describe('Rendering (static)', () => {
 	})
 
 	it('shows a ?? (id) pill for an unknown value when allowCustom is false', () => {
-		const { container } = renderField({ initialValue: ['unknown-id' as DropdownChoiceId] })
+		const { container } = renderField({ initialValue: ['unknown-id'] })
 		const pills = container.querySelectorAll('.dropdown-field-pill-label')
 		expect(pills[0]?.textContent).toBe('?? (unknown-id)')
 	})
 
 	it('shows the raw value pill when allowCustom is true and value not in choices', () => {
-		const { container } = renderField({ initialValue: ['my-custom' as DropdownChoiceId], allowCustom: true })
+		const { container } = renderField({ initialValue: ['my-custom'], allowCustom: true })
 		const pills = container.querySelectorAll('.dropdown-field-pill-label')
 		expect(pills[0]?.textContent).toBe('my-custom')
 	})
@@ -309,12 +309,12 @@ describe('allowCustom', () => {
 
 describe('minSelection / maxSelection', () => {
 	it('disables pill remove buttons when at minSelection', () => {
-		const { container } = renderField({ minSelection: 1, initialValue: ['apple'] })
+		renderField({ minSelection: 1, initialValue: ['apple'] })
 		expect(screen.getByRole('button', { name: 'Remove Apple' })).toBeDisabled()
 	})
 
 	it('enables pill remove buttons when above minSelection', () => {
-		const { container } = renderField({ minSelection: 1, initialValue: ['apple', 'banana'] })
+		renderField({ minSelection: 1, initialValue: ['apple', 'banana'] })
 		expect(screen.getByRole('button', { name: 'Remove Apple' })).not.toBeDisabled()
 	})
 

--- a/webui/src/Components/__tests__/MultiDropdownInputField.test.tsx
+++ b/webui/src/Components/__tests__/MultiDropdownInputField.test.tsx
@@ -1,0 +1,398 @@
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React, { useState } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import type { DropdownChoiceId } from '@companion-app/shared/Model/Common.js'
+import type { DropdownChoicesOrGroups } from '../DropdownChoices.js'
+import { MultiDropdownInputField } from '../MultiDropdownInputField.js'
+import { MenuPortalContext } from '../MenuPortalContext.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CHOICES = [
+	{ id: 'apple', label: 'Apple' },
+	{ id: 'banana', label: 'Banana' },
+	{ id: 'cherry', label: 'Cherry' },
+	{ id: 'date', label: 'Date' },
+	{ id: 'elderberry', label: 'Elderberry' },
+]
+
+const GROUPED = [
+	{
+		label: 'Fruits',
+		options: [
+			{ id: 'apple', label: 'Apple' },
+			{ id: 'apricot', label: 'Apricot' },
+		],
+	},
+	{
+		label: 'Veggies',
+		options: [
+			{ id: 'carrot', label: 'Carrot' },
+			{ id: 'celery', label: 'Celery' },
+		],
+	},
+]
+
+interface RenderOptions {
+	choices?: DropdownChoicesOrGroups
+	initialValue?: DropdownChoiceId[]
+	allowCustom?: boolean
+	minSelection?: number
+	maxSelection?: number
+	sortSelection?: boolean
+	regex?: string
+	disabled?: boolean
+	onBlur?: () => void
+	checkValid?: (v: DropdownChoiceId[]) => boolean
+}
+
+function ControlledMultiDropdown({
+	initialValue = ['apple'],
+	setValue: externalSetValue,
+	...rest
+}: RenderOptions & { setValue?: (v: DropdownChoiceId[]) => void }) {
+	const [value, setValue] = useState<DropdownChoiceId[]>(initialValue)
+	return (
+		<MenuPortalContext.Provider value={document.body}>
+			<MultiDropdownInputField
+				choices={CHOICES}
+				{...rest}
+				value={value}
+				setValue={(v) => {
+					setValue(v)
+					externalSetValue?.(v)
+				}}
+			/>
+		</MenuPortalContext.Provider>
+	)
+}
+
+function renderField(opts: RenderOptions & { setValue?: (v: DropdownChoiceId[]) => void } = {}) {
+	const setValue = opts.setValue ?? vi.fn()
+	const user = userEvent.setup()
+	const utils = render(<ControlledMultiDropdown {...opts} setValue={setValue} />)
+	const input = utils.getByRole('combobox')
+	return { ...utils, input, setValue, user }
+}
+
+function getListbox() {
+	return screen.getByRole('listbox')
+}
+
+function queryListbox() {
+	return screen.queryByRole('listbox')
+}
+
+// ---------------------------------------------------------------------------
+// Rendering (static)
+// ---------------------------------------------------------------------------
+
+describe('Rendering (static)', () => {
+	it('shows a pill for each selected value', () => {
+		const { container } = renderField({ initialValue: ['apple', 'banana'] })
+		const pills = container.querySelectorAll('.dropdown-field-pill-label')
+		const labels = Array.from(pills).map((el) => el.textContent)
+		expect(labels).toContain('Apple')
+		expect(labels).toContain('Banana')
+	})
+
+	it('shows no pills when selection is empty', () => {
+		const { container } = renderField({ initialValue: [] })
+		expect(container.querySelectorAll('.dropdown-field-pill')).toHaveLength(0)
+	})
+
+	it('shows a ?? (id) pill for an unknown value when allowCustom is false', () => {
+		const { container } = renderField({ initialValue: ['unknown-id' as DropdownChoiceId] })
+		const pills = container.querySelectorAll('.dropdown-field-pill-label')
+		expect(pills[0]?.textContent).toBe('?? (unknown-id)')
+	})
+
+	it('shows the raw value pill when allowCustom is true and value not in choices', () => {
+		const { container } = renderField({ initialValue: ['my-custom' as DropdownChoiceId], allowCustom: true })
+		const pills = container.querySelectorAll('.dropdown-field-pill-label')
+		expect(pills[0]?.textContent).toBe('my-custom')
+	})
+
+	it('has a disabled input when disabled=true', () => {
+		const { input } = renderField({ disabled: true })
+		expect(input).toBeDisabled()
+	})
+
+	it('applies dropdown-field-invalid class when checkValid returns false', () => {
+		const { container } = renderField({ checkValid: () => false })
+		expect(container.querySelector('.dropdown-field-invalid')).toBeTruthy()
+	})
+
+	it('does not apply dropdown-field-invalid class when checkValid returns true', () => {
+		const { container } = renderField({ checkValid: () => true })
+		expect(container.querySelector('.dropdown-field-invalid')).toBeNull()
+	})
+
+	it('does not apply dropdown-field-invalid class when no checkValid is provided', () => {
+		const { container } = renderField()
+		expect(container.querySelector('.dropdown-field-invalid')).toBeNull()
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Popup open / close
+// ---------------------------------------------------------------------------
+
+describe('Popup open / close', () => {
+	it('opens the listbox when clicking the chevron trigger', async () => {
+		const { user, container } = renderField({ initialValue: [] })
+		await user.click(container.querySelector('.dropdown-field-trigger')!)
+		expect(getListbox()).toBeInTheDocument()
+	})
+
+	it('closes the listbox when pressing Escape', async () => {
+		const { user, container } = renderField({ initialValue: [] })
+		await user.click(container.querySelector('.dropdown-field-trigger')!)
+		expect(getListbox()).toBeInTheDocument()
+		await user.keyboard('{Escape}')
+		expect(queryListbox()).toBeNull()
+	})
+
+	it('shows all flat choices in the open popup', async () => {
+		const { user, container } = renderField({ initialValue: [] })
+		await user.click(container.querySelector('.dropdown-field-trigger')!)
+		const list = getListbox()
+		for (const c of CHOICES) {
+			expect(within(list).getByText(c.label)).toBeInTheDocument()
+		}
+	})
+
+	it('renders grouped choices with group labels', async () => {
+		const { user, container } = renderField({
+			choices: GROUPED,
+			initialValue: [],
+		})
+		await user.click(container.querySelector('.dropdown-field-trigger')!)
+		const list = getListbox()
+		expect(within(list).getByText('Fruits')).toBeInTheDocument()
+		expect(within(list).getByText('Veggies')).toBeInTheDocument()
+		expect(within(list).getByText('Apple')).toBeInTheDocument()
+		expect(within(list).getByText('Carrot')).toBeInTheDocument()
+	})
+
+	it('renders object-shaped (Record) choices', async () => {
+		const { user, container } = renderField({
+			choices: {
+				a: { id: 'a', label: 'Alpha' },
+				b: { id: 'b', label: 'Beta' },
+			},
+			initialValue: [],
+		})
+		await user.click(container.querySelector('.dropdown-field-trigger')!)
+		const list = getListbox()
+		expect(within(list).getByText('Alpha')).toBeInTheDocument()
+		expect(within(list).getByText('Beta')).toBeInTheDocument()
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Selection
+// ---------------------------------------------------------------------------
+
+describe('Selection', () => {
+	it('calls setValue with the newly added id appended to the existing selection', async () => {
+		const setValue = vi.fn()
+		const { user, container } = renderField({ initialValue: ['apple'], setValue })
+		await user.click(container.querySelector('.dropdown-field-trigger')!)
+		await user.click(within(getListbox()).getByText('Banana'))
+		expect(setValue).toHaveBeenCalledWith(expect.arrayContaining(['apple', 'banana']))
+		expect(setValue).toHaveBeenCalledWith(expect.not.arrayContaining(['cherry']))
+	})
+
+	it('calls setValue without the id when clicking an already-selected option (toggle off)', async () => {
+		const setValue = vi.fn()
+		const { user, container } = renderField({ initialValue: ['apple', 'banana'], setValue })
+		await user.click(container.querySelector('.dropdown-field-trigger')!)
+		await user.click(within(getListbox()).getByText('Apple'))
+		expect(setValue).toHaveBeenCalledWith(['banana'])
+	})
+
+	it('removes a value by clicking its pill remove button', async () => {
+		const setValue = vi.fn()
+		const { user } = renderField({ initialValue: ['apple', 'banana'], setValue })
+		await user.click(screen.getByRole('button', { name: 'Remove Apple' }))
+		expect(setValue).toHaveBeenCalledWith(['banana'])
+	})
+
+	it('adds multiple values building up the selection', async () => {
+		const { user, container } = renderField({ initialValue: [] })
+		await user.click(container.querySelector('.dropdown-field-trigger')!)
+		await user.click(within(getListbox()).getByText('Cherry'))
+		await user.click(within(getListbox()).getByText('Date'))
+		expect(container.querySelectorAll('.dropdown-field-pill')).toHaveLength(2)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Fuzzy filtering
+// ---------------------------------------------------------------------------
+
+describe('Fuzzy filtering', () => {
+	it('hides non-matching options when typing', async () => {
+		const { user, input } = renderField({ initialValue: [] })
+		await user.click(input)
+		await user.type(input, 'ban')
+		const list = getListbox()
+		expect(within(list).getByText('Banana')).toBeInTheDocument()
+		expect(within(list).queryByText('Apple')).toBeNull()
+	})
+
+	it('shows empty message when no options match', async () => {
+		const { user, input } = renderField({ initialValue: [] })
+		await user.click(input)
+		await user.type(input, 'zzzzz')
+		expect(screen.getByText('No options found.')).toBeInTheDocument()
+	})
+
+	it('shows custom noOptionsMessage when allowCustom=true and nothing matches regex', async () => {
+		const { user, input } = renderField({ allowCustom: true, regex: '/^\\d+$/', initialValue: [] })
+		await user.click(input)
+		await user.type(input, 'zzzzz')
+		expect(screen.getAllByText('Begin typing to use a custom value').length).toBeGreaterThan(0)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// allowCustom — Create "X" synthetic item
+// ---------------------------------------------------------------------------
+
+describe('allowCustom', () => {
+	it('shows a Create "X" synthetic item when typing a value not in choices', async () => {
+		const { user, input } = renderField({ allowCustom: true, initialValue: [] })
+		await user.click(input)
+		await user.type(input, 'my-custom-val')
+		expect(screen.getByText(/Create "my-custom-val"/)).toBeInTheDocument()
+	})
+
+	it('does not show Create "X" when input exactly matches an existing id', async () => {
+		const { user, input } = renderField({ allowCustom: true, initialValue: [] })
+		await user.click(input)
+		await user.type(input, 'apple')
+		expect(screen.queryByText(/Create "apple"/)).toBeNull()
+	})
+
+	it('adds the custom value to the selection when clicking the Create item', async () => {
+		const setValue = vi.fn()
+		const { user, input } = renderField({ allowCustom: true, initialValue: [], setValue })
+		await user.click(input)
+		await user.type(input, 'custom-value')
+		await user.click(screen.getByText(/Create "custom-value"/))
+		expect(setValue).toHaveBeenCalledWith(expect.arrayContaining(['custom-value']))
+	})
+
+	it('hides synthetic item when typed value fails regex', async () => {
+		const { user, input } = renderField({ allowCustom: true, regex: '/^\\d+$/', initialValue: [] })
+		await user.click(input)
+		await user.type(input, 'notanumber')
+		expect(screen.queryByText(/Create "notanumber"/)).toBeNull()
+	})
+
+	it('shows synthetic item when typed value passes regex', async () => {
+		const { user, input } = renderField({ allowCustom: true, regex: '/^\\d+$/', initialValue: [] })
+		await user.click(input)
+		await user.type(input, '12345')
+		expect(screen.getByText(/Create "12345"/)).toBeInTheDocument()
+	})
+})
+
+// ---------------------------------------------------------------------------
+// minSelection / maxSelection constraints
+// ---------------------------------------------------------------------------
+
+describe('minSelection / maxSelection', () => {
+	it('disables pill remove buttons when at minSelection', () => {
+		const { container } = renderField({ minSelection: 1, initialValue: ['apple'] })
+		expect(screen.getByRole('button', { name: 'Remove Apple' })).toBeDisabled()
+	})
+
+	it('enables pill remove buttons when above minSelection', () => {
+		const { container } = renderField({ minSelection: 1, initialValue: ['apple', 'banana'] })
+		expect(screen.getByRole('button', { name: 'Remove Apple' })).not.toBeDisabled()
+	})
+
+	it('does not call setValue when removing via the pill would go below minSelection', async () => {
+		const setValue = vi.fn()
+		const { user } = renderField({ minSelection: 1, initialValue: ['apple'], setValue })
+		await user.click(screen.getByRole('button', { name: 'Remove Apple' }))
+		expect(setValue).not.toHaveBeenCalled()
+	})
+
+	it('does not add items beyond maxSelection via the listbox', async () => {
+		const setValue = vi.fn()
+		const { user, container } = renderField({ maxSelection: 2, initialValue: ['apple', 'banana'], setValue })
+		await user.click(container.querySelector('.dropdown-field-trigger')!)
+		await user.click(within(getListbox()).getByText('Cherry'))
+		expect(setValue).not.toHaveBeenCalled()
+	})
+})
+
+// ---------------------------------------------------------------------------
+// onBlur callback
+// ---------------------------------------------------------------------------
+
+describe('onBlur callback', () => {
+	it('calls onBlur when the input loses focus', async () => {
+		const onBlur = vi.fn()
+		const { user, input } = renderField({ onBlur })
+		await user.click(input)
+		await user.tab()
+		expect(onBlur).toHaveBeenCalledTimes(1)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Grouped choices — interactions
+// ---------------------------------------------------------------------------
+
+describe('Grouped choices — interactions', () => {
+	it('calls setValue with the correct id when selecting an item from inside a group', async () => {
+		const setValue = vi.fn()
+		const { user, container } = renderField({ choices: GROUPED, setValue, initialValue: [] })
+		await user.click(container.querySelector('.dropdown-field-trigger')!)
+		await user.click(within(getListbox()).getByText('Carrot'))
+		expect(setValue).toHaveBeenCalledWith(['carrot'])
+	})
+
+	it('displays pills for values that live inside groups', () => {
+		const { container } = renderField({ choices: GROUPED, initialValue: ['carrot', 'apple'] })
+		const pillLabels = Array.from(container.querySelectorAll('.dropdown-field-pill-label')).map((el) => el.textContent)
+		expect(pillLabels).toContain('Carrot')
+		expect(pillLabels).toContain('Apple')
+	})
+
+	it('removes an entire group from the popup when none of its items match the filter', async () => {
+		const { user, input } = renderField({ choices: GROUPED, initialValue: [] })
+		await user.click(input)
+		await user.type(input, 'appl')
+		const list = getListbox()
+		expect(within(list).queryByText('Veggies')).toBeNull()
+	})
+
+	it('keeps a group in the popup but hides non-matching items within it', async () => {
+		const { user, input } = renderField({ choices: GROUPED, initialValue: [] })
+		await user.click(input)
+		await user.type(input, 'cel')
+		const list = getListbox()
+		expect(within(list).getByText('Celery')).toBeInTheDocument()
+		expect(within(list).queryByText('Carrot')).toBeNull()
+	})
+
+	it('shows the Create "X" item when allowCustom=true and choices are all grouped', async () => {
+		const { user, input } = renderField({
+			choices: GROUPED,
+			allowCustom: true,
+			initialValue: [],
+		})
+		await user.click(input)
+		await user.type(input, 'custom-grouped')
+		expect(screen.getByText(/Create "custom-grouped"/)).toBeInTheDocument()
+	})
+})

--- a/webui/src/Components/__tests__/NumberInputField.test.tsx
+++ b/webui/src/Components/__tests__/NumberInputField.test.tsx
@@ -1,0 +1,285 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { NumberInputField } from '../NumberInputField.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type Props = Parameters<typeof NumberInputField>[0]
+
+/** Controlled wrapper so the component's value updates on setValue calls */
+function ControlledNumber({
+	initialValue = 5,
+	setValue: externalSetValue,
+	...rest
+}: Omit<Props, 'value' | 'setValue'> & {
+	initialValue?: number | undefined
+	setValue?: (v: number) => void
+}) {
+	const [value, setValue] = useState<number | undefined>(initialValue)
+	return (
+		<NumberInputField
+			{...rest}
+			value={value}
+			setValue={(v) => {
+				setValue(v)
+				externalSetValue?.(v)
+			}}
+		/>
+	)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('NumberInputField', () => {
+	describe('Rendering', () => {
+		it('renders the numeric input', () => {
+			render(<NumberInputField value={42} setValue={vi.fn()} />)
+			expect(screen.getByRole('textbox')).toBeInTheDocument()
+		})
+
+		it('displays the provided value', () => {
+			render(<NumberInputField value={42} setValue={vi.fn()} />)
+			expect(screen.getByRole('textbox')).toHaveValue('42')
+		})
+
+		it('displays 0 when value is undefined', () => {
+			render(<NumberInputField value={undefined} setValue={vi.fn()} />)
+			expect(screen.getByRole('textbox')).toHaveValue('0')
+		})
+
+		it('does not render a slider when range is not set', () => {
+			const { container } = render(<NumberInputField value={5} setValue={vi.fn()} />)
+			expect(container.querySelector('input[type="range"]')).toBeNull()
+		})
+
+		it('renders a slider when range=true', () => {
+			const { container } = render(<NumberInputField value={5} setValue={vi.fn()} min={0} max={100} range />)
+			expect(container.querySelector('input[type="range"]')).toBeInTheDocument()
+		})
+
+		it('disables the input when disabled=true', () => {
+			render(<NumberInputField value={5} setValue={vi.fn()} disabled />)
+			expect(screen.getByRole('textbox')).toBeDisabled()
+		})
+
+		it('disables the slider when disabled=true', () => {
+			const { container } = render(<NumberInputField value={5} setValue={vi.fn()} min={0} max={100} range disabled />)
+			expect(container.querySelector('input[type="range"]')).toBeDisabled()
+		})
+	})
+
+	// -------------------------------------------------------------------------
+
+	describe('checkValid', () => {
+		it('applies invalid-value class when checkValid=false', () => {
+			render(<NumberInputField value={5} setValue={vi.fn()} checkValid={false} />)
+			expect(screen.getByRole('textbox')).toHaveClass('invalid-value')
+		})
+
+		it('does not apply invalid-value class when checkValid=true', () => {
+			render(<NumberInputField value={5} setValue={vi.fn()} checkValid={true} />)
+			expect(screen.getByRole('textbox')).not.toHaveClass('invalid-value')
+		})
+
+		it('applies invalid-value class when checkValid function returns false', () => {
+			render(<NumberInputField value={5} setValue={vi.fn()} checkValid={() => false} />)
+			expect(screen.getByRole('textbox')).toHaveClass('invalid-value')
+		})
+
+		it('does not apply invalid-value class when checkValid function returns true', () => {
+			render(<NumberInputField value={5} setValue={vi.fn()} checkValid={() => true} />)
+			expect(screen.getByRole('textbox')).not.toHaveClass('invalid-value')
+		})
+
+		it('passes the current value to checkValid', () => {
+			const checkValid = vi.fn(() => true)
+			render(<NumberInputField value={42} setValue={vi.fn()} checkValid={checkValid} />)
+			// Called at least once during render
+			expect(checkValid).toHaveBeenCalledWith(42)
+		})
+
+		it('is conditionally invalid based on checkValid function result', () => {
+			render(<NumberInputField value={5} setValue={vi.fn()} checkValid={(v) => v > 10} />)
+			// 5 is NOT > 10, so checkValid returns false → invalid
+			expect(screen.getByRole('textbox')).toHaveClass('invalid-value')
+		})
+
+		it('receives 0 (not NaN) when value is undefined', () => {
+			const checkValid = vi.fn(() => true)
+			render(<NumberInputField value={undefined} setValue={vi.fn()} checkValid={checkValid} />)
+			expect(checkValid).toHaveBeenCalledWith(0)
+		})
+	})
+
+	// -------------------------------------------------------------------------
+
+	describe('showMinAsNegativeInfinity', () => {
+		it('shows -∞ overlay when value equals min', () => {
+			render(<NumberInputField value={0} setValue={vi.fn()} min={0} showMinAsNegativeInfinity />)
+			expect(screen.getByText('-∞')).toBeInTheDocument()
+		})
+
+		it('shows -∞ overlay when value is below min', () => {
+			render(<NumberInputField value={-5} setValue={vi.fn()} min={0} showMinAsNegativeInfinity />)
+			expect(screen.getByText('-∞')).toBeInTheDocument()
+		})
+
+		it('does not show -∞ overlay when value is above min', () => {
+			render(<NumberInputField value={5} setValue={vi.fn()} min={0} showMinAsNegativeInfinity />)
+			expect(screen.queryByText('-∞')).toBeNull()
+		})
+
+		it('does not show -∞ overlay when showMinAsNegativeInfinity is not set', () => {
+			render(<NumberInputField value={0} setValue={vi.fn()} min={0} />)
+			expect(screen.queryByText('-∞')).toBeNull()
+		})
+
+		it('does not show -∞ overlay when min is not defined', () => {
+			render(<NumberInputField value={0} setValue={vi.fn()} showMinAsNegativeInfinity />)
+			expect(screen.queryByText('-∞')).toBeNull()
+		})
+
+		it('does not show -∞ overlay when value is undefined and min=0', () => {
+			render(<NumberInputField value={undefined} setValue={vi.fn()} min={0} showMinAsNegativeInfinity />)
+			expect(screen.queryByText('-∞')).toBeNull()
+		})
+
+		it('-∞ overlay also shows invalid-value class when checkValid=false', () => {
+			const { container } = render(
+				<NumberInputField value={0} setValue={vi.fn()} min={0} showMinAsNegativeInfinity checkValid={false} />
+			)
+			const overlay = container.querySelector('.number-field-inf-overlay')
+			expect(overlay).toHaveClass('invalid-value')
+		})
+	})
+
+	// -------------------------------------------------------------------------
+
+	describe('showMaxAsPositiveInfinity', () => {
+		it('shows ∞ overlay when value equals max', () => {
+			render(<NumberInputField value={100} setValue={vi.fn()} max={100} showMaxAsPositiveInfinity />)
+			expect(screen.getByText('∞')).toBeInTheDocument()
+		})
+
+		it('shows ∞ overlay when value is above max', () => {
+			render(<NumberInputField value={150} setValue={vi.fn()} max={100} showMaxAsPositiveInfinity />)
+			expect(screen.getByText('∞')).toBeInTheDocument()
+		})
+
+		it('does not show ∞ overlay when value is below max', () => {
+			render(<NumberInputField value={50} setValue={vi.fn()} max={100} showMaxAsPositiveInfinity />)
+			expect(screen.queryByText('∞')).toBeNull()
+		})
+
+		it('does not show ∞ overlay when showMaxAsPositiveInfinity is not set', () => {
+			render(<NumberInputField value={100} setValue={vi.fn()} max={100} />)
+			expect(screen.queryByText('∞')).toBeNull()
+		})
+
+		it('does not show ∞ overlay when max is not defined', () => {
+			render(<NumberInputField value={100} setValue={vi.fn()} showMaxAsPositiveInfinity />)
+			expect(screen.queryByText('∞')).toBeNull()
+		})
+	})
+
+	// -------------------------------------------------------------------------
+
+	describe('Value changes', () => {
+		it('calls setValue when the increment button is clicked', async () => {
+			const setValue = vi.fn()
+			const user = userEvent.setup()
+			const { container } = render(<ControlledNumber initialValue={5} setValue={setValue} min={0} max={100} />)
+
+			const incrementBtn = container.querySelector('.number-field-increment') as HTMLElement
+			await user.click(incrementBtn)
+
+			expect(setValue).toHaveBeenCalledWith(6)
+		})
+
+		it('calls setValue when the decrement button is clicked', async () => {
+			const setValue = vi.fn()
+			const user = userEvent.setup()
+			const { container } = render(<ControlledNumber initialValue={5} setValue={setValue} min={0} max={100} />)
+
+			const decrementBtn = container.querySelector('.number-field-decrement') as HTMLElement
+			await user.click(decrementBtn)
+
+			expect(setValue).toHaveBeenCalledWith(4)
+		})
+
+		it('does not call setValue with a value below min', async () => {
+			const setValue = vi.fn()
+			const user = userEvent.setup()
+			const { container } = render(<ControlledNumber initialValue={0} setValue={setValue} min={0} max={100} />)
+
+			const decrementBtn = container.querySelector('.number-field-decrement') as HTMLElement
+			await user.click(decrementBtn)
+
+			for (const [v] of setValue.mock.calls) {
+				expect(v).toBeGreaterThanOrEqual(0)
+			}
+		})
+
+		it('does not call setValue with a value above max', async () => {
+			const setValue = vi.fn()
+			const user = userEvent.setup()
+			const { container } = render(<ControlledNumber initialValue={100} setValue={setValue} min={0} max={100} />)
+
+			const incrementBtn = container.querySelector('.number-field-increment') as HTMLElement
+			await user.click(incrementBtn)
+
+			for (const [v] of setValue.mock.calls) {
+				expect(v).toBeLessThanOrEqual(100)
+			}
+		})
+	})
+
+	// -------------------------------------------------------------------------
+
+	describe('onBlur', () => {
+		it('calls onBlur when the input loses focus', async () => {
+			const onBlur = vi.fn()
+			const user = userEvent.setup()
+			render(<NumberInputField value={5} setValue={vi.fn()} onBlur={onBlur} />)
+
+			await user.click(screen.getByRole('textbox'))
+			await user.tab()
+
+			expect(onBlur).toHaveBeenCalled()
+		})
+	})
+
+	// -------------------------------------------------------------------------
+
+	describe('In-progress editing behaviour', () => {
+		/**
+		 * While the user is typing, external value updates from the parent are
+		 * intentionally ignored. Applying them would cause a fight between the
+		 * user's input and any value that commits (via setValue) and propagates
+		 * back — potentially stomping characters typed after the commit was issued.
+		 *
+		 * The component achieves this by holding an internal `tmpValue` that
+		 * takes precedence over the controlled `value` prop while editing.
+		 */
+		it('external value updates are ignored while the user is typing', async () => {
+			const user = userEvent.setup()
+			const { rerender } = render(<NumberInputField value={5} setValue={vi.fn()} />)
+			const input = screen.getByRole('textbox')
+
+			await user.clear(input)
+			await user.type(input, '10')
+
+			// Parent tries to push a different value mid-edit
+			rerender(<NumberInputField value={7} setValue={vi.fn()} />)
+
+			// tmpValue wins — the user's in-progress text is preserved
+			expect(input).toHaveValue('10')
+		})
+	})
+})

--- a/webui/src/Components/__tests__/VariablePickerField.test.tsx
+++ b/webui/src/Components/__tests__/VariablePickerField.test.tsx
@@ -1,0 +1,424 @@
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React, { useState } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import type { DropdownChoicesOrGroups } from '../DropdownChoices.js'
+import { MenuPortalContext } from '../MenuPortalContext.js'
+import { VariablePickerField } from '../VariablePickerField.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CHOICES = [
+	{ id: 'connection:var_a', label: 'Variable A' },
+	{ id: 'connection:var_b', label: 'Variable B' },
+	{ id: 'connection:var_c', label: 'Variable C' },
+	{ id: 'other:var_d', label: 'Variable D' },
+	{ id: 'other:var_e', label: 'Variable E' },
+]
+
+interface RenderOptions {
+	choices?: DropdownChoicesOrGroups
+	allowCustom?: boolean
+	regex?: string
+	disabled?: boolean
+}
+
+function ControlledPicker({
+	initialValue = 'connection:var_a',
+	setValue: externalSetValue,
+	...rest
+}: RenderOptions & { initialValue?: string; setValue?: (v: string) => void }) {
+	const [value, setValue] = useState<string>(initialValue)
+	return (
+		<MenuPortalContext.Provider value={document.body}>
+			<VariablePickerField
+				choices={CHOICES}
+				{...rest}
+				value={value}
+				setValue={(v) => {
+					setValue(v)
+					externalSetValue?.(v)
+				}}
+			/>
+		</MenuPortalContext.Provider>
+	)
+}
+
+function renderPicker(opts: RenderOptions & { initialValue?: string; setValue?: (v: string) => void } = {}) {
+	const setValue = opts.setValue ?? vi.fn()
+	const user = userEvent.setup()
+	const utils = render(
+		<ControlledPicker {...opts} setValue={setValue} initialValue={opts.initialValue ?? 'connection:var_a'} />
+	)
+	const input = utils.getByRole('combobox')
+	return { ...utils, input, setValue, user }
+}
+
+function getListbox() {
+	return screen.getByRole('listbox')
+}
+
+function queryListbox() {
+	return screen.queryByRole('listbox')
+}
+
+// ---------------------------------------------------------------------------
+// Rendering (static)
+// ---------------------------------------------------------------------------
+
+describe('Rendering (static)', () => {
+	it('has a disabled input when disabled=true', () => {
+		const { input } = renderPicker({ disabled: true })
+		expect(input).toBeDisabled()
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Popup open / close
+// ---------------------------------------------------------------------------
+
+describe('Popup open / close', () => {
+	it('opens the listbox when clicking the chevron trigger', async () => {
+		const { user } = renderPicker()
+		await user.click(screen.getByRole('button'))
+		expect(getListbox()).toBeInTheDocument()
+	})
+
+	it('closes the listbox when clicking the trigger a second time', async () => {
+		const { user } = renderPicker()
+		const trigger = screen.getByRole('button')
+		await user.click(trigger)
+		await user.click(trigger)
+		expect(queryListbox()).toBeNull()
+	})
+
+	it('closes the listbox when pressing Escape', async () => {
+		const { user } = renderPicker()
+		await user.click(screen.getByRole('button'))
+		expect(getListbox()).toBeInTheDocument()
+		await user.keyboard('{Escape}')
+		expect(queryListbox()).toBeNull()
+	})
+
+	it('shows all flat choices in the open popup', async () => {
+		const { user } = renderPicker()
+		await user.click(screen.getByRole('button'))
+		const list = getListbox()
+		for (const c of CHOICES) {
+			expect(within(list).getByText(c.label)).toBeInTheDocument()
+		}
+	})
+
+	it('renders grouped choices with group labels', async () => {
+		const { user } = renderPicker({
+			choices: [
+				{ label: 'Group A', options: [{ id: 'ga:one', label: 'One' }] },
+				{ label: 'Group B', options: [{ id: 'gb:two', label: 'Two' }] },
+			],
+			initialValue: 'ga:one',
+		})
+		await user.click(screen.getByRole('button'))
+		const list = getListbox()
+		expect(within(list).getByText('Group A')).toBeInTheDocument()
+		expect(within(list).getByText('Group B')).toBeInTheDocument()
+		expect(within(list).getByText('One')).toBeInTheDocument()
+		expect(within(list).getByText('Two')).toBeInTheDocument()
+	})
+
+	it('renders object-shaped (Record) choices', async () => {
+		const { user } = renderPicker({
+			choices: {
+				alpha: { id: 'ns:alpha', label: 'Alpha variable' },
+				beta: { id: 'ns:beta', label: 'Beta variable' },
+			},
+			initialValue: 'ns:alpha',
+		})
+		await user.click(screen.getByRole('button'))
+		const list = getListbox()
+		expect(within(list).getByText('Alpha variable')).toBeInTheDocument()
+		expect(within(list).getByText('Beta variable')).toBeInTheDocument()
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Selection
+// ---------------------------------------------------------------------------
+
+describe('Selection', () => {
+	it('calls setValue with the item id when clicking an option', async () => {
+		const setValue = vi.fn()
+		const { user } = renderPicker({ setValue })
+		await user.click(screen.getByRole('button'))
+		await user.click(within(getListbox()).getByText('Variable B'))
+		expect(setValue).toHaveBeenCalledWith('connection:var_b')
+	})
+
+	it('selects an item via keyboard Arrow + Enter', async () => {
+		const setValue = vi.fn()
+		const { user, input } = renderPicker({ setValue })
+		await user.click(input)
+		await user.keyboard('{ArrowDown}')
+		await user.keyboard('{Enter}')
+		expect(setValue).toHaveBeenCalledTimes(1)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Fuzzy filtering
+// ---------------------------------------------------------------------------
+
+describe('Fuzzy filtering', () => {
+	it('hides non-matching options when typing', async () => {
+		const { user, input } = renderPicker()
+		await user.click(input)
+		await user.clear(input)
+		await user.type(input, 'Variable B')
+		const list = getListbox()
+		expect(within(list).getByText('Variable B')).toBeInTheDocument()
+		expect(within(list).queryByText('Variable A')).toBeNull()
+	})
+
+	it('searches by id (not just label)', async () => {
+		// VPF always uses searchLabelsOnly=false, so typing an id fragment must work
+		const { user, input } = renderPicker()
+		await user.click(input)
+		await user.clear(input)
+		await user.type(input, 'other:var_d')
+		const list = getListbox()
+		expect(within(list).getByText('Variable D')).toBeInTheDocument()
+		expect(within(list).queryByText('Variable A')).toBeNull()
+	})
+
+	it('shows empty message when no options match', async () => {
+		const { user, input } = renderPicker()
+		await user.click(input)
+		await user.clear(input)
+		await user.type(input, 'zzzzz')
+		expect(screen.getByText('No options found.')).toBeInTheDocument()
+	})
+
+	it('shows custom noOptionsMessage when allowCustom + regex fails', async () => {
+		const { user, input } = renderPicker({ allowCustom: true, regex: '/^\\d+$/' })
+		await user.click(input)
+		await user.clear(input)
+		await user.type(input, 'zzzzz')
+		expect(screen.getAllByText('Begin typing to use a custom value').length).toBeGreaterThan(0)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// allowCustom=true (editing mode — isEditingMode is always true when allowCustom)
+// ---------------------------------------------------------------------------
+
+describe('allowCustom=true', () => {
+	it('pre-fills the input with the raw id on focus', async () => {
+		const { user, input } = renderPicker({ allowCustom: true, initialValue: 'connection:var_a' })
+		await user.click(input)
+		expect(input).toHaveValue('connection:var_a')
+	})
+
+	it('shows the Use "X" synthetic item when typing a value not in choices', async () => {
+		const { user, input } = renderPicker({ allowCustom: true })
+		await user.click(input)
+		await user.clear(input)
+		await user.type(input, 'my:custom-var')
+		expect(screen.getByText(/Use "my:custom-var"/)).toBeInTheDocument()
+	})
+
+	it('does not show Use "X" when input exactly matches an existing id', async () => {
+		const { user, input } = renderPicker({ allowCustom: true })
+		await user.click(input)
+		await user.clear(input)
+		await user.type(input, 'connection:var_a')
+		expect(screen.queryByText(/Use "connection:var_a"/)).toBeNull()
+	})
+
+	it('calls setValue with the typed text when selecting the synthetic item', async () => {
+		const setValue = vi.fn()
+		const { user, input } = renderPicker({ allowCustom: true, setValue })
+		await user.click(input)
+		await user.clear(input)
+		await user.type(input, 'custom:value')
+		await user.click(screen.getByText(/Use "custom:value"/))
+		expect(setValue).toHaveBeenCalledWith('custom:value')
+	})
+
+	it('commits the typed text via setValue on blur (no selection made)', async () => {
+		const setValue = vi.fn()
+		const { user, input } = renderPicker({ allowCustom: true, setValue })
+		await user.click(input)
+		await user.clear(input)
+		await user.type(input, 'blur:value')
+		await user.tab()
+		expect(setValue).toHaveBeenCalledWith('blur:value')
+	})
+
+	it('hides synthetic item when typed value fails regex', async () => {
+		const { user, input } = renderPicker({ allowCustom: true, regex: '/^[\\w-]+:[\\w-]+$/' })
+		await user.click(input)
+		await user.clear(input)
+		await user.type(input, 'not-valid-format')
+		expect(screen.queryByText(/Use "not-valid-format"/)).toBeNull()
+	})
+
+	it('shows synthetic item when typed value passes regex', async () => {
+		const { user, input } = renderPicker({ allowCustom: true, regex: '/^[\\w-]+:[\\w-]+$/' })
+		await user.click(input)
+		await user.clear(input)
+		await user.type(input, 'ns:varname')
+		expect(screen.getByText(/Use "ns:varname"/)).toBeInTheDocument()
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Grouped choices — interactions
+// ---------------------------------------------------------------------------
+
+describe('Grouped choices — interactions', () => {
+	const GROUPED = [
+		{
+			label: 'Group One',
+			options: [
+				{ id: 'g1:alpha', label: 'Alpha' },
+				{ id: 'g1:apricot', label: 'Apricot' },
+			],
+		},
+		{
+			label: 'Group Two',
+			options: [
+				{ id: 'g2:carrot', label: 'Carrot' },
+				{ id: 'g2:celery', label: 'Celery' },
+			],
+		},
+	]
+
+	it('calls setValue with the correct id when selecting an item from inside a group', async () => {
+		const setValue = vi.fn()
+		const { user } = renderPicker({ choices: GROUPED, setValue, initialValue: 'g1:alpha' })
+		await user.click(screen.getByRole('button'))
+		await user.click(within(getListbox()).getByText('Carrot'))
+		expect(setValue).toHaveBeenCalledWith('g2:carrot')
+	})
+
+	it('removes an entire group from the popup when none of its items match the filter', async () => {
+		const { user, input } = renderPicker({ choices: GROUPED, initialValue: 'g1:alpha' })
+		await user.click(input)
+		await user.clear(input)
+		await user.type(input, 'Alph')
+		const list = getListbox()
+		expect(within(list).queryByText('Group Two')).toBeNull()
+	})
+
+	it('keeps a group in the popup but hides non-matching items within it', async () => {
+		const { user, input } = renderPicker({ choices: GROUPED, initialValue: 'g1:alpha' })
+		await user.click(input)
+		await user.clear(input)
+		await user.type(input, 'Celery')
+		const list = getListbox()
+		expect(within(list).getByText('Celery')).toBeInTheDocument()
+		expect(within(list).queryByText('Carrot')).toBeNull()
+	})
+
+	it('still shows the synthetic "Use X" item when allowCustom=true and choices are all grouped', async () => {
+		const { user, input } = renderPicker({
+			choices: GROUPED,
+			allowCustom: true,
+			initialValue: 'g1:alpha',
+		})
+		await user.click(input)
+		await user.clear(input)
+		await user.type(input, 'custom:grouped')
+		expect(screen.getByText(/Use "custom:grouped"/)).toBeInTheDocument()
+	})
+})
+
+// ---------------------------------------------------------------------------
+// onPasteIntercept
+// ---------------------------------------------------------------------------
+
+describe('onPasteIntercept', () => {
+	it('transforms pasted text using onPasteIntercept', async () => {
+		const setValue = vi.fn()
+		const user = userEvent.setup()
+		render(
+			<MenuPortalContext.Provider value={document.body}>
+				<VariablePickerField
+					choices={CHOICES}
+					value="connection:var_a"
+					setValue={setValue}
+					allowCustom
+					onPasteIntercept={(v) => v.toUpperCase()}
+				/>
+			</MenuPortalContext.Provider>
+		)
+		const input = screen.getByRole('combobox')
+		await user.click(input)
+		await user.clear(input)
+		await user.paste('hello')
+		// The intercept uppercases the value, so the synthetic item should show the transformed string
+		expect(screen.getByText(/Use "HELLO"/)).toBeInTheDocument()
+	})
+
+	it('does not double-fire when onPasteIntercept returns unchanged value', async () => {
+		const onPasteIntercept = vi.fn((v: string) => v)
+		const user = userEvent.setup()
+		render(
+			<MenuPortalContext.Provider value={document.body}>
+				<VariablePickerField
+					choices={CHOICES}
+					value="connection:var_a"
+					setValue={vi.fn()}
+					allowCustom
+					onPasteIntercept={onPasteIntercept}
+				/>
+			</MenuPortalContext.Provider>
+		)
+		const input = screen.getByRole('combobox')
+		await user.click(input)
+		await user.clear(input)
+		await user.paste('connection:var_a')
+		expect(onPasteIntercept).toHaveBeenCalledTimes(1)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Fancy two-line format
+// ---------------------------------------------------------------------------
+
+describe('VariablePickerField — fancy format', () => {
+	const fancyChoices: DropdownChoicesOrGroups = [
+		{ id: 'internal:time_hms', label: 'Current time (HH:MM:SS)' },
+		{ id: 'internal:date_y', label: 'Current year' },
+	]
+
+	it('renders two lines per item: var-name (id) and var-label (label)', async () => {
+		const user = userEvent.setup()
+		render(
+			<MenuPortalContext.Provider value={document.body}>
+				<VariablePickerField choices={fancyChoices} value="internal:time_hms" setValue={vi.fn()} />
+			</MenuPortalContext.Provider>
+		)
+		await user.click(screen.getByRole('button'))
+		const list = getListbox()
+		expect(list.querySelector('.var-name')).toBeInTheDocument()
+		expect(list.querySelector('.var-label')).toBeInTheDocument()
+	})
+
+	it('searches both id and label', async () => {
+		const user = userEvent.setup()
+		render(
+			<MenuPortalContext.Provider value={document.body}>
+				<VariablePickerField choices={fancyChoices} value="internal:time_hms" setValue={vi.fn()} />
+			</MenuPortalContext.Provider>
+		)
+		const input = screen.getByRole('combobox')
+		await user.click(input)
+		await user.clear(input)
+		await user.type(input, 'internal:date')
+		const list = getListbox()
+		expect(within(list).getByText('Current year')).toBeInTheDocument()
+		expect(within(list).queryByText('Current time (HH:MM:SS)')).toBeNull()
+	})
+})

--- a/webui/src/Components/__tests__/VariablePickerField.test.tsx
+++ b/webui/src/Components/__tests__/VariablePickerField.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 import type { DropdownChoicesOrGroups } from '../DropdownChoices.js'
 import { MenuPortalContext } from '../MenuPortalContext.js'
@@ -38,8 +38,8 @@ function ControlledPicker({
 				{...rest}
 				value={value}
 				setValue={(v) => {
-					setValue(v)
-					externalSetValue?.(v)
+					setValue(v as string)
+					externalSetValue?.(v as string)
 				}}
 			/>
 		</MenuPortalContext.Provider>
@@ -72,6 +72,26 @@ describe('Rendering (static)', () => {
 	it('has a disabled input when disabled=true', () => {
 		const { input } = renderPicker({ disabled: true })
 		expect(input).toBeDisabled()
+	})
+
+	it('does not apply dropdown-field-warning when value is in choices', () => {
+		const { container } = renderPicker({ allowCustom: true })
+		expect(container.querySelector('.dropdown-field-warning')).toBeNull()
+	})
+
+	it('applies dropdown-field-warning when allowCustom=true and value is not in choices', () => {
+		const { container } = renderPicker({ allowCustom: true, initialValue: 'missing:variable' })
+		expect(container.querySelector('.dropdown-field-warning')).toBeTruthy()
+	})
+
+	it('does not apply dropdown-field-warning when allowCustom=false and value is not in choices', () => {
+		const { container } = renderPicker({ allowCustom: false, initialValue: 'missing:variable' })
+		expect(container.querySelector('.dropdown-field-warning')).toBeNull()
+	})
+
+	it('does not apply dropdown-field-warning when there are no options', () => {
+		const { container } = renderPicker({ allowCustom: true, choices: [], initialValue: 'missing:variable' })
+		expect(container.querySelector('.dropdown-field-warning')).toBeNull()
 	})
 })
 
@@ -306,6 +326,7 @@ describe('Grouped choices — interactions', () => {
 		const { user, input } = renderPicker({ choices: GROUPED, initialValue: 'g1:alpha' })
 		await user.click(input)
 		await user.clear(input)
+		// typos:disable-line
 		await user.type(input, 'Alph')
 		const list = getListbox()
 		expect(within(list).queryByText('Group Two')).toBeNull()

--- a/webui/src/Components/useRegex.tsx
+++ b/webui/src/Components/useRegex.tsx
@@ -1,0 +1,6 @@
+import { useMemo } from 'react'
+import { compileRegex } from '@companion-app/shared/ValidateInputValue.js'
+
+export function useRegex(regex: string | undefined): RegExp | null {
+	return useMemo(() => compileRegex(regex), [regex])
+}

--- a/webui/src/Controls/Components/AddEntityDropdown.tsx
+++ b/webui/src/Controls/Components/AddEntityDropdown.tsx
@@ -21,7 +21,7 @@ interface AddEntityOption extends DropdownChoice {
 interface AddEntityGroup {
 	id: string
 	label: string
-	options: AddEntityOption[]
+	items: AddEntityOption[]
 }
 interface AddEntityDropdownProps {
 	onSelect: (connectionId: string, definitionId: string) => void
@@ -44,7 +44,8 @@ export const AddEntityDropdown = observer(function AddEntityDropdown({
 	const recentlyUsedStore = entityDefinitions.getRecentlyUsedEntityDefinitionsStore(entityType)
 
 	const options = useComputed(() => {
-		const options: Array<AddEntityOption | AddEntityGroup> = []
+		const groups: Array<AddEntityGroup> = []
+		const allConnectionOptions: AddEntityOption[] = []
 		const pushConnection = (connectionId: string, label: string) => {
 			const entityDefinitions = definitions.connections.get(connectionId)
 			if (!entityDefinitions) return
@@ -66,13 +67,14 @@ export const AddEntityDropdown = observer(function AddEntityDropdown({
 
 			connectionOptions.sort((a, b) => a.sortKey.localeCompare(b.sortKey, undefined, { sensitivity: 'base' }))
 
-			options.push(...connectionOptions)
+			allConnectionOptions.push(...connectionOptions)
 		}
 
 		pushConnection('internal', 'internal')
 		for (const connection of connections.sortedConnections()) {
 			pushConnection(connection.id, connection.label)
 		}
+		groups.push({ id: '__all__', label: '', items: allConnectionOptions })
 
 		if (feedbackListType === FeedbackEntitySubType.Value) {
 			// Show the builtin value type options as special, to increase visibility
@@ -97,10 +99,10 @@ export const AddEntityDropdown = observer(function AddEntityDropdown({
 					})
 				}
 
-				options.push({
+				groups.push({
 					id: '__common__',
 					label: 'Common',
-					options: commonOptions,
+					items: commonOptions,
 				})
 			}
 		}
@@ -125,13 +127,13 @@ export const AddEntityDropdown = observer(function AddEntityDropdown({
 				fuzzy: fuzzyPrepare(optionLabel),
 			})
 		}
-		options.push({
+		groups.push({
 			id: '__recent__',
 			label: 'Recently Used',
-			options: recents,
+			items: recents,
 		})
 
-		return options
+		return groups
 	}, [definitions, connections, recentlyUsedStore.recentIds, feedbackListType])
 
 	const onChange = useCallback(
@@ -156,20 +158,20 @@ export const AddEntityDropdown = observer(function AddEntityDropdown({
 		}
 	}, [])
 
-	const filterOptions = useComputed<Array<DropdownChoice | AddEntityGroup> | undefined>(() => {
+	const filterOptions = useComputed<Array<AddEntityGroup> | undefined>(() => {
 		const filterArray = <T extends AddEntityOption | AddEntityGroup>(options: Array<T>) => {
 			const res: Array<T> = []
 
 			for (const option of options) {
-				if ('options' in option) {
-					const children = filterArray(option.options)
+				if ('items' in option) {
+					const children = filterArray(option.items)
 					if (children.length === 0) {
 						continue
 					}
 
 					res.push({
 						...option,
-						options: children,
+						items: children,
 					})
 				} else {
 					const include = inputValue
@@ -198,7 +200,7 @@ export const AddEntityDropdown = observer(function AddEntityDropdown({
 				disabled={disabled}
 				filteredItems={filterOptions}
 			>
-				<Combobox.InputGroup className="dropdown-field-input-group">
+				<Combobox.InputGroup className="dropdown-field-input-group rounded-end-0">
 					<Combobox.Input className="dropdown-field-input" placeholder={`+ Add ${entityTypeLabel}`} ref={inputRef} />
 					<Combobox.Trigger className="dropdown-field-trigger">
 						<ChevronDownIcon className="dropdown-field-icon" />

--- a/webui/src/Controls/InternalModuleField.tsx
+++ b/webui/src/Controls/InternalModuleField.tsx
@@ -366,8 +366,6 @@ const InternalVariableDropdown = observer(function InternalVariableDropdown({
 		return choices
 	}, [baseVariableDefinitions, localVariableDefinitions])
 
-	const hasMatch = choices.find((c) => c.id === value)
-
 	const onPasteIntercept = useCallback((pastedValue: string) => {
 		let value = pastedValue.trim()
 		if (value.length === 0) return pastedValue
@@ -380,7 +378,6 @@ const InternalVariableDropdown = observer(function InternalVariableDropdown({
 
 	return (
 		<VariablePickerField
-			className={hasMatch ? '' : 'select-warning'}
 			disabled={disabled}
 			value={value ?? ''}
 			choices={choices}

--- a/webui/src/Controls/InternalModuleField.tsx
+++ b/webui/src/Controls/InternalModuleField.tsx
@@ -11,6 +11,7 @@ import type { DropdownChoicesOrGroups } from '~/Components/DropdownChoices.js'
 import { DropdownInputField } from '~/Components/DropdownInputField.js'
 import { MultiDropdownInputField } from '~/Components/MultiDropdownInputField.js'
 import { PngImageInputField } from '~/Components/PngImageInputField.js'
+import { VariablePickerField } from '~/Components/VariablePickerField.js'
 import { groupItemsByCollection } from '~/Helpers/CollectionGrouping.js'
 import { useComputed } from '~/Resources/util.js'
 import type { GenericCollectionsStore } from '~/Stores/GenericCollectionsStore'
@@ -317,15 +318,7 @@ export const InternalCustomVariableDropdown = observer(function InternalCustomVa
 		return groupsOrItems
 	}, [customVariables, includeNone])
 
-	return (
-		<DropdownInputField
-			disabled={disabled}
-			value={value ?? ''}
-			choices={choices}
-			setValue={setValue}
-			fancyFormat={true}
-		/>
-	)
+	return <VariablePickerField disabled={disabled} value={value ?? ''} choices={choices} setValue={setValue} />
 })
 
 interface InternalVariableDropdownProps {
@@ -386,7 +379,7 @@ const InternalVariableDropdown = observer(function InternalVariableDropdown({
 	}, [])
 
 	return (
-		<DropdownInputField
+		<VariablePickerField
 			className={hasMatch ? '' : 'select-warning'}
 			disabled={disabled}
 			value={value ?? ''}
@@ -395,7 +388,6 @@ const InternalVariableDropdown = observer(function InternalVariableDropdown({
 			regex="/^([\w-_]+):([a-zA-Z0-9-_\.]+)$/"
 			allowCustom /* Allow specifying a variable which doesnt currently exist, perhaps as something is offline */
 			onPasteIntercept={onPasteIntercept}
-			fancyFormat={true}
 		/>
 	)
 })

--- a/webui/src/Controls/OptionsInputField.tsx
+++ b/webui/src/Controls/OptionsInputField.tsx
@@ -229,7 +229,6 @@ export const OptionsInputControl = observer(function OptionsInputControl({
 					choices={option.choices}
 					allowCustom={option.allowCustom}
 					minSelection={option.minSelection}
-					minChoicesForSearch={option.minChoicesForSearch}
 					maxSelection={option.maxSelection}
 					sortSelection={option.sortSelection}
 					regex={option.regex}

--- a/webui/src/Controls/OptionsInputField.tsx
+++ b/webui/src/Controls/OptionsInputField.tsx
@@ -214,7 +214,6 @@ export const OptionsInputControl = observer(function OptionsInputControl({
 					value={value as any}
 					choices={option.choices}
 					allowCustom={option.allowCustom}
-					minChoicesForSearch={option.minChoicesForSearch}
 					regex={option.regex}
 					disabled={readonly}
 					setValue={setValue}

--- a/webui/src/Instances/InstanceEdit/InstanceEditField.tsx
+++ b/webui/src/Instances/InstanceEdit/InstanceEditField.tsx
@@ -70,7 +70,6 @@ export function InstanceEditField({
 				<DropdownInputField
 					choices={definition.choices}
 					allowCustom={definition.allowCustom}
-					minChoicesForSearch={definition.minChoicesForSearch}
 					regex={definition.regex}
 					value={value as any}
 					setValue={setValue}

--- a/webui/src/Instances/InstanceEdit/InstanceEditField.tsx
+++ b/webui/src/Instances/InstanceEdit/InstanceEditField.tsx
@@ -83,7 +83,6 @@ export function InstanceEditField({
 					choices={definition.choices}
 					allowCustom={definition.allowCustom}
 					minSelection={definition.minSelection}
-					minChoicesForSearch={definition.minChoicesForSearch}
 					maxSelection={definition.maxSelection}
 					sortSelection={definition.sortSelection}
 					regex={definition.regex}

--- a/webui/src/Surfaces/EditPanelConfigField.tsx
+++ b/webui/src/Surfaces/EditPanelConfigField.tsx
@@ -107,7 +107,6 @@ export const EditPanelConfigField = observer(function EditPanelConfigField({
 				<DropdownInputField
 					choices={definition.choices}
 					allowCustom={definition.allowCustom}
-					minChoicesForSearch={definition.minChoicesForSearch}
 					regex={definition.regex}
 					value={value as any}
 					setValue={setValue2}

--- a/webui/src/Triggers/AddEventDropdown.tsx
+++ b/webui/src/Triggers/AddEventDropdown.tsx
@@ -57,7 +57,7 @@ export const AddEventDropdown = observer(function AddEventDropdown({ onSelect }:
 				onValueChange={onChange}
 				onOpenChange={onOpenChange}
 			>
-				<Combobox.InputGroup className="dropdown-field-input-group">
+				<Combobox.InputGroup className="dropdown-field-input-group rounded-end-0">
 					<Combobox.Input className="dropdown-field-input" placeholder={'+ Add event'} ref={inputRef} />
 					<Combobox.Trigger className="dropdown-field-trigger">
 						<ChevronDownIcon className="dropdown-field-icon" />

--- a/webui/src/scss/_button-grid.scss
+++ b/webui/src/scss/_button-grid.scss
@@ -20,10 +20,6 @@
 		.dropdown-field-input::placeholder {
 			color: #000;
 		}
-
-		.button-page-input-group {
-			border-radius: 0;
-		}
 	}
 
 	.right-buttons {

--- a/webui/src/scss/_button-grid.scss
+++ b/webui/src/scss/_button-grid.scss
@@ -16,6 +16,14 @@
 		// Fix for firefox blowout
 		display: grid;
 		grid-template-columns: minmax(0, 1fr);
+
+		.dropdown-field-input::placeholder {
+			color: #000;
+		}
+
+		.button-page-input-group {
+			border-radius: 0;
+		}
 	}
 
 	.right-buttons {

--- a/webui/src/scss/_common.scss
+++ b/webui/src/scss/_common.scss
@@ -375,12 +375,6 @@ table .td-reorder {
 	align-self: center;
 }
 
-.select-control {
-	// avoid blowout
-	display: grid;
-	grid-template-columns: minmax(0, 1fr);
-}
-
 .searchbox {
 	margin-bottom: 0.5rem;
 }

--- a/webui/src/scss/_common.scss
+++ b/webui/src/scss/_common.scss
@@ -160,6 +160,16 @@ code {
 	cursor: pointer;
 }
 
+.rounded-start-0 {
+	border-top-left-radius: 0;
+	border-bottom-left-radius: 0;
+}
+
+.rounded-end-0 {
+	border-top-right-radius: 0;
+	border-bottom-right-radius: 0;
+}
+
 .btn-danger {
 	background-color: $primary;
 }

--- a/webui/src/scss/_controls.scss
+++ b/webui/src/scss/_controls.scss
@@ -130,16 +130,10 @@ label.disabled {
 	}
 }
 
-.select-invalid {
-	.select-control__single-value {
-		color: red;
-	}
-}
-
-.select-warning {
-	.select-control__control {
-		box-shadow: orange 0 0 0 1px;
-	}
+.select-control {
+	// avoid blowout
+	display: grid;
+	grid-template-columns: minmax(0, 1fr);
 }
 
 .select-control__menu-portal {

--- a/webui/src/scss/components/_dropdown-field.scss
+++ b/webui/src/scss/components/_dropdown-field.scss
@@ -12,6 +12,7 @@
 	.dropdown-field-input-group {
 		@include form-input-base;
 
+		position: relative;
 		display: flex;
 		align-items: center;
 		cursor: text;
@@ -32,7 +33,10 @@
 		border: none;
 		background: transparent;
 		outline: none;
-		padding: 0;
+
+		&:not(.variable-dropdown-edit) {
+			padding: 0;
+		}
 		margin: 0;
 		font-size: inherit;
 		font-weight: inherit;
@@ -47,9 +51,71 @@
 			font-size: 0.9rem;
 		}
 
+		// When the placeholder is actually the current value (disableEditingCustom mode),
+		// style it identically to real text so it looks seamless.
+		&.dropdown-field-input-value-placeholder::placeholder {
+			color: var(--cui-body-color);
+			font-weight: inherit;
+			font-size: inherit;
+		}
+
 		&[data-popup-open] {
 			cursor: text;
 		}
+	}
+
+	// Fancy (2-line) display overlay shown when the field is not focused.
+	// The actual input is hidden below it; clicking passes through to focus the input.
+	.dropdown-field-fancy-display {
+		flex: 1;
+		min-width: 0;
+		overflow: hidden;
+		pointer-events: none;
+
+		.var-name {
+			font-weight: bold;
+			white-space: nowrap;
+			overflow: hidden;
+			text-overflow: ellipsis;
+		}
+
+		.var-label {
+			font-weight: normal;
+			white-space: nowrap;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			font-size: 0.9em;
+		}
+	}
+
+	// When focused or popup is open: show the real input, hide the fancy overlay (but keep its space so height stays consistent)
+	.dropdown-field-input-group:is([data-focused], [data-popup-open]) {
+		.dropdown-field-fancy-display {
+			visibility: hidden;
+		}
+
+		.variable-dropdown-edit {
+			opacity: 1;
+			pointer-events: auto;
+		}
+	}
+
+	// The fancyFormat input always sits absolutely over the container;
+	// overlay always takes layout space and defines the height.
+	// Padding matches form-input-base so text aligns with the container's padding.
+	.variable-dropdown-edit {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		padding: 0.375rem 0.75rem;
+		border: none;
+		background: transparent;
+		outline: none;
+		box-sizing: border-box;
+		opacity: 0;
+		pointer-events: none;
 	}
 
 	.dropdown-field-trigger {
@@ -62,6 +128,8 @@
 		background: transparent;
 		cursor: pointer;
 		color: var(--cui-secondary-color);
+		position: relative;
+		z-index: 1;
 	}
 
 	.dropdown-field-icon {
@@ -301,5 +369,30 @@
 		color: var(--popup-color);
 		color: hsl(0, 0%, 60%);
 		text-align: center;
+	}
+
+	// Two-line content layout for fancyFormat items
+	.dropdown-field-item-content {
+		flex: 1;
+		min-width: 0;
+		overflow: hidden;
+
+		.var-name {
+			display: block;
+			font-weight: bold;
+			white-space: nowrap;
+			overflow: hidden;
+			text-overflow: ellipsis;
+		}
+
+		.var-label {
+			display: block;
+			font-weight: normal;
+			white-space: nowrap;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			font-size: 0.9em;
+			color: hsl(0, 0%, 50%);
+		}
 	}
 }

--- a/webui/src/scss/components/_dropdown-field.scss
+++ b/webui/src/scss/components/_dropdown-field.scss
@@ -174,6 +174,12 @@
 		}
 	}
 
+	&.dropdown-field-warning {
+		.dropdown-field-input-group {
+			border-color: var(--cui-warning);
+		}
+	}
+
 	.dropdown-field-multi-input-group {
 		height: auto;
 		min-height: calc(var(--cui-body-font-size) * var(--cui-body-line-height) + 0.375rem * 2 + 2px);

--- a/webui/src/scss/components/_dropdown-field.scss
+++ b/webui/src/scss/components/_dropdown-field.scss
@@ -99,6 +99,77 @@
 		text-overflow: ellipsis;
 		white-space: nowrap;
 	}
+
+	&.dropdown-field-invalid {
+		.dropdown-field-input-group {
+			border-color: var(--cui-danger);
+		}
+	}
+
+	.dropdown-field-multi-input-group {
+		height: auto;
+		min-height: calc(var(--cui-body-font-size) * var(--cui-body-line-height) + 0.375rem * 2 + 2px);
+		flex-wrap: wrap;
+		gap: 0.25rem;
+		padding: 0.25rem 0.5rem;
+		align-items: center;
+		cursor: default;
+
+		.dropdown-field-input {
+			flex: 1 1 4rem;
+			min-width: 4rem;
+		}
+	}
+
+	.dropdown-field-pill {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.2rem;
+		background-color: rgb(230, 230, 230);
+		border-radius: var(--cui-border-radius-sm, 0.2rem);
+		font-size: 0.77em;
+		line-height: 1.2;
+		max-width: 14rem;
+		white-space: nowrap;
+	}
+
+	.dropdown-field-pill-label {
+		padding: 0.25rem 0.125rem 0.25rem 0.375rem;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		font-weight: 700;
+	}
+
+	.dropdown-field-pill-remove {
+		all: unset;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		flex-shrink: 0;
+		align-self: stretch;
+		width: 1em;
+		border-radius: 2px;
+		font-size: 1.5em;
+		cursor: pointer;
+
+		background-color: rgb(215, 215, 215);
+		padding-right: 0.1em;
+
+		&:hover:not(:disabled) {
+			background: rgba(0, 0, 0, 0.15);
+		}
+
+		&:disabled {
+			opacity: 0.3;
+			cursor: not-allowed;
+		}
+	}
+
+	.dropdown-field-pill-remove-icon {
+		width: 0.75em;
+		height: 0.75em;
+	}
 }
 
 .dropdown-field-positioner {
@@ -110,14 +181,15 @@
 		--popup-color: var(--cui-body-color);
 		--popup-hover-bg: #deebff;
 		--popup-hover-color: var(--cui-body-color);
-		--popup-selected-bg: rgb(178, 197, 251);
+		--popup-selected-bg: rgb(199, 222, 255);
+		--popup-max-height: min(300px, var(--available-height, 300px));
 
 		background-color: var(--popup-bg);
 		border: 1px solid rgba(0, 0, 0, 0.2);
 		border-radius: var(--cui-border-radius);
 		box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
 		padding: 0.25rem 0;
-		max-height: 300px;
+		max-height: var(--popup-max-height);
 		overflow: hidden;
 		display: flex;
 		flex-direction: column;
@@ -125,6 +197,27 @@
 
 	.dropdown-field-list {
 		overflow-y: auto;
+		flex: 1;
+		min-height: 0;
+
+		&.dropdown-field-list--virtualized {
+			overflow: hidden;
+			padding: 0;
+		}
+
+		&.dropdown-field-list--max-reached {
+			.dropdown-field-item:not([data-selected]) {
+				cursor: not-allowed;
+			}
+		}
+	}
+
+	.dropdown-field-list-scroller {
+		height: min(var(--total-size), var(--popup-max-height, 300px));
+		max-height: var(--popup-max-height, 300px);
+		overflow-y: auto;
+		overscroll-behavior: contain;
+		scroll-padding-block: 4px;
 	}
 
 	.dropdown-field-group {
@@ -183,7 +276,18 @@
 		justify-content: center;
 		width: 1.25rem;
 		flex-shrink: 0;
-		color: var(--cui-primary);
+		// color: #000;
+		visibility: hidden;
+		margin-left: -0.5rem;
+		margin-right: 0.125rem;
+	}
+
+	.dropdown-field-item[data-selected] .dropdown-field-item-indicator {
+		visibility: visible;
+	}
+
+	.dropdown-field-item-indicator-icon--always {
+		visibility: visible;
 	}
 
 	.dropdown-field-item-indicator-icon {

--- a/webui/src/scss/components/_switch-field.scss
+++ b/webui/src/scss/components/_switch-field.scss
@@ -1,5 +1,5 @@
 .switch-input-with-label {
-	display: flex;
+	// display: flex;
 }
 
 .switch-input {
@@ -76,4 +76,9 @@
 			transition: none;
 		}
 	}
+}
+
+// When a checkbox is disabled, also visually indicate that the label is disabled by reducing its opacity
+.switch-input[data-disabled] ~ .form-label {
+	opacity: 0.5;
 }

--- a/webui/src/test-setup.ts
+++ b/webui/src/test-setup.ts
@@ -1,0 +1,48 @@
+import '@testing-library/jest-dom/vitest'
+import { cleanup } from '@testing-library/react'
+import { afterEach } from 'vitest'
+
+afterEach(() => {
+	cleanup()
+})
+
+// @tanstack/react-virtual and @base-ui/react use ResizeObserver in jsdom where it doesn't exist
+class ResizeObserverStub {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+}
+window.ResizeObserver = ResizeObserverStub
+
+// @tanstack/react-virtual uses offsetHeight to calculate scroll range; jsdom always returns 0.
+// Without a non-zero value the virtualizer renders no items.
+Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+	configurable: true,
+	get() {
+		return 400
+	},
+})
+
+// base-ui wraps open/close in requestAnimationFrame (a macrotask). jsdom's RAF is never
+// flushed by React's act(), so popups never open. Use queueMicrotask instead — microtasks
+// are flushed by act().
+window.requestAnimationFrame = (fn: FrameRequestCallback): number => {
+	queueMicrotask(() => fn(performance.now()))
+	return 0
+}
+window.cancelAnimationFrame = () => {}
+
+// base-ui uses matchMedia for responsive behaviour
+Object.defineProperty(window, 'matchMedia', {
+	writable: true,
+	value: (query: string) => ({
+		matches: false,
+		media: query,
+		onchange: null,
+		addListener: () => {},
+		removeListener: () => {},
+		addEventListener: () => {},
+		removeEventListener: () => {},
+		dispatchEvent: () => false,
+	}),
+})

--- a/webui/tsconfig.json
+++ b/webui/tsconfig.json
@@ -1,9 +1,9 @@
 {
-	"include": ["src/**/*.js", "src/**/*.jsx", "src/**/*.ts", "src/**/*.tsx"],
+	"include": ["src/**/*.js", "src/**/*.jsx", "src/**/*.ts", "src/**/*.tsx", ".storybook/**/*"],
 	"exclude": ["node_modules/**"],
 	"compilerOptions": {
 		"outDir": "./dist",
-		"rootDir": "./src",
+		"rootDir": ".",
 		"paths": {
 			"*": ["./node_modules/*"],
 			"~/*": ["./src/*"],

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -52,6 +52,15 @@ export default defineConfig(({ mode }) => {
 			chunkSizeWarningLimit: 1 * 1000 * 1000, // Disable warning about large chunks
 			sourcemap: true,
 		},
+		// esbuild 0.27.7 introduced lowering of destructuring for Safari 10-14.0 / iOS 10-14.4
+		// (due to a real but rare Safari bug), but it can't actually perform the lowering.
+		// This tells esbuild to treat destructuring as natively supported, matching the
+		// behaviour of esbuild <0.27.7. See https://github.com/vitejs/vite/pull/22346
+		esbuild: {
+			supported: {
+				destructuring: true,
+			},
+		},
 		server: {
 			port: parseInt(env.COMPANION_UI_PORT || '', 10) || undefined,
 			allowedHosts: ['bs-local.com'],

--- a/webui/vitest.config.ts
+++ b/webui/vitest.config.ts
@@ -1,10 +1,13 @@
+import tsconfigPaths from 'vite-tsconfig-paths'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+	plugins: [tsconfigPaths()],
 	test: {
 		name: 'webui',
 		exclude: ['**/node_modules/**', '**/dist/**', '**/build/**', '**/coverage/**'],
 		environment: 'jsdom',
 		css: true,
+		setupFiles: ['./src/test-setup.ts'],
 	},
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@adobe/css-tools@npm:^4.4.0":
+  version: 4.4.4
+  resolution: "@adobe/css-tools@npm:4.4.4"
+  checksum: 10c0/8f3e6cfaa5e6286e6f05de01d91d060425be2ebaef490881f5fe6da8bbdb336835c5d373ea337b0c3b0a1af4be048ba18780f0f6021d30809b4545922a7e13d9
+  languageName: node
+  linkType: hard
+
 "@algolia/abtesting@npm:1.8.0":
   version: 1.8.0
   resolution: "@algolia/abtesting@npm:1.8.0"
@@ -1558,7 +1565,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.21.3, @babel/types@npm:^7.23.6, @babel/types@npm:^7.26.0, @babel/types@npm:^7.27.1, @babel/types@npm:^7.27.3, @babel/types@npm:^7.28.5, @babel/types@npm:^7.28.6, @babel/types@npm:^7.29.0, @babel/types@npm:^7.4.4":
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.21.3, @babel/types@npm:^7.23.6, @babel/types@npm:^7.26.0, @babel/types@npm:^7.27.1, @babel/types@npm:^7.27.3, @babel/types@npm:^7.28.2, @babel/types@npm:^7.28.5, @babel/types@npm:^7.28.6, @babel/types@npm:^7.29.0, @babel/types@npm:^7.4.4":
   version: 7.29.0
   resolution: "@babel/types@npm:7.29.0"
   dependencies:
@@ -1765,6 +1772,7 @@ __metadata:
     "@popperjs/core": "npm:^2.11.8"
     "@sentry/react": "npm:^10.52.0"
     "@sentry/vite-plugin": "npm:^5.2.1"
+    "@storybook/react-vite": "npm:^10.3.6"
     "@tanstack/react-form": "npm:^1.29.1"
     "@tanstack/react-query": "npm:^5.100.9"
     "@tanstack/react-query-devtools": "npm:^5.100.9"
@@ -1828,6 +1836,7 @@ __metadata:
     remark-gfm: "npm:^4.0.1"
     sanitize-html: "npm:^2.17.3"
     sass-embedded: "npm:^1.99.0"
+    storybook: "npm:^10.3.6"
     terser: "npm:^5.47.1"
     type-fest: "npm:^5.6.0"
     typescript: "npm:~6.0.3"
@@ -3596,184 +3605,184 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/aix-ppc64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/aix-ppc64@npm:0.27.1"
+"@esbuild/aix-ppc64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/aix-ppc64@npm:0.27.7"
   conditions: os=aix & cpu=ppc64
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/android-arm64@npm:0.27.1"
+"@esbuild/android-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/android-arm64@npm:0.27.7"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/android-arm@npm:0.27.1"
+"@esbuild/android-arm@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/android-arm@npm:0.27.7"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
-"@esbuild/android-x64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/android-x64@npm:0.27.1"
+"@esbuild/android-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/android-x64@npm:0.27.7"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/darwin-arm64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/darwin-arm64@npm:0.27.1"
+"@esbuild/darwin-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/darwin-arm64@npm:0.27.7"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/darwin-x64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/darwin-x64@npm:0.27.1"
+"@esbuild/darwin-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/darwin-x64@npm:0.27.7"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/freebsd-arm64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/freebsd-arm64@npm:0.27.1"
+"@esbuild/freebsd-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/freebsd-arm64@npm:0.27.7"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/freebsd-x64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/freebsd-x64@npm:0.27.1"
+"@esbuild/freebsd-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/freebsd-x64@npm:0.27.7"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-arm64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/linux-arm64@npm:0.27.1"
+"@esbuild/linux-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-arm64@npm:0.27.7"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-arm@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/linux-arm@npm:0.27.1"
+"@esbuild/linux-arm@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-arm@npm:0.27.7"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@esbuild/linux-ia32@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/linux-ia32@npm:0.27.1"
+"@esbuild/linux-ia32@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-ia32@npm:0.27.7"
   conditions: os=linux & cpu=ia32
   languageName: node
   linkType: hard
 
-"@esbuild/linux-loong64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/linux-loong64@npm:0.27.1"
+"@esbuild/linux-loong64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-loong64@npm:0.27.7"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-mips64el@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/linux-mips64el@npm:0.27.1"
+"@esbuild/linux-mips64el@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-mips64el@npm:0.27.7"
   conditions: os=linux & cpu=mips64el
   languageName: node
   linkType: hard
 
-"@esbuild/linux-ppc64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/linux-ppc64@npm:0.27.1"
+"@esbuild/linux-ppc64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-ppc64@npm:0.27.7"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-riscv64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/linux-riscv64@npm:0.27.1"
+"@esbuild/linux-riscv64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-riscv64@npm:0.27.7"
   conditions: os=linux & cpu=riscv64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-s390x@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/linux-s390x@npm:0.27.1"
+"@esbuild/linux-s390x@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-s390x@npm:0.27.7"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
 
-"@esbuild/linux-x64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/linux-x64@npm:0.27.1"
+"@esbuild/linux-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-x64@npm:0.27.7"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/netbsd-arm64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/netbsd-arm64@npm:0.27.1"
+"@esbuild/netbsd-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/netbsd-arm64@npm:0.27.7"
   conditions: os=netbsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/netbsd-x64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/netbsd-x64@npm:0.27.1"
+"@esbuild/netbsd-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/netbsd-x64@npm:0.27.7"
   conditions: os=netbsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/openbsd-arm64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/openbsd-arm64@npm:0.27.1"
+"@esbuild/openbsd-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/openbsd-arm64@npm:0.27.7"
   conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/openbsd-x64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/openbsd-x64@npm:0.27.1"
+"@esbuild/openbsd-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/openbsd-x64@npm:0.27.7"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/openharmony-arm64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/openharmony-arm64@npm:0.27.1"
+"@esbuild/openharmony-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/openharmony-arm64@npm:0.27.7"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/sunos-x64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/sunos-x64@npm:0.27.1"
+"@esbuild/sunos-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/sunos-x64@npm:0.27.7"
   conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/win32-arm64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/win32-arm64@npm:0.27.1"
+"@esbuild/win32-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/win32-arm64@npm:0.27.7"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/win32-ia32@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/win32-ia32@npm:0.27.1"
+"@esbuild/win32-ia32@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/win32-ia32@npm:0.27.7"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@esbuild/win32-x64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/win32-x64@npm:0.27.1"
+"@esbuild/win32-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/win32-x64@npm:0.27.7"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -4181,6 +4190,22 @@ __metadata:
     "@types/yargs": "npm:^17.0.8"
     chalk: "npm:^4.0.0"
   checksum: 10c0/ea4e493dd3fb47933b8ccab201ae573dcc451f951dc44ed2a86123cd8541b82aa9d2b1031caf9b1080d6673c517e2dcc25a44b2dc4f3fbc37bfc965d444888c0
+  languageName: node
+  linkType: hard
+
+"@joshwooding/vite-plugin-react-docgen-typescript@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "@joshwooding/vite-plugin-react-docgen-typescript@npm:0.7.0"
+  dependencies:
+    glob: "npm:^13.0.1"
+    react-docgen-typescript: "npm:^2.2.2"
+  peerDependencies:
+    typescript: ">= 4.3.x"
+    vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/6d1a353e4dd0d9d641beafcf8d5c36805ad7f916ae07b817642033bc85c388f819f92dc94db192117dedfaa5d981ac5ef72911315e3e4bf2fe9e23d8956618e6
   languageName: node
   linkType: hard
 
@@ -5211,13 +5236,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@oxc-project/types@npm:=0.122.0":
-  version: 0.122.0
-  resolution: "@oxc-project/types@npm:0.122.0"
-  checksum: 10c0/2c64dd0db949426fd0c86d4f61eded5902e7b7b166356a825bd3a248aeaa29a495f78918f66ab78e99644b67bd7556096e2a8123cec74ca4141c604f424f4f74
-  languageName: node
-  linkType: hard
-
 "@paralleldrive/cuid2@npm:^2.2.2":
   version: 2.2.2
   resolution: "@paralleldrive/cuid2@npm:2.2.2"
@@ -5632,124 +5650,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-android-arm64@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-android-arm64@npm:1.0.0-rc.12"
-  conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-darwin-arm64@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-darwin-arm64@npm:1.0.0-rc.12"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-darwin-x64@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-darwin-x64@npm:1.0.0-rc.12"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-freebsd-x64@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-freebsd-x64@npm:1.0.0-rc.12"
-  conditions: os=freebsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-rc.12"
-  conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-linux-arm64-gnu@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.0.0-rc.12"
-  conditions: os=linux & cpu=arm64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.12"
-  conditions: os=linux & cpu=arm64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-linux-ppc64-gnu@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.0.0-rc.12"
-  conditions: os=linux & cpu=ppc64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-linux-s390x-gnu@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.0.0-rc.12"
-  conditions: os=linux & cpu=s390x & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-linux-x64-gnu@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.0.0-rc.12"
-  conditions: os=linux & cpu=x64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-linux-x64-musl@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-linux-x64-musl@npm:1.0.0-rc.12"
-  conditions: os=linux & cpu=x64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.12"
-  conditions: os=openharmony & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-wasm32-wasi@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-wasm32-wasi@npm:1.0.0-rc.12"
-  dependencies:
-    "@napi-rs/wasm-runtime": "npm:^1.1.1"
-  conditions: cpu=wasm32
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.12"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.12"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@rolldown/pluginutils@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/pluginutils@npm:1.0.0-rc.12"
-  checksum: 10c0/f785d1180ea4876bf6a6a67135822808d1c07f902409524ff1088779f7d5318f6e603d281fb107a5145c1ca54b7cabebd359629ec474ebbc2812f2cf53db4023
-  languageName: node
-  linkType: hard
-
 "@rolldown/pluginutils@npm:1.0.0-rc.3":
   version: 1.0.0-rc.3
   resolution: "@rolldown/pluginutils@npm:1.0.0-rc.3"
   checksum: 10c0/3928b6282a30f307d1b075d2f217180ae173ea9e00638ce46ab65f089bd5f7a0b2c488ae1ce530f509387793c656a2910337c4cd68fa9d37d7e439365989e699
+  languageName: node
+  linkType: hard
+
+"@rollup/pluginutils@npm:^5.0.2":
+  version: 5.3.0
+  resolution: "@rollup/pluginutils@npm:5.3.0"
+  dependencies:
+    "@types/estree": "npm:^1.0.0"
+    estree-walker: "npm:^2.0.2"
+    picomatch: "npm:^4.0.2"
+  peerDependencies:
+    rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+  peerDependenciesMeta:
+    rollup:
+      optional: true
+  checksum: 10c0/001834bf62d7cf5bac424d2617c113f7f7d3b2bf3c1778cbcccb72cdc957b68989f8e7747c782c2b911f1dde8257f56f8ac1e779e29e74e638e3f1e2cac2bcd0
   languageName: node
   linkType: hard
 
@@ -6590,6 +6510,113 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/builder-vite@npm:10.3.6":
+  version: 10.3.6
+  resolution: "@storybook/builder-vite@npm:10.3.6"
+  dependencies:
+    "@storybook/csf-plugin": "npm:10.3.6"
+    ts-dedent: "npm:^2.0.0"
+  peerDependencies:
+    storybook: ^10.3.6
+    vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+  checksum: 10c0/f7e5c57362ba8df8dac4f71dc86d4117cd1edfaf2f61a3ecb0d6bece6b37357f1dc0bf135fd27b5552055b47e0fce5ffba67ffeb2fdedbc75fc986997062bf28
+  languageName: node
+  linkType: hard
+
+"@storybook/csf-plugin@npm:10.3.6":
+  version: 10.3.6
+  resolution: "@storybook/csf-plugin@npm:10.3.6"
+  dependencies:
+    unplugin: "npm:^2.3.5"
+  peerDependencies:
+    esbuild: "*"
+    rollup: "*"
+    storybook: ^10.3.6
+    vite: "*"
+    webpack: "*"
+  peerDependenciesMeta:
+    esbuild:
+      optional: true
+    rollup:
+      optional: true
+    vite:
+      optional: true
+    webpack:
+      optional: true
+  checksum: 10c0/593fc6b9b6073c9dacd26f595ccb58f1ac28f3ab3cf63bf3d8d6913285765eb9c4fdb3e1c54356804ec8eccdde24f14cfa7af3e528731eb6d7e52266d81c4213
+  languageName: node
+  linkType: hard
+
+"@storybook/global@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@storybook/global@npm:5.0.0"
+  checksum: 10c0/8f1b61dcdd3a89584540896e659af2ecc700bc740c16909a7be24ac19127ea213324de144a141f7caf8affaed017d064fea0618d453afbe027cf60f54b4a6d0b
+  languageName: node
+  linkType: hard
+
+"@storybook/icons@npm:^2.0.1":
+  version: 2.0.2
+  resolution: "@storybook/icons@npm:2.0.2"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/072486356fc929ba5a1a225a8636f0e50b2019083e86e4d48d55aeeae4b40f17731cd1eea9cf1785c53e5fc4409fa93aeca15dccb96675c8e7ab536b18ba864c
+  languageName: node
+  linkType: hard
+
+"@storybook/react-dom-shim@npm:10.3.6":
+  version: 10.3.6
+  resolution: "@storybook/react-dom-shim@npm:10.3.6"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    storybook: ^10.3.6
+  checksum: 10c0/60183fc05b0410ca174f215d3271ffbccdc2680bd0704f58dc931cf60e72f497a9f22c00afa868398ad693c7ec633ef619541d4b0611fc2a577fb09609fcc3c7
+  languageName: node
+  linkType: hard
+
+"@storybook/react-vite@npm:^10.3.6":
+  version: 10.3.6
+  resolution: "@storybook/react-vite@npm:10.3.6"
+  dependencies:
+    "@joshwooding/vite-plugin-react-docgen-typescript": "npm:^0.7.0"
+    "@rollup/pluginutils": "npm:^5.0.2"
+    "@storybook/builder-vite": "npm:10.3.6"
+    "@storybook/react": "npm:10.3.6"
+    empathic: "npm:^2.0.0"
+    magic-string: "npm:^0.30.0"
+    react-docgen: "npm:^8.0.0"
+    resolve: "npm:^1.22.8"
+    tsconfig-paths: "npm:^4.2.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    storybook: ^10.3.6
+    vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+  checksum: 10c0/3b939caf05985f0c6d5049c49b71fd8c7abac1f94f1559cfa135a755f3d94c0ef29bdd8d7f7f68c4676ea66852ed4b43d2e33d18434aa1c72f4aebca928b3e13
+  languageName: node
+  linkType: hard
+
+"@storybook/react@npm:10.3.6":
+  version: 10.3.6
+  resolution: "@storybook/react@npm:10.3.6"
+  dependencies:
+    "@storybook/global": "npm:^5.0.0"
+    "@storybook/react-dom-shim": "npm:10.3.6"
+    react-docgen: "npm:^8.0.2"
+    react-docgen-typescript: "npm:^2.2.2"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    storybook: ^10.3.6
+    typescript: ">= 4.9.x"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/3d3af66105cdca98c537b4bcc3e92f87e3b56d154b24e9b167300e9d5de8a7ba6a5ef3c22203ccb6f4c2f0602a5546273b2b49728aa383ba0f98e66a286647a8
+  languageName: node
+  linkType: hard
+
 "@svgr/babel-plugin-add-jsx-attribute@npm:8.0.0":
   version: 8.0.0
   resolution: "@svgr/babel-plugin-add-jsx-attribute@npm:8.0.0"
@@ -7208,6 +7235,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/jest-dom@npm:^6.9.1":
+  version: 6.9.1
+  resolution: "@testing-library/jest-dom@npm:6.9.1"
+  dependencies:
+    "@adobe/css-tools": "npm:^4.4.0"
+    aria-query: "npm:^5.0.0"
+    css.escape: "npm:^1.5.1"
+    dom-accessibility-api: "npm:^0.6.3"
+    picocolors: "npm:^1.1.1"
+    redent: "npm:^3.0.0"
+  checksum: 10c0/4291ebd2f0f38d14cefac142c56c337941775a5807e2a3d6f1a14c2fbd6be76a18e498ed189e95bedc97d9e8cf1738049bc76c85b5bc5e23fae7c9e10f7b3a12
+  languageName: node
+  linkType: hard
+
+"@testing-library/user-event@npm:^14.6.1":
+  version: 14.6.1
+  resolution: "@testing-library/user-event@npm:14.6.1"
+  peerDependencies:
+    "@testing-library/dom": ">=7.21.4"
+  checksum: 10c0/75fea130a52bf320d35d46ed54f3eec77e71a56911b8b69a3fe29497b0b9947b2dc80d30f04054ad4ce7f577856ae3e5397ea7dff0ef14944d3909784c7a93fe
+  languageName: node
+  linkType: hard
+
 "@trpc/client@npm:^11.17.0":
   version: 11.17.0
   resolution: "@trpc/client@npm:11.17.0"
@@ -7348,12 +7398,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/babel__traverse@npm:*":
-  version: 7.20.6
-  resolution: "@types/babel__traverse@npm:7.20.6"
+"@types/babel__traverse@npm:*, @types/babel__traverse@npm:^7.20.7":
+  version: 7.28.0
+  resolution: "@types/babel__traverse@npm:7.28.0"
   dependencies:
-    "@babel/types": "npm:^7.20.7"
-  checksum: 10c0/7ba7db61a53e28cac955aa99af280d2600f15a8c056619c05b6fc911cbe02c61aa4f2823299221b23ce0cce00b294c0e5f618ec772aa3f247523c2e48cf7b888
+    "@babel/types": "npm:^7.28.2"
+  checksum: 10c0/b52d7d4e8fc6a9018fe7361c4062c1c190f5778cf2466817cb9ed19d69fbbb54f9a85ffedeb748ed8062d2cf7d4cc088ee739848f47c57740de1c48cbf0d0994
   languageName: node
   linkType: hard
 
@@ -7480,6 +7530,13 @@ __metadata:
   version: 4.0.2
   resolution: "@types/deep-eql@npm:4.0.2"
   checksum: 10c0/bf3f811843117900d7084b9d0c852da9a044d12eb40e6de73b552598a6843c21291a8a381b0532644574beecd5e3491c5ff3a0365ab86b15d59862c025384844
+  languageName: node
+  linkType: hard
+
+"@types/doctrine@npm:^0.0.9":
+  version: 0.0.9
+  resolution: "@types/doctrine@npm:0.0.9"
+  checksum: 10c0/cdaca493f13c321cf0cacd1973efc0ae74569633145d9e6fc1128f32217a6968c33bea1f858275239fe90c98f3be57ec8f452b416a9ff48b8e8c1098b20fa51c
   languageName: node
   linkType: hard
 
@@ -7955,6 +8012,13 @@ __metadata:
     "@types/prop-types": "npm:*"
     csstype: "npm:^3.2.2"
   checksum: 10c0/683e19cd12b5c691215529af2e32b5ffbaccae3bf0ba93bfafa0e460e8dfee18423afed568be2b8eadf4b837c3749dd296a4f64e2d79f68fa66962c05f5af661
+  languageName: node
+  linkType: hard
+
+"@types/resolve@npm:^1.20.2":
+  version: 1.20.6
+  resolution: "@types/resolve@npm:1.20.6"
+  checksum: 10c0/a9b0549d816ff2c353077365d865a33655a141d066d0f5a3ba6fd4b28bc2f4188a510079f7c1f715b3e7af505a27374adce2a5140a3ece2a059aab3d6e1a4244
   languageName: node
   linkType: hard
 
@@ -8482,6 +8546,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vitest/expect@npm:3.2.4":
+  version: 3.2.4
+  resolution: "@vitest/expect@npm:3.2.4"
+  dependencies:
+    "@types/chai": "npm:^5.2.2"
+    "@vitest/spy": "npm:3.2.4"
+    "@vitest/utils": "npm:3.2.4"
+    chai: "npm:^5.2.0"
+    tinyrainbow: "npm:^2.0.0"
+  checksum: 10c0/7586104e3fd31dbe1e6ecaafb9a70131e4197dce2940f727b6a84131eee3decac7b10f9c7c72fa5edbdb68b6f854353bd4c0fa84779e274207fb7379563b10db
+  languageName: node
+  linkType: hard
+
 "@vitest/expect@npm:4.1.5":
   version: 4.1.5
   resolution: "@vitest/expect@npm:4.1.5"
@@ -8512,6 +8589,15 @@ __metadata:
     vite:
       optional: true
   checksum: 10c0/bcfe97700476130933c7ea33fa670c8d2768a81de5325ce407f901e55c2f66cabbb88a7b6cffb46ddf33dff7d8fc209d769fb298f568e310fbeead9b36f6fdb9
+  languageName: node
+  linkType: hard
+
+"@vitest/pretty-format@npm:3.2.4":
+  version: 3.2.4
+  resolution: "@vitest/pretty-format@npm:3.2.4"
+  dependencies:
+    tinyrainbow: "npm:^2.0.0"
+  checksum: 10c0/5ad7d4278e067390d7d633e307fee8103958806a419ca380aec0e33fae71b44a64415f7a9b4bc11635d3c13d4a9186111c581d3cef9c65cc317e68f077456887
   languageName: node
   linkType: hard
 
@@ -8546,6 +8632,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vitest/spy@npm:3.2.4":
+  version: 3.2.4
+  resolution: "@vitest/spy@npm:3.2.4"
+  dependencies:
+    tinyspy: "npm:^4.0.3"
+  checksum: 10c0/6ebf0b4697dc238476d6b6a60c76ba9eb1dd8167a307e30f08f64149612fd50227682b876420e4c2e09a76334e73f72e3ebf0e350714dc22474258292e202024
+  languageName: node
+  linkType: hard
+
 "@vitest/spy@npm:4.1.5":
   version: 4.1.5
   resolution: "@vitest/spy@npm:4.1.5"
@@ -8567,6 +8662,17 @@ __metadata:
   peerDependencies:
     vitest: 4.1.5
   checksum: 10c0/2109480d08516abe3350994ebfcb9adc8a2eb4bb1839c48a336d6ff3378eb49a520ad6490f177e60034ed4fcf579206d9ab14995e951cbf6d4c7c792c46fe202
+  languageName: node
+  linkType: hard
+
+"@vitest/utils@npm:3.2.4":
+  version: 3.2.4
+  resolution: "@vitest/utils@npm:3.2.4"
+  dependencies:
+    "@vitest/pretty-format": "npm:3.2.4"
+    loupe: "npm:^3.1.4"
+    tinyrainbow: "npm:^2.0.0"
+  checksum: 10c0/024a9b8c8bcc12cf40183c246c244b52ecff861c6deb3477cbf487ac8781ad44c68a9c5fd69f8c1361878e55b97c10d99d511f2597f1f7244b5e5101d028ba64
   languageName: node
   linkType: hard
 
@@ -8729,6 +8835,13 @@ __metadata:
     "@webassemblyjs/ast": "npm:1.14.1"
     "@xtuc/long": "npm:4.2.2"
   checksum: 10c0/8d7768608996a052545251e896eac079c98e0401842af8dd4de78fba8d90bd505efb6c537e909cd6dae96e09db3fa2e765a6f26492553a675da56e2db51f9d24
+  languageName: node
+  linkType: hard
+
+"@webcontainer/env@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@webcontainer/env@npm:1.1.1"
+  checksum: 10c0/bc64114ffa7ee92f4985cc2bdd5e27f6f31d892b9aa5cde68eaf93df02d13ee6edf13faeebdd701464183b6f8f9c47c14975958cdd6fc20e7356ad32f6ee39e7
   languageName: node
   linkType: hard
 
@@ -9262,6 +9375,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"aria-query@npm:^5.0.0":
+  version: 5.3.2
+  resolution: "aria-query@npm:5.3.2"
+  checksum: 10c0/003c7e3e2cff5540bf7a7893775fc614de82b0c5dde8ae823d47b7a28a9d4da1f7ed85f340bdb93d5649caa927755f0e31ecc7ab63edfdfc00c8ef07e505e03e
+  languageName: node
+  linkType: hard
+
 "array-buffer-byte-length@npm:^1.0.1, array-buffer-byte-length@npm:^1.0.2":
   version: 1.0.2
   resolution: "array-buffer-byte-length@npm:1.0.2"
@@ -9400,6 +9520,13 @@ __metadata:
   version: 1.0.0
   resolution: "assert-plus@npm:1.0.0"
   checksum: 10c0/b194b9d50c3a8f872ee85ab110784911e696a4d49f7ee6fc5fb63216dedbefd2c55999c70cb2eaeb4cf4a0e0338b44e9ace3627117b5bf0d42460e9132f21b91
+  languageName: node
+  linkType: hard
+
+"assertion-error@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "assertion-error@npm:2.0.1"
+  checksum: 10c0/bbbcb117ac6480138f8c93cf7f535614282dea9dc828f540cdece85e3c665e8f78958b96afac52f29ff883c72638e6a87d469ecc9fe5bc902df03ed24a55dba8
   languageName: node
   linkType: hard
 
@@ -10173,6 +10300,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chai@npm:^5.2.0":
+  version: 5.3.3
+  resolution: "chai@npm:5.3.3"
+  dependencies:
+    assertion-error: "npm:^2.0.1"
+    check-error: "npm:^2.1.1"
+    deep-eql: "npm:^5.0.1"
+    loupe: "npm:^3.1.0"
+    pathval: "npm:^2.0.0"
+  checksum: 10c0/b360fd4d38861622e5010c2f709736988b05c7f31042305fa3f4e9911f6adb80ccfb4e302068bf8ed10e835c2e2520cba0f5edc13d878b886987e5aa62483f53
+  languageName: node
+  linkType: hard
+
 "chai@npm:^6.2.2":
   version: 6.2.2
   resolution: "chai@npm:6.2.2"
@@ -10236,6 +10376,13 @@ __metadata:
   version: 2.0.1
   resolution: "character-reference-invalid@npm:2.0.1"
   checksum: 10c0/2ae0dec770cd8659d7e8b0ce24392d83b4c2f0eb4a3395c955dce5528edd4cc030a794cfa06600fcdd700b3f2de2f9b8e40e309c0011c4180e3be64a0b42e6a1
+  languageName: node
+  linkType: hard
+
+"check-error@npm:^2.1.1":
+  version: 2.1.3
+  resolution: "check-error@npm:2.1.3"
+  checksum: 10c0/878e99038fb6476316b74668cd6a498c7e66df3efe48158fa40db80a06ba4258742ac3ee2229c4a2a98c5e73f5dff84eb3e50ceb6b65bbd8f831eafc8338607d
   languageName: node
   linkType: hard
 
@@ -11327,6 +11474,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"css.escape@npm:^1.5.1":
+  version: 1.5.1
+  resolution: "css.escape@npm:1.5.1"
+  checksum: 10c0/5e09035e5bf6c2c422b40c6df2eb1529657a17df37fda5d0433d722609527ab98090baf25b13970ca754079a0f3161dd3dfc0e743563ded8cfa0749d861c1525
+  languageName: node
+  linkType: hard
+
 "cssdb@npm:^8.4.2":
   version: 8.4.2
   resolution: "cssdb@npm:8.4.2"
@@ -11588,6 +11742,13 @@ __metadata:
     babel-plugin-macros:
       optional: true
   checksum: 10c0/ae29ec1c5bd5216c698c9f23acaa5b720260fd4cef3c8b5af887eb5f8c9e6fdd5fed8668767437b4efea35e2991bd798987717633411a1734807c28255769b78
+  languageName: node
+  linkType: hard
+
+"deep-eql@npm:^5.0.1":
+  version: 5.0.2
+  resolution: "deep-eql@npm:5.0.2"
+  checksum: 10c0/7102cf3b7bb719c6b9c0db2e19bf0aa9318d141581befe8c7ce8ccd39af9eaa4346e5e05adef7f9bd7015da0f13a3a25dcfe306ef79dc8668aedbecb658dd247
   languageName: node
   linkType: hard
 
@@ -11868,6 +12029,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"doctrine@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "doctrine@npm:3.0.0"
+  dependencies:
+    esutils: "npm:^2.0.2"
+  checksum: 10c0/c96bdccabe9d62ab6fea9399fdff04a66e6563c1d6fb3a3a063e8d53c3bb136ba63e84250bbf63d00086a769ad53aef92d2bd483f03f837fc97b71cbee6b2520
+  languageName: node
+  linkType: hard
+
 "docusaurus-lunr-search@npm:3.6.1":
   version: 3.6.1
   resolution: "docusaurus-lunr-search@npm:3.6.1"
@@ -11891,6 +12061,13 @@ __metadata:
     react: ^16.8.4 || ^17 || ^18 || ^19
     react-dom: ^16.8.4 || ^17 || ^18 || ^19
   checksum: 10c0/89962e2a8004bac0fa0999cd189c05ee0b34a4268c038f10db62d5ec41de89d9b672375832a21d93776d277c4a14bc022a717dffdc7a85048255969cc0eeb583
+  languageName: node
+  linkType: hard
+
+"dom-accessibility-api@npm:^0.6.3":
+  version: 0.6.3
+  resolution: "dom-accessibility-api@npm:0.6.3"
+  checksum: 10c0/10bee5aa514b2a9a37c87cd81268db607a2e933a050074abc2f6fa3da9080ebed206a320cbc123567f2c3087d22292853bdfdceaffdd4334ffe2af9510b29360
   languageName: node
   linkType: hard
 
@@ -12260,6 +12437,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"empathic@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "empathic@npm:2.0.0"
+  checksum: 10c0/7d3b14b04a93b35c47bcc950467ec914fd241cd9acc0269b0ea160f13026ec110f520c90fae64720fde72cc1757b57f3f292fb606617b7fccac1f4d008a76506
+  languageName: node
+  linkType: hard
+
 "enabled@npm:2.0.x":
   version: 2.0.0
   resolution: "enabled@npm:2.0.0"
@@ -12578,36 +12762,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.27.0, esbuild@npm:~0.27.0":
-  version: 0.27.1
-  resolution: "esbuild@npm:0.27.1"
+"esbuild@npm:^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0, esbuild@npm:^0.27.0, esbuild@npm:~0.27.0":
+  version: 0.27.7
+  resolution: "esbuild@npm:0.27.7"
   dependencies:
-    "@esbuild/aix-ppc64": "npm:0.27.1"
-    "@esbuild/android-arm": "npm:0.27.1"
-    "@esbuild/android-arm64": "npm:0.27.1"
-    "@esbuild/android-x64": "npm:0.27.1"
-    "@esbuild/darwin-arm64": "npm:0.27.1"
-    "@esbuild/darwin-x64": "npm:0.27.1"
-    "@esbuild/freebsd-arm64": "npm:0.27.1"
-    "@esbuild/freebsd-x64": "npm:0.27.1"
-    "@esbuild/linux-arm": "npm:0.27.1"
-    "@esbuild/linux-arm64": "npm:0.27.1"
-    "@esbuild/linux-ia32": "npm:0.27.1"
-    "@esbuild/linux-loong64": "npm:0.27.1"
-    "@esbuild/linux-mips64el": "npm:0.27.1"
-    "@esbuild/linux-ppc64": "npm:0.27.1"
-    "@esbuild/linux-riscv64": "npm:0.27.1"
-    "@esbuild/linux-s390x": "npm:0.27.1"
-    "@esbuild/linux-x64": "npm:0.27.1"
-    "@esbuild/netbsd-arm64": "npm:0.27.1"
-    "@esbuild/netbsd-x64": "npm:0.27.1"
-    "@esbuild/openbsd-arm64": "npm:0.27.1"
-    "@esbuild/openbsd-x64": "npm:0.27.1"
-    "@esbuild/openharmony-arm64": "npm:0.27.1"
-    "@esbuild/sunos-x64": "npm:0.27.1"
-    "@esbuild/win32-arm64": "npm:0.27.1"
-    "@esbuild/win32-ia32": "npm:0.27.1"
-    "@esbuild/win32-x64": "npm:0.27.1"
+    "@esbuild/aix-ppc64": "npm:0.27.7"
+    "@esbuild/android-arm": "npm:0.27.7"
+    "@esbuild/android-arm64": "npm:0.27.7"
+    "@esbuild/android-x64": "npm:0.27.7"
+    "@esbuild/darwin-arm64": "npm:0.27.7"
+    "@esbuild/darwin-x64": "npm:0.27.7"
+    "@esbuild/freebsd-arm64": "npm:0.27.7"
+    "@esbuild/freebsd-x64": "npm:0.27.7"
+    "@esbuild/linux-arm": "npm:0.27.7"
+    "@esbuild/linux-arm64": "npm:0.27.7"
+    "@esbuild/linux-ia32": "npm:0.27.7"
+    "@esbuild/linux-loong64": "npm:0.27.7"
+    "@esbuild/linux-mips64el": "npm:0.27.7"
+    "@esbuild/linux-ppc64": "npm:0.27.7"
+    "@esbuild/linux-riscv64": "npm:0.27.7"
+    "@esbuild/linux-s390x": "npm:0.27.7"
+    "@esbuild/linux-x64": "npm:0.27.7"
+    "@esbuild/netbsd-arm64": "npm:0.27.7"
+    "@esbuild/netbsd-x64": "npm:0.27.7"
+    "@esbuild/openbsd-arm64": "npm:0.27.7"
+    "@esbuild/openbsd-x64": "npm:0.27.7"
+    "@esbuild/openharmony-arm64": "npm:0.27.7"
+    "@esbuild/sunos-x64": "npm:0.27.7"
+    "@esbuild/win32-arm64": "npm:0.27.7"
+    "@esbuild/win32-ia32": "npm:0.27.7"
+    "@esbuild/win32-x64": "npm:0.27.7"
   dependenciesMeta:
     "@esbuild/aix-ppc64":
       optional: true
@@ -12663,7 +12847,7 @@ __metadata:
       optional: true
   bin:
     esbuild: bin/esbuild
-  checksum: 10c0/8bfcf13a499a9e7b7da4b68273e12b453c7d7a5e39c944c2e5a4c64a0594d6df1391fc168a5353c22bc94eeae38dd9897199ddbbc4973525b0aae18186e996bd
+  checksum: 10c0/ccd51f0555708bc9ff4ec9dc3ac92d3daacd45ecaac949ca8645984c5c323bf8cefe98c2df307418685e0b4ce37f9a3bdbfe8e3651fe632a0059a436195a17d4
   languageName: node
   linkType: hard
 
@@ -13033,6 +13217,13 @@ __metadata:
     "@types/estree-jsx": "npm:^1.0.0"
     "@types/unist": "npm:^3.0.0"
   checksum: 10c0/acda8b03cc8f890d79c7c7361f6c95331ba84b7ccc0c32b49f447fc30206b20002b37ffdfc97b6ad16e6fe065c63ecbae1622492e2b6b4775c15966606217f39
+  languageName: node
+  linkType: hard
+
+"estree-walker@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "estree-walker@npm:2.0.2"
+  checksum: 10c0/53a6c54e2019b8c914dc395890153ffdc2322781acf4bd7d1a32d7aedc1710807bdcd866ac133903d5629ec601fbb50abe8c2e5553c7f5a0afdd9b6af6c945af
   languageName: node
   linkType: hard
 
@@ -14079,7 +14270,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^13.0.6":
+"glob@npm:^13.0.1, glob@npm:^13.0.6":
   version: 13.0.6
   resolution: "glob@npm:13.0.6"
   dependencies:
@@ -16451,7 +16642,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lightningcss@npm:1.32.0, lightningcss@npm:^1.32.0":
+"lightningcss@npm:1.32.0":
   version: 1.32.0
   resolution: "lightningcss@npm:1.32.0"
   dependencies:
@@ -16743,6 +16934,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"loupe@npm:^3.1.0, loupe@npm:^3.1.4":
+  version: 3.2.1
+  resolution: "loupe@npm:3.2.1"
+  checksum: 10c0/910c872cba291309664c2d094368d31a68907b6f5913e989d301b5c25f30e97d76d77f23ab3bf3b46d0f601ff0b6af8810c10c31b91d2c6b2f132809ca2cc705
+  languageName: node
+  linkType: hard
+
 "lower-case@npm:^2.0.2":
   version: 2.0.2
   resolution: "lower-case@npm:2.0.2"
@@ -16814,7 +17012,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"magic-string@npm:^0.30.17, magic-string@npm:^0.30.21, magic-string@npm:~0.30.8":
+"magic-string@npm:^0.30.0, magic-string@npm:^0.30.17, magic-string@npm:^0.30.21, magic-string@npm:~0.30.8":
   version: 0.30.21
   resolution: "magic-string@npm:0.30.21"
   dependencies:
@@ -17898,6 +18096,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"min-indent@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "min-indent@npm:1.0.1"
+  checksum: 10c0/7e207bd5c20401b292de291f02913230cb1163abca162044f7db1d951fa245b174dc00869d40dd9a9f32a885ad6a5f3e767ee104cf278f399cb4e92d3f582d5c
+  languageName: node
+  linkType: hard
+
 "mini-css-extract-plugin@npm:^2.9.2":
   version: 2.9.4
   resolution: "mini-css-extract-plugin@npm:2.9.4"
@@ -18609,7 +18814,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"open@npm:^10.0.3":
+"open@npm:^10.0.3, open@npm:^10.2.0":
   version: 10.2.0
   resolution: "open@npm:10.2.0"
   dependencies:
@@ -19175,6 +19380,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pathval@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "pathval@npm:2.0.1"
+  checksum: 10c0/460f4709479fbf2c45903a65655fc8f0a5f6d808f989173aeef5fdea4ff4f303dc13f7870303999add60ec49d4c14733895c0a869392e9866f1091fa64fd7581
+  languageName: node
+  linkType: hard
+
 "pe-library@npm:^0.4.1":
   version: 0.4.1
   resolution: "pe-library@npm:0.4.1"
@@ -19230,7 +19442,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^4.0.2, picomatch@npm:^4.0.3, picomatch@npm:^4.0.4":
+"picomatch@npm:^4.0.2, picomatch@npm:^4.0.3":
   version: 4.0.4
   resolution: "picomatch@npm:4.0.4"
   checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
@@ -20134,7 +20346,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.3.11, postcss@npm:^8.4.21, postcss@npm:^8.4.24, postcss@npm:^8.4.33, postcss@npm:^8.5.4, postcss@npm:^8.5.6, postcss@npm:^8.5.8":
+"postcss@npm:^8.3.11, postcss@npm:^8.4.21, postcss@npm:^8.4.24, postcss@npm:^8.4.33, postcss@npm:^8.5.4, postcss@npm:^8.5.6":
   version: 8.5.10
   resolution: "postcss@npm:8.5.10"
   dependencies:
@@ -20659,6 +20871,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-docgen-typescript@npm:^2.2.2":
+  version: 2.4.0
+  resolution: "react-docgen-typescript@npm:2.4.0"
+  peerDependencies:
+    typescript: ">= 4.3.x"
+  checksum: 10c0/18e3e1c80d28abcdd72e62261d2f70b0904d9b088f9c2ebe485ffee5e46f5735208bc174a20ed2772112b3ca6432b5f3d5f0ac345872fe76e541f84543e49e50
+  languageName: node
+  linkType: hard
+
+"react-docgen@npm:^8.0.0, react-docgen@npm:^8.0.2":
+  version: 8.0.3
+  resolution: "react-docgen@npm:8.0.3"
+  dependencies:
+    "@babel/core": "npm:^7.28.0"
+    "@babel/traverse": "npm:^7.28.0"
+    "@babel/types": "npm:^7.28.2"
+    "@types/babel__core": "npm:^7.20.5"
+    "@types/babel__traverse": "npm:^7.20.7"
+    "@types/doctrine": "npm:^0.0.9"
+    "@types/resolve": "npm:^1.20.2"
+    doctrine: "npm:^3.0.0"
+    resolve: "npm:^1.22.1"
+    strip-indent: "npm:^4.0.0"
+  checksum: 10c0/0231fb9177bc7c633f3d1f228eebb0ee90a2f0feac50b1869ef70b0a3683b400d7875547a2d5168f2619b63d4cc29d7c45ae33d3f621fc67a7fa6790ac2049f6
+  languageName: node
+  linkType: hard
+
 "react-dom@npm:^18.3.1":
   version: 18.3.1
   resolution: "react-dom@npm:18.3.1"
@@ -21048,7 +21287,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"recast@npm:^0.23.11":
+"recast@npm:^0.23.11, recast@npm:^0.23.5":
   version: 0.23.11
   resolution: "recast@npm:0.23.11"
   dependencies:
@@ -21117,6 +21356,16 @@ __metadata:
     unified: "npm:^11.0.0"
     vfile: "npm:^6.0.0"
   checksum: 10c0/c2ed4c0e8cf8a09aedcd47c5d016d47f6e1ff6c2d4b220e2abaf1b77713bf404756af2ea3ea7999aec5862e8825aff035edceb370c7fd8603a7e9da03bd6987e
+  languageName: node
+  linkType: hard
+
+"redent@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "redent@npm:3.0.0"
+  dependencies:
+    indent-string: "npm:^4.0.0"
+    strip-indent: "npm:^3.0.0"
+  checksum: 10c0/d64a6b5c0b50eb3ddce3ab770f866658a2b9998c678f797919ceb1b586bab9259b311407280bd80b804e2a7c7539b19238ae6a2a20c843f1a7fcff21d48c2eae
   languageName: node
   linkType: hard
 
@@ -21500,16 +21749,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.19.0, resolve@npm:^1.20.0, resolve@npm:^1.22.11":
-  version: 1.22.11
-  resolution: "resolve@npm:1.22.11"
+"resolve@npm:^1.19.0, resolve@npm:^1.20.0, resolve@npm:^1.22.1, resolve@npm:^1.22.11, resolve@npm:^1.22.8":
+  version: 1.22.12
+  resolution: "resolve@npm:1.22.12"
   dependencies:
+    es-errors: "npm:^1.3.0"
     is-core-module: "npm:^2.16.1"
     path-parse: "npm:^1.0.7"
     supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
     resolve: bin/resolve
-  checksum: 10c0/f657191507530f2cbecb5815b1ee99b20741ea6ee02a59c57028e9ec4c2c8d7681afcc35febbd554ac0ded459db6f2d8153382c53a2f266cee2575e512674409
+  checksum: 10c0/b16dc9b537c02e8c3388f7d3dcff9741d3071625f9a97ac1c885f2b0ca51e78df22328fb6d6ef214dd9101fb7cfc19aa2836fe3410402a94f3f7b8639c7149bf
   languageName: node
   linkType: hard
 
@@ -21526,16 +21776,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A^1.19.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.11#optional!builtin<compat/resolve>":
-  version: 1.22.11
-  resolution: "resolve@patch:resolve@npm%3A1.22.11#optional!builtin<compat/resolve>::version=1.22.11&hash=c3c19d"
+"resolve@patch:resolve@npm%3A^1.19.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.11#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.8#optional!builtin<compat/resolve>":
+  version: 1.22.12
+  resolution: "resolve@patch:resolve@npm%3A1.22.12#optional!builtin<compat/resolve>::version=1.22.12&hash=c3c19d"
   dependencies:
+    es-errors: "npm:^1.3.0"
     is-core-module: "npm:^2.16.1"
     path-parse: "npm:^1.0.7"
     supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
     resolve: bin/resolve
-  checksum: 10c0/ee5b182f2e37cb1165465e58c6abc797fec0a80b5ba3231607beb4677db0c9291ac010c47cf092b6daa2b7f518d69a0e21888e7e2b633f68d501a874212a8c63
+  checksum: 10c0/fc6519984ae1f894d877c0060ba8b1f5ba3bc0e85a02f74e141929c118c23d74d9735619a9cc2965397387e514884245c65d72a40731dcb6cfc84c7bcdc8321e
   languageName: node
   linkType: hard
 
@@ -21626,64 +21877,6 @@ __metadata:
     semver-compare: "npm:^1.0.0"
     sprintf-js: "npm:^1.1.2"
   checksum: 10c0/7d01d4c14513c461778dd673a8f9e53255221f8d04173aafeb8e11b23d8b659bb83f1c90cfe81af7f9c213b8084b404b918108fd792bda76678f555340cc64ec
-  languageName: node
-  linkType: hard
-
-"rolldown@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "rolldown@npm:1.0.0-rc.12"
-  dependencies:
-    "@oxc-project/types": "npm:=0.122.0"
-    "@rolldown/binding-android-arm64": "npm:1.0.0-rc.12"
-    "@rolldown/binding-darwin-arm64": "npm:1.0.0-rc.12"
-    "@rolldown/binding-darwin-x64": "npm:1.0.0-rc.12"
-    "@rolldown/binding-freebsd-x64": "npm:1.0.0-rc.12"
-    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.0.0-rc.12"
-    "@rolldown/binding-linux-arm64-gnu": "npm:1.0.0-rc.12"
-    "@rolldown/binding-linux-arm64-musl": "npm:1.0.0-rc.12"
-    "@rolldown/binding-linux-ppc64-gnu": "npm:1.0.0-rc.12"
-    "@rolldown/binding-linux-s390x-gnu": "npm:1.0.0-rc.12"
-    "@rolldown/binding-linux-x64-gnu": "npm:1.0.0-rc.12"
-    "@rolldown/binding-linux-x64-musl": "npm:1.0.0-rc.12"
-    "@rolldown/binding-openharmony-arm64": "npm:1.0.0-rc.12"
-    "@rolldown/binding-wasm32-wasi": "npm:1.0.0-rc.12"
-    "@rolldown/binding-win32-arm64-msvc": "npm:1.0.0-rc.12"
-    "@rolldown/binding-win32-x64-msvc": "npm:1.0.0-rc.12"
-    "@rolldown/pluginutils": "npm:1.0.0-rc.12"
-  dependenciesMeta:
-    "@rolldown/binding-android-arm64":
-      optional: true
-    "@rolldown/binding-darwin-arm64":
-      optional: true
-    "@rolldown/binding-darwin-x64":
-      optional: true
-    "@rolldown/binding-freebsd-x64":
-      optional: true
-    "@rolldown/binding-linux-arm-gnueabihf":
-      optional: true
-    "@rolldown/binding-linux-arm64-gnu":
-      optional: true
-    "@rolldown/binding-linux-arm64-musl":
-      optional: true
-    "@rolldown/binding-linux-ppc64-gnu":
-      optional: true
-    "@rolldown/binding-linux-s390x-gnu":
-      optional: true
-    "@rolldown/binding-linux-x64-gnu":
-      optional: true
-    "@rolldown/binding-linux-x64-musl":
-      optional: true
-    "@rolldown/binding-openharmony-arm64":
-      optional: true
-    "@rolldown/binding-wasm32-wasi":
-      optional: true
-    "@rolldown/binding-win32-arm64-msvc":
-      optional: true
-    "@rolldown/binding-win32-x64-msvc":
-      optional: true
-  bin:
-    rolldown: bin/cli.mjs
-  checksum: 10c0/0c4e5e3cdcdddce282cb2d84e1c98d6ad8d4e452d5c1402e498b35ec1060026e552dd783efc9f4ba876d7c0863b5973edc79b6a546f565e9832dc1077ec18c2c
   languageName: node
   linkType: hard
 
@@ -23075,6 +23268,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"storybook@npm:^10.3.6":
+  version: 10.3.6
+  resolution: "storybook@npm:10.3.6"
+  dependencies:
+    "@storybook/global": "npm:^5.0.0"
+    "@storybook/icons": "npm:^2.0.1"
+    "@testing-library/jest-dom": "npm:^6.9.1"
+    "@testing-library/user-event": "npm:^14.6.1"
+    "@vitest/expect": "npm:3.2.4"
+    "@vitest/spy": "npm:3.2.4"
+    "@webcontainer/env": "npm:^1.1.1"
+    esbuild: "npm:^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0"
+    open: "npm:^10.2.0"
+    recast: "npm:^0.23.5"
+    semver: "npm:^7.7.3"
+    use-sync-external-store: "npm:^1.5.0"
+    ws: "npm:^8.18.0"
+  peerDependencies:
+    prettier: ^2 || ^3
+    vite-plus: ^0.1.15
+  peerDependenciesMeta:
+    prettier:
+      optional: true
+    vite-plus:
+      optional: true
+  bin:
+    storybook: ./dist/bin/dispatcher.js
+  checksum: 10c0/ee6702667459ba2d49269ddd63a7281f17816fcdd4bacd338ed47a4a8e7ad65760c90d99f6b2dfdfd0a564bcfcab3c1ea05b50bf3aafc6b5b19a039a5da77870
+  languageName: node
+  linkType: hard
+
 "stream-demux@npm:^10.0.1":
   version: 10.0.1
   resolution: "stream-demux@npm:10.0.1"
@@ -23319,6 +23543,22 @@ __metadata:
   version: 4.0.0
   resolution: "strip-final-newline@npm:4.0.0"
   checksum: 10c0/b0cf2b62d597a1b0e3ebc42b88767f0a0d45601f89fd379a928a1812c8779440c81abba708082c946445af1d6b62d5f16e2a7cf4f30d9d6587b89425fae801ff
+  languageName: node
+  linkType: hard
+
+"strip-indent@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "strip-indent@npm:3.0.0"
+  dependencies:
+    min-indent: "npm:^1.0.0"
+  checksum: 10c0/ae0deaf41c8d1001c5d4fbe16cb553865c1863da4fae036683b474fa926af9fc121e155cb3fc57a68262b2ae7d5b8420aa752c97a6428c315d00efe2a3875679
+  languageName: node
+  linkType: hard
+
+"strip-indent@npm:^4.0.0":
+  version: 4.1.1
+  resolution: "strip-indent@npm:4.1.1"
+  checksum: 10c0/5b23dd5934be0ef6b6fe1b802887f83e56ad9dcd9f6c3896a637da2c6c3a6da3fdf3e51354a98e6cccb6f1c41863e7b9b9deaa348639dfd35f71f3549edb4dff
   languageName: node
   linkType: hard
 
@@ -23787,10 +24027,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinyrainbow@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "tinyrainbow@npm:2.0.0"
+  checksum: 10c0/c83c52bef4e0ae7fb8ec6a722f70b5b6fa8d8be1c85792e829f56c0e1be94ab70b293c032dc5048d4d37cfe678f1f5babb04bdc65fd123098800148ca989184f
+  languageName: node
+  linkType: hard
+
 "tinyrainbow@npm:^3.1.0":
   version: 3.1.0
   resolution: "tinyrainbow@npm:3.1.0"
   checksum: 10c0/f11cf387a26c5c9255bec141a90ac511b26172981b10c3e50053bc6700ea7d2336edcc4a3a21dbb8412fe7c013477d2ba4d7e4877800f3f8107be5105aad6511
+  languageName: node
+  linkType: hard
+
+"tinyspy@npm:^4.0.3":
+  version: 4.0.4
+  resolution: "tinyspy@npm:4.0.4"
+  checksum: 10c0/a8020fc17799251e06a8398dcc352601d2770aa91c556b9531ecd7a12581161fd1c14e81cbdaff0c1306c93bfdde8ff6d1c1a3f9bbe6d91604f0fd4e01e2f1eb
   languageName: node
   linkType: hard
 
@@ -23954,6 +24208,13 @@ __metadata:
   peerDependencies:
     typescript: ">=4.8.4"
   checksum: 10c0/767849383c114e7f1971fa976b20e73ac28fd0c70d8d65c0004790bf4d8f89888c7e4cf6d5949f9c1beae9bc3c64835bef77bbe27fddf45a3c7b60cebcf85c8c
+  languageName: node
+  linkType: hard
+
+"ts-dedent@npm:^2.0.0":
+  version: 2.2.0
+  resolution: "ts-dedent@npm:2.2.0"
+  checksum: 10c0/175adea838468cc2ff7d5e97f970dcb798bbcb623f29c6088cb21aa2880d207c5784be81ab1741f56b9ac37840cbaba0c0d79f7f8b67ffe61c02634cafa5c303
   languageName: node
   linkType: hard
 
@@ -24508,6 +24769,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unplugin@npm:^2.3.5":
+  version: 2.3.11
+  resolution: "unplugin@npm:2.3.11"
+  dependencies:
+    "@jridgewell/remapping": "npm:^2.3.5"
+    acorn: "npm:^8.15.0"
+    picomatch: "npm:^4.0.3"
+    webpack-virtual-modules: "npm:^0.6.2"
+  checksum: 10c0/273c1eab0eca4470c7317428689295c31dbe8ab0b306504de9f03cd20c156debb4131bef24b27ac615862958c5dd950a3951d26c0723ea774652ab3624149cff
+  languageName: node
+  linkType: hard
+
 "unplugin@npm:^3.0.0":
   version: 3.0.0
   resolution: "unplugin@npm:3.0.0"
@@ -24665,7 +24938,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-sync-external-store@npm:^1.4.0, use-sync-external-store@npm:^1.6.0":
+"use-sync-external-store@npm:^1.4.0, use-sync-external-store@npm:^1.5.0, use-sync-external-store@npm:^1.6.0":
   version: 1.6.0
   resolution: "use-sync-external-store@npm:1.6.0"
   peerDependencies:
@@ -24859,64 +25132,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0":
-  version: 8.0.3
-  resolution: "vite@npm:8.0.3"
-  dependencies:
-    fsevents: "npm:~2.3.3"
-    lightningcss: "npm:^1.32.0"
-    picomatch: "npm:^4.0.4"
-    postcss: "npm:^8.5.8"
-    rolldown: "npm:1.0.0-rc.12"
-    tinyglobby: "npm:^0.2.15"
-  peerDependencies:
-    "@types/node": ^20.19.0 || >=22.12.0
-    "@vitejs/devtools": ^0.1.0
-    esbuild: ^0.27.0
-    jiti: ">=1.21.0"
-    less: ^4.0.0
-    sass: ^1.70.0
-    sass-embedded: ^1.70.0
-    stylus: ">=0.54.8"
-    sugarss: ^5.0.0
-    terser: ^5.16.0
-    tsx: ^4.8.1
-    yaml: ^2.4.2
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-    "@vitejs/devtools":
-      optional: true
-    esbuild:
-      optional: true
-    jiti:
-      optional: true
-    less:
-      optional: true
-    sass:
-      optional: true
-    sass-embedded:
-      optional: true
-    stylus:
-      optional: true
-    sugarss:
-      optional: true
-    terser:
-      optional: true
-    tsx:
-      optional: true
-    yaml:
-      optional: true
-  bin:
-    vite: bin/vite.js
-  checksum: 10c0/bed9520358080393a02fe22565b3309b4b3b8f916afe4c97577528f3efb05c1bf4b29f7b552179bc5b3938629e50fbd316231727457411dbc96648fa5c9d14bf
-  languageName: node
-  linkType: hard
-
-"vite@npm:^7.3.3":
+"vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0, vite@npm:^7.3.3":
   version: 7.3.3
   resolution: "vite@npm:7.3.3"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -293,7 +293,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.26.2, @babel/code-frame@npm:^7.28.6, @babel/code-frame@npm:^7.29.0":
+"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.26.2, @babel/code-frame@npm:^7.28.6, @babel/code-frame@npm:^7.29.0":
   version: 7.29.0
   resolution: "@babel/code-frame@npm:7.29.0"
   dependencies:
@@ -1781,6 +1781,10 @@ __metadata:
     "@tanstack/react-virtual": "npm:^3.13.24"
     "@tanstack/router-plugin": "npm:^1.167.35"
     "@tanstack/virtual-file-routes": "npm:^1.161.7"
+    "@testing-library/dom": "npm:^10.4.0"
+    "@testing-library/jest-dom": "npm:^6.6.3"
+    "@testing-library/react": "npm:^16.3.0"
+    "@testing-library/user-event": "npm:^14.6.1"
     "@trpc/client": "npm:^11.17.0"
     "@trpc/tanstack-react-query": "npm:^11.17.0"
     "@types/crypto-js": "npm:^4.2.2"
@@ -7235,7 +7239,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/jest-dom@npm:^6.9.1":
+"@testing-library/dom@npm:^10.4.0":
+  version: 10.4.1
+  resolution: "@testing-library/dom@npm:10.4.1"
+  dependencies:
+    "@babel/code-frame": "npm:^7.10.4"
+    "@babel/runtime": "npm:^7.12.5"
+    "@types/aria-query": "npm:^5.0.1"
+    aria-query: "npm:5.3.0"
+    dom-accessibility-api: "npm:^0.5.9"
+    lz-string: "npm:^1.5.0"
+    picocolors: "npm:1.1.1"
+    pretty-format: "npm:^27.0.2"
+  checksum: 10c0/19ce048012d395ad0468b0dbcc4d0911f6f9e39464d7a8464a587b29707eed5482000dad728f5acc4ed314d2f4d54f34982999a114d2404f36d048278db815b1
+  languageName: node
+  linkType: hard
+
+"@testing-library/jest-dom@npm:^6.6.3, @testing-library/jest-dom@npm:^6.9.1":
   version: 6.9.1
   resolution: "@testing-library/jest-dom@npm:6.9.1"
   dependencies:
@@ -7246,6 +7266,26 @@ __metadata:
     picocolors: "npm:^1.1.1"
     redent: "npm:^3.0.0"
   checksum: 10c0/4291ebd2f0f38d14cefac142c56c337941775a5807e2a3d6f1a14c2fbd6be76a18e498ed189e95bedc97d9e8cf1738049bc76c85b5bc5e23fae7c9e10f7b3a12
+  languageName: node
+  linkType: hard
+
+"@testing-library/react@npm:^16.3.0":
+  version: 16.3.2
+  resolution: "@testing-library/react@npm:16.3.2"
+  dependencies:
+    "@babel/runtime": "npm:^7.12.5"
+  peerDependencies:
+    "@testing-library/dom": ^10.0.0
+    "@types/react": ^18.0.0 || ^19.0.0
+    "@types/react-dom": ^18.0.0 || ^19.0.0
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/f9c7f0915e1b5f7b750e6c7d8b51f091b8ae7ea99bacb761d7b8505ba25de9cfcb749a0f779f1650fb268b499dd79165dc7e1ee0b8b4cb63430d3ddc81ffe044
   languageName: node
   linkType: hard
 
@@ -7353,6 +7393,13 @@ __metadata:
     "@types/socketcluster-server": "npm:*"
     "@types/writable-consumable-stream": "npm:*"
   checksum: 10c0/813700a84f09e74763232ab04a13a2601319d01fedcc4b16c283f474cd8e27f665cccc19e916ca67302ef91e5987cea059e2284de499e602a1d42044473d42b6
+  languageName: node
+  linkType: hard
+
+"@types/aria-query@npm:^5.0.1":
+  version: 5.0.4
+  resolution: "@types/aria-query@npm:5.0.4"
+  checksum: 10c0/dc667bc6a3acc7bba2bccf8c23d56cb1f2f4defaa704cfef595437107efaa972d3b3db9ec1d66bc2711bfc35086821edd32c302bffab36f2e79b97f312069f08
   languageName: node
   linkType: hard
 
@@ -9213,6 +9260,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-styles@npm:^5.0.0":
+  version: 5.2.0
+  resolution: "ansi-styles@npm:5.2.0"
+  checksum: 10c0/9c4ca80eb3c2fb7b33841c210d2f20807f40865d27008d7c3f707b7f95cab7d67462a565e2388ac3285b71cb3d9bb2173de8da37c57692a362885ec34d6e27df
+  languageName: node
+  linkType: hard
+
 "ansi-styles@npm:^6.1.0, ansi-styles@npm:^6.2.1":
   version: 6.2.3
   resolution: "ansi-styles@npm:6.2.3"
@@ -9372,6 +9426,15 @@ __metadata:
   version: 2.0.1
   resolution: "argparse@npm:2.0.1"
   checksum: 10c0/c5640c2d89045371c7cedd6a70212a04e360fd34d6edeae32f6952c63949e3525ea77dbec0289d8213a99bbaeab5abfa860b5c12cf88a2e6cf8106e90dd27a7e
+  languageName: node
+  linkType: hard
+
+"aria-query@npm:5.3.0":
+  version: 5.3.0
+  resolution: "aria-query@npm:5.3.0"
+  dependencies:
+    dequal: "npm:^2.0.3"
+  checksum: 10c0/2bff0d4eba5852a9dd578ecf47eaef0e82cc52569b48469b0aac2db5145db0b17b7a58d9e01237706d1e14b7a1b0ac9b78e9c97027ad97679dd8f91b85da1469
   languageName: node
   linkType: hard
 
@@ -11854,7 +11917,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dequal@npm:2.0.3, dequal@npm:^2.0.0":
+"dequal@npm:2.0.3, dequal@npm:^2.0.0, dequal@npm:^2.0.3":
   version: 2.0.3
   resolution: "dequal@npm:2.0.3"
   checksum: 10c0/f98860cdf58b64991ae10205137c0e97d384c3a4edc7f807603887b7c4b850af1224a33d88012009f150861cbee4fa2d322c4cc04b9313bee312e47f6ecaa888
@@ -12061,6 +12124,13 @@ __metadata:
     react: ^16.8.4 || ^17 || ^18 || ^19
     react-dom: ^16.8.4 || ^17 || ^18 || ^19
   checksum: 10c0/89962e2a8004bac0fa0999cd189c05ee0b34a4268c038f10db62d5ec41de89d9b672375832a21d93776d277c4a14bc022a717dffdc7a85048255969cc0eeb583
+  languageName: node
+  linkType: hard
+
+"dom-accessibility-api@npm:^0.5.9":
+  version: 0.5.16
+  resolution: "dom-accessibility-api@npm:0.5.16"
+  checksum: 10c0/b2c2eda4fae568977cdac27a9f0c001edf4f95a6a6191dfa611e3721db2478d1badc01db5bb4fa8a848aeee13e442a6c2a4386d65ec65a1436f24715a2f8d053
   languageName: node
   linkType: hard
 
@@ -17012,6 +17082,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lz-string@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "lz-string@npm:1.5.0"
+  bin:
+    lz-string: bin/bin.js
+  checksum: 10c0/36128e4de34791838abe979b19927c26e67201ca5acf00880377af7d765b38d1c60847e01c5ec61b1a260c48029084ab3893a3925fd6e48a04011364b089991b
+  languageName: node
+  linkType: hard
+
 "magic-string@npm:^0.30.0, magic-string@npm:^0.30.17, magic-string@npm:^0.30.21, magic-string@npm:~0.30.8":
   version: 0.30.21
   resolution: "magic-string@npm:0.30.21"
@@ -19428,7 +19507,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picocolors@npm:^1.0.0, picocolors@npm:^1.1.1":
+"picocolors@npm:1.1.1, picocolors@npm:^1.0.0, picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
   checksum: 10c0/e2e3e8170ab9d7c7421969adaa7e1b31434f789afb9b3f115f6b96d91945041ac3ceb02e9ec6fe6510ff036bcc0bf91e69a1772edc0b707e12b19c0f2d6bcf58
@@ -20451,6 +20530,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pretty-format@npm:^27.0.2":
+  version: 27.5.1
+  resolution: "pretty-format@npm:27.5.1"
+  dependencies:
+    ansi-regex: "npm:^5.0.1"
+    ansi-styles: "npm:^5.0.0"
+    react-is: "npm:^17.0.1"
+  checksum: 10c0/0cbda1031aa30c659e10921fa94e0dd3f903ecbbbe7184a729ad66f2b6e7f17891e8c7d7654c458fa4ccb1a411ffb695b4f17bbcd3fe075fabe181027c4040ed
+  languageName: node
+  linkType: hard
+
 "pretty-ms@npm:^9.2.0":
   version: 9.3.0
   resolution: "pretty-ms@npm:9.3.0"
@@ -20997,6 +21087,13 @@ __metadata:
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: 10c0/33977da7a5f1a287936a0c85639fec6ca74f4f15ef1e59a6bc20338fc73dc69555381e211f7a3529b8150a1f71e4225525b41b60b52965bda53ce7d47377ada1
+  languageName: node
+  linkType: hard
+
+"react-is@npm:^17.0.1":
+  version: 17.0.2
+  resolution: "react-is@npm:17.0.2"
+  checksum: 10c0/2bdb6b93fbb1820b024b496042cce405c57e2f85e777c9aabd55f9b26d145408f9f74f5934676ffdc46f3dcff656d78413a6e43968e7b3f92eea35b3052e9053
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
continuation of #4147

This focuses on the dropdowns and replacing react-select, as the styling of that doesn't quite match the rest of the ui and is getting very little maintenance these days.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reworked dropdowns (single & multi) with fuzzy search, combobox UX, virtualized lists, and regex-backed custom-value support; synthetic "Create …" options when allowed
  * Many new Storybook component demos for interactive visual testing
  * Variable and image pickers now respect a disabled state

* **Bug Fixes**
  * Color input alpha defaults to opaque when missing
  * Number input infinity overlays now reflect explicit user-set values
  * Improved dropdown placeholder, warning/invalid visuals, and multi-select constraint handling

* **Tests**
  * Extensive component test suites and test setup added

* **Chores**
  * Added Storybook dev script and test/config updates

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitfocus/companion/pull/4172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->