### PR TITLE
feat: replace some coreui with base-ui

### DIFF
--- a/webui/src/App.scss
+++ b/webui/src/App.scss
@@ -7,6 +7,15 @@
 @use 'scss/react-time-picker';
 @use 'scss/react-date-picker';
 
+@use 'scss/components/alert';
+@use 'scss/components/button';
+@use 'scss/components/checkbox-field';
+@use 'scss/components/dropdown-field';
+@use 'scss/components/number-field';
+@use 'scss/components/number-range';
+@use 'scss/components/switch-field';
+@use 'scss/components/tab-area';
+
 @use 'scss/layout';
 @use 'scss/common';
 @use 'scss/tablet';
@@ -34,15 +43,6 @@
 @use 'scss/sticky-tables';
 @use 'scss/expression';
 @use 'scss/image-library';
-
-@use 'scss/components/alert';
-@use 'scss/components/button';
-@use 'scss/components/checkbox-field';
-@use 'scss/components/dropdown-field';
-@use 'scss/components/number-field';
-@use 'scss/components/number-range';
-@use 'scss/components/switch-field';
-@use 'scss/components/tab-area';
 
 //@debug "$primary = #{$primary}"; // should be red (#d50215), not the coreui default blue (#5856d6).
 

--- a/webui/src/App.scss
+++ b/webui/src/App.scss
@@ -36,6 +36,7 @@
 @use 'scss/image-library';
 
 @use 'scss/components/alert';
+@use 'scss/components/button';
 @use 'scss/components/checkbox-field';
 @use 'scss/components/dropdown-field';
 @use 'scss/components/number-field';

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -1,4 +1,4 @@
-import { CButton, CCol, CContainer, CForm, CFormInput, CProgress, CRow } from '@coreui/react'
+import { CCol, CContainer, CForm, CFormInput, CProgress, CRow } from '@coreui/react'
 import { Outlet } from '@tanstack/react-router'
 import { useSubscription } from '@trpc/tanstack-react-query'
 import { observer } from 'mobx-react-lite'
@@ -10,6 +10,7 @@ import { useIdleTimer } from 'react-idle-timer'
 import { PuffLoader } from 'react-spinners'
 import { useMountEffect } from '~/Resources/util.js'
 import { RootAppStoreContext } from '~/Stores/RootAppStore.js'
+import { Button } from './Components/Button.js'
 import { ContextData } from './ContextData.js'
 import { TRPCConnectionStatus, useTRPCConnectionStatus } from './Hooks/useTRPCConnectionStatus.js'
 import { MyHeader } from './Layout/Header.js'
@@ -339,9 +340,9 @@ const AppAuthWrapper = observer(function AppAuthWrapper({ setUnlocked }: AppAuth
 								invalid={showError}
 								readOnly={!userConfig.properties}
 							/>
-							<CButton type="submit" color="primary">
+							<Button type="submit" color="primary">
 								Unlock
-							</CButton>
+							</Button>
 						</div>
 					</CForm>
 				</CCol>

--- a/webui/src/Buttons/ActionRecorder/ButtonPicker.tsx
+++ b/webui/src/Buttons/ActionRecorder/ButtonPicker.tsx
@@ -147,20 +147,11 @@ export const ButtonPicker = observer(function ButtonPicker({ selectButton }: But
 
 	return (
 		<>
-			<div>
-				<Button
-					color="light"
-					style={{
-						float: 'right',
-						marginTop: 10,
-					}}
-					onClick={resetPosition}
-				>
+			<ButtonGridHeader pageNumber={pageNumber} changePage={changePage} setPage={setPageNumber}>
+				<Button color="light" onClick={resetPosition}>
 					<FontAwesomeIcon icon={faHome} /> Home Position
 				</Button>
-
-				<ButtonGridHeader pageNumber={pageNumber} changePage={changePage} setPage={setPageNumber} />
-			</div>
+			</ButtonGridHeader>
 			<div className="buttongrid" ref={isInViewRef}>
 				{hasBeenInView && gridSize && (
 					<ButtonInfiniteGrid

--- a/webui/src/Buttons/ActionRecorder/ButtonPicker.tsx
+++ b/webui/src/Buttons/ActionRecorder/ButtonPicker.tsx
@@ -1,4 +1,4 @@
-import { CButtonGroup, CCol, CForm, CFormLabel, CRow } from '@coreui/react'
+import { CCol, CForm, CFormLabel, CRow } from '@coreui/react'
 import { faHome } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
@@ -6,7 +6,7 @@ import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'r
 import type { ActionSetId } from '@companion-app/shared/Model/ActionModel.js'
 import type { LayeredButtonModel } from '@companion-app/shared/Model/ButtonModel.js'
 import type { ControlLocation, DropdownChoice, DropdownChoiceId } from '@companion-app/shared/Model/Common.js'
-import { Button } from '~/Components/Button'
+import { Button, ButtonGroup } from '~/Components/Button'
 import { SimpleDropdownInputField } from '~/Components/DropdownInputFieldSimple.js'
 import { useControlConfig } from '~/Hooks/useControlConfig.js'
 import { useHasBeenRendered } from '~/Hooks/useHasBeenRendered.js'
@@ -198,7 +198,7 @@ export const ButtonPicker = observer(function ButtonPicker({ selectButton }: But
 							/>
 						</CCol>
 						<CCol className="py-1" sm={10} xs={9}>
-							<CButtonGroup>
+							<ButtonGroup>
 								<Button
 									color="primary"
 									title="Replace all the actions on the trigger"
@@ -215,7 +215,7 @@ export const ButtonPicker = observer(function ButtonPicker({ selectButton }: But
 								>
 									Append
 								</Button>
-							</CButtonGroup>
+							</ButtonGroup>
 						</CCol>
 					</CRow>
 				</CForm>

--- a/webui/src/Buttons/ActionRecorder/ButtonPicker.tsx
+++ b/webui/src/Buttons/ActionRecorder/ButtonPicker.tsx
@@ -1,4 +1,4 @@
-import { CButton, CButtonGroup, CCol, CForm, CFormLabel, CRow } from '@coreui/react'
+import { CButtonGroup, CCol, CForm, CFormLabel, CRow } from '@coreui/react'
 import { faHome } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
@@ -6,6 +6,7 @@ import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'r
 import type { ActionSetId } from '@companion-app/shared/Model/ActionModel.js'
 import type { LayeredButtonModel } from '@companion-app/shared/Model/ButtonModel.js'
 import type { ControlLocation, DropdownChoice, DropdownChoiceId } from '@companion-app/shared/Model/Common.js'
+import { Button } from '~/Components/Button'
 import { SimpleDropdownInputField } from '~/Components/DropdownInputFieldSimple.js'
 import { useControlConfig } from '~/Hooks/useControlConfig.js'
 import { useHasBeenRendered } from '~/Hooks/useHasBeenRendered.js'
@@ -147,7 +148,7 @@ export const ButtonPicker = observer(function ButtonPicker({ selectButton }: But
 	return (
 		<>
 			<div>
-				<CButton
+				<Button
 					color="light"
 					style={{
 						float: 'right',
@@ -156,7 +157,7 @@ export const ButtonPicker = observer(function ButtonPicker({ selectButton }: But
 					onClick={resetPosition}
 				>
 					<FontAwesomeIcon icon={faHome} /> Home Position
-				</CButton>
+				</Button>
 
 				<ButtonGridHeader pageNumber={pageNumber} changePage={changePage} setPage={setPageNumber} />
 			</div>
@@ -198,22 +199,22 @@ export const ButtonPicker = observer(function ButtonPicker({ selectButton }: But
 						</CCol>
 						<CCol className="py-1" sm={10} xs={9}>
 							<CButtonGroup>
-								<CButton
+								<Button
 									color="primary"
 									title="Replace all the actions on the trigger"
 									disabled={!selectedControl || !selectedSet}
 									onClick={replaceActions}
 								>
 									Replace
-								</CButton>
-								<CButton
+								</Button>
+								<Button
 									color="info"
 									title="Append to the existing actions"
 									disabled={!selectedControl || !selectedSet}
 									onClick={appendActions}
 								>
 									Append
-								</CButton>
+								</Button>
 							</CButtonGroup>
 						</CCol>
 					</CRow>

--- a/webui/src/Buttons/ActionRecorder/RecorderSessionFinishModal.tsx
+++ b/webui/src/Buttons/ActionRecorder/RecorderSessionFinishModal.tsx
@@ -1,8 +1,9 @@
-import { CButton, CCol, CForm, CModal, CModalBody, CModalFooter, CModalHeader, CRow } from '@coreui/react'
+import { CCol, CForm, CModal, CModalBody, CModalFooter, CModalHeader, CRow } from '@coreui/react'
 import { faCalendarAlt, faClock } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useCallback, useState } from 'react'
 import type { ActionSetId } from '@companion-app/shared/Model/ActionModel.js'
+import { Button } from '~/Components/Button'
 import { MenuPortalContext } from '~/Components/MenuPortalContext.js'
 import { TabArea } from '~/Components/TabArea.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC.js'
@@ -65,9 +66,9 @@ export function RecorderSessionFinishModal({ doClose, sessionId }: RecorderSessi
 						</TabArea.Root>
 					</CModalBody>
 					<CModalFooter>
-						<CButton color="secondary" onClick={doClose}>
+						<Button color="secondary" onClick={doClose}>
 							Cancel
-						</CButton>
+						</Button>
 					</CModalFooter>
 				</CForm>
 			</MenuPortalContext.Provider>

--- a/webui/src/Buttons/ActionRecorder/RecorderSessionHeading.tsx
+++ b/webui/src/Buttons/ActionRecorder/RecorderSessionHeading.tsx
@@ -1,8 +1,9 @@
-import { CButton, CButtonGroup, CForm, CFormLabel, CRow } from '@coreui/react'
+import { CButtonGroup, CForm, CFormLabel, CRow } from '@coreui/react'
 import { observer } from 'mobx-react-lite'
 import { useCallback, useContext, type RefObject } from 'react'
 import type { RecordSessionInfo } from '@companion-app/shared/Model/ActionRecorderModel.js'
 import type { DropdownChoice, DropdownChoiceId } from '@companion-app/shared/Model/Common.js'
+import { Button } from '~/Components/Button'
 import type { GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
 import { MultiDropdownInputField } from '~/Components/MultiDropdownInputField.js'
 import { SwitchInputField } from '~/Components/SwitchInputField'
@@ -115,15 +116,15 @@ export const RecorderSessionHeading = observer(function RecorderSessionHeading({
 				<CRow className="flex-form-row" style={{ clear: 'both' }}>
 					<div>
 						<CButtonGroup className={'margin-bottom'}>
-							<CButton onClick={doClearActions} color="secondary" disabled={!sessionInfo.actions?.length}>
+							<Button onClick={doClearActions} color="secondary" disabled={!sessionInfo.actions?.length}>
 								Clear Actions
-							</CButton>
-							<CButton onClick={doAbort} color="danger">
+							</Button>
+							<Button onClick={doAbort} color="danger">
 								Discard
-							</CButton>
-							<CButton onClick={doFinish2} color="secondary" disabled={!sessionInfo.actions?.length}>
+							</Button>
+							<Button onClick={doFinish2} color="secondary" disabled={!sessionInfo.actions?.length}>
 								Finish
-							</CButton>
+							</Button>
 						</CButtonGroup>
 					</div>
 				</CRow>

--- a/webui/src/Buttons/ActionRecorder/RecorderSessionHeading.tsx
+++ b/webui/src/Buttons/ActionRecorder/RecorderSessionHeading.tsx
@@ -1,9 +1,9 @@
-import { CButtonGroup, CForm, CFormLabel, CRow } from '@coreui/react'
+import { CForm, CFormLabel, CRow } from '@coreui/react'
 import { observer } from 'mobx-react-lite'
 import { useCallback, useContext, type RefObject } from 'react'
 import type { RecordSessionInfo } from '@companion-app/shared/Model/ActionRecorderModel.js'
 import type { DropdownChoice, DropdownChoiceId } from '@companion-app/shared/Model/Common.js'
-import { Button } from '~/Components/Button'
+import { Button, ButtonGroup } from '~/Components/Button'
 import type { GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
 import { MultiDropdownInputField } from '~/Components/MultiDropdownInputField.js'
 import { SwitchInputField } from '~/Components/SwitchInputField'
@@ -115,7 +115,7 @@ export const RecorderSessionHeading = observer(function RecorderSessionHeading({
 
 				<CRow className="flex-form-row" style={{ clear: 'both' }}>
 					<div>
-						<CButtonGroup className={'margin-bottom'}>
+						<ButtonGroup className="margin-bottom">
 							<Button onClick={doClearActions} color="secondary" disabled={!sessionInfo.actions?.length}>
 								Clear Actions
 							</Button>
@@ -125,7 +125,7 @@ export const RecorderSessionHeading = observer(function RecorderSessionHeading({
 							<Button onClick={doFinish2} color="secondary" disabled={!sessionInfo.actions?.length}>
 								Finish
 							</Button>
-						</CButtonGroup>
+						</ButtonGroup>
 					</div>
 				</CRow>
 			</CForm>

--- a/webui/src/Buttons/ActionRecorder/TriggerPicker.tsx
+++ b/webui/src/Buttons/ActionRecorder/TriggerPicker.tsx
@@ -1,11 +1,10 @@
-import { CButtonGroup } from '@coreui/react'
 import { faList } from '@fortawesome/free-solid-svg-icons'
 import { observer } from 'mobx-react-lite'
 import { useCallback, useContext } from 'react'
 import { CreateTriggerControlId } from '@companion-app/shared/ControlId.js'
 import type { ActionSetId } from '@companion-app/shared/Model/ActionModel.js'
 import type { ClientTriggerData } from '@companion-app/shared/Model/TriggerModel.js'
-import { Button } from '~/Components/Button'
+import { Button, ButtonGroup } from '~/Components/Button'
 import { NonIdealState } from '~/Components/NonIdealState.js'
 import { RootAppStoreContext } from '~/Stores/RootAppStore.js'
 
@@ -22,14 +21,14 @@ function TriggerPickerRow({ id, trigger, selectTrigger }: TriggerPickerRowProps)
 		<tr>
 			<td>{trigger.name}</td>
 			<td>
-				<CButtonGroup>
+				<ButtonGroup>
 					<Button color="primary" title="Replace all the actions on the trigger" onClick={replaceActions}>
 						Replace
 					</Button>
 					<Button color="info" title="Append to the existing actions" onClick={appendActions}>
 						Append
 					</Button>
-				</CButtonGroup>
+				</ButtonGroup>
 			</td>
 		</tr>
 	)

--- a/webui/src/Buttons/ActionRecorder/TriggerPicker.tsx
+++ b/webui/src/Buttons/ActionRecorder/TriggerPicker.tsx
@@ -1,10 +1,11 @@
-import { CButton, CButtonGroup } from '@coreui/react'
+import { CButtonGroup } from '@coreui/react'
 import { faList } from '@fortawesome/free-solid-svg-icons'
 import { observer } from 'mobx-react-lite'
 import { useCallback, useContext } from 'react'
 import { CreateTriggerControlId } from '@companion-app/shared/ControlId.js'
 import type { ActionSetId } from '@companion-app/shared/Model/ActionModel.js'
 import type { ClientTriggerData } from '@companion-app/shared/Model/TriggerModel.js'
+import { Button } from '~/Components/Button'
 import { NonIdealState } from '~/Components/NonIdealState.js'
 import { RootAppStoreContext } from '~/Stores/RootAppStore.js'
 
@@ -22,12 +23,12 @@ function TriggerPickerRow({ id, trigger, selectTrigger }: TriggerPickerRowProps)
 			<td>{trigger.name}</td>
 			<td>
 				<CButtonGroup>
-					<CButton color="primary" title="Replace all the actions on the trigger" onClick={replaceActions}>
+					<Button color="primary" title="Replace all the actions on the trigger" onClick={replaceActions}>
 						Replace
-					</CButton>
-					<CButton color="info" title="Append to the existing actions" onClick={appendActions}>
+					</Button>
+					<Button color="info" title="Append to the existing actions" onClick={appendActions}>
 						Append
-					</CButton>
+					</Button>
 				</CButtonGroup>
 			</td>
 		</tr>

--- a/webui/src/Buttons/ButtonGridActions.tsx
+++ b/webui/src/Buttons/ButtonGridActions.tsx
@@ -1,4 +1,4 @@
-import { CButton, CCol } from '@coreui/react'
+import { CCol } from '@coreui/react'
 import type { IconProp } from '@fortawesome/fontawesome-svg-core'
 import { faArrowsAlt, faArrowsLeftRight, faCompass, faCopy, faEraser, faTrash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -6,6 +6,7 @@ import classnames from 'classnames'
 import { forwardRef, useCallback, useImperativeHandle, useRef, useState } from 'react'
 import { useResizeObserver } from 'usehooks-ts'
 import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
+import { Button, type ButtonColor } from '~/Components/Button'
 import { GenericConfirmModal, type GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC'
 
@@ -60,7 +61,7 @@ export const ButtonGridActions = forwardRef<ButtonGridActionsRef, ButtonGridActi
 	const useCompactButtons = (holderSize.width ?? 0) < 670 // Cutoff for what of the action buttons fit in their large mode
 
 	const getButton = (label: string, icon: IconProp, func: string) => {
-		let color = 'light'
+		let color: ButtonColor = 'light'
 		let disabled = false
 		if (activeFunction === func) {
 			color = 'success'
@@ -70,9 +71,9 @@ export const ButtonGridActions = forwardRef<ButtonGridActionsRef, ButtonGridActi
 
 		return (
 			!disabled && (
-				<CButton color={color} disabled={disabled} onClick={() => startFunction(func)} title={label}>
+				<Button color={color} disabled={disabled} onClick={() => startFunction(func)} title={label}>
 					<FontAwesomeIcon icon={icon} /> {useCompactButtons ? '' : label}
-				</CButton>
+				</Button>
 			)
 		)
 	}
@@ -211,20 +212,20 @@ export const ButtonGridActions = forwardRef<ButtonGridActionsRef, ButtonGridActi
 						&nbsp;
 					</div>
 					<div style={{ display: activeFunction ? '' : 'none' }}>
-						<CButton color="danger" onClick={() => stopFunction()} title="Cancel">
+						<Button color="danger" onClick={() => stopFunction()} title="Cancel">
 							Cancel
-						</CButton>
+						</Button>
 						&nbsp;
-						<CButton color="disabled">{hintText}</CButton>
+						<Button color="disabled">{hintText}</Button>
 					</div>
 					<div style={{ display: activeFunction ? 'none' : undefined }} title="Reset page buttons">
-						<CButton color="light" onClick={() => resetPageNav()}>
+						<Button color="light" onClick={() => resetPageNav()}>
 							<FontAwesomeIcon icon={faCompass} /> {useCompactButtons ? '' : 'Reset page buttons'}
-						</CButton>
+						</Button>
 						&nbsp;
-						<CButton color="light" onClick={() => resetPage()} title="Wipe page">
+						<Button color="light" onClick={() => resetPage()} title="Wipe page">
 							<FontAwesomeIcon icon={faEraser} /> {useCompactButtons ? '' : 'Wipe page'}
-						</CButton>
+						</Button>
 					</div>
 				</div>
 			</CCol>

--- a/webui/src/Buttons/ButtonGridHeader.tsx
+++ b/webui/src/Buttons/ButtonGridHeader.tsx
@@ -1,5 +1,5 @@
 import { Combobox } from '@base-ui/react/combobox'
-import { CButton, CInputGroup } from '@coreui/react'
+import { CInputGroup } from '@coreui/react'
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { prepare as fuzzyPrepare } from 'fuzzysort'
@@ -7,6 +7,7 @@ import { ChevronDownIcon } from 'lucide-react'
 import { observer } from 'mobx-react-lite'
 import { useCallback, useContext, useState } from 'react'
 import type { DropdownChoice } from '@companion-app/shared/Model/Common.js'
+import { Button } from '~/Components/Button'
 import { DropdownInputPopup } from '~/Components/DropdownInputField/Popup.js'
 import { MenuPortalContext } from '~/Components/MenuPortalContext.js'
 import { useComputed } from '~/Resources/util.js'
@@ -102,9 +103,9 @@ export const PageNumberPicker = observer(function ButtonGridHeader({
 	return (
 		<div className="button-grid-header">
 			<CInputGroup>
-				<CButton color="dark" hidden={!changePage} onClick={prevPage}>
+				<Button color="dark" hidden={!changePage} onClick={prevPage}>
 					<FontAwesomeIcon icon={faChevronLeft} />
-				</CButton>
+				</Button>
 				<div className="dropdown-field button-page-input">
 					<Combobox.Root<number | null>
 						autoHighlight
@@ -128,9 +129,9 @@ export const PageNumberPicker = observer(function ButtonGridHeader({
 						<DropdownInputPopup menuPortal={menuPortal ?? undefined} />
 					</Combobox.Root>
 				</div>
-				<CButton color="dark" hidden={!changePage} onClick={nextPage}>
+				<Button color="dark" hidden={!changePage} onClick={nextPage}>
 					<FontAwesomeIcon icon={faChevronRight} />
-				</CButton>
+				</Button>
 			</CInputGroup>
 			<div className="right-buttons">{children}</div>
 		</div>

--- a/webui/src/Buttons/ButtonGridPanel.tsx
+++ b/webui/src/Buttons/ButtonGridPanel.tsx
@@ -1,10 +1,11 @@
-import { CButton, CCol, CRow } from '@coreui/react'
+import { CCol, CRow } from '@coreui/react'
 import { faFileExport, faHome, faPencil } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
 import React, { useCallback, useContext, useRef, useState } from 'react'
 import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
 import { StaticAlert } from '~/Components/Alert.js'
+import { Button } from '~/Components/Button.js'
 import { ConfirmExportModal, type ConfirmExportModalRef } from '~/Components/ConfirmExportModal.js'
 import { useHasBeenRendered } from '~/Hooks/useHasBeenRendered.js'
 import { ContextHelpButton } from '~/Layout/PanelIcons.js'
@@ -121,15 +122,15 @@ export const ButtonsGridPanel = observer(function ButtonsPage({
 				<CRow>
 					<CCol sm={12}>
 						<ButtonGridHeader pageNumber={pageNumber} changePage={changePage2} setPage={setPage}>
-							<CButton color="light" onClick={showExportModal} title="Export Page" className="btn-right">
+							<Button color="light" onClick={showExportModal} title="Export Page" className="btn-right">
 								<FontAwesomeIcon icon={faFileExport} />
-							</CButton>
-							<CButton color="light" onClick={configurePage} title="Edit Page" className="btn-right">
+							</Button>
+							<Button color="light" onClick={configurePage} title="Edit Page" className="btn-right">
 								<FontAwesomeIcon icon={faPencil} />
-							</CButton>
-							<CButton color="light" onClick={resetPosition} title="Home Position" className="btn-right">
+							</Button>
+							<Button color="light" onClick={resetPosition} title="Home Position" className="btn-right">
 								<FontAwesomeIcon icon={faHome} />
-							</CButton>
+							</Button>
 							<ButtonGridZoomControl
 								useCompactButtons={true}
 								gridZoomValue={gridZoomValue}

--- a/webui/src/Buttons/ButtonGridPanel.tsx
+++ b/webui/src/Buttons/ButtonGridPanel.tsx
@@ -108,7 +108,7 @@ export const ButtonsGridPanel = observer(function ButtonsPage({
 				<ConfirmExportModal ref={exportModalRef} title="Export Page" />
 				<EditPagePropertiesModal ref={editRef} includeName />
 
-				<h4 className="btn-inline">
+				<h4 className="button-inline">
 					Buttons
 					<ContextHelpButton action="/user-guide/config/buttons/" />
 				</h4>
@@ -122,20 +122,20 @@ export const ButtonsGridPanel = observer(function ButtonsPage({
 				<CRow>
 					<CCol sm={12}>
 						<ButtonGridHeader pageNumber={pageNumber} changePage={changePage2} setPage={setPage}>
-							<Button color="light" onClick={showExportModal} title="Export Page" className="btn-right">
-								<FontAwesomeIcon icon={faFileExport} />
-							</Button>
-							<Button color="light" onClick={configurePage} title="Edit Page" className="btn-right">
-								<FontAwesomeIcon icon={faPencil} />
-							</Button>
-							<Button color="light" onClick={resetPosition} title="Home Position" className="btn-right">
-								<FontAwesomeIcon icon={faHome} />
-							</Button>
 							<ButtonGridZoomControl
 								useCompactButtons={true}
 								gridZoomValue={gridZoomValue}
 								gridZoomController={gridZoomController}
 							/>
+							<Button color="light" onClick={resetPosition} title="Home Position" className="ms-1">
+								<FontAwesomeIcon icon={faHome} />
+							</Button>
+							<Button color="light" onClick={configurePage} title="Edit Page" className="ms-1">
+								<FontAwesomeIcon icon={faPencil} />
+							</Button>
+							<Button color="light" onClick={showExportModal} title="Export Page" className="ms-1">
+								<FontAwesomeIcon icon={faFileExport} />
+							</Button>
 						</ButtonGridHeader>
 					</CCol>
 				</CRow>

--- a/webui/src/Buttons/ButtonGridResizePrompt.tsx
+++ b/webui/src/Buttons/ButtonGridResizePrompt.tsx
@@ -1,9 +1,9 @@
-import { CButton } from '@coreui/react'
 import { faExpand } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
 import { useContext } from 'react'
 import { DismissableAlert } from '~/Components/Alert'
+import { Button } from '~/Components/Button'
 import { trpc, useMutationExt } from '~/Resources/TRPC'
 import { RootAppStoreContext } from '~/Stores/RootAppStore.js'
 
@@ -34,10 +34,10 @@ export const ButtonGridResizePrompt = observer(function ButtonGridResizePrompt()
 						<li key={s.id}>{s.displayName}</li>
 					))}
 				</ul>
-				<CButton color="info" onClick={doAutoResize}>
+				<Button color="info" onClick={doAutoResize}>
 					<FontAwesomeIcon icon={faExpand} />
 					&nbsp;Resize grid to fit
-				</CButton>
+				</Button>
 			</DismissableAlert>
 		</>
 	)

--- a/webui/src/Buttons/ButtonGridZoomControl.tsx
+++ b/webui/src/Buttons/ButtonGridZoomControl.tsx
@@ -1,5 +1,4 @@
 import {
-	CButton,
 	CDropdown,
 	CDropdownMenu,
 	CDropdownToggle,
@@ -10,6 +9,7 @@ import {
 } from '@coreui/react'
 import { faMagnifyingGlass, faMinus, faPlus } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { Button } from '~/Components/Button.js'
 import { NumberInputField } from '~/Components/NumberInputField.js'
 import { ZOOM_MAX, ZOOM_MIN, ZOOM_STEP, type GridZoomController } from './GridZoom.js'
 
@@ -31,9 +31,9 @@ export function ButtonGridZoomControl({
 			</CDropdownToggle>
 			<CDropdownMenu>
 				<CInputGroup>
-					<CButton onClick={() => gridZoomController.zoomOut()}>
+					<Button onClick={() => gridZoomController.zoomOut()}>
 						<FontAwesomeIcon icon={faMinus} />
-					</CButton>
+					</Button>
 					<CFormRange
 						name="scale"
 						min={ZOOM_MIN}
@@ -43,9 +43,9 @@ export function ButtonGridZoomControl({
 						value={gridZoomValue}
 						onChange={(e) => gridZoomController.setZoom(parseInt(e.currentTarget.value))}
 					/>
-					<CButton onClick={() => gridZoomController.zoomIn()}>
+					<Button onClick={() => gridZoomController.zoomIn()}>
 						<FontAwesomeIcon icon={faPlus} />
-					</CButton>
+					</Button>
 				</CInputGroup>
 				<CInputGroup className="dropdown-item-padding">
 					<NumberInputField value={gridZoomValue} setValue={gridZoomController.setZoom} min={ZOOM_MIN} max={ZOOM_MAX} />

--- a/webui/src/Buttons/ButtonGridZoomControl.tsx
+++ b/webui/src/Buttons/ButtonGridZoomControl.tsx
@@ -24,7 +24,7 @@ export function ButtonGridZoomControl({
 	gridZoomController,
 }: ButtonGridZoomControlProps): React.JSX.Element {
 	return (
-		<CDropdown className="dropdown-zoom btn-right" autoClose="outside" title="View Scale">
+		<CDropdown className="dropdown-zoom" autoClose="outside" title="View Scale">
 			<CDropdownToggle caret={!useCompactButtons} color="light">
 				{/* <span className="sr-only">View Scale</span> */}
 				<FontAwesomeIcon icon={faMagnifyingGlass} /> {useCompactButtons ? '' : `${Math.round(gridZoomValue)}%`}

--- a/webui/src/Buttons/EditButton/ButtonEditorTabs.tsx
+++ b/webui/src/Buttons/EditButton/ButtonEditorTabs.tsx
@@ -1,4 +1,3 @@
-import { CButton } from '@coreui/react'
 import { faClone, faPlus } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import classNames from 'classnames'
@@ -8,6 +7,7 @@ import { GetStepIds } from '@companion-app/shared/Controls.js'
 import type { ActionStepOptions } from '@companion-app/shared/Model/ActionModel.js'
 import type { NormalButtonSteps } from '@companion-app/shared/Model/ButtonModel.js'
 import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
+import { Button } from '~/Components/Button'
 import { GenericConfirmModal, type GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
 import { TabArea } from '~/Components/TabArea.js'
 import { TextInputField } from '~/Components/TextInputField.js'
@@ -114,12 +114,12 @@ export function ButtonEditorTabs({
 
 						{stepKeys.length === 1 && (
 							<div className="tab-end-area align-self-center">
-								<CButton title="Add step" size="sm" onClick={service.appendStep}>
+								<Button title="Add step" size="sm" onClick={service.appendStep}>
 									<FontAwesomeIcon icon={faPlus} />
-								</CButton>
-								<CButton title="Duplicate step" size="sm" onClick={() => service.duplicateStep(stepKeys[0])}>
+								</Button>
+								<Button title="Duplicate step" size="sm" onClick={() => service.duplicateStep(stepKeys[0])}>
 									<FontAwesomeIcon icon={faClone} />
-								</CButton>
+								</Button>
 							</div>
 						)}
 					</TabArea.List>

--- a/webui/src/Buttons/EditButton/ControlActionStepTab.tsx
+++ b/webui/src/Buttons/EditButton/ControlActionStepTab.tsx
@@ -1,10 +1,9 @@
-import { CButtonGroup } from '@coreui/react'
 import { faChevronLeft, faChevronRight, faClone, faPlus, faTrash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import type { NormalButtonSteps } from '@companion-app/shared/Model/ButtonModel.js'
 import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
 import { EntityModelType } from '@companion-app/shared/Model/EntityModel.js'
-import { Button } from '~/Components/Button'
+import { Button, ButtonGroup } from '~/Components/Button'
 import { ControlEntitiesEditor } from '~/Controls/EntitiesEditor.js'
 import { MyErrorBoundary } from '~/Resources/Error.js'
 import type { IControlActionStepsAndSetsService } from '~/Services/Controls/ControlActionStepsAndSetsService.js'
@@ -40,60 +39,62 @@ export function ControlActionStepTab({
 }: ControlActionStepTabProps): React.JSX.Element {
 	return (
 		<>
-			<CButtonGroup hidden={stepKeys.length === 1} className="mt-2">
-				<Button
-					color="danger"
-					title="Move step before"
-					disabled={selectedIndex === 0}
-					onClick={() => service.swapSteps(selectedKey, stepKeys[selectedIndex - 1])}
-				>
-					<FontAwesomeIcon icon={faChevronLeft} />
-				</Button>
-				<Button
-					color="danger"
-					title="Move step after"
-					disabled={selectedIndex === stepKeys.length - 1}
-					onClick={() => service.swapSteps(selectedKey, stepKeys[selectedIndex + 1])}
-				>
-					<FontAwesomeIcon icon={faChevronRight} />
-				</Button>
+			{stepKeys.length > 1 && (
+				<ButtonGroup className="mt-2">
+					<Button
+						color="danger"
+						title="Move step before"
+						disabled={selectedIndex === 0}
+						onClick={() => service.swapSteps(selectedKey, stepKeys[selectedIndex - 1])}
+					>
+						<FontAwesomeIcon icon={faChevronLeft} />
+					</Button>
+					<Button
+						color="danger"
+						title="Move step after"
+						disabled={selectedIndex === stepKeys.length - 1}
+						onClick={() => service.swapSteps(selectedKey, stepKeys[selectedIndex + 1])}
+					>
+						<FontAwesomeIcon icon={faChevronRight} />
+					</Button>
 
-				<Button
-					color="success"
-					style={{
-						fontWeight: 'bold',
-						opacity: runtimeProps.current_step_id === selectedKey || disabledSetStep ? 0.3 : 1,
-					}}
-					disabled={runtimeProps.current_step_id === selectedKey || disabledSetStep}
-					onClick={() => service.setCurrentStep(selectedKey)}
-					title="Make this step the current step, without executing any actions."
-				>
-					Select
-				</Button>
-				<Button
-					style={{ backgroundColor: '#f0f0f0', marginRight: 1 }}
-					title="Add step"
-					disabled={stepKeys.length === 1}
-					onClick={service.appendStep}
-				>
-					<FontAwesomeIcon icon={faPlus} />
-				</Button>
-				<Button
-					style={{ backgroundColor: '#f0f0f0' }}
-					title="Duplicate step"
-					onClick={() => service.duplicateStep(selectedKey)}
-				>
-					<FontAwesomeIcon icon={faClone} />
-				</Button>
-				<Button
-					style={{ backgroundColor: '#f0f0f0' }}
-					title="Delete step"
-					disabled={stepKeys.length === 1}
-					onClick={() => service.removeStep(selectedKey)}
-				>
-					<FontAwesomeIcon icon={faTrash} />
-				</Button>
-			</CButtonGroup>
+					<Button
+						color="success"
+						style={{
+							fontWeight: 'bold',
+							opacity: runtimeProps.current_step_id === selectedKey || disabledSetStep ? 0.3 : 1,
+						}}
+						disabled={runtimeProps.current_step_id === selectedKey || disabledSetStep}
+						onClick={() => service.setCurrentStep(selectedKey)}
+						title="Make this step the current step, without executing any actions."
+					>
+						Select
+					</Button>
+					<Button
+						style={{ backgroundColor: '#f0f0f0', marginRight: 1 }}
+						title="Add step"
+						disabled={stepKeys.length === 1}
+						onClick={service.appendStep}
+					>
+						<FontAwesomeIcon icon={faPlus} />
+					</Button>
+					<Button
+						style={{ backgroundColor: '#f0f0f0' }}
+						title="Duplicate step"
+						onClick={() => service.duplicateStep(selectedKey)}
+					>
+						<FontAwesomeIcon icon={faClone} />
+					</Button>
+					<Button
+						style={{ backgroundColor: '#f0f0f0' }}
+						title="Delete step"
+						disabled={stepKeys.length === 1}
+						onClick={() => service.removeStep(selectedKey)}
+					>
+						<FontAwesomeIcon icon={faTrash} />
+					</Button>
+				</ButtonGroup>
+			)}
 
 			<div className="mt-10">
 				{/* Wrap the entity-category, for :first-child to work */}

--- a/webui/src/Buttons/EditButton/ControlActionStepTab.tsx
+++ b/webui/src/Buttons/EditButton/ControlActionStepTab.tsx
@@ -42,7 +42,7 @@ export function ControlActionStepTab({
 			{stepKeys.length > 1 && (
 				<ButtonGroup className="mt-2">
 					<Button
-						color="danger"
+						color="primary"
 						title="Move step before"
 						disabled={selectedIndex === 0}
 						onClick={() => service.swapSteps(selectedKey, stepKeys[selectedIndex - 1])}
@@ -50,7 +50,7 @@ export function ControlActionStepTab({
 						<FontAwesomeIcon icon={faChevronLeft} />
 					</Button>
 					<Button
-						color="danger"
+						color="primary"
 						title="Move step after"
 						disabled={selectedIndex === stepKeys.length - 1}
 						onClick={() => service.swapSteps(selectedKey, stepKeys[selectedIndex + 1])}
@@ -60,33 +60,22 @@ export function ControlActionStepTab({
 
 					<Button
 						color="success"
-						style={{
-							fontWeight: 'bold',
-							opacity: runtimeProps.current_step_id === selectedKey || disabledSetStep ? 0.3 : 1,
-						}}
+						className="fw-medium"
+						variant={runtimeProps.current_step_id === selectedKey || disabledSetStep ? 'outline' : undefined}
 						disabled={runtimeProps.current_step_id === selectedKey || disabledSetStep}
 						onClick={() => service.setCurrentStep(selectedKey)}
 						title="Make this step the current step, without executing any actions."
 					>
 						Select
 					</Button>
-					<Button
-						style={{ backgroundColor: '#f0f0f0', marginRight: 1 }}
-						title="Add step"
-						disabled={stepKeys.length === 1}
-						onClick={service.appendStep}
-					>
+					<Button color="secondary" title="Add step" disabled={stepKeys.length === 1} onClick={service.appendStep}>
 						<FontAwesomeIcon icon={faPlus} />
 					</Button>
-					<Button
-						style={{ backgroundColor: '#f0f0f0' }}
-						title="Duplicate step"
-						onClick={() => service.duplicateStep(selectedKey)}
-					>
+					<Button color="secondary" title="Duplicate step" onClick={() => service.duplicateStep(selectedKey)}>
 						<FontAwesomeIcon icon={faClone} />
 					</Button>
 					<Button
-						style={{ backgroundColor: '#f0f0f0' }}
+						color="secondary"
 						title="Delete step"
 						disabled={stepKeys.length === 1}
 						onClick={() => service.removeStep(selectedKey)}

--- a/webui/src/Buttons/EditButton/ControlActionStepTab.tsx
+++ b/webui/src/Buttons/EditButton/ControlActionStepTab.tsx
@@ -1,9 +1,10 @@
-import { CButton, CButtonGroup } from '@coreui/react'
+import { CButtonGroup } from '@coreui/react'
 import { faChevronLeft, faChevronRight, faClone, faPlus, faTrash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import type { NormalButtonSteps } from '@companion-app/shared/Model/ButtonModel.js'
 import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
 import { EntityModelType } from '@companion-app/shared/Model/EntityModel.js'
+import { Button } from '~/Components/Button'
 import { ControlEntitiesEditor } from '~/Controls/EntitiesEditor.js'
 import { MyErrorBoundary } from '~/Resources/Error.js'
 import type { IControlActionStepsAndSetsService } from '~/Services/Controls/ControlActionStepsAndSetsService.js'
@@ -40,24 +41,24 @@ export function ControlActionStepTab({
 	return (
 		<>
 			<CButtonGroup hidden={stepKeys.length === 1} className="mt-2">
-				<CButton
+				<Button
 					color="danger"
 					title="Move step before"
 					disabled={selectedIndex === 0}
 					onClick={() => service.swapSteps(selectedKey, stepKeys[selectedIndex - 1])}
 				>
 					<FontAwesomeIcon icon={faChevronLeft} />
-				</CButton>
-				<CButton
+				</Button>
+				<Button
 					color="danger"
 					title="Move step after"
 					disabled={selectedIndex === stepKeys.length - 1}
 					onClick={() => service.swapSteps(selectedKey, stepKeys[selectedIndex + 1])}
 				>
 					<FontAwesomeIcon icon={faChevronRight} />
-				</CButton>
+				</Button>
 
-				<CButton
+				<Button
 					color="success"
 					style={{
 						fontWeight: 'bold',
@@ -68,30 +69,30 @@ export function ControlActionStepTab({
 					title="Make this step the current step, without executing any actions."
 				>
 					Select
-				</CButton>
-				<CButton
+				</Button>
+				<Button
 					style={{ backgroundColor: '#f0f0f0', marginRight: 1 }}
 					title="Add step"
 					disabled={stepKeys.length === 1}
 					onClick={service.appendStep}
 				>
 					<FontAwesomeIcon icon={faPlus} />
-				</CButton>
-				<CButton
+				</Button>
+				<Button
 					style={{ backgroundColor: '#f0f0f0' }}
 					title="Duplicate step"
 					onClick={() => service.duplicateStep(selectedKey)}
 				>
 					<FontAwesomeIcon icon={faClone} />
-				</CButton>
-				<CButton
+				</Button>
+				<Button
 					style={{ backgroundColor: '#f0f0f0' }}
 					title="Delete step"
 					disabled={stepKeys.length === 1}
 					onClick={() => service.removeStep(selectedKey)}
 				>
 					<FontAwesomeIcon icon={faTrash} />
-				</CButton>
+				</Button>
 			</CButtonGroup>
 
 			<div className="mt-10">
@@ -162,9 +163,9 @@ export function ControlActionStepTab({
 			</div>
 
 			<div className="my-3">
-				<CButton onClick={() => service.appendSet(selectedKey)} color="primary">
+				<Button onClick={() => service.appendSet(selectedKey)} color="primary">
 					<FontAwesomeIcon icon={faPlus} /> Add duration group
-				</CButton>
+				</Button>
 			</div>
 		</>
 	)

--- a/webui/src/Buttons/EditButton/ControlClearButton.tsx
+++ b/webui/src/Buttons/EditButton/ControlClearButton.tsx
@@ -1,9 +1,9 @@
-import { CButton } from '@coreui/react'
 import { faTrashAlt } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useCallback } from 'react'
 import { formatLocation } from '@companion-app/shared/ControlId.js'
 import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
+import { Button } from '~/Components/Button'
 import type { GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC'
 
@@ -30,8 +30,8 @@ export function ControlClearButton({
 	}, [resetControlMutation, location, resetModalRef])
 
 	return (
-		<CButton color="danger" onClick={clearButton} title="Clear Button">
+		<Button color="danger" onClick={clearButton} title="Clear Button">
 			<FontAwesomeIcon icon={faTrashAlt} />
-		</CButton>
+		</Button>
 	)
 }

--- a/webui/src/Buttons/EditButton/ControlClearButton.tsx
+++ b/webui/src/Buttons/EditButton/ControlClearButton.tsx
@@ -30,7 +30,7 @@ export function ControlClearButton({
 	}, [resetControlMutation, location, resetModalRef])
 
 	return (
-		<Button color="danger" onClick={clearButton} title="Clear Button">
+		<Button color="danger" onClick={clearButton} title="Clear Button" aria-label="Clear button">
 			<FontAwesomeIcon icon={faTrashAlt} />
 		</Button>
 	)

--- a/webui/src/Buttons/EditButton/ControlHotPressButtons.tsx
+++ b/webui/src/Buttons/EditButton/ControlHotPressButtons.tsx
@@ -49,40 +49,29 @@ export function ControlHotPressButtons({
 					color="warning"
 					onMouseDown={hotPressDown}
 					onMouseUp={hotPressUp}
-					style={{ color: 'white' }}
 					title="Test press button"
 				>
 					<FontAwesomeIcon icon={faPlay} />
 					&nbsp;Test
 				</Button>
+
+				{showRotaries && (
+					<MyErrorBoundary>
+						<Button color="warning" onMouseDown={hotRotateLeft} title="Test rotate left">
+							<FontAwesomeIcon icon={faUndo} />
+						</Button>
+
+						<Button color="warning" onMouseDown={hotRotateRight} title="Test rotate right">
+							<FontAwesomeIcon icon={faRedo} />
+						</Button>
+					</MyErrorBoundary>
+				)}
+
 				<Button color="secondary" onMouseDown={hotAbortActions} title="Abort running actions">
 					<FontAwesomeIcon icon={faStop} />
 					&nbsp;Stop
 				</Button>
 			</ButtonGroup>
-			{showRotaries && (
-				<MyErrorBoundary>
-					<Button
-						className="ms-1"
-						color="warning"
-						onMouseDown={hotRotateLeft}
-						style={{ color: 'white' }}
-						title="Test rotate left"
-					>
-						<FontAwesomeIcon icon={faUndo} />
-					</Button>
-
-					<Button
-						className="ms-1"
-						color="warning"
-						onMouseDown={hotRotateRight}
-						style={{ color: 'white' }}
-						title="Test rotate right"
-					>
-						<FontAwesomeIcon icon={faRedo} />
-					</Button>
-				</MyErrorBoundary>
-			)}
 		</>
 	)
 }

--- a/webui/src/Buttons/EditButton/ControlHotPressButtons.tsx
+++ b/webui/src/Buttons/EditButton/ControlHotPressButtons.tsx
@@ -1,8 +1,9 @@
-import { CButton, CButtonGroup } from '@coreui/react'
+import { CButtonGroup } from '@coreui/react'
 import { faPlay, faRedo, faStop, faUndo } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useCallback } from 'react'
 import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
+import { Button } from '~/Components/Button'
 import { MyErrorBoundary } from '~/Resources/Error'
 import { trpc, useMutationExt } from '~/Resources/TRPC'
 
@@ -44,7 +45,7 @@ export function ControlHotPressButtons({
 	return (
 		<>
 			<CButtonGroup>
-				<CButton
+				<Button
 					className="ms-1"
 					color="warning"
 					onMouseDown={hotPressDown}
@@ -54,15 +55,15 @@ export function ControlHotPressButtons({
 				>
 					<FontAwesomeIcon icon={faPlay} />
 					&nbsp;Test
-				</CButton>
-				<CButton color="secondary" onMouseDown={hotAbortActions} title="Abort running actions">
+				</Button>
+				<Button color="secondary" onMouseDown={hotAbortActions} title="Abort running actions">
 					<FontAwesomeIcon icon={faStop} />
 					&nbsp;Stop
-				</CButton>
+				</Button>
 			</CButtonGroup>
 			{showRotaries && (
 				<MyErrorBoundary>
-					<CButton
+					<Button
 						className="ms-1"
 						color="warning"
 						onMouseDown={hotRotateLeft}
@@ -70,9 +71,9 @@ export function ControlHotPressButtons({
 						title="Test rotate left"
 					>
 						<FontAwesomeIcon icon={faUndo} />
-					</CButton>
+					</Button>
 
-					<CButton
+					<Button
 						className="ms-1"
 						color="warning"
 						onMouseDown={hotRotateRight}
@@ -80,7 +81,7 @@ export function ControlHotPressButtons({
 						title="Test rotate right"
 					>
 						<FontAwesomeIcon icon={faRedo} />
-					</CButton>
+					</Button>
 				</MyErrorBoundary>
 			)}
 		</>

--- a/webui/src/Buttons/EditButton/ControlHotPressButtons.tsx
+++ b/webui/src/Buttons/EditButton/ControlHotPressButtons.tsx
@@ -1,9 +1,8 @@
-import { CButtonGroup } from '@coreui/react'
 import { faPlay, faRedo, faStop, faUndo } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useCallback } from 'react'
 import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
-import { Button } from '~/Components/Button'
+import { Button, ButtonGroup } from '~/Components/Button'
 import { MyErrorBoundary } from '~/Resources/Error'
 import { trpc, useMutationExt } from '~/Resources/TRPC'
 
@@ -44,7 +43,7 @@ export function ControlHotPressButtons({
 
 	return (
 		<>
-			<CButtonGroup>
+			<ButtonGroup>
 				<Button
 					className="ms-1"
 					color="warning"
@@ -60,7 +59,7 @@ export function ControlHotPressButtons({
 					<FontAwesomeIcon icon={faStop} />
 					&nbsp;Stop
 				</Button>
-			</CButtonGroup>
+			</ButtonGroup>
 			{showRotaries && (
 				<MyErrorBoundary>
 					<Button

--- a/webui/src/Buttons/EditButton/EditActionsRelease.tsx
+++ b/webui/src/Buttons/EditButton/EditActionsRelease.tsx
@@ -80,10 +80,10 @@ export function EditActionsRelease({
 					key={id}
 					heading={`${ident} actions`}
 					headingActions={[
-						<Button key="rename" color="white" title="Configure" size="sm" onClick={() => configureSet(id)}>
+						<Button key="rename" title="Configure" size="sm" onClick={() => configureSet(id)}>
 							<FontAwesomeIcon icon={faPencil} />
 						</Button>,
-						<Button key="delete" color="white" title="Delete step" size="sm" onClick={() => removeSet(stepId, id)}>
+						<Button key="delete" title="Delete step" size="sm" onClick={() => removeSet(stepId, id)}>
 							<FontAwesomeIcon icon={faTrash} />
 						</Button>,
 					]}

--- a/webui/src/Buttons/EditButton/EditActionsRelease.tsx
+++ b/webui/src/Buttons/EditButton/EditActionsRelease.tsx
@@ -1,10 +1,10 @@
-import { CButton } from '@coreui/react'
 import { faPencil, faTrash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useCallback, useRef } from 'react'
 import type { ActionSetsModel, ActionStepOptions } from '@companion-app/shared/Model/ActionModel.js'
 import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
 import { EntityModelType, type SomeEntityModel } from '@companion-app/shared/Model/EntityModel.js'
+import { Button } from '~/Components/Button'
 import { ControlEntitiesEditor } from '~/Controls/EntitiesEditor.js'
 import { MyErrorBoundary } from '~/Resources/Error.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC.js'
@@ -80,12 +80,12 @@ export function EditActionsRelease({
 					key={id}
 					heading={`${ident} actions`}
 					headingActions={[
-						<CButton key="rename" color="white" title="Configure" size="sm" onClick={() => configureSet(id)}>
+						<Button key="rename" color="white" title="Configure" size="sm" onClick={() => configureSet(id)}>
 							<FontAwesomeIcon icon={faPencil} />
-						</CButton>,
-						<CButton key="delete" color="white" title="Delete step" size="sm" onClick={() => removeSet(stepId, id)}>
+						</Button>,
+						<Button key="delete" color="white" title="Delete step" size="sm" onClick={() => removeSet(stepId, id)}>
 							<FontAwesomeIcon icon={faTrash} />
-						</CButton>,
+						</Button>,
 					]}
 					controlId={controlId}
 					location={location}

--- a/webui/src/Buttons/EditButton/EditDurationGroupPropertiesModal.tsx
+++ b/webui/src/Buttons/EditButton/EditDurationGroupPropertiesModal.tsx
@@ -1,5 +1,6 @@
-import { CButton, CCol, CForm, CFormLabel, CModalBody, CModalFooter, CModalHeader } from '@coreui/react'
+import { CCol, CForm, CFormLabel, CModalBody, CModalFooter, CModalHeader } from '@coreui/react'
 import { forwardRef, useCallback, useImperativeHandle, useRef, useState } from 'react'
+import { Button } from '~/Components/Button'
 import { CModalExt } from '~/Components/CModalExt.js'
 import { NumberInputField } from '~/Components/NumberInputField.js'
 import { SwitchInputField } from '~/Components/SwitchInputField'
@@ -93,12 +94,12 @@ export const EditDurationGroupPropertiesModal = forwardRef<EditDurationGroupProp
 					</CForm>
 				</CModalBody>
 				<CModalFooter>
-					<CButton color="secondary" onClick={doClose}>
+					<Button color="secondary" onClick={doClose}>
 						Cancel
-					</CButton>
-					<CButton ref={buttonRef} color="primary" onClick={doAction}>
+					</Button>
+					<Button ref={buttonRef} color="primary" onClick={doAction}>
 						Save
-					</CButton>
+					</Button>
 				</CModalFooter>
 			</CModalExt>
 		)

--- a/webui/src/Buttons/EditButton/LayeredButtonEditor/Buttons.tsx
+++ b/webui/src/Buttons/EditButton/LayeredButtonEditor/Buttons.tsx
@@ -124,7 +124,7 @@ function AddElementDropdownPopoverButton({
 	}, [addElementMutation, controlId, elementType, styleStore])
 
 	return (
-		<Button onMouseDown={addCallback} color="secondary" title={`Add ${label}`} style={{ textAlign: 'left' }}>
+		<Button onMouseDown={addCallback} color="secondary" title={`Add ${label}`} className="text-start">
 			<Tuck>
 				<FontAwesomeIcon icon={icon} />
 			</Tuck>

--- a/webui/src/Buttons/EditButton/LayeredButtonEditor/Buttons.tsx
+++ b/webui/src/Buttons/EditButton/LayeredButtonEditor/Buttons.tsx
@@ -1,12 +1,4 @@
-import {
-	CAccordion,
-	CAccordionBody,
-	CAccordionHeader,
-	CAccordionItem,
-	CButton,
-	CButtonGroup,
-	CPopover,
-} from '@coreui/react'
+import { CAccordion, CAccordionBody, CAccordionHeader, CAccordionItem, CButtonGroup, CPopover } from '@coreui/react'
 import type { IconProp } from '@fortawesome/fontawesome-svg-core'
 import {
 	faCircle,
@@ -25,6 +17,7 @@ import { observer } from 'mobx-react-lite'
 import React, { useCallback, useContext, useMemo, useState } from 'react'
 import type { UICompositeElementDefinition } from '@companion-app/shared/Model/EntityDefinitionModel.js'
 import type { SomeButtonGraphicsElement } from '@companion-app/shared/Model/StyleLayersModel.js'
+import { Button } from '~/Components/Button'
 import type { GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
 import { Tuck } from '~/Components/Tuck.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC.js'
@@ -56,9 +49,9 @@ export function RemoveElementButton({
 	}, [removeElementMutation, confirmModalRef, controlId, elementId])
 
 	return (
-		<CButton color="white" size="sm" onClick={removeElement} title="Remove">
+		<Button color="white" size="sm" onClick={removeElement} title="Remove">
 			<FontAwesomeIcon icon={faTrash} />
-		</CButton>
+		</Button>
 	)
 }
 
@@ -74,14 +67,9 @@ export const ToggleVisibilityButton = observer(function ToggleVisibilityButton({
 	const isVisible = styleStore.isElementVisible(elementId)
 
 	return (
-		<CButton
-			color="white"
-			size="sm"
-			onClick={toggleVisibility}
-			title={isVisible ? 'Preview visible' : 'Preview hidden'}
-		>
+		<Button color="white" size="sm" onClick={toggleVisibility} title={isVisible ? 'Preview visible' : 'Preview hidden'}>
 			<FontAwesomeIcon icon={faEye} style={{ opacity: isVisible ? undefined : 0.3 }} />
-		</CButton>
+		</Button>
 	)
 })
 
@@ -101,9 +89,9 @@ export function AddElementDropdownButton({
 			style={{ backgroundColor: 'white' }}
 			className="add-layered-element-popover"
 		>
-			<CButton color="white" size="sm" title="Add element">
+			<Button color="white" size="sm" title="Add element">
 				<FontAwesomeIcon icon={faPlus} />
-			</CButton>
+			</Button>
 		</CPopover>
 	)
 }
@@ -136,12 +124,12 @@ function AddElementDropdownPopoverButton({
 	}, [addElementMutation, controlId, elementType, styleStore])
 
 	return (
-		<CButton onMouseDown={addCallback} color="secondary" title={`Add ${label}`} style={{ textAlign: 'left' }}>
+		<Button onMouseDown={addCallback} color="secondary" title={`Add ${label}`} style={{ textAlign: 'left' }}>
 			<Tuck>
 				<FontAwesomeIcon icon={icon} />
 			</Tuck>
 			{label}
-		</CButton>
+		</Button>
 	)
 }
 

--- a/webui/src/Buttons/EditButton/LayeredButtonEditor/Buttons.tsx
+++ b/webui/src/Buttons/EditButton/LayeredButtonEditor/Buttons.tsx
@@ -49,7 +49,7 @@ export function RemoveElementButton({
 	}, [removeElementMutation, confirmModalRef, controlId, elementId])
 
 	return (
-		<Button color="white" size="sm" onClick={removeElement} title="Remove">
+		<Button size="sm" onClick={removeElement} title="Remove">
 			<FontAwesomeIcon icon={faTrash} />
 		</Button>
 	)
@@ -67,7 +67,7 @@ export const ToggleVisibilityButton = observer(function ToggleVisibilityButton({
 	const isVisible = styleStore.isElementVisible(elementId)
 
 	return (
-		<Button color="white" size="sm" onClick={toggleVisibility} title={isVisible ? 'Preview visible' : 'Preview hidden'}>
+		<Button size="sm" onClick={toggleVisibility} title={isVisible ? 'Preview visible' : 'Preview hidden'}>
 			<FontAwesomeIcon icon={faEye} style={{ opacity: isVisible ? undefined : 0.3 }} />
 		</Button>
 	)
@@ -89,7 +89,7 @@ export function AddElementDropdownButton({
 			style={{ backgroundColor: 'white' }}
 			className="add-layered-element-popover"
 		>
-			<Button color="white" size="sm" title="Add element">
+			<Button size="sm" title="Add element">
 				<FontAwesomeIcon icon={faPlus} />
 			</Button>
 		</CPopover>

--- a/webui/src/Buttons/EditButton/LayeredButtonEditor/Buttons.tsx
+++ b/webui/src/Buttons/EditButton/LayeredButtonEditor/Buttons.tsx
@@ -1,4 +1,4 @@
-import { CAccordion, CAccordionBody, CAccordionHeader, CAccordionItem, CButtonGroup, CPopover } from '@coreui/react'
+import { CAccordion, CAccordionBody, CAccordionHeader, CAccordionItem, CPopover } from '@coreui/react'
 import type { IconProp } from '@fortawesome/fontawesome-svg-core'
 import {
 	faCircle,
@@ -17,7 +17,7 @@ import { observer } from 'mobx-react-lite'
 import React, { useCallback, useContext, useMemo, useState } from 'react'
 import type { UICompositeElementDefinition } from '@companion-app/shared/Model/EntityDefinitionModel.js'
 import type { SomeButtonGraphicsElement } from '@companion-app/shared/Model/StyleLayersModel.js'
-import { Button } from '~/Components/Button'
+import { Button, ButtonGroup } from '~/Components/Button'
 import type { GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
 import { Tuck } from '~/Components/Tuck.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC.js'
@@ -165,7 +165,7 @@ const CompositeElementConnectionGroup = observer(function CompositeElementConnec
 			<CAccordionItem itemKey={group.connectionId}>
 				<CAccordionHeader onMouseDown={toggleOpen}>{group.connectionLabel}</CAccordionHeader>
 				<CAccordionBody>
-					<CButtonGroup vertical>
+					<ButtonGroup vertical>
 						{group.elements.map(({ elementId, definition }) => (
 							<AddElementDropdownPopoverButton
 								key={`${group.connectionId};${elementId}`}
@@ -176,7 +176,7 @@ const CompositeElementConnectionGroup = observer(function CompositeElementConnec
 								icon={faCube}
 							/>
 						))}
-					</CButtonGroup>
+					</ButtonGroup>
 				</CAccordionBody>
 			</CAccordionItem>
 		</CAccordion>
@@ -217,7 +217,7 @@ const AddElementDropdownPopoverContent = observer(function AddElementDropdownPop
 	return (
 		<>
 			{/* Note: the popover closing due to focus loss stops mouseup/click events propagating */}
-			<CButtonGroup vertical>
+			<ButtonGroup vertical>
 				<AddElementDropdownPopoverButton
 					styleStore={styleStore}
 					controlId={controlId}
@@ -260,7 +260,7 @@ const AddElementDropdownPopoverContent = observer(function AddElementDropdownPop
 					label="Circle"
 					icon={faCircle}
 				/>
-			</CButtonGroup>
+			</ButtonGroup>
 
 			{/* Composite Elements grouped by connection */}
 			{compositeGroups.map((group) => (

--- a/webui/src/Buttons/EditButton/SelectButtonTypeDropdown.tsx
+++ b/webui/src/Buttons/EditButton/SelectButtonTypeDropdown.tsx
@@ -1,7 +1,8 @@
-import { CButton, CDropdown, CDropdownItem, CDropdownMenu, CDropdownToggle } from '@coreui/react'
+import { CDropdown, CDropdownItem, CDropdownMenu, CDropdownToggle } from '@coreui/react'
 import { useCallback } from 'react'
 import type { SomeButtonModel } from '@companion-app/shared/Model/ButtonModel.js'
 import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
+import { Button } from '~/Components/Button'
 import type { GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC'
 
@@ -56,9 +57,9 @@ export function SelectButtonTypeDropdown({
 
 	return (
 		<CDropdown variant="btn-group">
-			<CButton color="danger" onClick={() => setButtonType('button-layered')} title="Create regular button.">
+			<Button color="danger" onClick={() => setButtonType('button-layered')} title="Create regular button.">
 				Create button
-			</CButton>
+			</Button>
 			<CDropdownToggle
 				color="danger"
 				split

--- a/webui/src/Buttons/EditButton/SelectButtonTypeDropdown.tsx
+++ b/webui/src/Buttons/EditButton/SelectButtonTypeDropdown.tsx
@@ -57,11 +57,11 @@ export function SelectButtonTypeDropdown({
 
 	return (
 		<CDropdown variant="btn-group">
-			<Button color="danger" onClick={() => setButtonType('button-layered')} title="Create regular button.">
+			<Button color="primary" onClick={() => setButtonType('button-layered')} title="Create regular button.">
 				Create button
 			</Button>
 			<CDropdownToggle
-				color="danger"
+				color="primary"
 				split
 				style={{ opacity: 0.7, padding: '0 0.75em' }}
 				aria-label="Toggle Button-Type Dropdown"

--- a/webui/src/Buttons/EditPageProperties.tsx
+++ b/webui/src/Buttons/EditPageProperties.tsx
@@ -1,15 +1,6 @@
-import {
-	CButton,
-	CCol,
-	CForm,
-	CFormInput,
-	CFormLabel,
-	CModalBody,
-	CModalFooter,
-	CModalHeader,
-	CRow,
-} from '@coreui/react'
+import { CCol, CForm, CFormInput, CFormLabel, CModalBody, CModalFooter, CModalHeader, CRow } from '@coreui/react'
 import { forwardRef, useCallback, useImperativeHandle, useRef, useState } from 'react'
+import { Button } from '~/Components/Button'
 import { CModalExt } from '~/Components/CModalExt.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC'
 import type { PagesStoreModel } from '~/Stores/PagesStore.js'
@@ -106,12 +97,12 @@ export const EditPagePropertiesModal = forwardRef<EditPagePropertiesModalRef, Ed
 					</CForm>
 				</CModalBody>
 				<CModalFooter>
-					<CButton color="secondary" onClick={doClose}>
+					<Button color="secondary" onClick={doClose}>
 						Cancel
-					</CButton>
-					<CButton color="primary" onClick={doAction}>
+					</Button>
+					<Button color="primary" onClick={doAction}>
 						Save
-					</CButton>
+					</Button>
 				</CModalFooter>
 			</CModalExt>
 		)

--- a/webui/src/Buttons/Pages.tsx
+++ b/webui/src/Buttons/Pages.tsx
@@ -1,9 +1,10 @@
-import { CButton, CButtonGroup, CCol, CRow } from '@coreui/react'
+import { CButtonGroup, CCol, CRow } from '@coreui/react'
 import { faPlus, faShareFromSquare, faSort, faTrash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
 import { useCallback, useContext, useRef } from 'react'
 import { useDrag, useDrop } from 'react-dnd'
+import { Button } from '~/Components/Button'
 import { GenericConfirmModal, type GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
 import { TextInputField } from '~/Components/TextInputField.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC.js'
@@ -104,15 +105,9 @@ export const PagesList = observer(function PagesList({ setPageNumber }: PagesLis
 								<th>Name</th>
 								<th>
 									<CButtonGroup style={{ width: '100%' }}>
-										<CButton
-											color="warning"
-											size="sm"
-											onClick={doInsertPage}
-											title="Insert page at start"
-											data-page={1}
-										>
+										<Button color="warning" size="sm" onClick={doInsertPage} title="Insert page at start" data-page={1}>
 											<FontAwesomeIcon icon={faPlus} />
-										</CButton>
+										</Button>
 									</CButtonGroup>
 								</th>
 							</tr>
@@ -241,10 +236,10 @@ const PageListRow = observer(function PageListRow({
 			</td>
 			<td style={{ width: 100, textAlign: 'right' }}>
 				<CButtonGroup>
-					<CButton color="secondary" size="sm" onClick={goToPage} title="Jump to page" data-page={pageNumber}>
+					<Button color="secondary" size="sm" onClick={goToPage} title="Jump to page" data-page={pageNumber}>
 						<FontAwesomeIcon icon={faShareFromSquare} />
-					</CButton>
-					{/* <CButton
+					</Button>
+					{/* <Button
 						TODO: for future use, once the modal has more properties
 						color="info"
 						size="sm"
@@ -254,18 +249,12 @@ const PageListRow = observer(function PageListRow({
 						data-page-info={JSON.stringify(info)}
 					>
 						<FontAwesomeIcon icon={faPencil} />
-					</CButton> */}
-					<CButton
-						color="warning"
-						size="sm"
-						onClick={doInsertPage}
-						title="Insert page after"
-						data-page={pageNumber + 1}
-					>
+					</Button> */}
+					<Button color="warning" size="sm" onClick={doInsertPage} title="Insert page after" data-page={pageNumber + 1}>
 						<FontAwesomeIcon icon={faPlus} />
-					</CButton>
+					</Button>
 
-					<CButton
+					<Button
 						color="primary"
 						size="sm"
 						onClick={doDeletePage}
@@ -275,7 +264,7 @@ const PageListRow = observer(function PageListRow({
 						disabled={pageCount <= 1}
 					>
 						<FontAwesomeIcon icon={faTrash} />
-					</CButton>
+					</Button>
 				</CButtonGroup>
 			</td>
 		</tr>

--- a/webui/src/Buttons/Pages.tsx
+++ b/webui/src/Buttons/Pages.tsx
@@ -1,10 +1,10 @@
-import { CButtonGroup, CCol, CRow } from '@coreui/react'
+import { CCol, CRow } from '@coreui/react'
 import { faPlus, faShareFromSquare, faSort, faTrash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
 import { useCallback, useContext, useRef } from 'react'
 import { useDrag, useDrop } from 'react-dnd'
-import { Button } from '~/Components/Button'
+import { Button, ButtonGroup } from '~/Components/Button'
 import { GenericConfirmModal, type GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
 import { TextInputField } from '~/Components/TextInputField.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC.js'
@@ -104,11 +104,11 @@ export const PagesList = observer(function PagesList({ setPageNumber }: PagesLis
 								<th style={{ textAlign: 'center' }}>Number</th>
 								<th>Name</th>
 								<th>
-									<CButtonGroup style={{ width: '100%' }}>
+									<ButtonGroup className="w-full">
 										<Button color="warning" size="sm" onClick={doInsertPage} title="Insert page at start" data-page={1}>
 											<FontAwesomeIcon icon={faPlus} />
 										</Button>
-									</CButtonGroup>
+									</ButtonGroup>
 								</th>
 							</tr>
 						</thead>
@@ -235,7 +235,7 @@ const PageListRow = observer(function PageListRow({
 				<TextInputField value={info.name ?? ''} setValue={changeName} placeholder="Unnamed page" />
 			</td>
 			<td style={{ width: 100, textAlign: 'right' }}>
-				<CButtonGroup>
+				<ButtonGroup>
 					<Button color="secondary" size="sm" onClick={goToPage} title="Jump to page" data-page={pageNumber}>
 						<FontAwesomeIcon icon={faShareFromSquare} />
 					</Button>
@@ -265,7 +265,7 @@ const PageListRow = observer(function PageListRow({
 					>
 						<FontAwesomeIcon icon={faTrash} />
 					</Button>
-				</CButtonGroup>
+				</ButtonGroup>
 			</td>
 		</tr>
 	)

--- a/webui/src/Buttons/Presets/PresetsSectionsList.tsx
+++ b/webui/src/Buttons/Presets/PresetsSectionsList.tsx
@@ -1,4 +1,4 @@
-import { CButtonGroup, CCallout } from '@coreui/react'
+import { CCallout } from '@coreui/react'
 import { faArrowLeft, faSearch } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
@@ -6,7 +6,7 @@ import { useMemo, useState } from 'react'
 import type { ClientConnectionConfig } from '@companion-app/shared/Model/Connections.js'
 import type { UIPresetSection } from '@companion-app/shared/Model/Presets.js'
 import { StaticAlert } from '~/Components/Alert.js'
-import { Button } from '~/Components/Button'
+import { Button, ButtonGroup } from '~/Components/Button'
 import { PanelCollapseHelperProvider } from '~/Helpers/CollapseHelper.js'
 import { useComputed } from '~/Resources/util.js'
 import { NonIdealState } from '../../Components/NonIdealState.js'
@@ -120,15 +120,15 @@ export const PresetsSectionsList = observer(function PresetsCategoryList({
 			<div>
 				<h5>Presets</h5>
 				<div style={{ marginBottom: 10 }}>
-					<CButtonGroup size="sm">
-						<Button color="primary" onClick={clearSelectedConnectionId}>
+					<ButtonGroup>
+						<Button color="primary" size="sm" onClick={clearSelectedConnectionId}>
 							<FontAwesomeIcon icon={faArrowLeft} />
 							&nbsp; Go back
 						</Button>
-						<Button color="secondary" disabled>
+						<Button color="secondary" size="sm" disabled>
 							{connectionInfo?.label || selectedConnectionId}
 						</Button>
-					</CButtonGroup>
+					</ButtonGroup>
 				</div>
 				<SearchBox filter={searchQuery} setFilter={setSearchQuery} />
 				{allSections.length === 0 ? (

--- a/webui/src/Buttons/Presets/PresetsSectionsList.tsx
+++ b/webui/src/Buttons/Presets/PresetsSectionsList.tsx
@@ -1,4 +1,4 @@
-import { CButton, CButtonGroup, CCallout } from '@coreui/react'
+import { CButtonGroup, CCallout } from '@coreui/react'
 import { faArrowLeft, faSearch } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
@@ -6,6 +6,7 @@ import { useMemo, useState } from 'react'
 import type { ClientConnectionConfig } from '@companion-app/shared/Model/Connections.js'
 import type { UIPresetSection } from '@companion-app/shared/Model/Presets.js'
 import { StaticAlert } from '~/Components/Alert.js'
+import { Button } from '~/Components/Button'
 import { PanelCollapseHelperProvider } from '~/Helpers/CollapseHelper.js'
 import { useComputed } from '~/Resources/util.js'
 import { NonIdealState } from '../../Components/NonIdealState.js'
@@ -120,13 +121,13 @@ export const PresetsSectionsList = observer(function PresetsCategoryList({
 				<h5>Presets</h5>
 				<div style={{ marginBottom: 10 }}>
 					<CButtonGroup size="sm">
-						<CButton color="primary" onClick={clearSelectedConnectionId}>
+						<Button color="primary" onClick={clearSelectedConnectionId}>
 							<FontAwesomeIcon icon={faArrowLeft} />
 							&nbsp; Go back
-						</CButton>
-						<CButton color="secondary" disabled>
+						</Button>
+						<Button color="secondary" disabled>
 							{connectionInfo?.label || selectedConnectionId}
-						</CButton>
+						</Button>
 					</CButtonGroup>
 				</div>
 				<SearchBox filter={searchQuery} setFilter={setSearchQuery} />

--- a/webui/src/Cloud/UserPass.tsx
+++ b/webui/src/Cloud/UserPass.tsx
@@ -1,8 +1,9 @@
-import { CButton, CCol, CForm, CFormInput, CFormLabel, CRow } from '@coreui/react'
+import { CCol, CForm, CFormInput, CFormLabel, CRow } from '@coreui/react'
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { memo, useState } from 'react'
 import { StaticAlert } from '~/Components/Alert'
+import { Button } from '~/Components/Button'
 import { trpc, useMutationExt } from '~/Resources/TRPC'
 
 interface CloudUserPassProps {
@@ -51,9 +52,9 @@ export const CloudUserPass = memo(function CloudUserPass({
 				<CCol sm={6}></CCol>
 
 				<CCol sm={6}>
-					<CButton color="success" type="submit" disabled={working || !email || !password}>
+					<Button color="success" type="submit" disabled={working || !email || !password}>
 						Log in
-					</CButton>
+					</Button>
 				</CCol>
 
 				<CCol sm={12}>

--- a/webui/src/Cloud/index.tsx
+++ b/webui/src/Cloud/index.tsx
@@ -1,18 +1,9 @@
-import {
-	CButton,
-	CCallout,
-	CCard,
-	CCardBody,
-	CCardHeader,
-	CCol,
-	CFormInput,
-	CFormLabel,
-	CListGroup,
-} from '@coreui/react'
+import { CCallout, CCard, CCardBody, CCardHeader, CCol, CFormInput, CFormLabel, CListGroup } from '@coreui/react'
 import { useSubscription } from '@trpc/tanstack-react-query'
 import { memo, useState } from 'react'
 import type { CloudControllerState } from '@companion-app/shared/Model/Cloud.js'
 import { StaticAlert } from '~/Components/Alert.js'
+import { Button } from '~/Components/Button'
 import { SwitchInputFieldWithLabel } from '~/Components/SwitchInputField.js'
 import { LoadingRetryOrError } from '~/Resources/Loading.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC.js'
@@ -129,7 +120,7 @@ function AuthState({ authenticatedAs, cloudActive, clearError }: AuthStateProps)
 			<CFormInput readOnly type="text" value={authenticatedAs} />
 			{!cloudActive && (
 				<div className="my-3">
-					<CButton
+					<Button
 						color="success"
 						onClick={() => {
 							clearError()
@@ -137,7 +128,7 @@ function AuthState({ authenticatedAs, cloudActive, clearError }: AuthStateProps)
 						}}
 					>
 						Log out
-					</CButton>
+					</Button>
 				</div>
 			)}
 		</CCol>
@@ -206,9 +197,9 @@ const SecretKeyPanel = memo(function SecretKeyPanel({ uuid }: { uuid: string }) 
 			<StaticAlert color="success">{uuid}</StaticAlert>
 
 			<div className="my-3">
-				<CButton color="primary" onClick={() => regenerateUUIDMutation.mutate()}>
+				<Button color="primary" onClick={() => regenerateUUIDMutation.mutate()}>
 					Regenerate secret key
-				</CButton>
+				</Button>
 			</div>
 		</CCol>
 	)

--- a/webui/src/Components/AlignmentInputField.tsx
+++ b/webui/src/Components/AlignmentInputField.tsx
@@ -1,4 +1,4 @@
-import { CButton, CButtonGroup } from '@coreui/react'
+import { CButtonGroup } from '@coreui/react'
 import classnames from 'classnames'
 import {
 	AlignHorizontalJustifyCenter,
@@ -10,6 +10,7 @@ import {
 } from 'lucide-react'
 import { ALIGNMENT_OPTIONS } from '@companion-app/shared/Model/Alignment.js'
 import type { CompanionAlignment } from '@companion-module/base'
+import { Button } from './Button'
 
 interface AlignmentInputFieldProps {
 	value: CompanionAlignment
@@ -93,7 +94,7 @@ function AlignmentButton({
 	children,
 }: React.PropsWithChildren<AlignmentButtonProps>) {
 	return (
-		<CButton
+		<Button
 			color={value === buttonValue ? 'primary' : 'secondary'}
 			onClick={() => setValue(buttonValue)}
 			title={title}
@@ -101,6 +102,6 @@ function AlignmentButton({
 			disabled={disabled}
 		>
 			{children}
-		</CButton>
+		</Button>
 	)
 }

--- a/webui/src/Components/AlignmentInputField.tsx
+++ b/webui/src/Components/AlignmentInputField.tsx
@@ -1,4 +1,3 @@
-import { CButtonGroup } from '@coreui/react'
 import classnames from 'classnames'
 import {
 	AlignHorizontalJustifyCenter,
@@ -10,7 +9,7 @@ import {
 } from 'lucide-react'
 import { ALIGNMENT_OPTIONS } from '@companion-app/shared/Model/Alignment.js'
 import type { CompanionAlignment } from '@companion-module/base'
-import { Button } from './Button'
+import { Button, ButtonGroup } from './Button'
 
 interface AlignmentInputFieldProps {
 	value: CompanionAlignment
@@ -43,7 +42,7 @@ export function HorizontalAlignmentInputField({
 	disabled = false,
 }: SplitAlignmentInputFieldProps): React.JSX.Element {
 	return (
-		<CButtonGroup>
+		<ButtonGroup>
 			<AlignmentButton value={value} setValue={setValue} buttonValue={'left'} title="Left" disabled={disabled}>
 				<AlignHorizontalJustifyStart size="1.3rem" />
 			</AlignmentButton>
@@ -53,7 +52,7 @@ export function HorizontalAlignmentInputField({
 			<AlignmentButton value={value} setValue={setValue} buttonValue={'right'} title="Right" disabled={disabled}>
 				<AlignHorizontalJustifyEnd size="1.3rem" />
 			</AlignmentButton>
-		</CButtonGroup>
+		</ButtonGroup>
 	)
 }
 
@@ -63,7 +62,7 @@ export function VerticalAlignmentInputField({
 	disabled = false,
 }: SplitAlignmentInputFieldProps): React.JSX.Element {
 	return (
-		<CButtonGroup>
+		<ButtonGroup>
 			<AlignmentButton value={value} setValue={setValue} buttonValue={'top'} title="Top" disabled={disabled}>
 				<AlignVerticalJustifyStart size="1.3rem" />
 			</AlignmentButton>
@@ -73,7 +72,7 @@ export function VerticalAlignmentInputField({
 			<AlignmentButton value={value} setValue={setValue} buttonValue={'bottom'} title="Bottom" disabled={disabled}>
 				<AlignVerticalJustifyEnd size="1.3rem" />
 			</AlignmentButton>
-		</CButtonGroup>
+		</ButtonGroup>
 	)
 }
 

--- a/webui/src/Components/Button.stories.tsx
+++ b/webui/src/Components/Button.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Button, LinkButton, LinkButtonExternal } from './Button'
+
+const meta = {
+	component: Button,
+	args: {
+		children: 'Button',
+		color: 'primary',
+	},
+} satisfies Meta<typeof Button>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const Ghost: Story = { args: { variant: 'ghost' } }
+
+export const Small: Story = { args: { size: 'sm' } }
+
+export const Disabled: Story = { args: { disabled: true, children: 'Disabled' } }
+
+export const Hidden: Story = { args: { hidden: true, children: 'Hidden (not rendered)' } }
+
+export const AllColors: Story = {
+	argTypes: {
+		color: { table: { disable: true } },
+		variant: { control: 'radio', options: [undefined, 'ghost', 'outline'] },
+		size: { control: 'radio', options: [undefined, 'sm'] },
+		disabled: { control: 'boolean' },
+	},
+	render: function Render({ variant, size, disabled }) {
+		const colors = [
+			'primary',
+			'secondary',
+			'success',
+			'danger',
+			'warning',
+			'info',
+			'light',
+			'dark',
+			'disabled',
+			'link',
+		] as const
+		return (
+			<div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+				{colors.map((color) => (
+					<Button key={color} color={color} variant={variant} size={size} disabled={disabled}>
+						{color}
+					</Button>
+				))}
+			</div>
+		)
+	},
+}
+
+export const InternalLink: StoryObj<typeof LinkButton> = {
+	render: (args) => <LinkButton {...args} />,
+	args: {
+		children: 'Go to connections',
+		color: 'primary',
+		to: '/connections',
+	},
+}
+
+export const ExternalLink: StoryObj<typeof LinkButtonExternal> = {
+	render: (args) => <LinkButtonExternal {...args} />,
+	args: {
+		children: 'Open docs',
+		color: 'info',
+		href: 'https://bitfocus.io',
+		target: '_blank',
+		rel: 'noopener noreferrer',
+	},
+}

--- a/webui/src/Components/Button.stories.tsx
+++ b/webui/src/Components/Button.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { Button, LinkButton, LinkButtonExternal } from './Button'
+import { Button, ButtonGroup, LinkButton, LinkButtonExternal } from './Button'
 
 const meta = {
 	component: Button,
@@ -72,4 +72,34 @@ export const ExternalLink: StoryObj<typeof LinkButtonExternal> = {
 		target: '_blank',
 		rel: 'noopener noreferrer',
 	},
+}
+
+export const Group: StoryObj<typeof ButtonGroup> = {
+	render: (args) => (
+		<ButtonGroup {...args}>
+			<Button color="primary">Left</Button>
+			<Button color="primary">Middle</Button>
+			<Button color="primary">Right</Button>
+		</ButtonGroup>
+	),
+}
+
+export const GroupVertical: StoryObj<typeof ButtonGroup> = {
+	render: (args) => (
+		<ButtonGroup {...args} vertical>
+			<Button color="primary">Top</Button>
+			<Button color="primary">Middle</Button>
+			<Button color="primary">Bottom</Button>
+		</ButtonGroup>
+	),
+}
+
+export const GroupMixedColors: StoryObj<typeof ButtonGroup> = {
+	render: (args) => (
+		<ButtonGroup {...args}>
+			<Button color="success">Save</Button>
+			<Button color="warning">Reset</Button>
+			<Button color="danger">Delete</Button>
+		</ButtonGroup>
+	),
 }

--- a/webui/src/Components/Button.tsx
+++ b/webui/src/Components/Button.tsx
@@ -18,23 +18,58 @@ export type ButtonColor =
 	| 'link'
 
 interface ButtonVisualProps {
+	className?: string
 	color?: ButtonColor
 	/** 'ghost' renders a text-only button with no background or border */
 	variant?: 'ghost' | 'outline'
 	size?: 'sm' | 'lg'
 	hidden?: boolean
+
+	disabled?: boolean
 }
 
-export interface ButtonProps extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'color'>, ButtonVisualProps {}
+// function getColorClasses(props: ButtonVisualProps): string {
+// 	return classNames(
+// 		'btn',
+// 		{
+// 			[`btn-${props.variant}-${props.color}`]: props.variant && props.color,
+// 			[`btn-${props.variant}`]: props.variant && !props.color,
+// 			[`btn-${props.color}`]: !props.variant && props.color,
+// 			[`btn-${props.size}`]: props.size,
+// 		},
+// 		// props.shape,
+// 		props.className
+// 	)
+// }
+
+export interface ButtonProps extends React.PropsWithChildren<ButtonVisualProps> {
+	title?: string
+	type?: 'submit' | 'reset'
+	autoFocus?: boolean
+	tabIndex?: number
+
+	onClick?: React.MouseEventHandler<HTMLElement>
+	onMouseDown?: React.MouseEventHandler<HTMLElement>
+	onMouseUp?: React.MouseEventHandler<HTMLElement>
+}
 
 // TODO - rebuild this!
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(props, ref) {
+	// return (
+	// 	<CLink
+	// 		// as={rest.href ? 'a' : as}
+	// 		// {...(!rest.href && { type: type })}
+	// 		className={getColorClasses(props)}
+	// 		// {...rest}
+	// 		ref={ref}
+	// 	>
+	// 		{props.children}
+	// 	</CLink>
+	// )
 	return <CButton {...props} ref={ref} />
 })
 
-interface LinkButtonBaseProps extends ButtonVisualProps {
-	children?: React.ReactNode
-	className?: string
+interface LinkButtonBaseProps extends React.PropsWithChildren<ButtonVisualProps> {
 	onClick?: React.MouseEventHandler
 	title?: string
 }

--- a/webui/src/Components/Button.tsx
+++ b/webui/src/Components/Button.tsx
@@ -1,0 +1,67 @@
+import { CButton } from '@coreui/react'
+import { Link, type RegisteredRouter, type ToPathOption } from '@tanstack/react-router'
+import * as React from 'react'
+
+export type ButtonColor =
+	| 'primary'
+	| 'secondary'
+	| 'success'
+	| 'danger'
+	| 'warning'
+	| 'info'
+	| 'light'
+	| 'dark'
+	| 'gray'
+	| 'white'
+	| 'disabled'
+	| 'link'
+
+interface ButtonVisualProps {
+	color?: ButtonColor
+	/** 'ghost' renders a text-only button with no background or border */
+	variant?: 'ghost' | 'outline'
+	size?: 'sm' | 'lg'
+	hidden?: boolean
+}
+
+export interface ButtonProps extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'color'>, ButtonVisualProps {}
+
+// TODO - rebuild this!
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(props, ref) {
+	return <CButton {...props} ref={ref} />
+})
+
+interface LinkButtonBaseProps extends ButtonVisualProps {
+	children?: React.ReactNode
+	className?: string
+	onClick?: React.MouseEventHandler
+	title?: string
+}
+
+export interface LinkButtonProps<
+	TFrom extends string = string,
+	TTo extends string | undefined = undefined,
+> extends LinkButtonBaseProps {
+	to: ToPathOption<RegisteredRouter, TFrom, TTo>
+}
+
+// TODO - rebuild this!
+export function LinkButton<const TFrom extends string = string, const TTo extends string | undefined = undefined>({
+	to,
+	...rest
+}: LinkButtonProps<TFrom, TTo>): React.JSX.Element {
+	return <CButton as={Link} to={to} {...rest} />
+}
+
+export interface LinkButtonExternalProps extends LinkButtonBaseProps {
+	href: string
+	target?: string
+	rel?: string
+}
+
+// TODO - rebuild this!
+export function LinkButtonExternal({ href, ...rest }: LinkButtonExternalProps): React.JSX.Element {
+	return (
+		<CButton as="a" href={href} {...rest} target={rest.target ?? '_blank'} rel={rest.rel ?? 'noopener noreferrer'} />
+	)
+}

--- a/webui/src/Components/Button.tsx
+++ b/webui/src/Components/Button.tsx
@@ -1,4 +1,4 @@
-import { CButton } from '@coreui/react'
+import { CButton, CButtonGroup } from '@coreui/react'
 import { Link, type RegisteredRouter, type ToPathOption } from '@tanstack/react-router'
 import * as React from 'react'
 
@@ -63,5 +63,28 @@ export interface LinkButtonExternalProps extends LinkButtonBaseProps {
 export function LinkButtonExternal({ href, ...rest }: LinkButtonExternalProps): React.JSX.Element {
 	return (
 		<CButton as="a" href={href} {...rest} target={rest.target ?? '_blank'} rel={rest.rel ?? 'noopener noreferrer'} />
+	)
+}
+
+export interface ButtonGroupProps {
+	/**
+	 * A string of all className you want applied to the base component.
+	 */
+	className?: string
+	/**
+	 * Create a set of buttons that appear vertically stacked rather than horizontally. Split button dropdowns are not supported here.
+	 */
+	vertical?: boolean
+}
+
+export function ButtonGroup({
+	className,
+	vertical,
+	children,
+}: React.PropsWithChildren<ButtonGroupProps>): React.JSX.Element {
+	return (
+		<CButtonGroup className={className} role="group" vertical={vertical}>
+			{children}
+		</CButtonGroup>
 	)
 }

--- a/webui/src/Components/Button.tsx
+++ b/webui/src/Components/Button.tsx
@@ -1,5 +1,6 @@
-import { CButton, CButtonGroup } from '@coreui/react'
+import { CButton } from '@coreui/react'
 import { Link, type RegisteredRouter, type ToPathOption } from '@tanstack/react-router'
+import classNames from 'classnames'
 import * as React from 'react'
 
 export type ButtonColor =
@@ -83,8 +84,12 @@ export function ButtonGroup({
 	children,
 }: React.PropsWithChildren<ButtonGroupProps>): React.JSX.Element {
 	return (
-		<CButtonGroup className={className} role="group" vertical={vertical}>
+		<div
+			className={classNames(vertical ? 'button-group-vertical' : 'button-group', className)}
+			role="group"
+			// ref={ref}
+		>
 			{children}
-		</CButtonGroup>
+		</div>
 	)
 }

--- a/webui/src/Components/Button.tsx
+++ b/webui/src/Components/Button.tsx
@@ -1,7 +1,8 @@
-import { CButton } from '@coreui/react'
+import { Button as ButtonBase } from '@base-ui/react'
 import { Link, type RegisteredRouter, type ToPathOption } from '@tanstack/react-router'
 import classNames from 'classnames'
 import * as React from 'react'
+import type { Complete } from '@companion-module/base'
 
 export type ButtonColor =
 	| 'primary'
@@ -12,8 +13,6 @@ export type ButtonColor =
 	| 'info'
 	| 'light'
 	| 'dark'
-	| 'gray'
-	| 'white'
 	| 'disabled'
 	| 'link'
 
@@ -26,51 +25,55 @@ interface ButtonVisualProps {
 	hidden?: boolean
 
 	disabled?: boolean
+	active?: boolean
 }
 
-// function getColorClasses(props: ButtonVisualProps): string {
-// 	return classNames(
-// 		'btn',
-// 		{
-// 			[`btn-${props.variant}-${props.color}`]: props.variant && props.color,
-// 			[`btn-${props.variant}`]: props.variant && !props.color,
-// 			[`btn-${props.color}`]: !props.variant && props.color,
-// 			[`btn-${props.size}`]: props.size,
-// 		},
-// 		// props.shape,
-// 		props.className
-// 	)
-// }
-
-export interface ButtonProps extends React.PropsWithChildren<ButtonVisualProps> {
-	title?: string
-	type?: 'submit' | 'reset'
-	autoFocus?: boolean
-	tabIndex?: number
-
-	onClick?: React.MouseEventHandler<HTMLElement>
-	onMouseDown?: React.MouseEventHandler<HTMLElement>
-	onMouseUp?: React.MouseEventHandler<HTMLElement>
+function getColorClasses(props: ButtonVisualProps): string {
+	return classNames(
+		'button',
+		'btn', // For backwards compatibility with coreui - should be removed eventually
+		{
+			[`button-${props.variant}-${props.color}`]: props.variant && props.color,
+			[`button-${props.variant}`]: props.variant && !props.color,
+			[`button-${props.color}`]: !props.variant && props.color,
+			[`button-${props.size}`]: props.size,
+			active: props.active,
+			disabled: props.disabled,
+		},
+		props.className
+	)
 }
 
-// TODO - rebuild this!
-export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(props, ref) {
-	// return (
-	// 	<CLink
-	// 		// as={rest.href ? 'a' : as}
-	// 		// {...(!rest.href && { type: type })}
-	// 		className={getColorClasses(props)}
-	// 		// {...rest}
-	// 		ref={ref}
-	// 	>
-	// 		{props.children}
-	// 	</CLink>
-	// )
-	return <CButton {...props} ref={ref} />
+export interface ButtonProps
+	extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'color' | 'size'>, ButtonVisualProps {}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+	{ className, color, variant, size, hidden, active, disabled, children, ...rest },
+	ref
+) {
+	return (
+		<ButtonBase
+			className={getColorClasses({
+				className,
+				color,
+				variant,
+				size,
+				hidden,
+				active,
+				disabled,
+			} satisfies Complete<ButtonVisualProps>)}
+			{...(active && { 'aria-current': 'page' })}
+			{...rest}
+			disabled={disabled}
+			hidden={hidden}
+			ref={ref}
+		>
+			{children}
+		</ButtonBase>
+	)
 })
 
 interface LinkButtonBaseProps extends React.PropsWithChildren<ButtonVisualProps> {
-	onClick?: React.MouseEventHandler
 	title?: string
 }
 
@@ -81,24 +84,69 @@ export interface LinkButtonProps<
 	to: ToPathOption<RegisteredRouter, TFrom, TTo>
 }
 
-// TODO - rebuild this!
 export function LinkButton<const TFrom extends string = string, const TTo extends string | undefined = undefined>({
+	className,
+	color,
+	variant,
+	size,
+	hidden,
+	active,
+	disabled,
+	title,
 	to,
-	...rest
+	children,
 }: LinkButtonProps<TFrom, TTo>): React.JSX.Element {
-	return <CButton as={Link} to={to} {...rest} />
+	return (
+		<Link
+			className={getColorClasses({ className, color, variant, size, hidden, active, disabled })}
+			{...(active && { 'aria-current': 'page' })}
+			{...(disabled && { 'aria-disabled': true, tabIndex: -1 })}
+			disabled={disabled}
+			title={title}
+			to={to}
+		>
+			{children}
+		</Link>
+	)
 }
 
 export interface LinkButtonExternalProps extends LinkButtonBaseProps {
 	href: string
 	target?: string
 	rel?: string
+	onClick?: React.MouseEventHandler<HTMLAnchorElement>
 }
 
-// TODO - rebuild this!
-export function LinkButtonExternal({ href, ...rest }: LinkButtonExternalProps): React.JSX.Element {
+export function LinkButtonExternal({
+	className,
+	color,
+	variant,
+	size,
+	hidden,
+	active,
+	disabled,
+	title,
+	href,
+	target,
+	rel,
+	onClick,
+	children,
+}: LinkButtonExternalProps): React.JSX.Element {
 	return (
-		<CButton as="a" href={href} {...rest} target={rest.target ?? '_blank'} rel={rest.rel ?? 'noopener noreferrer'} />
+		<a
+			className={getColorClasses({ className, color, variant, size, hidden, active, disabled })}
+			{...(active && { 'aria-current': 'page' })}
+			{...(disabled && { 'aria-disabled': true, tabIndex: -1 })}
+			onClick={(event: React.MouseEvent<HTMLAnchorElement>) => {
+				if (!disabled) onClick?.(event)
+			}}
+			title={title}
+			href={href}
+			target={target ?? '_blank'}
+			rel={rel ?? 'noopener noreferrer'}
+		>
+			{children}
+		</a>
 	)
 }
 
@@ -119,11 +167,7 @@ export function ButtonGroup({
 	children,
 }: React.PropsWithChildren<ButtonGroupProps>): React.JSX.Element {
 	return (
-		<div
-			className={classNames(vertical ? 'button-group-vertical' : 'button-group', className)}
-			role="group"
-			// ref={ref}
-		>
+		<div className={classNames(vertical ? 'button-group-vertical' : 'button-group', className)} role="group">
 			{children}
 		</div>
 	)

--- a/webui/src/Components/CollectionsNestingTable/CollectionsNestingTableGroupRow.tsx
+++ b/webui/src/Components/CollectionsNestingTable/CollectionsNestingTableGroupRow.tsx
@@ -1,8 +1,8 @@
-import { CButton } from '@coreui/react'
 import { faCaretDown, faCaretRight, faCheckCircle, faPencilAlt, faTrash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
 import { useCallback, useState } from 'react'
+import { Button } from '~/Components/Button'
 import { TextInputField } from '../TextInputField.js'
 import { CollectionsNestingTableCollectionRowWrapper } from './CollectionsNestingTableRowWrappers.js'
 import type { CollectionsNestingTableCollection, NestingCollectionsApi } from './Types.js'
@@ -93,18 +93,18 @@ export const CollectionsNestingTableCollectionRow = observer(function Collection
 					{children}
 
 					{isEditing ? (
-						<CButton color="link" onClick={handleNameFieldBlur}>
+						<Button color="link" onClick={handleNameFieldBlur}>
 							<FontAwesomeIcon icon={faCheckCircle} />
-						</CButton>
+						</Button>
 					) : (
-						<CButton color="link" onClick={clickEditName}>
+						<Button color="link" onClick={clickEditName}>
 							<FontAwesomeIcon icon={faPencilAlt} />
-						</CButton>
+						</Button>
 					)}
 
-					<CButton color="link" onClick={clickDeleteCollection}>
+					<Button color="link" onClick={clickDeleteCollection}>
 						<FontAwesomeIcon icon={faTrash} />
-					</CButton>
+					</Button>
 				</div>
 			</div>
 		</CollectionsNestingTableCollectionRowWrapper>

--- a/webui/src/Components/CollectionsNestingTable/CollectionsNestingTableGroupsList.tsx
+++ b/webui/src/Components/CollectionsNestingTable/CollectionsNestingTableGroupsList.tsx
@@ -1,8 +1,8 @@
-import { CButton } from '@coreui/react'
 import { faCompressArrowsAlt, faExpandArrowsAlt } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
 import { useCallback } from 'react'
+import { Button } from '~/Components/Button.js'
 import { usePanelCollapseHelperContext, usePanelCollapseHelperContextForPanel } from '~/Helpers/CollapseHelper.js'
 import { useCollectionsNestingTableContext } from './CollectionsNestingTableContext.js'
 import { CollectionsNestingTableDropZone } from './CollectionsNestingTableDropZone.js'
@@ -150,14 +150,14 @@ export const CollectionItemsCollapseButtons = observer(function CollectionItemsC
 	return (
 		<>
 			{hasCollapsed && (
-				<CButton size="sm" color="link" onClick={expandAll} title="Expand all items">
+				<Button size="sm" color="link" onClick={expandAll} title="Expand all items">
 					<FontAwesomeIcon icon={faExpandArrowsAlt} />
-				</CButton>
+				</Button>
 			)}
 			{hasExpanded && (
-				<CButton size="sm" color="link" onClick={collapseAll} title="Collapse all items">
+				<Button size="sm" color="link" onClick={collapseAll} title="Collapse all items">
 					<FontAwesomeIcon icon={faCompressArrowsAlt} />
-				</CButton>
+				</Button>
 			)}
 		</>
 	)

--- a/webui/src/Components/ConfirmExportModal.tsx
+++ b/webui/src/Components/ConfirmExportModal.tsx
@@ -1,6 +1,7 @@
-import { CButton, CCol, CForm, CFormLabel, CModal, CModalBody, CModalFooter, CModalHeader } from '@coreui/react'
+import { CCol, CForm, CFormLabel, CModal, CModalBody, CModalFooter, CModalHeader } from '@coreui/react'
 import { observer } from 'mobx-react-lite'
 import { forwardRef, useCallback, useContext, useImperativeHandle, useRef, useState } from 'react'
+import { Button } from '~/Components/Button'
 import { windowLinkOpen } from '~/Helpers/Window.js'
 import { ExportFormatDefault, SelectExportFormat } from '~/ImportExport/ExportFormat.js'
 import { RootAppStoreContext } from '~/Stores/RootAppStore.js'
@@ -113,12 +114,12 @@ export const ConfirmExportModal = observer(
 						</CForm>
 					</CModalBody>
 					<CModalFooter>
-						<CButton color="secondary" onClick={doClose}>
+						<Button color="secondary" onClick={doClose}>
 							Cancel
-						</CButton>
-						<CButton ref={buttonRef} color="primary" onClick={doAction}>
+						</Button>
+						<Button ref={buttonRef} color="primary" onClick={doAction}>
 							Export
-						</CButton>
+						</Button>
 					</CModalFooter>
 				</MenuPortalContext.Provider>
 			</CModal>

--- a/webui/src/Components/FieldOrExpression.tsx
+++ b/webui/src/Components/FieldOrExpression.tsx
@@ -1,4 +1,3 @@
-import { CButton } from '@coreui/react'
 import { faFilter, faSquareRootVariable } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
@@ -8,6 +7,7 @@ import type { EntityModelType } from '@companion-app/shared/Model/EntityModel.js
 import type { ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
 import { stringifyVariableValue } from '@companion-app/shared/Model/Variables.js'
 import type { LocalVariablesStore } from '~/Controls/LocalVariablesStore.js'
+import { Button } from './Button'
 import { ExpressionInputField } from './ExpressionInputField'
 
 interface FieldOrExpressionProps {
@@ -77,7 +77,7 @@ export const FieldOrExpression = observer(function FieldOrExpression({
 				)}
 			</div>
 			<div className="expression-toggle-button">
-				<CButton
+				<Button
 					color="info"
 					variant="outline"
 					onClick={toggleExpression}
@@ -85,7 +85,7 @@ export const FieldOrExpression = observer(function FieldOrExpression({
 					disabled={disabled}
 				>
 					<FontAwesomeIcon icon={value.isExpression ? faSquareRootVariable : faFilter} />
-				</CButton>
+				</Button>
 			</div>
 		</div>
 	)

--- a/webui/src/Components/FieldOrExpression.tsx
+++ b/webui/src/Components/FieldOrExpression.tsx
@@ -82,6 +82,7 @@ export const FieldOrExpression = observer(function FieldOrExpression({
 					variant="outline"
 					onClick={toggleExpression}
 					title={value.isExpression ? 'Expression mode' : 'Value mode'}
+					aria-label={value.isExpression ? 'Switch to value mode' : 'Switch to expression mode'}
 					disabled={disabled}
 				>
 					<FontAwesomeIcon icon={value.isExpression ? faSquareRootVariable : faFilter} />

--- a/webui/src/Components/GenericConfirmModal.tsx
+++ b/webui/src/Components/GenericConfirmModal.tsx
@@ -1,5 +1,6 @@
-import { CButton, CModalBody, CModalFooter, CModalHeader } from '@coreui/react'
+import { CModalBody, CModalFooter, CModalHeader } from '@coreui/react'
 import { forwardRef, useCallback, useImperativeHandle, useRef, useState } from 'react'
+import { Button } from '~/Components/Button'
 import { CModalExt } from './CModalExt.js'
 
 export interface GenericConfirmModalRef {
@@ -70,12 +71,12 @@ export const GenericConfirmModal = forwardRef<GenericConfirmModalRef, GenericCon
 				</CModalHeader>
 				<CModalBody>{content}</CModalBody>
 				<CModalFooter>
-					<CButton color="secondary" onClick={doClose}>
+					<Button color="secondary" onClick={doClose}>
 						Cancel
-					</CButton>
-					<CButton ref={buttonRef} color="primary" onClick={doAction} autoFocus>
+					</Button>
+					<Button ref={buttonRef} color="primary" onClick={doAction} autoFocus>
 						{data?.buttonLabel}
-					</CButton>
+					</Button>
 				</CModalFooter>
 			</CModalExt>
 		)

--- a/webui/src/Components/LearnButton.tsx
+++ b/webui/src/Components/LearnButton.tsx
@@ -1,9 +1,9 @@
-import { CButton } from '@coreui/react'
 import { faSync } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
 import { useContext } from 'react'
 import { RootAppStoreContext } from '~/Stores/RootAppStore.js'
+import { Button } from './Button'
 
 interface LearnButtonProps {
 	id: string
@@ -17,7 +17,7 @@ export const LearnButton = observer(function LearnButton({ id, disabled, doLearn
 	const isActive = rootAppStore.activeLearns.has(id)
 
 	return (
-		<CButton
+		<Button
 			disabled={isActive || disabled}
 			color="info"
 			size="sm"
@@ -25,6 +25,6 @@ export const LearnButton = observer(function LearnButton({ id, disabled, doLearn
 			title="Capture the current values from the device"
 		>
 			Learn values {isActive && <FontAwesomeIcon icon={faSync} spin />}
-		</CButton>
+		</Button>
 	)
 })

--- a/webui/src/Components/PNGInputField.tsx
+++ b/webui/src/Components/PNGInputField.tsx
@@ -1,8 +1,9 @@
-import { CButton, CFormInput } from '@coreui/react'
+import { CFormInput } from '@coreui/react'
 import { faFolderOpen } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useCallback, useRef } from 'react'
 import { blobToDataURL } from '~/Helpers/FileUpload.js'
+import { Button } from './Button'
 
 const allowedImageTypesPng = ['image/png']
 const allowedImageTypesExtended = [...allowedImageTypesPng, 'image/jpeg', 'image/gif', 'image/webp', 'image/svg+xml']
@@ -120,7 +121,7 @@ export function PNGInputField({
 	)
 
 	return (
-		<CButton
+		<Button
 			color="primary"
 			className="pnginputfield"
 			onClick={onClick}
@@ -129,6 +130,6 @@ export function PNGInputField({
 		>
 			<FontAwesomeIcon icon={faFolderOpen} />
 			<CFormInput type="file" ref={inputRef} onChange={onChange} disabled={!apiIsSupported || disabled} />
-		</CButton>
+		</Button>
 	)
 }

--- a/webui/src/Components/PngImageInputField.tsx
+++ b/webui/src/Components/PngImageInputField.tsx
@@ -1,7 +1,8 @@
-import { CButton, CButtonGroup } from '@coreui/react'
+import { CButtonGroup } from '@coreui/react'
 import { faTrash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import React, { useCallback, useState } from 'react'
+import { Button } from '~/Components/Button'
 import { DismissableAlert } from './Alert.js'
 import { PNGInputField } from './PNGInputField.js'
 
@@ -48,9 +49,9 @@ export function PngImageInputField({
 					allowNonPng={allowNonPng}
 					disabled={disabled}
 				/>
-				<CButton color="danger" disabled={disabled || !value} onClick={clearImage}>
+				<Button color="danger" disabled={disabled || !value} onClick={clearImage}>
 					<FontAwesomeIcon icon={faTrash} />
-				</CButton>
+				</Button>
 			</CButtonGroup>
 			{imageLoadError && (
 				<DismissableAlert color="warning" onClose={() => setImageLoadError(null)}>

--- a/webui/src/Components/PngImageInputField.tsx
+++ b/webui/src/Components/PngImageInputField.tsx
@@ -1,8 +1,7 @@
-import { CButtonGroup } from '@coreui/react'
 import { faTrash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import React, { useCallback, useState } from 'react'
-import { Button } from '~/Components/Button'
+import { Button, ButtonGroup } from '~/Components/Button'
 import { DismissableAlert } from './Alert.js'
 import { PNGInputField } from './PNGInputField.js'
 
@@ -40,7 +39,7 @@ export function PngImageInputField({
 
 	return (
 		<>
-			<CButtonGroup className="png-browse">
+			<ButtonGroup className="png-browse">
 				<PNGInputField
 					onSelect={setImageDataAndClearError}
 					onError={setImageLoadError}
@@ -52,7 +51,7 @@ export function PngImageInputField({
 				<Button color="danger" disabled={disabled || !value} onClick={clearImage}>
 					<FontAwesomeIcon icon={faTrash} />
 				</Button>
-			</CButtonGroup>
+			</ButtonGroup>
 			{imageLoadError && (
 				<DismissableAlert color="warning" onClose={() => setImageLoadError(null)}>
 					{imageLoadError}

--- a/webui/src/Components/PngImageInputField.tsx
+++ b/webui/src/Components/PngImageInputField.tsx
@@ -48,7 +48,13 @@ export function PngImageInputField({
 					allowNonPng={allowNonPng}
 					disabled={disabled}
 				/>
-				<Button color="danger" disabled={disabled || !value} onClick={clearImage}>
+				<Button
+					color="danger"
+					disabled={disabled || !value}
+					onClick={clearImage}
+					aria-label="Clear image"
+					title="Clear image"
+				>
 					<FontAwesomeIcon icon={faTrash} />
 				</Button>
 			</ButtonGroup>

--- a/webui/src/Components/SearchBox.tsx
+++ b/webui/src/Components/SearchBox.tsx
@@ -25,7 +25,7 @@ export function SearchBox({ filter, setFilter }: SearchBoxProps): React.JSX.Elem
 				value={filter}
 				style={{ fontSize: '1.2em' }}
 			/>
-			<Button color="danger" onClick={clearFilter}>
+			<Button color="primary" onClick={clearFilter}>
 				<FontAwesomeIcon icon={faTimes} />
 			</Button>
 		</CInputGroup>

--- a/webui/src/Components/SearchBox.tsx
+++ b/webui/src/Components/SearchBox.tsx
@@ -1,7 +1,8 @@
-import { CButton, CFormInput, CInputGroup } from '@coreui/react'
+import { CFormInput, CInputGroup } from '@coreui/react'
 import { faTimes } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useCallback } from 'react'
+import { Button } from '~/Components/Button'
 
 export interface SearchBoxProps {
 	filter: string
@@ -24,9 +25,9 @@ export function SearchBox({ filter, setFilter }: SearchBoxProps): React.JSX.Elem
 				value={filter}
 				style={{ fontSize: '1.2em' }}
 			/>
-			<CButton color="danger" onClick={clearFilter}>
+			<Button color="danger" onClick={clearFilter}>
 				<FontAwesomeIcon icon={faTimes} />
-			</CButton>
+			</Button>
 		</CInputGroup>
 	)
 }

--- a/webui/src/Components/SearchBox.tsx
+++ b/webui/src/Components/SearchBox.tsx
@@ -25,7 +25,7 @@ export function SearchBox({ filter, setFilter }: SearchBoxProps): React.JSX.Elem
 				value={filter}
 				style={{ fontSize: '1.2em' }}
 			/>
-			<Button color="primary" onClick={clearFilter}>
+			<Button color="primary" onClick={clearFilter} aria-label="Clear search filter" title="Clear search filter">
 				<FontAwesomeIcon icon={faTimes} />
 			</Button>
 		</CInputGroup>

--- a/webui/src/Components/SecretTextInputField.tsx
+++ b/webui/src/Components/SecretTextInputField.tsx
@@ -1,8 +1,9 @@
-import { CButton, CFormInput, CInputGroup } from '@coreui/react'
+import { CFormInput, CInputGroup } from '@coreui/react'
 import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
 import { useCallback, useMemo, useRef, useState } from 'react'
+import { Button } from './Button'
 
 interface SecretTextInputFieldProps {
 	tooltip?: string
@@ -63,13 +64,13 @@ export const SecretTextInputField = observer(function SecretTextInputField({
 					onFocus={focusStoreValue}
 					onBlur={blurClearValue}
 				/>
-				<CButton
+				<Button
 					color="secondary"
 					title={showSecretValue ? 'Hide secret' : 'Show secret'}
 					onClick={toggleShowSecretValue}
 				>
 					<FontAwesomeIcon icon={showSecretValue ? faEyeSlash : faEye} />
-				</CButton>
+				</Button>
 			</CInputGroup>
 		</>
 	)

--- a/webui/src/Components/SecretTextInputField.tsx
+++ b/webui/src/Components/SecretTextInputField.tsx
@@ -67,6 +67,7 @@ export const SecretTextInputField = observer(function SecretTextInputField({
 				<Button
 					color="secondary"
 					title={showSecretValue ? 'Hide secret' : 'Show secret'}
+					aria-label={showSecretValue ? 'Hide secret value' : 'Show secret value'}
 					onClick={toggleShowSecretValue}
 				>
 					<FontAwesomeIcon icon={showSecretValue ? faEyeSlash : faEye} />

--- a/webui/src/Components/TableVisibility.tsx
+++ b/webui/src/Components/TableVisibility.tsx
@@ -1,6 +1,6 @@
-import { CButton } from '@coreui/react'
 import classNames from 'classnames'
 import { useCallback, useEffect, useState } from 'react'
+import { Button, type ButtonColor } from './Button'
 
 export interface TableVisibilityHelper<T extends Record<string, any>> {
 	visibility: T
@@ -51,7 +51,7 @@ export function useTableVisibilityHelper<T extends Record<string, any>>(
 
 interface VisibilityButtonProps<T extends Record<string, boolean>> extends TableVisibilityHelper<T> {
 	keyId: keyof T
-	color: string
+	color: ButtonColor
 	label: string
 	title?: string
 }
@@ -67,7 +67,7 @@ export function VisibilityButton<T extends Record<string, any>>({
 	const doToggle = useCallback(() => toggleVisibility(keyId), [keyId, toggleVisibility])
 
 	return (
-		<CButton
+		<Button
 			size="sm"
 			color={color}
 			className={classNames({ active: visibility[keyId] })}
@@ -75,6 +75,6 @@ export function VisibilityButton<T extends Record<string, any>>({
 			title={title}
 		>
 			{label}
-		</CButton>
+		</Button>
 	)
 }

--- a/webui/src/Components/VariableInputGroup.tsx
+++ b/webui/src/Components/VariableInputGroup.tsx
@@ -1,7 +1,8 @@
-import { CButton, CFormInput, CInputGroup } from '@coreui/react'
+import { CFormInput, CInputGroup } from '@coreui/react'
 import JSON5 from 'json5'
 import { useEffect, useRef, useState } from 'react'
 import type { JsonValue } from 'type-fest'
+import { Button } from '~/Components/Button.js'
 import { VariableTypeIcon } from './VariableTypeIcon.js'
 
 interface VariableInputGroupProps {
@@ -121,8 +122,8 @@ const VariableInputGroup: React.FC<VariableInputGroupProps> = ({ value, setCurre
 					marginBottom: '0.5rem',
 				}}
 			>
-				<CButton
-					color={disabled ? '#888888' : 'info'}
+				<Button
+					color="info"
 					style={buttonProps.style}
 					variant="outline"
 					title={buttonProps.title}
@@ -131,7 +132,7 @@ const VariableInputGroup: React.FC<VariableInputGroupProps> = ({ value, setCurre
 					disabled={disabled}
 				>
 					{buttonProps.label}
-				</CButton>
+				</Button>
 				<CFormInput
 					value={localValue}
 					onChange={(e) => handleInputChange(e.target.value)}

--- a/webui/src/Components/VariableInputGroup.tsx
+++ b/webui/src/Components/VariableInputGroup.tsx
@@ -93,12 +93,10 @@ const VariableInputGroup: React.FC<VariableInputGroupProps> = ({ value, setCurre
 	const buttonProps = isString
 		? {
 				title: 'String entry',
-				style: { color: '#0000cc', boxSizing: 'content-box' as const, height: '24px' },
 				label: <VariableTypeIcon width={14} height={14} fill="#0000cc" icon="string" />,
 			}
 		: {
 				title: 'JSON entry',
-				style: { color: '#cc0000', boxSizing: 'content-box' as const, height: '24px' },
 				label: <VariableTypeIcon width={14} height={14} fill="#cc0000" icon="object" />,
 			}
 
@@ -124,7 +122,6 @@ const VariableInputGroup: React.FC<VariableInputGroupProps> = ({ value, setCurre
 			>
 				<Button
 					color="info"
-					style={buttonProps.style}
 					variant="outline"
 					title={buttonProps.title}
 					onClick={handleToggle}

--- a/webui/src/Components/VariableValueDisplay.tsx
+++ b/webui/src/Components/VariableValueDisplay.tsx
@@ -1,8 +1,9 @@
-import { CButton, CPopover } from '@coreui/react'
+import { CPopover } from '@coreui/react'
 import { faCopy, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useCallback, useRef, useState } from 'react'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
+import { Button } from '~/Components/Button.js'
 import type { PanelCollapseHelperLite } from '~/Helpers/CollapseHelper.js'
 import { VARIABLE_UNKNOWN_VALUE } from '~/Resources/Constants.js'
 import { StaticAlert } from './Alert.js'
@@ -238,9 +239,9 @@ export const VariableValueDisplay: React.FC<VariableValueDisplay> = ({
 				{valuePill}
 				{showCopy && (
 					<CopyToClipboard text={valueStr} onCopy={onCopied}>
-						<CButton size="sm" title="Copy variable value">
+						<Button size="sm" title="Copy variable value">
 							<FontAwesomeIcon icon={faCopy} color={color} />
-						</CButton>
+						</Button>
 					</CopyToClipboard>
 				)}
 			</div>

--- a/webui/src/Components/VariablesTable.tsx
+++ b/webui/src/Components/VariablesTable.tsx
@@ -100,7 +100,7 @@ export const VariablesTable = observer(function VariablesTable({ label }: Variab
 					value={filter}
 					style={{ fontSize: '1.2em' }}
 				/>
-				<Button color="primary" onClick={clearFilter}>
+				<Button color="primary" onClick={clearFilter} aria-label="Clear search filter" title="Clear search filter">
 					<FontAwesomeIcon icon={faTimes} />
 				</Button>
 			</CInputGroup>

--- a/webui/src/Components/VariablesTable.tsx
+++ b/webui/src/Components/VariablesTable.tsx
@@ -100,7 +100,7 @@ export const VariablesTable = observer(function VariablesTable({ label }: Variab
 					value={filter}
 					style={{ fontSize: '1.2em' }}
 				/>
-				<Button color="danger" onClick={clearFilter}>
+				<Button color="primary" onClick={clearFilter}>
 					<FontAwesomeIcon icon={faTimes} />
 				</Button>
 			</CInputGroup>

--- a/webui/src/Components/VariablesTable.tsx
+++ b/webui/src/Components/VariablesTable.tsx
@@ -1,4 +1,4 @@
-import { CButton, CFormInput, CInputGroup } from '@coreui/react'
+import { CFormInput, CInputGroup } from '@coreui/react'
 import { faCopy, faSearch, faTimes } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useVirtualizer } from '@tanstack/react-virtual'
@@ -8,6 +8,7 @@ import { observer } from 'mobx-react-lite'
 import { useCallback, useContext, useRef, useState } from 'react'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
 import type { VariableValue } from '@companion-app/shared/Model/Variables.js'
+import { Button } from '~/Components/Button.js'
 import { NonIdealState } from '~/Components/NonIdealState.js'
 import { usePanelCollapseHelperLite, type PanelCollapseHelperLite } from '~/Helpers/CollapseHelper.js'
 import { useComputed } from '~/Resources/util.js'
@@ -99,9 +100,9 @@ export const VariablesTable = observer(function VariablesTable({ label }: Variab
 					value={filter}
 					style={{ fontSize: '1.2em' }}
 				/>
-				<CButton color="danger" onClick={clearFilter}>
+				<Button color="danger" onClick={clearFilter}>
 					<FontAwesomeIcon icon={faTimes} />
-				</CButton>
+				</Button>
 			</CInputGroup>
 			<p className="variables-table-count">
 				{filter ? (
@@ -191,9 +192,9 @@ const VariablesTableRow = observer(function VariablesTableRow({
 							{variableId}
 						</span>
 						<CopyToClipboard text={variableId} onCopy={onCopied}>
-							<CButton size="sm" title="Copy variable name">
+							<Button size="sm" title="Copy variable name">
 								<FontAwesomeIcon icon={faCopy} color="#d50215" />
-							</CButton>
+							</Button>
 						</CopyToClipboard>
 					</div>
 					<div className="autowrap" title={variable.description}>

--- a/webui/src/Connections/ConnectionList/ConnectionList.tsx
+++ b/webui/src/Connections/ConnectionList/ConnectionList.tsx
@@ -88,7 +88,7 @@ export const ConnectionsList = observer(function ConnectionsList({ selectedConne
 	return (
 		<div className="connections-list-container flex-column-layout">
 			<div className="connections-list-header fixed-header">
-				<h4 className="btn-inline">
+				<h4 className="button-inline">
 					Connections <ContextHelpButton action="/user-guide/config/connections" />
 				</h4>
 

--- a/webui/src/Connections/ConnectionList/ConnectionList.tsx
+++ b/webui/src/Connections/ConnectionList/ConnectionList.tsx
@@ -1,4 +1,4 @@
-import { CButton, CButtonGroup } from '@coreui/react'
+import { CButtonGroup } from '@coreui/react'
 import { faLayerGroup, faPlug } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useNavigate } from '@tanstack/react-router'
@@ -8,6 +8,7 @@ import type { ClientConnectionConfig, ConnectionCollection } from '@companion-ap
 import { ModuleInstanceType } from '@companion-app/shared/Model/Instance.js'
 import type { InstanceStatusEntry } from '@companion-app/shared/Model/InstanceStatus.js'
 import { stringifyError } from '@companion-app/shared/Stringify.js'
+import { Button } from '~/Components/Button.js'
 import { CollectionsNestingTable } from '~/Components/CollectionsNestingTable/CollectionsNestingTable.js'
 import { GenericConfirmModal, type GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
 import { NonIdealState } from '~/Components/NonIdealState.js'
@@ -103,7 +104,7 @@ export const ConnectionsList = observer(function ConnectionsList({ selectedConne
 				<ConnectionVariablesModal ref={variablesModalRef} />
 
 				<CButtonGroup className="connection-group-actions mb-2">
-					<CButton
+					<Button
 						color="primary"
 						size="sm"
 						className="d-xl-none"
@@ -111,7 +112,7 @@ export const ConnectionsList = observer(function ConnectionsList({ selectedConne
 					>
 						<FontAwesomeIcon icon={faPlug} className="me-1" />
 						Add Connection
-					</CButton>
+					</Button>
 					<CreateCollectionButton />
 				</CButtonGroup>
 			</div>
@@ -238,8 +239,8 @@ function CreateCollectionButton() {
 	}, [createMutation])
 
 	return (
-		<CButton color="info" size="sm" onClick={doCreateCollection}>
+		<Button color="info" size="sm" onClick={doCreateCollection}>
 			<FontAwesomeIcon icon={faLayerGroup} /> Create Collection
-		</CButton>
+		</Button>
 	)
 }

--- a/webui/src/Connections/ConnectionList/ConnectionList.tsx
+++ b/webui/src/Connections/ConnectionList/ConnectionList.tsx
@@ -1,4 +1,3 @@
-import { CButtonGroup } from '@coreui/react'
 import { faLayerGroup, faPlug } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useNavigate } from '@tanstack/react-router'
@@ -8,7 +7,7 @@ import type { ClientConnectionConfig, ConnectionCollection } from '@companion-ap
 import { ModuleInstanceType } from '@companion-app/shared/Model/Instance.js'
 import type { InstanceStatusEntry } from '@companion-app/shared/Model/InstanceStatus.js'
 import { stringifyError } from '@companion-app/shared/Stringify.js'
-import { Button } from '~/Components/Button.js'
+import { Button, ButtonGroup } from '~/Components/Button.js'
 import { CollectionsNestingTable } from '~/Components/CollectionsNestingTable/CollectionsNestingTable.js'
 import { GenericConfirmModal, type GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
 import { NonIdealState } from '~/Components/NonIdealState.js'
@@ -103,7 +102,7 @@ export const ConnectionsList = observer(function ConnectionsList({ selectedConne
 				<GenericConfirmModal ref={confirmModalRef} />
 				<ConnectionVariablesModal ref={variablesModalRef} />
 
-				<CButtonGroup className="connection-group-actions mb-2">
+				<ButtonGroup className="connection-group-actions mb-2">
 					<Button
 						color="primary"
 						size="sm"
@@ -114,7 +113,7 @@ export const ConnectionsList = observer(function ConnectionsList({ selectedConne
 						Add Connection
 					</Button>
 					<CreateCollectionButton />
-				</CButtonGroup>
+				</ButtonGroup>
 			</div>
 
 			<div className="connections-list-table-container scrollable-content">
@@ -160,12 +159,12 @@ function ConnectionListTableHeading() {
 		<div className="flex flex-row">
 			<div className="grow">Connection</div>
 			<div className="no-break">
-				<CButtonGroup className="table-header-buttons">
+				<ButtonGroup className="table-header-buttons">
 					<VisibilityButton {...visibleConnections} keyId="disabled" color="secondary" label="Disabled" />
 					<VisibilityButton {...visibleConnections} keyId="ok" color="success" label="OK" />
 					<VisibilityButton {...visibleConnections} keyId="warning" color="warning" label="Warning" />
 					<VisibilityButton {...visibleConnections} keyId="error" color="danger" label="Error" />
-				</CButtonGroup>
+				</ButtonGroup>
 			</div>
 		</div>
 	)

--- a/webui/src/Connections/ConnectionList/ConnectionsTableRow.tsx
+++ b/webui/src/Connections/ConnectionList/ConnectionsTableRow.tsx
@@ -68,7 +68,7 @@ export const ConnectionsTableRow = observer(function ConnectionsTableRow({
 					title="Variables"
 					color="secondary"
 					disabled={!isEnabled || !(connectionVariables && connectionVariables.size > 0)}
-					style={{ textAlign: 'left' }}
+					className="text-start"
 				>
 					<Tuck>
 						<FontAwesomeIcon icon={faDollarSign} />

--- a/webui/src/Connections/ConnectionList/ConnectionsTableRow.tsx
+++ b/webui/src/Connections/ConnectionList/ConnectionsTableRow.tsx
@@ -1,8 +1,8 @@
-import { CButton } from '@coreui/react'
 import { faDollarSign } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
 import { useCallback, useContext } from 'react'
+import { Button } from '~/Components/Button.js'
 import { Tuck } from '~/Components/Tuck.js'
 import { InstancesListTableRow } from '~/Instances/List/InstancesListTableRow.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC.js'
@@ -63,7 +63,7 @@ export const ConnectionsTableRow = observer(function ConnectionsTableRow({
 			instance={connection}
 			instanceStatus={connection.status}
 			extraMenuItems={
-				<CButton
+				<Button
 					onMouseDown={doShowVariables}
 					title="Variables"
 					color="secondary"
@@ -74,7 +74,7 @@ export const ConnectionsTableRow = observer(function ConnectionsTableRow({
 						<FontAwesomeIcon icon={faDollarSign} />
 					</Tuck>
 					Variables
-				</CButton>
+				</Button>
 			}
 			labelStr="connection"
 			doDelete={doDelete}

--- a/webui/src/Controls/Components/AddElementPickerModal.tsx
+++ b/webui/src/Controls/Components/AddElementPickerModal.tsx
@@ -1,8 +1,9 @@
-import { CButton, CModal, CModalBody, CModalFooter, CModalHeader, CModalTitle } from '@coreui/react'
+import { CModal, CModalBody, CModalFooter, CModalHeader, CModalTitle } from '@coreui/react'
 import { faCheck, faTimes } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import React, { useCallback, useState } from 'react'
 import { elementSchemas } from '@companion-app/shared/Graphics/ElementPropertiesSchemas.js'
+import { Button } from '~/Components/Button.js'
 import { ElementPicker } from './ElementPicker.js'
 import { useLayeredStyleElementsContext } from './LayeredStyleElementsContext.js'
 
@@ -70,12 +71,12 @@ export function AddElementPickerModal({ isOpen, onClose, onSave }: AddElementPic
 				/>
 			</CModalBody>
 			<CModalFooter>
-				<CButton color="secondary" onClick={handleClose}>
+				<Button color="secondary" onClick={handleClose}>
 					<FontAwesomeIcon icon={faTimes} /> Cancel
-				</CButton>
-				<CButton color="primary" onClick={handleSave} disabled={!canSave}>
+				</Button>
+				<Button color="primary" onClick={handleSave} disabled={!canSave}>
 					<FontAwesomeIcon icon={faCheck} /> Add Properties
-				</CButton>
+				</Button>
 			</CModalFooter>
 		</CModal>
 	)

--- a/webui/src/Controls/Components/AddEntitiesModal.tsx
+++ b/webui/src/Controls/Components/AddEntitiesModal.tsx
@@ -1,4 +1,4 @@
-import { CButton, CFormInput, CModalBody, CModalFooter, CModalHeader } from '@coreui/react'
+import { CFormInput, CModalBody, CModalFooter, CModalHeader } from '@coreui/react'
 import { faPlus, faSearch } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { go as fuzzySearch } from 'fuzzysort'
@@ -8,6 +8,7 @@ import { createContext, forwardRef, useCallback, useContext, useImperativeHandle
 import { canAddEntityToFeedbackList } from '@companion-app/shared/Entity.js'
 import type { ClientConnectionConfig } from '@companion-app/shared/Model/Connections.js'
 import type { EntityModelType, FeedbackEntitySubType } from '@companion-app/shared/Model/EntityModel.js'
+import { Button } from '~/Components/Button.js'
 import { CModalExt } from '~/Components/CModalExt.js'
 import {
 	CollapsibleTree,
@@ -241,9 +242,9 @@ export const AddEntitiesModal = observer(
 						/>
 					</CModalBody>
 					<CModalFooter>
-						<CButton color="secondary" onClick={doClose}>
+						<Button color="secondary" onClick={doClose}>
 							Done
-						</CButton>
+						</Button>
 					</CModalFooter>
 				</CModalExt>
 			</EntityTypeLabelContext.Provider>

--- a/webui/src/Controls/Components/AddEntityPanel.tsx
+++ b/webui/src/Controls/Components/AddEntityPanel.tsx
@@ -55,15 +55,7 @@ export function AddEntityPanel({
 				feedbackListType={feedbackListType}
 				disabled={readonly}
 			/>
-			<Button
-				color="primary"
-				onClick={showAddModal}
-				style={{
-					borderTopLeftRadius: 0,
-					borderBottomLeftRadius: 0,
-				}}
-				disabled={readonly}
-			>
+			<Button color="primary" onClick={showAddModal} className="rounded-start-0" disabled={readonly}>
 				<FontAwesomeIcon icon={faFolderOpen} />
 			</Button>
 

--- a/webui/src/Controls/Components/AddEntityPanel.tsx
+++ b/webui/src/Controls/Components/AddEntityPanel.tsx
@@ -1,8 +1,8 @@
-import { CButton } from '@coreui/react'
 import { faFolderOpen } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useCallback, useRef } from 'react'
 import type { EntityModelType, EntityOwner, FeedbackEntitySubType } from '@companion-app/shared/Model/EntityModel.js'
+import { Button } from '~/Components/Button.js'
 import { usePanelCollapseHelperContext } from '~/Helpers/CollapseHelper.js'
 import { MyErrorBoundary } from '~/Resources/Error.js'
 import { AddEntitiesModal, type AddEntitiesModalRef } from './AddEntitiesModal.js'
@@ -55,7 +55,7 @@ export function AddEntityPanel({
 				feedbackListType={feedbackListType}
 				disabled={readonly}
 			/>
-			<CButton
+			<Button
 				color="primary"
 				onClick={showAddModal}
 				style={{
@@ -65,7 +65,7 @@ export function AddEntityPanel({
 				disabled={readonly}
 			>
 				<FontAwesomeIcon icon={faFolderOpen} />
-			</CButton>
+			</Button>
 
 			<MyErrorBoundary>
 				<AddEntitiesModal

--- a/webui/src/Controls/Components/ElementPickerModal.tsx
+++ b/webui/src/Controls/Components/ElementPickerModal.tsx
@@ -1,9 +1,10 @@
-import { CButton, CModal, CModalBody, CModalFooter, CModalHeader, CModalTitle } from '@coreui/react'
+import { CModal, CModalBody, CModalFooter, CModalHeader, CModalTitle } from '@coreui/react'
 import { faCheck, faTimes } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import React, { useCallback, useState } from 'react'
 import { elementSchemas } from '@companion-app/shared/Graphics/ElementPropertiesSchemas.js'
 import type { FeedbackEntityStyleOverride } from '@companion-app/shared/Model/EntityModel.js'
+import { Button } from '~/Components/Button.js'
 import { ElementPicker } from './ElementPicker.js'
 import { useLayeredStyleElementsContext } from './LayeredStyleElementsContext.js'
 
@@ -71,12 +72,12 @@ export function ElementPickerModal({
 				/>
 			</CModalBody>
 			<CModalFooter>
-				<CButton color="secondary" onClick={handleClose}>
+				<Button color="secondary" onClick={handleClose}>
 					<FontAwesomeIcon icon={faTimes} /> Cancel
-				</CButton>
-				<CButton color="primary" onClick={handleSave} disabled={!canSave}>
+				</Button>
+				<Button color="primary" onClick={handleSave} disabled={!canSave}>
 					<FontAwesomeIcon icon={faCheck} /> Save
-				</CButton>
+				</Button>
 			</CModalFooter>
 		</CModal>
 	)

--- a/webui/src/Controls/Components/EntityCellControls.tsx
+++ b/webui/src/Controls/Components/EntityCellControls.tsx
@@ -1,9 +1,10 @@
-import { CButton, CButtonGroup } from '@coreui/react'
+import { CButtonGroup } from '@coreui/react'
 import { faClone, faCompressArrowsAlt, faExpandArrowsAlt, faPencil, faTrash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
 import { useCallback } from 'react'
 import { EntityModelType, type EntityOwner, type SomeEntityModel } from '@companion-app/shared/Model/EntityModel.js'
+import { Button } from '~/Components/Button.js'
 import { SwitchInputField } from '~/Components/SwitchInputField'
 import { TextInputField } from '~/Components/TextInputField.js'
 import type { IEntityEditorActionService } from '~/Services/Controls/ControlEntitiesService.js'
@@ -65,30 +66,30 @@ export const EntityRowHeader = observer(function EntityRowHeader({
 			<div className="cell-controls">
 				<CButtonGroup className="me-1">
 					{canSetHeadline && !headlineExpanded && !isPanelCollapsed && (
-						<CButton size="sm" onClick={setHeadlineExpanded} title="Set headline">
+						<Button size="sm" onClick={setHeadlineExpanded} title="Set headline">
 							<FontAwesomeIcon icon={faPencil} />
-						</CButton>
+						</Button>
 					)}
 					{isPanelCollapsed ? (
-						<CButton size="sm" onClick={doExpand} title={`Expand ${entityTypeLabel} view`}>
+						<Button size="sm" onClick={doExpand} title={`Expand ${entityTypeLabel} view`}>
 							<FontAwesomeIcon icon={faExpandArrowsAlt} />
-						</CButton>
+						</Button>
 					) : (
-						<CButton size="sm" onClick={doCollapse} title={`Collapse ${entityTypeLabel} view`}>
+						<Button size="sm" onClick={doCollapse} title={`Collapse ${entityTypeLabel} view`}>
 							<FontAwesomeIcon icon={faCompressArrowsAlt} />
-						</CButton>
+						</Button>
 					)}
-					<CButton
+					<Button
 						size="sm"
 						disabled={readonly}
 						onClick={service.performDuplicate}
 						title={`Duplicate ${entityTypeLabel}`}
 					>
 						<FontAwesomeIcon icon={faClone} />
-					</CButton>
-					<CButton size="sm" disabled={readonly} onClick={service.performDelete} title={`Remove ${entityTypeLabel}`}>
+					</Button>
+					<Button size="sm" disabled={readonly} onClick={service.performDelete} title={`Remove ${entityTypeLabel}`}>
 						<FontAwesomeIcon icon={faTrash} />
-					</CButton>
+					</Button>
 					{!!service.setEnabled && (
 						<>
 							&nbsp;

--- a/webui/src/Controls/Components/EntityCellControls.tsx
+++ b/webui/src/Controls/Components/EntityCellControls.tsx
@@ -1,10 +1,9 @@
-import { CButtonGroup } from '@coreui/react'
 import { faClone, faCompressArrowsAlt, faExpandArrowsAlt, faPencil, faTrash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
 import { useCallback } from 'react'
 import { EntityModelType, type EntityOwner, type SomeEntityModel } from '@companion-app/shared/Model/EntityModel.js'
-import { Button } from '~/Components/Button.js'
+import { Button, ButtonGroup } from '~/Components/Button.js'
 import { SwitchInputField } from '~/Components/SwitchInputField'
 import { TextInputField } from '~/Components/TextInputField.js'
 import type { IEntityEditorActionService } from '~/Services/Controls/ControlEntitiesService.js'
@@ -64,7 +63,7 @@ export const EntityRowHeader = observer(function EntityRowHeader({
 				)}
 			</div>
 			<div className="cell-controls">
-				<CButtonGroup className="me-1">
+				<ButtonGroup className="me-1">
 					{canSetHeadline && !headlineExpanded && !isPanelCollapsed && (
 						<Button size="sm" onClick={setHeadlineExpanded} title="Set headline">
 							<FontAwesomeIcon icon={faPencil} />
@@ -101,7 +100,7 @@ export const EntityRowHeader = observer(function EntityRowHeader({
 							/>
 						</>
 					)}
-				</CButtonGroup>
+				</ButtonGroup>
 			</div>
 		</div>
 	)

--- a/webui/src/Controls/Components/EntityCommonCells.tsx
+++ b/webui/src/Controls/Components/EntityCommonCells.tsx
@@ -1,4 +1,4 @@
-import { CButton, CCol, CForm, CFormLabel } from '@coreui/react'
+import { CCol, CForm, CFormLabel } from '@coreui/react'
 import { faCopy, faQuestionCircle } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useSubscription } from '@trpc/tanstack-react-query'
@@ -16,6 +16,7 @@ import {
 import type { CompanionInputFieldCheckboxExtended, ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
 import { stringifyVariableValue } from '@companion-app/shared/Model/Variables.js'
 import { StaticAlert } from '~/Components/Alert.js'
+import { Button } from '~/Components/Button.js'
 import { InlineHelpIcon } from '~/Components/InlineHelp.js'
 import { NonIdealState } from '~/Components/NonIdealState.js'
 import { VariableValueDisplay } from '~/Components/VariableValueDisplay.js'
@@ -94,9 +95,9 @@ export const EntityCommonCells = observer(function EntityCommonCells({
 										The name to give this value as a {localVariablePrefix} variable
 									</InlineHelpIcon>
 									<CopyToClipboard text={`$(${localVariablePrefix}:${entity.variableName ?? ''})`} onCopy={onCopied}>
-										<CButton size="sm" title="Copy variable name" className="ps-0">
+										<Button size="sm" title="Copy variable name" className="ps-0">
 											<FontAwesomeIcon icon={faCopy} color="#d50215" />
-										</CButton>
+										</Button>
 									</CopyToClipboard>
 								</CFormLabel>
 								<CCol sm={8}>

--- a/webui/src/Controls/Components/EntityEditorHeadingProps.tsx
+++ b/webui/src/Controls/Components/EntityEditorHeadingProps.tsx
@@ -1,8 +1,9 @@
-import { CButton, CButtonGroup } from '@coreui/react'
+import { CButtonGroup } from '@coreui/react'
 import { faCompressArrowsAlt, faExpandArrowsAlt } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
 import type { EntityOwner } from '@companion-app/shared/Model/EntityModel.js'
+import { Button } from '~/Components/Button.js'
 import { usePanelCollapseHelperContext } from '~/Helpers/CollapseHelper.js'
 import { stringifyEntityOwnerId } from '../Util.js'
 
@@ -28,24 +29,24 @@ export const EntityEditorHeading = observer(function EntityEditorHeading({
 			{heading}&nbsp;
 			<CButtonGroup className="right">
 				{childEntityIds.length >= 1 && panelCollapseHelper.canExpandAll(ownerIdString, childEntityIds) && (
-					<CButton
+					<Button
 						color="white"
 						size="sm"
 						onClick={() => panelCollapseHelper.setAllExpanded(ownerIdString, childEntityIds)}
 						title="Expand all"
 					>
 						<FontAwesomeIcon icon={faExpandArrowsAlt} />
-					</CButton>
+					</Button>
 				)}
 				{childEntityIds.length >= 1 && panelCollapseHelper.canCollapseAll(ownerIdString, childEntityIds) && (
-					<CButton
+					<Button
 						color="white"
 						size="sm"
 						onClick={() => panelCollapseHelper.setAllCollapsed(ownerIdString, childEntityIds)}
 						title="Collapse all"
 					>
 						<FontAwesomeIcon icon={faCompressArrowsAlt} />
-					</CButton>
+					</Button>
 				)}
 				{headingActions || ''}
 			</CButtonGroup>

--- a/webui/src/Controls/Components/EntityEditorHeadingProps.tsx
+++ b/webui/src/Controls/Components/EntityEditorHeadingProps.tsx
@@ -1,9 +1,8 @@
-import { CButtonGroup } from '@coreui/react'
 import { faCompressArrowsAlt, faExpandArrowsAlt } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
 import type { EntityOwner } from '@companion-app/shared/Model/EntityModel.js'
-import { Button } from '~/Components/Button.js'
+import { Button, ButtonGroup } from '~/Components/Button.js'
 import { usePanelCollapseHelperContext } from '~/Helpers/CollapseHelper.js'
 import { stringifyEntityOwnerId } from '../Util.js'
 
@@ -27,7 +26,7 @@ export const EntityEditorHeading = observer(function EntityEditorHeading({
 	return (
 		<h5>
 			{heading}&nbsp;
-			<CButtonGroup className="right">
+			<ButtonGroup className="right">
 				{childEntityIds.length >= 1 && panelCollapseHelper.canExpandAll(ownerIdString, childEntityIds) && (
 					<Button
 						color="white"
@@ -49,7 +48,7 @@ export const EntityEditorHeading = observer(function EntityEditorHeading({
 					</Button>
 				)}
 				{headingActions || ''}
-			</CButtonGroup>
+			</ButtonGroup>
 		</h5>
 	)
 })

--- a/webui/src/Controls/Components/EntityEditorHeadingProps.tsx
+++ b/webui/src/Controls/Components/EntityEditorHeadingProps.tsx
@@ -29,7 +29,6 @@ export const EntityEditorHeading = observer(function EntityEditorHeading({
 			<ButtonGroup className="right">
 				{childEntityIds.length >= 1 && panelCollapseHelper.canExpandAll(ownerIdString, childEntityIds) && (
 					<Button
-						color="white"
 						size="sm"
 						onClick={() => panelCollapseHelper.setAllExpanded(ownerIdString, childEntityIds)}
 						title="Expand all"
@@ -39,7 +38,6 @@ export const EntityEditorHeading = observer(function EntityEditorHeading({
 				)}
 				{childEntityIds.length >= 1 && panelCollapseHelper.canCollapseAll(ownerIdString, childEntityIds) && (
 					<Button
-						color="white"
 						size="sm"
 						onClick={() => panelCollapseHelper.setAllCollapsed(ownerIdString, childEntityIds)}
 						title="Collapse all"

--- a/webui/src/Controls/Components/LayeredStylesOverrides.tsx
+++ b/webui/src/Controls/Components/LayeredStylesOverrides.tsx
@@ -130,7 +130,7 @@ export const LayeredStylesOverrides = observer(function LayeredStylesOverrides({
 						<th>Element & Property</th>
 						<th>Value</th>
 						<th className="fit">
-							<Button color="white" size="sm" title="Add override" onClick={() => setIsAddModalOpen(true)}>
+							<Button size="sm" title="Add override" onClick={() => setIsAddModalOpen(true)} className="py-0">
 								<FontAwesomeIcon icon={faPlus} />
 							</Button>
 						</th>
@@ -198,7 +198,7 @@ const LayeredStylesOverridesRow = observer(function LayeredStylesOverridesRow({
 						<div className="flex-grow-1">
 							<SelectedElementProperty row={row} />
 						</div>
-						<Button color="white" size="sm" title="Edit element and property">
+						<Button size="sm" title="Edit element and property">
 							<FontAwesomeIcon icon={faPencil} />
 						</Button>
 					</div>
@@ -212,7 +212,7 @@ const LayeredStylesOverridesRow = observer(function LayeredStylesOverridesRow({
 					/>
 				</td>
 				<td>
-					<Button color="white" size="sm" title="Delete override" onClick={() => deleteRow(row.overrideId)}>
+					<Button size="sm" title="Delete override" onClick={() => deleteRow(row.overrideId)}>
 						<FontAwesomeIcon icon={faTrash} />
 					</Button>
 				</td>

--- a/webui/src/Controls/Components/LayeredStylesOverrides.tsx
+++ b/webui/src/Controls/Components/LayeredStylesOverrides.tsx
@@ -1,4 +1,3 @@
-import { CButton } from '@coreui/react'
 import { faPencil, faPlus, faTrash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
@@ -17,6 +16,7 @@ import type { ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
 import type { SomeButtonGraphicsElement } from '@companion-app/shared/Model/StyleLayersModel.js'
 import { ButtonStylePropertiesWithBuffer } from '@companion-app/shared/Style.js'
 import { assertNever } from '@companion-app/shared/Util.js'
+import { Button } from '~/Components/Button.js'
 import { DropdownInputField } from '~/Components/DropdownInputField.js'
 import { FieldOrExpression } from '~/Components/FieldOrExpression.js'
 import { useComputed } from '~/Resources/util.js'
@@ -130,9 +130,9 @@ export const LayeredStylesOverrides = observer(function LayeredStylesOverrides({
 						<th>Element & Property</th>
 						<th>Value</th>
 						<th className="fit">
-							<CButton color="white" size="sm" title="Add override" onClick={() => setIsAddModalOpen(true)}>
+							<Button color="white" size="sm" title="Add override" onClick={() => setIsAddModalOpen(true)}>
 								<FontAwesomeIcon icon={faPlus} />
-							</CButton>
+							</Button>
 						</th>
 					</tr>
 				</thead>
@@ -198,9 +198,9 @@ const LayeredStylesOverridesRow = observer(function LayeredStylesOverridesRow({
 						<div className="flex-grow-1">
 							<SelectedElementProperty row={row} />
 						</div>
-						<CButton color="white" size="sm" title="Edit element and property">
+						<Button color="white" size="sm" title="Edit element and property">
 							<FontAwesomeIcon icon={faPencil} />
-						</CButton>
+						</Button>
 					</div>
 				</td>
 				<td>
@@ -212,9 +212,9 @@ const LayeredStylesOverridesRow = observer(function LayeredStylesOverridesRow({
 					/>
 				</td>
 				<td>
-					<CButton color="white" size="sm" title="Delete override" onClick={() => deleteRow(row.overrideId)}>
+					<Button color="white" size="sm" title="Delete override" onClick={() => deleteRow(row.overrideId)}>
 						<FontAwesomeIcon icon={faTrash} />
-					</CButton>
+					</Button>
 				</td>
 			</tr>
 

--- a/webui/src/Emulator/Emulator.tsx
+++ b/webui/src/Emulator/Emulator.tsx
@@ -1,4 +1,4 @@
-import { CButton, CCol, CForm, CRow } from '@coreui/react'
+import { CCol, CForm, CRow } from '@coreui/react'
 import { faCancel, faExpand, faGamepad } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useNavigate, useParams } from '@tanstack/react-router'
@@ -6,6 +6,7 @@ import { useSubscription } from '@trpc/tanstack-react-query'
 import { observer } from 'mobx-react-lite'
 import { useCallback, useState } from 'react'
 import type { EmulatorConfig } from '@companion-app/shared/Model/Common.js'
+import { Button } from '~/Components/Button.js'
 import { NonIdealState } from '~/Components/NonIdealState.js'
 import { useWakeLock } from '~/Hooks/useScreenWakeLock.js'
 import { LoadingRetryOrError } from '~/Resources/Loading.js'
@@ -98,16 +99,16 @@ function ConfigurePanel({ config }: ConfigurePanelProps): JSX.Element | null {
 				<CForm onSubmit={PreventDefaultHandler}>
 					<CRow>
 						<CCol xs={12}>
-							<CButton
+							<Button
 								onClick={doRequestFullscreen}
 								title="Fullscreen"
 								disabled={!document.documentElement.requestFullscreen}
 							>
 								<FontAwesomeIcon icon={faExpand} /> Fullscreen
-							</CButton>
-							<CButton onClick={doDismiss} title="Dismiss">
+							</Button>
+							<Button onClick={doDismiss} title="Dismiss">
 								<FontAwesomeIcon icon={faCancel} /> Dismiss
-							</CButton>
+							</Button>
 						</CCol>
 					</CRow>
 				</CForm>
@@ -126,14 +127,14 @@ function EmulatorNotFound({ emulatorId }: { emulatorId: string }) {
 					The emulator with ID <code>{emulatorId}</code> was not found.
 				</div>
 				<div>
-					<CButton
+					<Button
 						color="warning"
 						className="emulator-back-button"
 						onClick={() => void navigate({ to: '/emulators' })}
 						title="Back to emulator list"
 					>
 						Back
-					</CButton>
+					</Button>
 				</div>
 			</NonIdealState>
 		</div>

--- a/webui/src/Emulator/List.tsx
+++ b/webui/src/Emulator/List.tsx
@@ -1,10 +1,11 @@
-import { CButton, CCol, CContainer, CRow } from '@coreui/react'
+import { CCol, CContainer, CRow } from '@coreui/react'
 import { faGamepad } from '@fortawesome/free-solid-svg-icons'
 import { useNavigate } from '@tanstack/react-router'
 import { useSubscription } from '@trpc/tanstack-react-query'
 import { observer } from 'mobx-react-lite'
 import { useCallback } from 'react'
 import { StaticAlert } from '~/Components/Alert'
+import { Button } from '~/Components/Button.js'
 import { NonIdealState } from '~/Components/NonIdealState'
 import { LoadingRetryOrError } from '~/Resources/Loading.js'
 import { trpc } from '~/Resources/TRPC'
@@ -43,7 +44,7 @@ export const EmulatorList = observer(function EmulatorList() {
 						<CRow>
 							{emulatorList.data.map((surface) => (
 								<CCol sm={12} md={6} lg={4} key={surface.id} className="mb-4">
-									<CButton
+									<Button
 										color="dark"
 										className="w-100 d-flex flex-column align-items-center justify-content-center emulator-button"
 										onClick={() =>
@@ -54,7 +55,7 @@ export const EmulatorList = observer(function EmulatorList() {
 										}
 									>
 										<div className="mt-2">{surface.name || 'Emulator'}</div>
-									</CButton>
+									</Button>
 								</CCol>
 							))}
 

--- a/webui/src/ImageLibrary/ImageAddModal.tsx
+++ b/webui/src/ImageLibrary/ImageAddModal.tsx
@@ -1,8 +1,9 @@
-import { CButton, CModal, CModalBody, CModalFooter, CModalHeader, CModalTitle } from '@coreui/react'
+import { CModal, CModalBody, CModalFooter, CModalHeader, CModalTitle } from '@coreui/react'
 import { observer } from 'mobx-react-lite'
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useState } from 'react'
 import { isLabelValid } from '@companion-app/shared/Label.js'
 import { stringifyError } from '@companion-app/shared/Stringify.js'
+import { Button } from '~/Components/Button.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC'
 import { ImageNameInput } from './ImageNameInput'
 
@@ -119,12 +120,12 @@ export const ImageAddModal = observer(
 					/>
 				</CModalBody>
 				<CModalFooter>
-					<CButton color="secondary" onClick={handleCancel} disabled={isCreating}>
+					<Button color="secondary" onClick={handleCancel} disabled={isCreating}>
 						Cancel
-					</CButton>
-					<CButton color="primary" onClick={handleCreate} disabled={!canCreate || isCreating}>
+					</Button>
+					<Button color="primary" onClick={handleCreate} disabled={!canCreate || isCreating}>
 						{isCreating ? 'Creating...' : 'Create'}
-					</CButton>
+					</Button>
 				</CModalFooter>
 			</CModal>
 		)

--- a/webui/src/ImageLibrary/ImageAddModal.tsx
+++ b/webui/src/ImageLibrary/ImageAddModal.tsx
@@ -120,7 +120,7 @@ export const ImageAddModal = observer(
 					/>
 				</CModalBody>
 				<CModalFooter>
-					<Button color="secondary" onClick={handleCancel} disabled={isCreating}>
+					<Button type="button" color="secondary" onClick={handleCancel} disabled={isCreating}>
 						Cancel
 					</Button>
 					<Button color="primary" onClick={handleCreate} disabled={!canCreate || isCreating}>

--- a/webui/src/ImageLibrary/ImageLibraryEditor.tsx
+++ b/webui/src/ImageLibrary/ImageLibraryEditor.tsx
@@ -1,10 +1,11 @@
-import { CButton, CCol, CForm, CFormLabel } from '@coreui/react'
+import { CCol, CForm, CFormLabel } from '@coreui/react'
 import { faCopy, faDownload, faEdit, faTrashAlt, faUpload } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
 import React, { useCallback, useContext, useId, useRef, useState } from 'react'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
 import { StaticAlert } from '~/Components/Alert.js'
+import { Button } from '~/Components/Button.js'
 import { GenericConfirmModal, type GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
 import { trpc, trpcClient, useMutationExt } from '~/Resources/TRPC.js'
 import { RootAppStoreContext } from '~/Stores/RootAppStore.js'
@@ -196,18 +197,18 @@ export const ImageLibraryEditor = observer(function ImageLibraryEditor({
 
 			<div className="mb-3">
 				<div className="d-flex flex-wrap gap-2">
-					<CButton color="danger" onClick={handleDelete} title="Delete Image">
+					<Button color="danger" onClick={handleDelete} title="Delete Image">
 						<FontAwesomeIcon icon={faTrashAlt} />
-					</CButton>
+					</Button>
 
-					<CButton color="secondary" onClick={handleDownload}>
+					<Button color="secondary" onClick={handleDownload}>
 						<FontAwesomeIcon icon={faDownload} /> Download
-					</CButton>
+					</Button>
 
-					<CButton color="warning" onClick={() => fileInputRef.current?.click()} disabled={uploading}>
+					<Button color="warning" onClick={() => fileInputRef.current?.click()} disabled={uploading}>
 						<FontAwesomeIcon icon={faUpload} />
 						{uploading ? ' Replacing...' : ' Replace'}
-					</CButton>
+					</Button>
 				</div>
 
 				<input
@@ -225,14 +226,14 @@ export const ImageLibraryEditor = observer(function ImageLibraryEditor({
 					<div className="d-flex align-items-center">
 						<span className="font-monospace">{imageInfo.name}</span>
 						<CopyToClipboard text={`$(image:${imageInfo.name})`} onCopy={handleCopyVariableValue}>
-							<CButton size="sm" title="Copy variable name">
+							<Button size="sm" title="Copy variable name">
 								<FontAwesomeIcon icon={faCopy} />
-							</CButton>
+							</Button>
 						</CopyToClipboard>
 					</div>
-					<CButton color="secondary" size="sm" onClick={() => setShowNameEditModal(true)} title="Edit Image name">
+					<Button color="secondary" size="sm" onClick={() => setShowNameEditModal(true)} title="Edit Image name">
 						<FontAwesomeIcon icon={faEdit} />
-					</CButton>
+					</Button>
 				</CCol>
 			</CForm>
 			<CForm className="row mb-3">

--- a/webui/src/ImageLibrary/ImageLibraryGrid.tsx
+++ b/webui/src/ImageLibrary/ImageLibraryGrid.tsx
@@ -1,4 +1,4 @@
-import { CButtonGroup, CFormInput } from '@coreui/react'
+import { CFormInput } from '@coreui/react'
 import { faImage, faLayerGroup, faPlus } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import fuzzysort from 'fuzzysort'
@@ -6,7 +6,7 @@ import { humanId } from 'human-id'
 import { observer } from 'mobx-react-lite'
 import { useCallback, useContext, useRef, useState } from 'react'
 import type { ImageLibraryInfo } from '@companion-app/shared/Model/ImageLibraryModel.js'
-import { Button } from '~/Components/Button.js'
+import { Button, ButtonGroup } from '~/Components/Button.js'
 import { CollectionsNestingTable } from '~/Components/CollectionsNestingTable/CollectionsNestingTable.js'
 import type { CollectionsNestingTableItem } from '~/Components/CollectionsNestingTable/Types.js'
 import { GenericConfirmModal, type GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
@@ -144,7 +144,7 @@ export const ImageLibraryGrid = observer(function ImageLibraryGridInner({
 
 				<div className="image-library-controls">
 					<div className="d-flex gap-2 mb-3">
-						<CButtonGroup>
+						<ButtonGroup>
 							<Button color="primary" size="sm" onClick={handleImportFiles}>
 								<FontAwesomeIcon icon={faPlus} /> Import Images
 							</Button>
@@ -152,7 +152,7 @@ export const ImageLibraryGrid = observer(function ImageLibraryGridInner({
 								<FontAwesomeIcon icon={faPlus} /> Add Placeholder
 							</Button>
 							<CreateCollectionButton />
-						</CButtonGroup>
+						</ButtonGroup>
 					</div>
 
 					<CFormInput

--- a/webui/src/ImageLibrary/ImageLibraryGrid.tsx
+++ b/webui/src/ImageLibrary/ImageLibraryGrid.tsx
@@ -1,4 +1,4 @@
-import { CButton, CButtonGroup, CFormInput } from '@coreui/react'
+import { CButtonGroup, CFormInput } from '@coreui/react'
 import { faImage, faLayerGroup, faPlus } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import fuzzysort from 'fuzzysort'
@@ -6,6 +6,7 @@ import { humanId } from 'human-id'
 import { observer } from 'mobx-react-lite'
 import { useCallback, useContext, useRef, useState } from 'react'
 import type { ImageLibraryInfo } from '@companion-app/shared/Model/ImageLibraryModel.js'
+import { Button } from '~/Components/Button.js'
 import { CollectionsNestingTable } from '~/Components/CollectionsNestingTable/CollectionsNestingTable.js'
 import type { CollectionsNestingTableItem } from '~/Components/CollectionsNestingTable/Types.js'
 import { GenericConfirmModal, type GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
@@ -144,12 +145,12 @@ export const ImageLibraryGrid = observer(function ImageLibraryGridInner({
 				<div className="image-library-controls">
 					<div className="d-flex gap-2 mb-3">
 						<CButtonGroup>
-							<CButton color="primary" size="sm" onClick={handleImportFiles}>
+							<Button color="primary" size="sm" onClick={handleImportFiles}>
 								<FontAwesomeIcon icon={faPlus} /> Import Images
-							</CButton>
-							<CButton color="primary" size="sm" onClick={handleCreateNew}>
+							</Button>
+							<Button color="primary" size="sm" onClick={handleCreateNew}>
 								<FontAwesomeIcon icon={faPlus} /> Add Placeholder
-							</CButton>
+							</Button>
 							<CreateCollectionButton />
 						</CButtonGroup>
 					</div>
@@ -199,8 +200,8 @@ function CreateCollectionButton() {
 	}, [createMutation])
 
 	return (
-		<CButton color="info" size="sm" onClick={doCreateCollection}>
+		<Button color="info" size="sm" onClick={doCreateCollection}>
 			<FontAwesomeIcon icon={faLayerGroup} /> Create Collection
-		</CButton>
+		</Button>
 	)
 }

--- a/webui/src/ImageLibrary/ImageNameEditModal.tsx
+++ b/webui/src/ImageLibrary/ImageNameEditModal.tsx
@@ -1,8 +1,9 @@
-import { CButton, CModal, CModalBody, CModalFooter, CModalHeader, CModalTitle } from '@coreui/react'
+import { CModal, CModalBody, CModalFooter, CModalHeader, CModalTitle } from '@coreui/react'
 import { observer } from 'mobx-react-lite'
 import { useCallback, useEffect, useState } from 'react'
 import { isLabelValid } from '@companion-app/shared/Label.js'
 import { stringifyError } from '@companion-app/shared/Stringify.js'
+import { Button } from '~/Components/Button'
 import { trpc, useMutationExt } from '~/Resources/TRPC'
 import { ImageNameInput } from './ImageNameInput'
 
@@ -113,12 +114,12 @@ export const ImageNameEditModal = observer(function ImageNameEditModal({
 				/>
 			</CModalBody>
 			<CModalFooter>
-				<CButton color="secondary" onClick={handleCancel} disabled={isSaving}>
+				<Button color="secondary" onClick={handleCancel} disabled={isSaving}>
 					Cancel
-				</CButton>
-				<CButton color="primary" onClick={handleSave} disabled={!canSave || isSaving}>
+				</Button>
+				<Button color="primary" onClick={handleSave} disabled={!canSave || isSaving}>
 					{isSaving ? 'Saving...' : 'Save'}
-				</CButton>
+				</Button>
 			</CModalFooter>
 		</CModal>
 	)

--- a/webui/src/ImageLibrary/ImageNameEditModal.tsx
+++ b/webui/src/ImageLibrary/ImageNameEditModal.tsx
@@ -114,7 +114,7 @@ export const ImageNameEditModal = observer(function ImageNameEditModal({
 				/>
 			</CModalBody>
 			<CModalFooter>
-				<Button color="secondary" onClick={handleCancel} disabled={isSaving}>
+				<Button type="button" color="secondary" onClick={handleCancel} disabled={isSaving}>
 					Cancel
 				</Button>
 				<Button color="primary" onClick={handleSave} disabled={!canSave || isSaving}>

--- a/webui/src/ImportExport/Export.tsx
+++ b/webui/src/ImportExport/Export.tsx
@@ -1,9 +1,10 @@
-import { CButton, CForm, CFormLabel, CModal, CModalBody, CModalFooter, CModalHeader } from '@coreui/react'
+import { CForm, CFormLabel, CModal, CModalBody, CModalFooter, CModalHeader } from '@coreui/react'
 import { useForm } from '@tanstack/react-form'
 import { observer } from 'mobx-react-lite'
 import { forwardRef, useCallback, useContext, useImperativeHandle, useState } from 'react'
 import type { ClientExportSelection } from '@companion-app/shared/Model/ImportExport.js'
 import { flattenToQueryParams } from '@companion-app/shared/Util/QueryParamUtil.js'
+import { Button } from '~/Components/Button'
 import { CheckboxInputFieldWithLabel } from '~/Components/CheckboxInputField.js'
 import { InlineHelpIcon } from '~/Components/InlineHelp.js'
 import { MenuPortalContext } from '~/Components/MenuPortalContext.js'
@@ -331,12 +332,12 @@ export const ExportWizardModal = observer(
 								selector={(state) => [state.canSubmit, state.isSubmitting]}
 								children={([canSubmit, isSubmitting]) => (
 									<>
-										<CButton color="secondary" onClick={doClose} disabled={isSubmitting}>
+										<Button color="secondary" onClick={doClose} disabled={isSubmitting}>
 											Close
-										</CButton>
-										<CButton color="primary" disabled={!canSubmit || isSubmitting} type="submit">
+										</Button>
+										<Button color="primary" disabled={!canSubmit || isSubmitting} type="submit">
 											Download {isSubmitting ? '...' : ''}
-										</CButton>
+										</Button>
 									</>
 								)}
 							/>

--- a/webui/src/ImportExport/Import/Full.tsx
+++ b/webui/src/ImportExport/Import/Full.tsx
@@ -1,4 +1,4 @@
-import { CButton, CCallout } from '@coreui/react'
+import { CCallout } from '@coreui/react'
 import {
 	faCircleInfo,
 	faClock,
@@ -19,6 +19,7 @@ import type {
 } from '@companion-app/shared/Model/ImportExport.js'
 import { stringifyError } from '@companion-app/shared/Stringify.js'
 import { StaticAlert } from '~/Components/Alert.js'
+import { Button, LinkButtonExternal } from '~/Components/Button.js'
 import { CheckboxInputFieldWithLabel } from '~/Components/CheckboxInputField.js'
 import { InlineHelpIcon } from '~/Components/InlineHelp.js'
 import { TabArea } from '~/Components/TabArea.js'
@@ -209,9 +210,9 @@ function FullImportTab({ snapshot }: FullImportTabProps) {
 					It is <strong>highly recommended</strong> to export the current system configuration before performing a full
 					import.
 				</p>
-				<CButton color="warning" href={makeAbsolutePath('/int/export/full')} target="_blank">
+				<LinkButtonExternal color="warning" href={makeAbsolutePath('/int/export/full')}>
 					<FontAwesomeIcon icon={faDownload} /> Export Current Configuration
-				</CButton>
+				</LinkButtonExternal>
 			</CCallout>
 			<h5>Components</h5>
 			<p>
@@ -368,7 +369,7 @@ function FullImportTab({ snapshot }: FullImportTabProps) {
 								const anythingEnabled = isAnythingEnabled(sanitiseSelection(values, snapshot, false))
 								return (
 									<>
-										<CButton
+										<Button
 											color="success"
 											type="submit"
 											disabled={!anythingEnabled}
@@ -379,7 +380,7 @@ function FullImportTab({ snapshot }: FullImportTabProps) {
 											}}
 										>
 											<FontAwesomeIcon icon={faFileImport} /> Import Preserving Unselected
-										</CButton>
+										</Button>
 									</>
 								)
 							}}
@@ -398,7 +399,7 @@ function FullImportTab({ snapshot }: FullImportTabProps) {
 							{([values]) => {
 								const anythingEnabled = isAnythingEnabled(sanitiseSelection(values, snapshot, false))
 								return (
-									<CButton
+									<Button
 										color="primary"
 										type="submit"
 										disabled={!anythingEnabled}
@@ -410,7 +411,7 @@ function FullImportTab({ snapshot }: FullImportTabProps) {
 										}}
 									>
 										<FontAwesomeIcon icon={faFileImport} /> Full Reset & Import
-									</CButton>
+									</Button>
 								)
 							}}
 						</form.Subscribe>

--- a/webui/src/ImportExport/Import/Page.tsx
+++ b/webui/src/ImportExport/Import/Page.tsx
@@ -1,4 +1,4 @@
-import { CButton, CCallout, CCol, CRow } from '@coreui/react'
+import { CCallout, CCol, CRow } from '@coreui/react'
 import { faFileCircleExclamation, faFileCirclePlus, faHome } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useQuery } from '@tanstack/react-query'
@@ -18,6 +18,7 @@ import {
 	type ButtonInfiniteGridRef,
 } from '~/Buttons/ButtonInfiniteGrid.js'
 import { useGridZoom } from '~/Buttons/GridZoom.js'
+import { Button } from '~/Components/Button'
 import { SimpleDropdownInputField } from '~/Components/DropdownInputFieldSimple'
 import { useHasBeenRendered } from '~/Hooks/useHasBeenRendered.js'
 import { usePagePicker } from '~/Hooks/usePagePicker.js'
@@ -129,9 +130,9 @@ export const ImportPageWizard = observer(function ImportPageWizard({
 									setPage={isSinglePage ? undefined : setImportPageNumber}
 									pageOptions={snapshotPageOptions}
 								>
-									<CButton color="light" className="btn-right" title="Home Position" onClick={resetSourcePosition}>
+									<Button color="light" className="btn-right" title="Home Position" onClick={resetSourcePosition}>
 										<FontAwesomeIcon icon={faHome} />
-									</CButton>
+									</Button>
 								</PageNumberPicker>
 							</CCol>
 							<div className="buttongrid" ref={hasBeenRenderedRef}>
@@ -162,9 +163,9 @@ export const ImportPageWizard = observer(function ImportPageWizard({
 										gridZoomController={gridZoomController}
 									/>
 
-									<CButton color="light" className="btn-right" title="Home Position" onClick={resetDestinationPosition}>
+									<Button color="light" className="btn-right" title="Home Position" onClick={resetDestinationPosition}>
 										<FontAwesomeIcon icon={faHome} />
-									</CButton>
+									</Button>
 								</ButtonGridHeader>
 							</CCol>
 							<div className="buttongrid">
@@ -207,10 +208,10 @@ export const ImportPageWizard = observer(function ImportPageWizard({
 						: ' completely override the button on the existing destination page with the buttons on the selected source page'}
 					.
 				</p>
-				<CButton color={pageNumber == -1 ? 'success' : 'warning'} onClick={doImport2} disabled={isRunning}>
+				<Button color={pageNumber == -1 ? 'success' : 'warning'} onClick={doImport2} disabled={isRunning}>
 					<FontAwesomeIcon icon={pageNumber == -1 ? faFileCirclePlus : faFileCircleExclamation} />
 					{pageNumber == -1 ? ' Import to new page' : ` Replace page ${pageNumber} with imported page`}
-				</CButton>
+				</Button>
 			</CCallout>
 		</>
 	)

--- a/webui/src/ImportExport/Import/Page.tsx
+++ b/webui/src/ImportExport/Import/Page.tsx
@@ -130,7 +130,7 @@ export const ImportPageWizard = observer(function ImportPageWizard({
 									setPage={isSinglePage ? undefined : setImportPageNumber}
 									pageOptions={snapshotPageOptions}
 								>
-									<Button color="light" className="btn-right" title="Home Position" onClick={resetSourcePosition}>
+									<Button color="light" title="Home Position" onClick={resetSourcePosition}>
 										<FontAwesomeIcon icon={faHome} />
 									</Button>
 								</PageNumberPicker>
@@ -163,7 +163,7 @@ export const ImportPageWizard = observer(function ImportPageWizard({
 										gridZoomController={gridZoomController}
 									/>
 
-									<Button color="light" className="btn-right" title="Home Position" onClick={resetDestinationPosition}>
+									<Button color="light" className="ms-1" title="Home Position" onClick={resetDestinationPosition}>
 										<FontAwesomeIcon icon={faHome} />
 									</Button>
 								</ButtonGridHeader>

--- a/webui/src/ImportExport/Import/Triggers.tsx
+++ b/webui/src/ImportExport/Import/Triggers.tsx
@@ -1,8 +1,9 @@
-import { CButton, CButtonGroup, CCallout } from '@coreui/react'
+import { CButtonGroup, CCallout } from '@coreui/react'
 import { faFileCircleExclamation, faFileCirclePlus } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useCallback, useContext, useEffect, useState } from 'react'
 import type { ClientImportObject } from '@companion-app/shared/Model/ImportExport.js'
+import { Button } from '~/Components/Button'
 import { CheckboxInputField } from '~/Components/CheckboxInputField.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC.js'
 import { RootAppStoreContext } from '~/Stores/RootAppStore.js'
@@ -109,16 +110,16 @@ export function ImportTriggersTab({
 				</tbody>
 			</table>
 			<CButtonGroup className="mb-3">
-				<CButton
+				<Button
 					color="info"
 					onClick={selectAllTriggers}
 					disabled={selectedTriggers.length === Object.keys(snapshot.triggers || {}).length}
 				>
 					Select all
-				</CButton>
-				<CButton color="info" onClick={unselectAllTriggers} disabled={selectedTriggers.length === 0}>
+				</Button>
+				<Button color="info" onClick={unselectAllTriggers} disabled={selectedTriggers.length === 0}>
 					Unselect all
-				</CButton>
+				</Button>
 			</CButtonGroup>
 
 			<ImportRemap snapshot={snapshot} connectionRemap={connectionRemap} setConnectionRemap={setConnectionRemap2} />
@@ -126,16 +127,16 @@ export function ImportTriggersTab({
 			<CCallout color="success">
 				<h5>Import to Existing Triggers</h5>
 				<p>This will import the selected triggers, while keeping your existing triggers.</p>
-				<CButton color="success" data-replace={false} onClick={doImport} disabled={selectedTriggers.length === 0}>
+				<Button color="success" data-replace={false} onClick={doImport} disabled={selectedTriggers.length === 0}>
 					<FontAwesomeIcon icon={faFileCirclePlus} /> Add to existing triggers
-				</CButton>
+				</Button>
 			</CCallout>
 			<CCallout color="warning">
 				<h5>Reset & Import Triggers</h5>
 				<p>This will remove all existing triggers and replace them with the selected ones.</p>
-				<CButton color="warning" data-replace={true} onClick={doImport} disabled={selectedTriggers.length === 0}>
+				<Button color="warning" data-replace={true} onClick={doImport} disabled={selectedTriggers.length === 0}>
 					<FontAwesomeIcon icon={faFileCircleExclamation} /> Reset and import triggers
-				</CButton>
+				</Button>
 			</CCallout>
 		</>
 	)

--- a/webui/src/ImportExport/Import/Triggers.tsx
+++ b/webui/src/ImportExport/Import/Triggers.tsx
@@ -1,9 +1,9 @@
-import { CButtonGroup, CCallout } from '@coreui/react'
+import { CCallout } from '@coreui/react'
 import { faFileCircleExclamation, faFileCirclePlus } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useCallback, useContext, useEffect, useState } from 'react'
 import type { ClientImportObject } from '@companion-app/shared/Model/ImportExport.js'
-import { Button } from '~/Components/Button'
+import { Button, ButtonGroup } from '~/Components/Button'
 import { CheckboxInputField } from '~/Components/CheckboxInputField.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC.js'
 import { RootAppStoreContext } from '~/Stores/RootAppStore.js'
@@ -109,7 +109,7 @@ export function ImportTriggersTab({
 					))}
 				</tbody>
 			</table>
-			<CButtonGroup className="mb-3">
+			<ButtonGroup className="mb-3">
 				<Button
 					color="info"
 					onClick={selectAllTriggers}
@@ -120,7 +120,7 @@ export function ImportTriggersTab({
 				<Button color="info" onClick={unselectAllTriggers} disabled={selectedTriggers.length === 0}>
 					Unselect all
 				</Button>
-			</CButtonGroup>
+			</ButtonGroup>
 
 			<ImportRemap snapshot={snapshot} connectionRemap={connectionRemap} setConnectionRemap={setConnectionRemap2} />
 

--- a/webui/src/ImportExport/Import/index.tsx
+++ b/webui/src/ImportExport/Import/index.tsx
@@ -1,6 +1,6 @@
-import { CButton } from '@coreui/react'
 import { useCallback, useContext, useEffect, useState } from 'react'
 import type { ClientImportObject } from '@companion-app/shared/Model/ImportExport.js'
+import { Button } from '~/Components/Button'
 import { trpc, useMutationExt } from '~/Resources/TRPC.js'
 import { RootAppStoreContext } from '~/Stores/RootAppStore.js'
 import { ImportFullWizard } from './Full.js'
@@ -51,9 +51,9 @@ export function ImportWizard({ importInfo, clearImport }: ImportWizardProps): Re
 		<div className="import-wizard single-page px-1">
 			<h4>
 				Import Single Page
-				<CButton color="danger" size="sm" onClick={clearImport}>
+				<Button color="danger" size="sm" onClick={clearImport}>
 					Cancel
-				</CButton>
+				</Button>
 			</h4>
 
 			<ImportPageWizard
@@ -67,9 +67,9 @@ export function ImportWizard({ importInfo, clearImport }: ImportWizardProps): Re
 		<div className="import-wizard import-full">
 			<h4>
 				Import Configuration
-				<CButton color="danger" size="sm" onClick={clearImport}>
+				<Button color="danger" size="sm" onClick={clearImport}>
 					Cancel
-				</CButton>
+				</Button>
 			</h4>
 			<ImportFullWizard snapshot={snapshot} connectionRemap={connectionRemap} setConnectionRemap={setConnectionRemap} />
 		</div>

--- a/webui/src/ImportExport/Reset.tsx
+++ b/webui/src/ImportExport/Reset.tsx
@@ -1,4 +1,4 @@
-import { CButton, CModal, CModalBody, CModalFooter, CModalHeader } from '@coreui/react'
+import { CModal, CModalBody, CModalFooter, CModalHeader } from '@coreui/react'
 import { faDownload } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { createFormHook, createFormHookContexts, formOptions } from '@tanstack/react-form'
@@ -6,6 +6,7 @@ import { observer } from 'mobx-react-lite'
 import { forwardRef, useCallback, useContext, useImperativeHandle, useState } from 'react'
 import type { ClientImportOrResetSelection, ResetType } from '@companion-app/shared/Model/ImportExport.js'
 import { StaticAlert } from '~/Components/Alert'
+import { Button, LinkButtonExternal } from '~/Components/Button'
 import { CheckboxInputFieldWithLabel } from '~/Components/CheckboxInputField'
 import { InlineHelpIcon } from '~/Components/InlineHelp'
 import { MenuPortalContext } from '~/Components/MenuPortalContext.js'
@@ -128,7 +129,7 @@ export const ResetWizardModal = observer(
 					<form.Subscribe
 						selector={(state) => [state.canSubmit, state.isSubmitting]}
 						children={([canSubmit, isSubmitting]) => (
-							<CButton
+							<Button
 								color="primary"
 								disabled={!canSubmit || isSubmitting}
 								onClick={() => {
@@ -138,23 +139,23 @@ export const ResetWizardModal = observer(
 								}}
 							>
 								Apply {isSubmitting ? '...' : ''}
-							</CButton>
+							</Button>
 						)}
 					/>
 				)
 				break
 			case maxSteps:
 				nextButton = (
-					<CButton color="primary" onClick={doClose}>
+					<Button color="primary" onClick={doClose}>
 						Finish
-					</CButton>
+					</Button>
 				)
 				break
 			default:
 				nextButton = (
-					<CButton color="primary" onClick={doNextStep}>
+					<Button color="primary" onClick={doNextStep}>
 						Next
-					</CButton>
+					</Button>
 				)
 		}
 
@@ -196,12 +197,12 @@ export const ResetWizardModal = observer(
 							<CModalFooter>
 								{currentStep <= applyStep && (
 									<>
-										<CButton color="secondary" onClick={doClose}>
+										<Button color="secondary" onClick={doClose}>
 											Cancel
-										</CButton>
-										<CButton color="secondary" disabled={currentStep === 1} onClick={doPrevStep}>
+										</Button>
+										<Button color="secondary" disabled={currentStep === 1} onClick={doPrevStep}>
 											Back
-										</CButton>
+										</Button>
 									</>
 								)}
 								{nextButton}
@@ -222,9 +223,9 @@ function ResetBeginStep() {
 			</p>
 			<p>It is recommended to export the system configuration first.</p>
 
-			<CButton color="success" href={makeAbsolutePath('/int/export/full')} target="_blank">
+			<LinkButtonExternal color="success" href={makeAbsolutePath('/int/export/full')}>
 				<FontAwesomeIcon icon={faDownload} /> Export
-			</CButton>
+			</LinkButtonExternal>
 		</div>
 	)
 }

--- a/webui/src/ImportExport/index.tsx
+++ b/webui/src/ImportExport/index.tsx
@@ -1,4 +1,4 @@
-import { CButton, CCallout } from '@coreui/react'
+import { CCallout } from '@coreui/react'
 import { faDownload, faFileImport, faTrashAlt } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import CryptoJS from 'crypto-js'
@@ -7,6 +7,7 @@ import { useCallback, useContext, useRef, useState } from 'react'
 import { BANNED_PROPS } from '@companion-app/shared/Expression/ExpressionResolve.js'
 import type { ClientImportObject } from '@companion-app/shared/Model/ImportExport.js'
 import { StaticAlert } from '~/Components/Alert.js'
+import { Button } from '~/Components/Button.js'
 import { ContextHelpButton } from '~/Layout/PanelIcons.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC.js'
 import { base64EncodeUint8Array } from '~/Resources/util.js'
@@ -184,10 +185,10 @@ export const ImportExportPage = observer(function ImportExport() {
 			<CCallout color="success">
 				<h5>Export</h5>
 				<p>Download a file containing all connections and button pages.</p>
-				<CButton color="success" onClick={doExport}>
+				<Button color="success" onClick={doExport}>
 					<FontAwesomeIcon icon={faDownload} style={{ marginRight: 7, marginLeft: -2 }} />
 					Export configuration
-				</CButton>
+				</Button>
 			</CCallout>
 
 			<CCallout color="warning">
@@ -225,10 +226,10 @@ export const ImportExportPage = observer(function ImportExport() {
 				<h5>Reset</h5>
 				<p>This will clear all connections, triggers and/or buttons.</p>
 				<div>
-					<CButton color="danger" style={{ backgroundColor: 'rgba(180,0,0,1)' }} onClick={doReset}>
+					<Button color="danger" style={{ backgroundColor: 'rgba(180,0,0,1)' }} onClick={doReset}>
 						<FontAwesomeIcon icon={faTrashAlt} style={{ marginRight: 7, marginLeft: -1 }} />
 						Reset configuration
-					</CButton>
+					</Button>
 				</div>
 			</CCallout>
 		</div>

--- a/webui/src/ImportExport/index.tsx
+++ b/webui/src/ImportExport/index.tsx
@@ -226,7 +226,7 @@ export const ImportExportPage = observer(function ImportExport() {
 				<h5>Reset</h5>
 				<p>This will clear all connections, triggers and/or buttons.</p>
 				<div>
-					<Button color="danger" style={{ backgroundColor: 'rgba(180,0,0,1)' }} onClick={doReset}>
+					<Button color="danger" onClick={doReset}>
 						<FontAwesomeIcon icon={faTrashAlt} style={{ marginRight: 7, marginLeft: -1 }} />
 						Reset configuration
 					</Button>

--- a/webui/src/ImportExport/index.tsx
+++ b/webui/src/ImportExport/index.tsx
@@ -176,7 +176,7 @@ export const ImportExportPage = observer(function ImportExport() {
 			<ResetWizardModal ref={resetRef} />
 			<ExportWizardModal ref={exportRef} />
 
-			<h4 className="btn-inline">
+			<h4 className="button-inline">
 				Import / Export Configuration
 				<ContextHelpButton action="/user-guide/config/import-export" />
 			</h4>
@@ -207,7 +207,7 @@ export const ImportExportPage = observer(function ImportExport() {
 						<div>
 							{loadError ? <StaticAlert color="warning">{loadError}</StaticAlert> : ''}
 
-							<label className="btn btn-warning btn-file">
+							<label className="button button-warning button-file">
 								<FontAwesomeIcon icon={faFileImport} style={{ marginRight: 8, marginLeft: -3 }} />
 								Import configuration
 								<input

--- a/webui/src/Instances/AddInstanceModal.tsx
+++ b/webui/src/Instances/AddInstanceModal.tsx
@@ -1,4 +1,4 @@
-import { CButton, CCol, CForm, CFormInput, CFormLabel, CModalBody, CModalFooter, CModalHeader } from '@coreui/react'
+import { CCol, CForm, CFormInput, CFormLabel, CModalBody, CModalFooter, CModalHeader } from '@coreui/react'
 import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
@@ -6,6 +6,7 @@ import { forwardRef, useCallback, useContext, useEffect, useImperativeHandle, us
 import { ModuleInstanceType } from '@companion-app/shared/Model/Instance.js'
 import type { ClientModuleVersionInfo } from '@companion-app/shared/Model/ModuleInfo.js'
 import { StaticAlert } from '~/Components/Alert.js'
+import { Button } from '~/Components/Button.js'
 import { CModalExt } from '~/Components/CModalExt.js'
 import { SimpleDropdownInputField } from '~/Components/DropdownInputFieldSimple.js'
 import type { FuzzyProduct } from '~/Hooks/useFilteredProducts.js'
@@ -217,16 +218,16 @@ export const AddInstanceModal = observer(
 							)}
 						</CModalBody>
 						<CModalFooter>
-							<CButton color="secondary" onClick={doClose}>
+							<Button color="secondary" onClick={doClose}>
 								Cancel
-							</CButton>
-							<CButton
+							</Button>
+							<Button
 								color="primary"
 								onClick={doAction}
 								disabled={!moduleInfo || !instanceLabel || !selectedVersion || !versionChoices.length}
 							>
 								Add
-							</CButton>
+							</Button>
 						</CModalFooter>
 					</>
 				)}

--- a/webui/src/Instances/AddInstancePanel.tsx
+++ b/webui/src/Instances/AddInstancePanel.tsx
@@ -1,4 +1,4 @@
-import { CButtonGroup, CTooltip } from '@coreui/react'
+import { CTooltip } from '@coreui/react'
 import { faGithub } from '@fortawesome/free-brands-svg-icons'
 import {
 	faCog,
@@ -13,7 +13,7 @@ import { observer } from 'mobx-react-lite'
 import { useCallback, useContext, useRef, useState } from 'react'
 import { ModuleInstanceType } from '@companion-app/shared/Model/Instance.js'
 import { StaticAlert } from '~/Components/Alert.js'
-import { Button } from '~/Components/Button.js'
+import { Button, ButtonGroup } from '~/Components/Button.js'
 import { InlineHelpCustom } from '~/Components/InlineHelp.js'
 import { NonIdealState } from '~/Components/NonIdealState.js'
 import { SearchBox } from '~/Components/SearchBox.js'
@@ -128,7 +128,7 @@ export const AddInstancePanel = observer(function AddInstancePanel({
 							<div className="intro-grid">
 								{description(storeModulesOfTypeCount)}
 								<div className="intro-filter">
-									<CButtonGroup role="group" aria-label="Module visibility filter">
+									<ButtonGroup aria-label="Module visibility filter">
 										<Button
 											size="sm"
 											color="info"
@@ -147,7 +147,7 @@ export const AddInstancePanel = observer(function AddInstancePanel({
 										>
 											All Available
 										</Button>
-									</CButtonGroup>
+									</ButtonGroup>
 								</div>
 							</div>
 						) : (

--- a/webui/src/Instances/AddInstancePanel.tsx
+++ b/webui/src/Instances/AddInstancePanel.tsx
@@ -1,4 +1,4 @@
-import { CButton, CButtonGroup, CTooltip } from '@coreui/react'
+import { CButtonGroup, CTooltip } from '@coreui/react'
 import { faGithub } from '@fortawesome/free-brands-svg-icons'
 import {
 	faCog,
@@ -13,6 +13,7 @@ import { observer } from 'mobx-react-lite'
 import { useCallback, useContext, useRef, useState } from 'react'
 import { ModuleInstanceType } from '@companion-app/shared/Model/Instance.js'
 import { StaticAlert } from '~/Components/Alert.js'
+import { Button } from '~/Components/Button.js'
 import { InlineHelpCustom } from '~/Components/InlineHelp.js'
 import { NonIdealState } from '~/Components/NonIdealState.js'
 import { SearchBox } from '~/Components/SearchBox.js'
@@ -128,22 +129,24 @@ export const AddInstancePanel = observer(function AddInstancePanel({
 								{description(storeModulesOfTypeCount)}
 								<div className="intro-filter">
 									<CButtonGroup role="group" aria-label="Module visibility filter">
-										<CButton
+										<Button
 											size="sm"
-											color={!typeFilter.visibility.available ? 'info' : 'outline-info'}
+											color="info"
+											variant={typeFilter.visibility.available ? 'outline' : undefined}
 											onClick={() => typeFilter.toggleVisibility('available')}
 											disabled={!typeFilter.visibility.available}
 										>
 											Installed Only
-										</CButton>
-										<CButton
+										</Button>
+										<Button
 											size="sm"
-											color={typeFilter.visibility.available ? 'info' : 'outline-info'}
+											color="info"
+											variant={!typeFilter.visibility.available ? 'outline' : undefined}
 											onClick={() => typeFilter.toggleVisibility('available')}
 											disabled={typeFilter.visibility.available}
 										>
 											All Available
-										</CButton>
+										</Button>
 									</CButtonGroup>
 								</div>
 							</div>
@@ -245,15 +248,15 @@ const AddInstanceEntry = observer(function AddInstanceEntry({ moduleInfo, addIns
 			{isLimitReached ? (
 				<CTooltip content="This module is limited to one instance">
 					<span>
-						<CButton color="primary" disabled>
+						<Button color="primary" disabled>
 							Add
-						</CButton>
+						</Button>
 					</span>
 				</CTooltip>
 			) : (
-				<CButton color="primary" onClick={addInstanceClick}>
+				<Button color="primary" onClick={addInstanceClick}>
 					Add
-				</CButton>
+				</Button>
 			)}
 			&nbsp;
 			{moduleInfo.installedInfo?.stableVersion?.isLegacy && (

--- a/webui/src/Instances/DebugLog.tsx
+++ b/webui/src/Instances/DebugLog.tsx
@@ -1,10 +1,10 @@
-import { CButtonGroup, CCol, CContainer, CRow } from '@coreui/react'
+import { CCol, CContainer, CRow } from '@coreui/react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { useSubscription } from '@trpc/tanstack-react-query'
 import { stringify as csvStringify } from 'csv-stringify/browser/esm/sync'
 import dayjs from 'dayjs'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Button } from '~/Components/Button'
+import { Button, ButtonGroup } from '~/Components/Button'
 import { useStickyScroll } from '~/Hooks/useStickyScroll.js'
 import { TRPCConnectionStatus, useTRPCConnectionStatus } from '~/Hooks/useTRPCConnectionStatus'
 import { trpc } from '~/Resources/TRPC'
@@ -129,32 +129,32 @@ export function InstanceDebugLog({
 			<div className="log-page">
 				<CRow className="log-debug-buttons">
 					<CCol>
-						<CButtonGroup>
+						<ButtonGroup>
 							<Button color={isConnected ? 'success' : 'warning'} size="sm" disabled>
 								{isConnected ? 'Connected' : 'Reconnecting'}
 							</Button>
-						</CButtonGroup>
+						</ButtonGroup>
 
-						<CButtonGroup>
+						<ButtonGroup>
 							<Button color="danger" size="sm" onClick={doClearLog}>
 								Clear log
 							</Button>
 							<Button color="info" size="sm" onClick={doExportLog}>
 								Export log
 							</Button>
-						</CButtonGroup>
+						</ButtonGroup>
 
-						<CButtonGroup>
+						<ButtonGroup>
 							<Button color="danger" size="sm" onClick={doStopInstance}>
 								Stop {instanceTypeStr}
 							</Button>
 							<Button color="success" size="sm" onClick={doStartInstance}>
 								Start {instanceTypeStr}
 							</Button>
-						</CButtonGroup>
+						</ButtonGroup>
 
 						<div className="float-right">
-							<CButtonGroup>
+							<ButtonGroup>
 								<Button color="danger" size="sm" onClick={doToggleError} style={{ opacity: config.error ? 1 : 0.2 }}>
 									Error
 								</Button>
@@ -175,7 +175,7 @@ export function InstanceDebugLog({
 								>
 									Console
 								</Button>
-							</CButtonGroup>
+							</ButtonGroup>
 						</div>
 					</CCol>
 				</CRow>

--- a/webui/src/Instances/DebugLog.tsx
+++ b/webui/src/Instances/DebugLog.tsx
@@ -155,23 +155,28 @@ export function InstanceDebugLog({
 
 						<div className="float-right">
 							<ButtonGroup>
-								<Button color="danger" size="sm" onClick={doToggleError} style={{ opacity: config.error ? 1 : 0.2 }}>
+								<Button color="danger" size="sm" onClick={doToggleError} variant={config.error ? undefined : 'outline'}>
 									Error
 								</Button>
-								<Button color="warning" size="sm" onClick={doToggleWarn} style={{ opacity: config.warn ? 1 : 0.2 }}>
+								<Button color="warning" size="sm" onClick={doToggleWarn} variant={config.warn ? undefined : 'outline'}>
 									Warning
 								</Button>
-								<Button color="info" size="sm" onClick={doToggleInfo} style={{ opacity: config.info ? 1 : 0.2 }}>
+								<Button color="info" size="sm" onClick={doToggleInfo} variant={config.info ? undefined : 'outline'}>
 									Info
 								</Button>
-								<Button color="secondary" size="sm" onClick={doToggleDebug} style={{ opacity: config.debug ? 1 : 0.2 }}>
+								<Button
+									color="secondary"
+									size="sm"
+									onClick={doToggleDebug}
+									variant={config.debug ? undefined : 'outline'}
+								>
 									Debug
 								</Button>
 								<Button
 									color="secondary"
 									size="sm"
 									onClick={doToggleConsole}
-									style={{ opacity: config.console ? 1 : 0.2 }}
+									variant={config.console ? undefined : 'outline'}
 								>
 									Console
 								</Button>

--- a/webui/src/Instances/DebugLog.tsx
+++ b/webui/src/Instances/DebugLog.tsx
@@ -1,9 +1,10 @@
-import { CButton, CButtonGroup, CCol, CContainer, CRow } from '@coreui/react'
+import { CButtonGroup, CCol, CContainer, CRow } from '@coreui/react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { useSubscription } from '@trpc/tanstack-react-query'
 import { stringify as csvStringify } from 'csv-stringify/browser/esm/sync'
 import dayjs from 'dayjs'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Button } from '~/Components/Button'
 import { useStickyScroll } from '~/Hooks/useStickyScroll.js'
 import { TRPCConnectionStatus, useTRPCConnectionStatus } from '~/Hooks/useTRPCConnectionStatus'
 import { trpc } from '~/Resources/TRPC'
@@ -129,56 +130,51 @@ export function InstanceDebugLog({
 				<CRow className="log-debug-buttons">
 					<CCol>
 						<CButtonGroup>
-							<CButton color={isConnected ? 'success' : 'warning'} size="sm" disabled>
+							<Button color={isConnected ? 'success' : 'warning'} size="sm" disabled>
 								{isConnected ? 'Connected' : 'Reconnecting'}
-							</CButton>
+							</Button>
 						</CButtonGroup>
 
 						<CButtonGroup>
-							<CButton color="danger" size="sm" onClick={doClearLog}>
+							<Button color="danger" size="sm" onClick={doClearLog}>
 								Clear log
-							</CButton>
-							<CButton color="info" size="sm" onClick={doExportLog}>
+							</Button>
+							<Button color="info" size="sm" onClick={doExportLog}>
 								Export log
-							</CButton>
+							</Button>
 						</CButtonGroup>
 
 						<CButtonGroup>
-							<CButton color="danger" size="sm" onClick={doStopInstance}>
+							<Button color="danger" size="sm" onClick={doStopInstance}>
 								Stop {instanceTypeStr}
-							</CButton>
-							<CButton color="success" size="sm" onClick={doStartInstance}>
+							</Button>
+							<Button color="success" size="sm" onClick={doStartInstance}>
 								Start {instanceTypeStr}
-							</CButton>
+							</Button>
 						</CButtonGroup>
 
 						<div className="float-right">
 							<CButtonGroup>
-								<CButton color="danger" size="sm" onClick={doToggleError} style={{ opacity: config.error ? 1 : 0.2 }}>
+								<Button color="danger" size="sm" onClick={doToggleError} style={{ opacity: config.error ? 1 : 0.2 }}>
 									Error
-								</CButton>
-								<CButton color="warning" size="sm" onClick={doToggleWarn} style={{ opacity: config.warn ? 1 : 0.2 }}>
+								</Button>
+								<Button color="warning" size="sm" onClick={doToggleWarn} style={{ opacity: config.warn ? 1 : 0.2 }}>
 									Warning
-								</CButton>
-								<CButton color="info" size="sm" onClick={doToggleInfo} style={{ opacity: config.info ? 1 : 0.2 }}>
+								</Button>
+								<Button color="info" size="sm" onClick={doToggleInfo} style={{ opacity: config.info ? 1 : 0.2 }}>
 									Info
-								</CButton>
-								<CButton
-									color="secondary"
-									size="sm"
-									onClick={doToggleDebug}
-									style={{ opacity: config.debug ? 1 : 0.2 }}
-								>
+								</Button>
+								<Button color="secondary" size="sm" onClick={doToggleDebug} style={{ opacity: config.debug ? 1 : 0.2 }}>
 									Debug
-								</CButton>
-								<CButton
+								</Button>
+								<Button
 									color="secondary"
 									size="sm"
 									onClick={doToggleConsole}
 									style={{ opacity: config.console ? 1 : 0.2 }}
 								>
 									Console
-								</CButton>
+								</Button>
 							</CButtonGroup>
 						</div>
 					</CCol>

--- a/webui/src/Instances/DebugLog.tsx
+++ b/webui/src/Instances/DebugLog.tsx
@@ -127,15 +127,15 @@ export function InstanceDebugLog({
 	return (
 		<CContainer style={{ height: 'calc(100vh - 10px)', padding: '10px', background: '#eee' }}>
 			<div className="log-page">
-				<CRow className="log-debug-buttons">
+				<CRow className="px-3">
 					<CCol>
-						<ButtonGroup>
+						<ButtonGroup className="me-2">
 							<Button color={isConnected ? 'success' : 'warning'} size="sm" disabled>
 								{isConnected ? 'Connected' : 'Reconnecting'}
 							</Button>
 						</ButtonGroup>
 
-						<ButtonGroup>
+						<ButtonGroup className="me-2">
 							<Button color="danger" size="sm" onClick={doClearLog}>
 								Clear log
 							</Button>
@@ -144,7 +144,7 @@ export function InstanceDebugLog({
 							</Button>
 						</ButtonGroup>
 
-						<ButtonGroup>
+						<ButtonGroup className="me-2">
 							<Button color="danger" size="sm" onClick={doStopInstance}>
 								Stop {instanceTypeStr}
 							</Button>

--- a/webui/src/Instances/InstanceEdit/InstanceEditPanel.tsx
+++ b/webui/src/Instances/InstanceEdit/InstanceEditPanel.tsx
@@ -1,4 +1,4 @@
-import { CButton, CCol, CForm, CFormLabel } from '@coreui/react'
+import { CCol, CForm, CFormLabel } from '@coreui/react'
 import { faCheck, faCircleExclamation, faGear } from '@fortawesome/free-solid-svg-icons'
 import classNames from 'classnames'
 import { capitalize } from 'lodash-es'
@@ -10,6 +10,7 @@ import type { ClientInstanceConfigBase, InstanceVersionUpdatePolicy } from '@com
 import type { ClientModuleInfo } from '@companion-app/shared/Model/ModuleInfo.js'
 import type { SomeCompanionInputField } from '@companion-app/shared/Model/Options.js'
 import { StaticAlert } from '~/Components/Alert.js'
+import { Button } from '~/Components/Button.js'
 import { SimpleDropdownInputField } from '~/Components/DropdownInputFieldSimple.js'
 import { InlineHelpIcon } from '~/Components/InlineHelp.js'
 import { NonIdealState } from '~/Components/NonIdealState.js'
@@ -364,7 +365,7 @@ const InstanceFormButtons = observer(function InstanceFormButtons<TConfig extend
 			<CCol sm={12}>
 				<div className="flex flex-row">
 					<div className="grow">
-						<CButton
+						<Button
 							color="success"
 							className="me-md-1"
 							disabled={isLoading || isSaving || !isValid || !panelStore.isDirty()}
@@ -372,17 +373,17 @@ const InstanceFormButtons = observer(function InstanceFormButtons<TConfig extend
 							title={!isValid ? 'Please fix the errors before saving' : undefined}
 						>
 							Save {isSaving ? '...' : ''}
-						</CButton>
+						</Button>
 
-						<CButton color="secondary" onClick={panelStore.service.closePanel} disabled={isSaving || isLoading}>
+						<Button color="secondary" onClick={panelStore.service.closePanel} disabled={isSaving || isLoading}>
 							{panelStore.isDirty() ? 'Cancel' : 'Done'}
-						</CButton>
+						</Button>
 					</div>
 
 					<div>
-						<CButton color="danger" onClick={doDelete} disabled={isSaving || isLoading}>
+						<Button color="danger" onClick={doDelete} disabled={isSaving || isLoading}>
 							Delete
-						</CButton>
+						</Button>
 					</div>
 				</div>
 			</CCol>

--- a/webui/src/Instances/InstanceEdit/InstanceVersionChangeButton.tsx
+++ b/webui/src/Instances/InstanceEdit/InstanceVersionChangeButton.tsx
@@ -1,4 +1,4 @@
-import { CButton, CCol, CCollapse, CForm, CFormLabel, CModalBody, CModalFooter, CModalHeader } from '@coreui/react'
+import { CCol, CCollapse, CForm, CFormLabel, CModalBody, CModalFooter, CModalHeader } from '@coreui/react'
 import { faPencil } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useForm } from '@tanstack/react-form'
@@ -7,6 +7,7 @@ import { useCallback, useContext, useRef, useState } from 'react'
 import type { DropdownChoice } from '@companion-app/shared/Model/Common.js'
 import type { ClientInstanceConfigBase, ModuleInstanceType } from '@companion-app/shared/Model/Instance.js'
 import { StaticAlert } from '~/Components/Alert'
+import { Button } from '~/Components/Button'
 import { CModalExt } from '~/Components/CModalExt.js'
 import { DropdownInputField } from '~/Components/DropdownInputField.js'
 import { SimpleDropdownInputField } from '~/Components/DropdownInputFieldSimple'
@@ -94,9 +95,9 @@ export function InstanceVersionChangeButton<TConfig extends ClientInstanceConfig
 
 	return (
 		<>
-			<CButton color="light" size="sm" title="Change module version" onClick={doShow}>
+			<Button color="light" size="sm" title="Change module version" onClick={doShow}>
 				<FontAwesomeIcon icon={faPencil} />
-			</CButton>
+			</Button>
 
 			<CModalExt visible={show} onClose={doClose} onClosed={onClosed} onOpened={buttonFocus}>
 				<CModalHeader closeButton>
@@ -160,10 +161,10 @@ export function InstanceVersionChangeButton<TConfig extends ClientInstanceConfig
 
 						<CCol sm={12} className="mt-3 mb-2">
 							<hr className="my-2" />
-							<CButton color="link" size="sm" onClick={toggleAdvancedMode} className="p-0 text-decoration-none">
+							<Button color="link" size="sm" onClick={toggleAdvancedMode} className="p-0 text-decoration-none">
 								<span className="me-1">{advancedMode ? '▼' : '▶'}</span>
 								Advanced Options
-							</CButton>
+							</Button>
 						</CCol>
 
 						<CCollapse visible={advancedMode} className="row g-sm-2 p-0">
@@ -201,10 +202,10 @@ export function InstanceVersionChangeButton<TConfig extends ClientInstanceConfig
 						selector={(state) => [state.canSubmit, state.isSubmitting]}
 						children={([canSubmit, isSubmitting]) => (
 							<>
-								<CButton color="secondary" onClick={doClose} disabled={!canSubmit}>
+								<Button color="secondary" onClick={doClose} disabled={!canSubmit}>
 									Cancel
-								</CButton>
-								<CButton
+								</Button>
+								<Button
 									ref={buttonRef}
 									color="primary"
 									type="submit"
@@ -216,7 +217,7 @@ export function InstanceVersionChangeButton<TConfig extends ClientInstanceConfig
 									}}
 								>
 									Save {isSubmitting ? '...' : ''}
-								</CButton>
+								</Button>
 							</>
 						)}
 					/>

--- a/webui/src/Instances/InstanceEdit/InstanceVersionChangeButton.tsx
+++ b/webui/src/Instances/InstanceEdit/InstanceVersionChangeButton.tsx
@@ -95,7 +95,7 @@ export function InstanceVersionChangeButton<TConfig extends ClientInstanceConfig
 
 	return (
 		<>
-			<Button color="light" size="sm" title="Change module version" onClick={doShow}>
+			<Button color="light" size="sm" title="Change module version" aria-label="Change module version" onClick={doShow}>
 				<FontAwesomeIcon icon={faPencil} />
 			</Button>
 

--- a/webui/src/Instances/List/InstancesListTableRow.tsx
+++ b/webui/src/Instances/List/InstancesListTableRow.tsx
@@ -1,4 +1,4 @@
-import { CButton, CButtonGroup, CPopover } from '@coreui/react'
+import { CButtonGroup, CPopover } from '@coreui/react'
 import {
 	faBug,
 	faEllipsisV,
@@ -13,6 +13,7 @@ import { observer } from 'mobx-react-lite'
 import { useCallback, useContext } from 'react'
 import type { ClientInstanceConfigBase } from '@companion-app/shared/Model/Instance.js'
 import type { InstanceStatusEntry } from '@companion-app/shared/Model/InstanceStatus.js'
+import { Button } from '~/Components/Button'
 import { SwitchInputField } from '~/Components/SwitchInputField'
 import { Tuck } from '~/Components/Tuck'
 import { windowLinkOpen } from '~/Helpers/Window'
@@ -128,7 +129,7 @@ export const InstancesListTableRow = observer(function InstancesListTableRow<TMe
 						<>
 							{/* Note: the popover closing due to focus loss stops mouseup/click events propagating */}
 							<CButtonGroup vertical>
-								<CButton
+								<Button
 									onMouseDown={doShowHelp}
 									color="secondary"
 									title="Help"
@@ -139,9 +140,9 @@ export const InstancesListTableRow = observer(function InstancesListTableRow<TMe
 										<FontAwesomeIcon icon={faQuestionCircle} />
 									</Tuck>
 									Help
-								</CButton>
+								</Button>
 
-								<CButton
+								<Button
 									onMouseDown={openBugUrl}
 									color="secondary"
 									title="Issue Tracker"
@@ -152,12 +153,12 @@ export const InstancesListTableRow = observer(function InstancesListTableRow<TMe
 										<FontAwesomeIcon icon={faBug} />
 									</Tuck>
 									Known issues
-								</CButton>
+								</Button>
 
 								{extraMenuItems}
 
 								{!!debugLogUrl && (
-									<CButton
+									<Button
 										onMouseDown={() => windowLinkOpen({ href: makeAbsolutePath(debugLogUrl), title: 'View debug log' })}
 										title="Logs"
 										color="secondary"
@@ -167,20 +168,20 @@ export const InstancesListTableRow = observer(function InstancesListTableRow<TMe
 											<FontAwesomeIcon icon={faTerminal} />
 										</Tuck>
 										View logs
-									</CButton>
+									</Button>
 								)}
 
-								<CButton onMouseDown={doDelete} title="Delete" color="secondary" style={{ textAlign: 'left' }}>
+								<Button onMouseDown={doDelete} title="Delete" color="secondary" style={{ textAlign: 'left' }}>
 									<Tuck>
 										<FontAwesomeIcon icon={faTrash} />
 									</Tuck>
 									Delete
-								</CButton>
+								</Button>
 							</CButtonGroup>
 						</>
 					}
 				>
-					<CButton
+					<Button
 						color="secondary"
 						style={{ padding: '3px 8px' }}
 						onClick={(e) => e.currentTarget.focus()}
@@ -188,7 +189,7 @@ export const InstancesListTableRow = observer(function InstancesListTableRow<TMe
 						aria-label="Click for additional options."
 					>
 						<FontAwesomeIcon icon={faEllipsisV} />
-					</CButton>
+					</Button>
 				</CPopover>
 			</div>
 		</div>

--- a/webui/src/Instances/List/InstancesListTableRow.tsx
+++ b/webui/src/Instances/List/InstancesListTableRow.tsx
@@ -134,7 +134,7 @@ export const InstancesListTableRow = observer(function InstancesListTableRow<TMe
 									color="secondary"
 									title="Help"
 									disabled={!moduleVersion?.helpPath}
-									style={{ textAlign: 'left' }}
+									className="text-start"
 								>
 									<Tuck>
 										<FontAwesomeIcon icon={faQuestionCircle} />
@@ -147,7 +147,7 @@ export const InstancesListTableRow = observer(function InstancesListTableRow<TMe
 									color="secondary"
 									title="Issue Tracker"
 									disabled={!moduleInfo?.display?.bugUrl}
-									style={{ textAlign: 'left' }}
+									className="text-start"
 								>
 									<Tuck>
 										<FontAwesomeIcon icon={faBug} />
@@ -162,7 +162,7 @@ export const InstancesListTableRow = observer(function InstancesListTableRow<TMe
 										onMouseDown={() => windowLinkOpen({ href: makeAbsolutePath(debugLogUrl), title: 'View debug log' })}
 										title="Logs"
 										color="secondary"
-										style={{ textAlign: 'left' }}
+										className="text-start"
 									>
 										<Tuck>
 											<FontAwesomeIcon icon={faTerminal} />
@@ -171,7 +171,7 @@ export const InstancesListTableRow = observer(function InstancesListTableRow<TMe
 									</Button>
 								)}
 
-								<Button onMouseDown={doDelete} title="Delete" color="secondary" style={{ textAlign: 'left' }}>
+								<Button onMouseDown={doDelete} title="Delete" color="secondary" className="text-start">
 									<Tuck>
 										<FontAwesomeIcon icon={faTrash} />
 									</Tuck>
@@ -183,7 +183,7 @@ export const InstancesListTableRow = observer(function InstancesListTableRow<TMe
 				>
 					<Button
 						color="secondary"
-						style={{ padding: '3px 8px' }}
+						className="py-1 px-2"
 						onClick={(e) => e.currentTarget.focus()}
 						title="Click for additional options."
 						aria-label="Click for additional options."

--- a/webui/src/Instances/List/InstancesListTableRow.tsx
+++ b/webui/src/Instances/List/InstancesListTableRow.tsx
@@ -1,4 +1,4 @@
-import { CButtonGroup, CPopover } from '@coreui/react'
+import { CPopover } from '@coreui/react'
 import {
 	faBug,
 	faEllipsisV,
@@ -13,7 +13,7 @@ import { observer } from 'mobx-react-lite'
 import { useCallback, useContext } from 'react'
 import type { ClientInstanceConfigBase } from '@companion-app/shared/Model/Instance.js'
 import type { InstanceStatusEntry } from '@companion-app/shared/Model/InstanceStatus.js'
-import { Button } from '~/Components/Button'
+import { Button, ButtonGroup } from '~/Components/Button'
 import { SwitchInputField } from '~/Components/SwitchInputField'
 import { Tuck } from '~/Components/Tuck'
 import { windowLinkOpen } from '~/Helpers/Window'
@@ -128,7 +128,7 @@ export const InstancesListTableRow = observer(function InstancesListTableRow<TMe
 					content={
 						<>
 							{/* Note: the popover closing due to focus loss stops mouseup/click events propagating */}
-							<CButtonGroup vertical>
+							<ButtonGroup vertical>
 								<Button
 									onMouseDown={doShowHelp}
 									color="secondary"
@@ -177,7 +177,7 @@ export const InstancesListTableRow = observer(function InstancesListTableRow<TMe
 									</Tuck>
 									Delete
 								</Button>
-							</CButtonGroup>
+							</ButtonGroup>
 						</>
 					}
 				>

--- a/webui/src/Instances/MissingVersionsWarning.tsx
+++ b/webui/src/Instances/MissingVersionsWarning.tsx
@@ -1,10 +1,10 @@
-import { CButton } from '@coreui/react'
 import { faDownload } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
 import { useCallback, useContext } from 'react'
 import type { ClientInstanceConfigBase, ModuleInstanceType } from '@companion-app/shared/Model/Instance.js'
 import { StaticAlert } from '~/Components/Alert'
+import { Button } from '~/Components/Button'
 import { trpc, useMutationExt } from '~/Resources/TRPC'
 import { useComputed } from '~/Resources/util.js'
 import { RootAppStoreContext } from '~/Stores/RootAppStore'
@@ -69,10 +69,10 @@ export const MissingVersionsWarning = observer(function MissingVersionsWarning({
 		<StaticAlert color="info">
 			Some modules do not have versions specified, or are not installed.
 			<br />
-			<CButton color="info" className="mt-2" onClick={doInstallAllMissing}>
+			<Button color="info" className="mt-2" onClick={doInstallAllMissing}>
 				<FontAwesomeIcon icon={faDownload} />
 				&nbsp;Download &amp; Install missing versions
-			</CButton>
+			</Button>
 		</StaticAlert>
 	)
 })

--- a/webui/src/Layout/PanelIcons.tsx
+++ b/webui/src/Layout/PanelIcons.tsx
@@ -1,7 +1,7 @@
-import { CButton } from '@coreui/react'
 import { faQuestionCircle, faTimes } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useCallback, useRef, type ElementType } from 'react'
+import { Button } from '~/Components/Button'
 import { InlineHelpCustom } from '~/Components/InlineHelp'
 import { makeAbsolutePath } from '~/Resources/util'
 
@@ -20,7 +20,7 @@ export interface ContextHelpButtonProps {
 */
 export function CloseButton({ closeFn, visibilityClass }: CloseButtonProps): React.JSX.Element {
 	return (
-		<CButton
+		<Button
 			color="dark"
 			className={`float_right${visibilityClass ? ' ' + visibilityClass : ''} p-1 ms-2 panel-close-button`}
 			onClick={closeFn}
@@ -29,7 +29,7 @@ export function CloseButton({ closeFn, visibilityClass }: CloseButtonProps): Rea
 		>
 			{/* The inline styling here is to make the icon square */}
 			<FontAwesomeIcon icon={faTimes} />
-		</CButton>
+		</Button>
 	)
 }
 
@@ -85,9 +85,9 @@ export function ContextHelpButton({ children, action }: ContextHelpButtonProps):
 	return (
 		<>
 			<HelpWrapper usePopover={!!children} help={children}>
-				<CButton variant="ghost" className={`context-help-button-btn p-0`} {...helpButtonProps}>
+				<Button variant="ghost" className="context-help-button-btn p-0" {...helpButtonProps}>
 					<FontAwesomeIcon icon={faQuestionCircle} aria-label="context help" />
-				</CButton>
+				</Button>
 			</HelpWrapper>
 			<span ref={afterElementRef} tabIndex={-1} style={{ outline: 'none' }} aria-hidden="true" />
 		</>

--- a/webui/src/Layout/PanelIcons.tsx
+++ b/webui/src/Layout/PanelIcons.tsx
@@ -78,7 +78,7 @@ export function ContextHelpButton({ children, action }: ContextHelpButtonProps):
 		children += ' Click the icon for further help.'
 	}
 
-	// note some styling here needs to be on the FontAwesomeIcon, not .context-help-button or the CButton,
+	// note some styling here needs to be on the FontAwesomeIcon, not .context-help-button or the Button,
 	//  in order to get the shadowing right. However it will have to be hand-coded for different sizes even if using em units
 	//  See _layout.scss for the context-help-button-2xl example (FontAwesomeIcons get class 'fa-<size>')
 	// NOTE: removed the float_right class here -- we end up fighting against its margin and it doesn't seem to do much else...

--- a/webui/src/LogPanel.tsx
+++ b/webui/src/LogPanel.tsx
@@ -78,13 +78,18 @@ export const LogPanel = memo(function LogPanel() {
 				<CRow>
 					<CCol lg={12} className="log-buttons">
 						<ButtonGroup>
-							<Button color="warning" size="sm" onClick={doToggleWarn} style={{ opacity: config.warn ? 1 : 0.2 }}>
+							<Button color="warning" size="sm" onClick={doToggleWarn} variant={config.warn ? undefined : 'outline'}>
 								Warning
 							</Button>
-							<Button color="info" size="sm" onClick={doToggleInfo} style={{ opacity: config.info ? 1 : 0.2 }}>
+							<Button color="info" size="sm" onClick={doToggleInfo} variant={config.info ? undefined : 'outline'}>
 								Info
 							</Button>
-							<Button color="secondary" size="sm" onClick={doToggleDebug} style={{ opacity: config.debug ? 1 : 0.2 }}>
+							<Button
+								color="secondary"
+								size="sm"
+								onClick={doToggleDebug}
+								variant={config.debug ? undefined : 'outline'}
+							>
 								Debug
 							</Button>
 						</ButtonGroup>

--- a/webui/src/LogPanel.tsx
+++ b/webui/src/LogPanel.tsx
@@ -95,7 +95,7 @@ export const LogPanel = memo(function LogPanel() {
 						</ButtonGroup>
 
 						<div className="float-right">
-							<Button color="danger" size="sm" onClick={doClearLog}>
+							<Button color="primary" size="sm" onClick={doClearLog}>
 								Clear log
 							</Button>
 							<LinkButtonExternal color="light" className="ms-2" size="sm" href={makeAbsolutePath(`/int/export/log`)}>

--- a/webui/src/LogPanel.tsx
+++ b/webui/src/LogPanel.tsx
@@ -1,4 +1,4 @@
-import { CButtonGroup, CCol, CRow } from '@coreui/react'
+import { CCol, CRow } from '@coreui/react'
 import { faFileExport } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useVirtualizer } from '@tanstack/react-virtual'
@@ -10,7 +10,7 @@ import type { ClientLogLine } from '@companion-app/shared/Model/LogLine.js'
 import { GenericConfirmModal, type GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
 import { useStickyScroll } from '~/Hooks/useStickyScroll.js'
 import { assertNever, makeAbsolutePath } from '~/Resources/util.js'
-import { Button, LinkButtonExternal } from './Components/Button'
+import { Button, ButtonGroup, LinkButtonExternal } from './Components/Button'
 import { trpc, useMutationExt } from './Resources/TRPC'
 
 interface LogConfig {
@@ -77,7 +77,7 @@ export const LogPanel = memo(function LogPanel() {
 			<div className="log-page">
 				<CRow>
 					<CCol lg={12} className="log-buttons">
-						<CButtonGroup>
+						<ButtonGroup>
 							<Button color="warning" size="sm" onClick={doToggleWarn} style={{ opacity: config.warn ? 1 : 0.2 }}>
 								Warning
 							</Button>
@@ -87,7 +87,7 @@ export const LogPanel = memo(function LogPanel() {
 							<Button color="secondary" size="sm" onClick={doToggleDebug} style={{ opacity: config.debug ? 1 : 0.2 }}>
 								Debug
 							</Button>
-						</CButtonGroup>
+						</ButtonGroup>
 
 						<div className="float-right">
 							<Button color="danger" size="sm" onClick={doClearLog}>

--- a/webui/src/LogPanel.tsx
+++ b/webui/src/LogPanel.tsx
@@ -1,4 +1,4 @@
-import { CButton, CButtonGroup, CCol, CRow } from '@coreui/react'
+import { CButtonGroup, CCol, CRow } from '@coreui/react'
 import { faFileExport } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useVirtualizer } from '@tanstack/react-virtual'
@@ -10,6 +10,7 @@ import type { ClientLogLine } from '@companion-app/shared/Model/LogLine.js'
 import { GenericConfirmModal, type GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
 import { useStickyScroll } from '~/Hooks/useStickyScroll.js'
 import { assertNever, makeAbsolutePath } from '~/Resources/util.js'
+import { Button, LinkButtonExternal } from './Components/Button'
 import { trpc, useMutationExt } from './Resources/TRPC'
 
 interface LogConfig {
@@ -77,42 +78,27 @@ export const LogPanel = memo(function LogPanel() {
 				<CRow>
 					<CCol lg={12} className="log-buttons">
 						<CButtonGroup>
-							<CButton color="warning" size="sm" onClick={doToggleWarn} style={{ opacity: config.warn ? 1 : 0.2 }}>
+							<Button color="warning" size="sm" onClick={doToggleWarn} style={{ opacity: config.warn ? 1 : 0.2 }}>
 								Warning
-							</CButton>
-							<CButton color="info" size="sm" onClick={doToggleInfo} style={{ opacity: config.info ? 1 : 0.2 }}>
+							</Button>
+							<Button color="info" size="sm" onClick={doToggleInfo} style={{ opacity: config.info ? 1 : 0.2 }}>
 								Info
-							</CButton>
-							<CButton color="secondary" size="sm" onClick={doToggleDebug} style={{ opacity: config.debug ? 1 : 0.2 }}>
+							</Button>
+							<Button color="secondary" size="sm" onClick={doToggleDebug} style={{ opacity: config.debug ? 1 : 0.2 }}>
 								Debug
-							</CButton>
+							</Button>
 						</CButtonGroup>
 
 						<div className="float-right">
-							<CButton color="danger" size="sm" onClick={doClearLog}>
+							<Button color="danger" size="sm" onClick={doClearLog}>
 								Clear log
-							</CButton>
-							<CButton
-								color="light"
-								style={{
-									marginLeft: 10,
-								}}
-								size="sm"
-								href={makeAbsolutePath(`/int/export/log`)}
-								target="_blank"
-							>
+							</Button>
+							<LinkButtonExternal color="light" className="ms-2" size="sm" href={makeAbsolutePath(`/int/export/log`)}>
 								<FontAwesomeIcon icon={faFileExport} /> Export log
-							</CButton>
-							<CButton
-								color="light"
-								style={{
-									marginLeft: 10,
-								}}
-								onClick={exportSupportModal}
-								size="sm"
-							>
+							</LinkButtonExternal>
+							<Button color="light" className="ms-2" onClick={exportSupportModal} size="sm">
 								<FontAwesomeIcon icon={faFileExport} /> Export support bundle
-							</CButton>
+							</Button>
 						</div>
 					</CCol>
 				</CRow>

--- a/webui/src/LogPanel.tsx
+++ b/webui/src/LogPanel.tsx
@@ -76,7 +76,7 @@ export const LogPanel = memo(function LogPanel() {
 			<GenericConfirmModal ref={exportRef} />
 			<div className="log-page">
 				<CRow>
-					<CCol lg={12} className="log-buttons">
+					<CCol lg={12} className="px-3">
 						<ButtonGroup>
 							<Button color="warning" size="sm" onClick={doToggleWarn} variant={config.warn ? undefined : 'outline'}>
 								Warning

--- a/webui/src/Modules/ImportCustomModule.tsx
+++ b/webui/src/Modules/ImportCustomModule.tsx
@@ -194,13 +194,13 @@ export function ImportModules(): React.JSX.Element {
 
 	return (
 		<div className="import-module">
-			<label className="btn btn-warning btn-file">
+			<label className="button button-warning button-file">
 				<FontAwesomeIcon icon={faFileImport} style={{ marginRight: 8, marginLeft: -3 }} />
 				Import module package
 				<input type="file" onChange={loadModuleFile} style={{ display: 'none' }} accept=".tgz" />
 			</label>
 			&nbsp;
-			<label className="btn btn-info btn-file">
+			<label className="button button-info button-file">
 				<FontAwesomeIcon icon={faFileImport} style={{ marginRight: 8, marginLeft: -3 }} />
 				Import offline module bundle
 				<input type="file" onChange={loadModuleBundle} style={{ display: 'none' }} accept=".tgz,.gz" />

--- a/webui/src/Modules/ModuleVersionsTable.tsx
+++ b/webui/src/Modules/ModuleVersionsTable.tsx
@@ -276,7 +276,7 @@ function ModuleUninstallButton({ moduleType, moduleId, versionId, disabled }: Mo
 	}, [uninstallModuleMutation, notifier, moduleType, moduleId, versionId])
 
 	return (
-		<Button color="white" disabled={isRunningInstallOrUninstall || disabled} onClick={doRemove}>
+		<Button disabled={isRunningInstallOrUninstall || disabled} onClick={doRemove}>
 			{isRunningInstallOrUninstall ? (
 				<span title="Removing">
 					<FontAwesomeIcon icon={faSync} spin />
@@ -340,7 +340,7 @@ function ModuleInstallButton({ moduleType, moduleId, versionId, apiVersion, hasT
 	}
 
 	return (
-		<Button color="white" disabled={isRunningInstallOrUninstall} onClick={doInstall}>
+		<Button disabled={isRunningInstallOrUninstall} onClick={doInstall}>
 			{isRunningInstallOrUninstall ? (
 				<span title="Installing">
 					<FontAwesomeIcon icon={faSync} />

--- a/webui/src/Modules/ModuleVersionsTable.tsx
+++ b/webui/src/Modules/ModuleVersionsTable.tsx
@@ -1,4 +1,4 @@
-import { CButton, CButtonGroup } from '@coreui/react'
+import { CButtonGroup } from '@coreui/react'
 import {
 	faCircleMinus,
 	faEyeSlash,
@@ -22,6 +22,7 @@ import type {
 	ModuleStoreModuleInfoVersion,
 } from '@companion-app/shared/Model/ModulesStore.js'
 import { isSomeModuleApiVersionCompatible } from '@companion-app/shared/ModuleApiVersionCheck.js'
+import { Button } from '~/Components/Button'
 import { useTableVisibilityHelper, VisibilityButton } from '~/Components/TableVisibility.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC.js'
 import { RootAppStoreContext } from '~/Stores/RootAppStore.js'
@@ -276,7 +277,7 @@ function ModuleUninstallButton({ moduleType, moduleId, versionId, disabled }: Mo
 	}, [uninstallModuleMutation, notifier, moduleType, moduleId, versionId])
 
 	return (
-		<CButton color="white" disabled={isRunningInstallOrUninstall || disabled} onClick={doRemove}>
+		<Button color="white" disabled={isRunningInstallOrUninstall || disabled} onClick={doRemove}>
 			{isRunningInstallOrUninstall ? (
 				<span title="Removing">
 					<FontAwesomeIcon icon={faSync} spin />
@@ -286,7 +287,7 @@ function ModuleUninstallButton({ moduleType, moduleId, versionId, disabled }: Mo
 					<FontAwesomeIcon icon={faTrash} />
 				</span>
 			)}
-		</CButton>
+		</Button>
 	)
 }
 
@@ -340,7 +341,7 @@ function ModuleInstallButton({ moduleType, moduleId, versionId, apiVersion, hasT
 	}
 
 	return (
-		<CButton color="white" disabled={isRunningInstallOrUninstall} onClick={doInstall}>
+		<Button color="white" disabled={isRunningInstallOrUninstall} onClick={doInstall}>
 			{isRunningInstallOrUninstall ? (
 				<span title="Installing">
 					<FontAwesomeIcon icon={faSync} />
@@ -350,6 +351,6 @@ function ModuleInstallButton({ moduleType, moduleId, versionId, apiVersion, hasT
 					<FontAwesomeIcon icon={faPlus} />
 				</span>
 			)}
-		</CButton>
+		</Button>
 	)
 }

--- a/webui/src/Modules/ModuleVersionsTable.tsx
+++ b/webui/src/Modules/ModuleVersionsTable.tsx
@@ -1,4 +1,3 @@
-import { CButtonGroup } from '@coreui/react'
 import {
 	faCircleMinus,
 	faEyeSlash,
@@ -22,7 +21,7 @@ import type {
 	ModuleStoreModuleInfoVersion,
 } from '@companion-app/shared/Model/ModulesStore.js'
 import { isSomeModuleApiVersionCompatible } from '@companion-app/shared/ModuleApiVersionCheck.js'
-import { Button } from '~/Components/Button'
+import { Button, ButtonGroup } from '~/Components/Button'
 import { useTableVisibilityHelper, VisibilityButton } from '~/Components/TableVisibility.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC.js'
 import { RootAppStoreContext } from '~/Stores/RootAppStore.js'
@@ -105,11 +104,11 @@ export const ModuleVersionsTable = observer(function ModuleVersionsTable({
 					<th>Version</th>
 					<th>&nbsp;</th>
 					<th colSpan={3} className="fit">
-						<CButtonGroup className="table-header-buttons">
+						<ButtonGroup className="table-header-buttons">
 							<VisibilityButton {...visibleVersions} keyId="availableStable" color="success" label="Stable" />
 							<VisibilityButton {...visibleVersions} keyId="availableBeta" color="warning" label="Beta" />
 							<VisibilityButton {...visibleVersions} keyId="availableDeprecated" color="primary" label="Deprecated" />
-						</CButtonGroup>
+						</ButtonGroup>
 					</th>
 				</tr>
 			</thead>

--- a/webui/src/Modules/ModulesList.tsx
+++ b/webui/src/Modules/ModulesList.tsx
@@ -1,4 +1,3 @@
-import { CButtonGroup } from '@coreui/react'
 import {
 	faEyeSlash,
 	faGamepad,
@@ -13,7 +12,7 @@ import { observer } from 'mobx-react-lite'
 import { useCallback, useContext, useState } from 'react'
 import { ModuleInstanceType } from '@companion-app/shared/Model/Instance.js'
 import { StaticAlert } from '~/Components/Alert.js'
-import { Button } from '~/Components/Button'
+import { Button, ButtonGroup } from '~/Components/Button'
 import { InlineHelpCustom } from '~/Components/InlineHelp.js'
 import { NonIdealState } from '~/Components/NonIdealState.js'
 import { SearchBox } from '~/Components/SearchBox.js'
@@ -197,7 +196,7 @@ export const ModulesList = observer(function ModulesList({ doManageModule, selec
 						<tr>
 							<th colSpan={3}>
 								Module
-								<CButtonGroup className="table-header-buttons">
+								<ButtonGroup className="table-header-buttons">
 									<VisibilityButton {...visibleModules} keyId="installed" color="success" label="Installed" />
 									<VisibilityButton {...visibleModules} keyId="available" color="warning" label="Available" />
 									<VisibilityButton
@@ -206,7 +205,7 @@ export const ModulesList = observer(function ModulesList({ doManageModule, selec
 										color="primary"
 										label="Deprecated"
 									/>
-								</CButtonGroup>
+								</ButtonGroup>
 							</th>
 						</tr>
 					</thead>

--- a/webui/src/Modules/ModulesList.tsx
+++ b/webui/src/Modules/ModulesList.tsx
@@ -331,13 +331,7 @@ const ModulesListRow = observer(function ModulesListRow({
 				{moduleInfo.name}
 			</td>
 			<td className="compact">
-				<Button
-					onMouseDown={doShowHelp}
-					color="white"
-					title="Show Help"
-					disabled={!moduleInfo.helpUrl}
-					style={{ textAlign: 'left' }}
-				>
+				<Button onMouseDown={doShowHelp} color="white" title="Show Help" disabled={!moduleInfo.helpUrl}>
 					<FontAwesomeIcon icon={faQuestionCircle} />
 				</Button>
 			</td>

--- a/webui/src/Modules/ModulesList.tsx
+++ b/webui/src/Modules/ModulesList.tsx
@@ -154,7 +154,7 @@ export const ModulesList = observer(function ModulesList({ doManageModule, selec
 	return (
 		<div className="flex-column-layout">
 			<div className="fixed-header">
-				<h4 className="btn-inline">
+				<h4 className="button-inline">
 					Manage Modules
 					<ContextHelpButton action="/user-guide/config/modules" />
 				</h4>
@@ -331,7 +331,7 @@ const ModulesListRow = observer(function ModulesListRow({
 				{moduleInfo.name}
 			</td>
 			<td className="compact">
-				<Button onMouseDown={doShowHelp} color="white" title="Show Help" disabled={!moduleInfo.helpUrl}>
+				<Button onMouseDown={doShowHelp} title="Show Help" disabled={!moduleInfo.helpUrl}>
 					<FontAwesomeIcon icon={faQuestionCircle} />
 				</Button>
 			</td>

--- a/webui/src/Modules/ModulesList.tsx
+++ b/webui/src/Modules/ModulesList.tsx
@@ -1,4 +1,4 @@
-import { CButton, CButtonGroup } from '@coreui/react'
+import { CButtonGroup } from '@coreui/react'
 import {
 	faEyeSlash,
 	faGamepad,
@@ -13,6 +13,7 @@ import { observer } from 'mobx-react-lite'
 import { useCallback, useContext, useState } from 'react'
 import { ModuleInstanceType } from '@companion-app/shared/Model/Instance.js'
 import { StaticAlert } from '~/Components/Alert.js'
+import { Button } from '~/Components/Button'
 import { InlineHelpCustom } from '~/Components/InlineHelp.js'
 import { NonIdealState } from '~/Components/NonIdealState.js'
 import { SearchBox } from '~/Components/SearchBox.js'
@@ -331,7 +332,7 @@ const ModulesListRow = observer(function ModulesListRow({
 				{moduleInfo.name}
 			</td>
 			<td className="compact">
-				<CButton
+				<Button
 					onMouseDown={doShowHelp}
 					color="white"
 					title="Show Help"
@@ -339,7 +340,7 @@ const ModulesListRow = observer(function ModulesListRow({
 					style={{ textAlign: 'left' }}
 				>
 					<FontAwesomeIcon icon={faQuestionCircle} />
-				</CButton>
+				</Button>
 			</td>
 		</tr>
 	)

--- a/webui/src/Modules/RefreshModuleInfo.tsx
+++ b/webui/src/Modules/RefreshModuleInfo.tsx
@@ -1,9 +1,9 @@
-import { CButton } from '@coreui/react'
 import { faSync } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
 import { useCallback, useContext } from 'react'
 import type { ModuleInstanceType } from '@companion-app/shared/Model/Instance.js'
+import { Button } from '~/Components/Button'
 import { trpc, useMutationExt } from '~/Resources/TRPC'
 import { RootAppStoreContext } from '~/Stores/RootAppStore.js'
 
@@ -30,17 +30,17 @@ export const RefreshModuleInfo = observer(function RefreshModuleInfo({
 
 	if (refreshProgress === 1) {
 		return (
-			<CButton color="primary" onClick={doRefreshModules}>
+			<Button color="primary" onClick={doRefreshModules}>
 				<FontAwesomeIcon icon={faSync} />
 				&nbsp;Refresh module info
-			</CButton>
+			</Button>
 		)
 	} else {
 		return (
-			<CButton color="primary" disabled>
+			<Button color="primary" disabled>
 				<FontAwesomeIcon icon={faSync} spin={true} />
 				&nbsp;Refreshing module info {Math.round(refreshProgress * 100)}%
-			</CButton>
+			</Button>
 		)
 	}
 })

--- a/webui/src/Modules/RefreshModulesList.tsx
+++ b/webui/src/Modules/RefreshModulesList.tsx
@@ -1,9 +1,9 @@
-import { CButton } from '@coreui/react'
 import { faSync } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
 import { useCallback, useContext, useState } from 'react'
 import { StaticAlert } from '~/Components/Alert'
+import { Button } from '~/Components/Button'
 import { trpc, useMutationExt } from '~/Resources/TRPC'
 import { RootAppStoreContext } from '~/Stores/RootAppStore.js'
 
@@ -28,15 +28,15 @@ export const RefreshModulesList = observer(function RefreshModulesList({ btnSize
 			{refreshError ? <StaticAlert color="warning">{refreshError}</StaticAlert> : ''}
 
 			{refreshProgress !== 1 ? (
-				<CButton color="primary" disabled size={btnSize}>
+				<Button color="primary" disabled size={btnSize}>
 					<FontAwesomeIcon icon={faSync} spin={true} />
 					&nbsp;Refreshing modules list {Math.round(refreshProgress * 100)}%
-				</CButton>
+				</Button>
 			) : (
-				<CButton color="primary" onClick={doRefreshModules} size={btnSize}>
+				<Button color="primary" onClick={doRefreshModules} size={btnSize}>
 					<FontAwesomeIcon icon={faSync} />
 					&nbsp;Refresh modules list
-				</CButton>
+				</Button>
 			)}
 		</div>
 	)

--- a/webui/src/Resources/Error.tsx
+++ b/webui/src/Resources/Error.tsx
@@ -1,16 +1,16 @@
-import { CButton } from '@coreui/react'
 import { ErrorBoundary, type FallbackProps } from 'react-error-boundary'
 import { stringifyError } from '@companion-app/shared/Stringify.js'
 import { StaticAlert } from '~/Components/Alert'
+import { Button } from '~/Components/Button'
 
 export function ErrorFallback({ error, resetErrorBoundary }: FallbackProps): React.JSX.Element {
 	return (
 		<StaticAlert color="danger">
 			<p>Something went wrong:</p>
 			<pre>{stringifyError(error, true)}</pre>
-			<CButton color="primary" size="sm" onClick={resetErrorBoundary}>
+			<Button color="primary" size="sm" onClick={resetErrorBoundary}>
 				Try again
-			</CButton>
+			</Button>
 		</StaticAlert>
 	)
 }

--- a/webui/src/Resources/Loading.tsx
+++ b/webui/src/Resources/Loading.tsx
@@ -1,9 +1,10 @@
-import { CButton, CCol } from '@coreui/react'
+import { CCol } from '@coreui/react'
 import type { TRPCClientErrorLike } from '@trpc/client'
 import { useEffect, useState } from 'react'
 import { BarLoader, PuffLoader } from 'react-spinners'
 import type { LoaderHeightWidthProps } from 'react-spinners/helpers/props.js'
 import { StaticAlert } from '~/Components/Alert.js'
+import { Button } from '~/Components/Button'
 import { PRIMARY_COLOR } from './Constants.js'
 
 type LoadingBarProps = LoaderHeightWidthProps
@@ -76,9 +77,9 @@ export function LoadingRetryOrError({
 						<p>{typeof error === 'string' ? error : error.message}</p>
 						{/* Show retry button with countdown when data is not ready and retry function is provided */}
 						{!dataReady && !!doRetry && (
-							<CButton color="primary" onClick={doRetry}>
+							<Button color="primary" onClick={doRetry}>
 								{retryLabel || 'Retry'} {countdown && '(' + countdown + ')'}
-							</CButton>
+							</Button>
 						)}
 					</StaticAlert>
 				</CCol>

--- a/webui/src/Surfaces/AddEmulatorModal.tsx
+++ b/webui/src/Surfaces/AddEmulatorModal.tsx
@@ -1,19 +1,10 @@
-import {
-	CButton,
-	CCol,
-	CForm,
-	CFormInput,
-	CFormLabel,
-	CModalBody,
-	CModalFooter,
-	CModalHeader,
-	CRow,
-} from '@coreui/react'
+import { CCol, CForm, CFormInput, CFormLabel, CModalBody, CModalFooter, CModalHeader, CRow } from '@coreui/react'
 import { useForm } from '@tanstack/react-form'
 import { nanoid } from 'nanoid'
 import { forwardRef, useCallback, useContext, useImperativeHandle, useState } from 'react'
 import { isEmulatorIdValid } from '@companion-app/shared/Label.js'
 import { StaticAlert } from '~/Components/Alert'
+import { Button } from '~/Components/Button'
 import { CModalExt } from '~/Components/CModalExt.js'
 import { InlineHelpIcon } from '~/Components/InlineHelp.js'
 import { NumberInputField } from '~/Components/NumberInputField.js'
@@ -229,11 +220,11 @@ export const AddEmulatorModal = forwardRef<AddEmulatorModalRef>(function Surface
 						selector={(state) => [state.canSubmit, state.isSubmitting]}
 						children={([canSubmit, isSubmitting]) => (
 							<>
-								<CButton color="secondary" onClick={doClose} disabled={isSubmitting}>
+								<Button color="secondary" onClick={doClose} disabled={isSubmitting}>
 									Cancel
-								</CButton>
+								</Button>
 
-								<CButton
+								<Button
 									color="primary"
 									className="me-md-1"
 									disabled={!canSubmit || isSubmitting}
@@ -245,7 +236,7 @@ export const AddEmulatorModal = forwardRef<AddEmulatorModalRef>(function Surface
 									}}
 								>
 									Add {isSubmitting ? '...' : ''}
-								</CButton>
+								</Button>
 							</>
 						)}
 					/>

--- a/webui/src/Surfaces/AddEmulatorModal.tsx
+++ b/webui/src/Surfaces/AddEmulatorModal.tsx
@@ -224,17 +224,7 @@ export const AddEmulatorModal = forwardRef<AddEmulatorModalRef>(function Surface
 									Cancel
 								</Button>
 
-								<Button
-									color="primary"
-									className="me-md-1"
-									disabled={!canSubmit || isSubmitting}
-									type="submit"
-									onClick={() => {
-										form.handleSubmit().catch((err) => {
-											console.error('Add emulator failed', err)
-										})
-									}}
-								>
+								<Button color="primary" className="me-md-1" disabled={!canSubmit || isSubmitting} type="submit">
 									Add {isSubmitting ? '...' : ''}
 								</Button>
 							</>

--- a/webui/src/Surfaces/AddGroupModal.tsx
+++ b/webui/src/Surfaces/AddGroupModal.tsx
@@ -1,19 +1,10 @@
-import {
-	CButton,
-	CCol,
-	CForm,
-	CFormInput,
-	CFormLabel,
-	CModalBody,
-	CModalFooter,
-	CModalHeader,
-	CRow,
-} from '@coreui/react'
+import { CCol, CForm, CFormInput, CFormLabel, CModalBody, CModalFooter, CModalHeader, CRow } from '@coreui/react'
 import { useForm } from '@tanstack/react-form'
 import { nanoid } from 'nanoid'
 import { forwardRef, useCallback, useContext, useImperativeHandle, useState } from 'react'
 import { isSurfaceGroupIdValid } from '@companion-app/shared/Label.js'
 import { StaticAlert } from '~/Components/Alert'
+import { Button } from '~/Components/Button'
 import { CModalExt } from '~/Components/CModalExt.js'
 import { InlineHelpIcon } from '~/Components/InlineHelp.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC'
@@ -157,11 +148,11 @@ export const AddSurfaceGroupModal = forwardRef<AddSurfaceGroupModalRef>(function
 						selector={(state) => [state.canSubmit, state.isSubmitting]}
 						children={([canSubmit, isSubmitting]) => (
 							<>
-								<CButton color="secondary" onClick={doClose} disabled={isSubmitting}>
+								<Button color="secondary" onClick={doClose} disabled={isSubmitting}>
 									Cancel
-								</CButton>
+								</Button>
 
-								<CButton
+								<Button
 									color="primary"
 									className="me-md-1"
 									disabled={!canSubmit || isSubmitting}
@@ -173,7 +164,7 @@ export const AddSurfaceGroupModal = forwardRef<AddSurfaceGroupModalRef>(function
 									}}
 								>
 									Add {isSubmitting ? '...' : ''}
-								</CButton>
+								</Button>
 							</>
 						)}
 					/>

--- a/webui/src/Surfaces/AddGroupModal.tsx
+++ b/webui/src/Surfaces/AddGroupModal.tsx
@@ -152,17 +152,7 @@ export const AddSurfaceGroupModal = forwardRef<AddSurfaceGroupModalRef>(function
 									Cancel
 								</Button>
 
-								<Button
-									color="primary"
-									className="me-md-1"
-									disabled={!canSubmit || isSubmitting}
-									type="submit"
-									onClick={() => {
-										form.handleSubmit().catch((err) => {
-											console.error('Form submission error', err)
-										})
-									}}
-								>
+								<Button color="primary" className="me-md-1" disabled={!canSubmit || isSubmitting} type="submit">
 									Add {isSubmitting ? '...' : ''}
 								</Button>
 							</>

--- a/webui/src/Surfaces/Discovery/SetupSatelliteModal.tsx
+++ b/webui/src/Surfaces/Discovery/SetupSatelliteModal.tsx
@@ -1,7 +1,8 @@
-import { CButton, CForm, CFormLabel, CModalBody, CModalFooter, CModalHeader } from '@coreui/react'
+import { CForm, CFormLabel, CModalBody, CModalFooter, CModalHeader } from '@coreui/react'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react'
 import type { ClientDiscoveredSurfaceInfoSatellite } from '@companion-app/shared/Model/Surfaces.js'
+import { Button } from '~/Components/Button.js'
 import { CModalExt } from '~/Components/CModalExt.js'
 import { DropdownInputField } from '~/Components/DropdownInputField.js'
 import { MenuPortalContext } from '~/Components/MenuPortalContext'
@@ -109,17 +110,17 @@ export const SetupSatelliteModal = forwardRef<SetupSatelliteModalRef>(function S
 					</CForm>
 				</CModalBody>
 				<CModalFooter>
-					<CButton color="secondary" onClick={doClose}>
+					<Button color="secondary" onClick={doClose}>
 						Cancel
-					</CButton>
-					<CButton
+					</Button>
+					<Button
 						ref={buttonRef}
 						color="primary"
 						onClick={doAction}
 						disabled={!externalAddressesQuery.data || !selectedAddress || saveMutation.isPending}
 					>
 						Setup
-					</CButton>
+					</Button>
 				</CModalFooter>
 			</MenuPortalContext.Provider>
 		</CModalExt>

--- a/webui/src/Surfaces/Discovery/SurfaceDiscoveryTable.tsx
+++ b/webui/src/Surfaces/Discovery/SurfaceDiscoveryTable.tsx
@@ -1,4 +1,4 @@
-import { CButton, CButtonGroup } from '@coreui/react'
+import { CButtonGroup } from '@coreui/react'
 import { faCheck, faPlus, faSearch } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useNavigate } from '@tanstack/react-router'
@@ -12,6 +12,7 @@ import type {
 	ClientDiscoveredSurfaceInfoPlugin,
 	ClientDiscoveredSurfaceInfoSatellite,
 } from '@companion-app/shared/Model/Surfaces.js'
+import { Button } from '~/Components/Button'
 import { NonIdealState } from '~/Components/NonIdealState.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC.js'
 import { assertNever, useComputed } from '~/Resources/util.js'
@@ -140,9 +141,9 @@ function SatelliteRow({ surfaceInfo, showSetupSatellite }: SatelliteRowProps) {
 			</td>
 			<td>
 				<CButtonGroup>
-					<CButton onClick={() => showSetupSatellite(surfaceInfo)} title="Setup">
+					<Button onClick={() => showSetupSatellite(surfaceInfo)} title="Setup">
 						<FontAwesomeIcon icon={faPlus} /> Setup
-					</CButton>
+					</Button>
 				</CButtonGroup>
 			</td>
 		</tr>
@@ -217,13 +218,13 @@ const PluginSurfaceRow = observer(function PluginSurfaceRow({ surfaceInfo, addCo
 			<td>
 				<CButtonGroup>
 					{isAlreadyAdded ? (
-						<CButton title={'Already added'} className="btn-undefined" disabled>
+						<Button title={'Already added'} className="btn-undefined" disabled>
 							<FontAwesomeIcon icon={faCheck} /> Already added
-						</CButton>
+						</Button>
 					) : (
-						<CButton onClick={() => addConnection(surfaceInfo)} title="Add Connection" className="btn-undefined">
+						<Button onClick={() => addConnection(surfaceInfo)} title="Add Connection" className="btn-undefined">
 							<FontAwesomeIcon icon={faPlus} /> Add Connection
-						</CButton>
+						</Button>
 					)}
 				</CButtonGroup>
 			</td>

--- a/webui/src/Surfaces/Discovery/SurfaceDiscoveryTable.tsx
+++ b/webui/src/Surfaces/Discovery/SurfaceDiscoveryTable.tsx
@@ -1,4 +1,3 @@
-import { CButtonGroup } from '@coreui/react'
 import { faCheck, faPlus, faSearch } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useNavigate } from '@tanstack/react-router'
@@ -12,7 +11,7 @@ import type {
 	ClientDiscoveredSurfaceInfoPlugin,
 	ClientDiscoveredSurfaceInfoSatellite,
 } from '@companion-app/shared/Model/Surfaces.js'
-import { Button } from '~/Components/Button'
+import { Button, ButtonGroup } from '~/Components/Button'
 import { NonIdealState } from '~/Components/NonIdealState.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC.js'
 import { assertNever, useComputed } from '~/Resources/util.js'
@@ -140,11 +139,11 @@ function SatelliteRow({ surfaceInfo, showSetupSatellite }: SatelliteRowProps) {
 				})}
 			</td>
 			<td>
-				<CButtonGroup>
+				<ButtonGroup>
 					<Button onClick={() => showSetupSatellite(surfaceInfo)} title="Setup">
 						<FontAwesomeIcon icon={faPlus} /> Setup
 					</Button>
-				</CButtonGroup>
+				</ButtonGroup>
 			</td>
 		</tr>
 	)
@@ -216,7 +215,7 @@ const PluginSurfaceRow = observer(function PluginSurfaceRow({ surfaceInfo, addCo
 				<p className="p-no-margin">{surfaceInfo.address ?? '-'}</p>
 			</td>
 			<td>
-				<CButtonGroup>
+				<ButtonGroup>
 					{isAlreadyAdded ? (
 						<Button title={'Already added'} className="btn-undefined" disabled>
 							<FontAwesomeIcon icon={faCheck} /> Already added
@@ -226,7 +225,7 @@ const PluginSurfaceRow = observer(function PluginSurfaceRow({ surfaceInfo, addCo
 							<FontAwesomeIcon icon={faPlus} /> Add Connection
 						</Button>
 					)}
-				</CButtonGroup>
+				</ButtonGroup>
 			</td>
 		</tr>
 	)

--- a/webui/src/Surfaces/Discovery/SurfaceDiscoveryTable.tsx
+++ b/webui/src/Surfaces/Discovery/SurfaceDiscoveryTable.tsx
@@ -217,11 +217,11 @@ const PluginSurfaceRow = observer(function PluginSurfaceRow({ surfaceInfo, addCo
 			<td>
 				<ButtonGroup>
 					{isAlreadyAdded ? (
-						<Button title={'Already added'} className="btn-undefined" disabled>
+						<Button title={'Already added'} disabled>
 							<FontAwesomeIcon icon={faCheck} /> Already added
 						</Button>
 					) : (
-						<Button onClick={() => addConnection(surfaceInfo)} title="Add Connection" className="btn-undefined">
+						<Button onClick={() => addConnection(surfaceInfo)} title="Add Connection">
 							<FontAwesomeIcon icon={faPlus} /> Add Connection
 						</Button>
 					)}

--- a/webui/src/Surfaces/Instances/SurfaceInstanceList/SurfaceInstanceList.tsx
+++ b/webui/src/Surfaces/Instances/SurfaceInstanceList/SurfaceInstanceList.tsx
@@ -1,4 +1,4 @@
-import { CButton, CButtonGroup } from '@coreui/react'
+import { CButtonGroup } from '@coreui/react'
 import { faLayerGroup, faPlug } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useNavigate } from '@tanstack/react-router'
@@ -11,6 +11,7 @@ import type {
 	SurfaceInstanceCollection,
 } from '@companion-app/shared/Model/SurfaceInstance.js'
 import { stringifyError } from '@companion-app/shared/Stringify.js'
+import { Button } from '~/Components/Button'
 import { CollectionsNestingTable } from '~/Components/CollectionsNestingTable/CollectionsNestingTable.js'
 import { GenericConfirmModal, type GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
 import { NonIdealState } from '~/Components/NonIdealState.js'
@@ -93,10 +94,10 @@ export const SurfaceInstancesList = observer(function SurfaceInstancesList({
 
 				<div className="d-flex align-items-center help-button-float">
 					<CButtonGroup className="connection-group-actions m-1 me-auto">
-						<CButton color="primary" size="sm" onClick={() => void navigate({ to: '/surfaces/integrations/add' })}>
+						<Button color="primary" size="sm" onClick={() => void navigate({ to: '/surfaces/integrations/add' })}>
 							<FontAwesomeIcon icon={faPlug} className="me-1" />
 							Add Surface Integration
-						</CButton>
+						</Button>
 						<CreateCollectionButton />
 					</CButtonGroup>
 					<ContextHelpButton action="/user-guide/surfaces">
@@ -230,8 +231,8 @@ function CreateCollectionButton() {
 	}, [createMutation])
 
 	return (
-		<CButton color="info" size="sm" onClick={doCreateCollection}>
+		<Button color="info" size="sm" onClick={doCreateCollection}>
 			<FontAwesomeIcon icon={faLayerGroup} /> Create Collection
-		</CButton>
+		</Button>
 	)
 }

--- a/webui/src/Surfaces/Instances/SurfaceInstanceList/SurfaceInstanceList.tsx
+++ b/webui/src/Surfaces/Instances/SurfaceInstanceList/SurfaceInstanceList.tsx
@@ -1,4 +1,3 @@
-import { CButtonGroup } from '@coreui/react'
 import { faLayerGroup, faPlug } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useNavigate } from '@tanstack/react-router'
@@ -11,7 +10,7 @@ import type {
 	SurfaceInstanceCollection,
 } from '@companion-app/shared/Model/SurfaceInstance.js'
 import { stringifyError } from '@companion-app/shared/Stringify.js'
-import { Button } from '~/Components/Button'
+import { Button, ButtonGroup } from '~/Components/Button'
 import { CollectionsNestingTable } from '~/Components/CollectionsNestingTable/CollectionsNestingTable.js'
 import { GenericConfirmModal, type GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
 import { NonIdealState } from '~/Components/NonIdealState.js'
@@ -93,13 +92,13 @@ export const SurfaceInstancesList = observer(function SurfaceInstancesList({
 				<GenericConfirmModal ref={confirmModalRef} />
 
 				<div className="d-flex align-items-center help-button-float">
-					<CButtonGroup className="connection-group-actions m-1 me-auto">
+					<ButtonGroup className="connection-group-actions m-1 me-auto">
 						<Button color="primary" size="sm" onClick={() => void navigate({ to: '/surfaces/integrations/add' })}>
 							<FontAwesomeIcon icon={faPlug} className="me-1" />
 							Add Surface Integration
 						</Button>
 						<CreateCollectionButton />
-					</CButtonGroup>
+					</ButtonGroup>
 					<ContextHelpButton action="/user-guide/surfaces">
 						<p>
 							Surface integrations are like connections but for input surfaces: they provide the ability to use
@@ -152,12 +151,12 @@ function SurfaceInstancesListTableHeading() {
 		<div className="flex flex-row">
 			<div className="grow">Surface Integrations </div>
 			<div className="no-break">
-				<CButtonGroup className="table-header-buttons">
+				<ButtonGroup className="table-header-buttons">
 					<VisibilityButton {...visibleInstances} keyId="disabled" color="secondary" label="Disabled" />
 					<VisibilityButton {...visibleInstances} keyId="ok" color="success" label="OK" />
 					<VisibilityButton {...visibleInstances} keyId="warning" color="warning" label="Warning" />
 					<VisibilityButton {...visibleInstances} keyId="error" color="danger" label="Error" />
-				</CButtonGroup>
+				</ButtonGroup>
 			</div>
 		</div>
 	)

--- a/webui/src/Surfaces/KnownSurfacesTable.tsx
+++ b/webui/src/Surfaces/KnownSurfacesTable.tsx
@@ -1,4 +1,4 @@
-import { CButton, CButtonGroup } from '@coreui/react'
+import { CButtonGroup } from '@coreui/react'
 import { faCircleUp, faCopy, faFolderOpen, faPowerOff, faSearch, faTrash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import classNames from 'classnames'
@@ -6,6 +6,7 @@ import { observer } from 'mobx-react-lite'
 import { useCallback, useContext, useRef } from 'react'
 import CopyToClipboard from 'react-copy-to-clipboard'
 import type { ClientDevicesListItem, ClientSurfaceItem } from '@companion-app/shared/Model/Surfaces.js'
+import { Button, LinkButtonExternal } from '~/Components/Button'
 import { GenericConfirmModal, type GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
 import { NonIdealState } from '~/Components/NonIdealState.js'
 import { WindowLinkOpen } from '~/Helpers/Window.js'
@@ -187,17 +188,17 @@ const ManualGroupRow = observer(function ManualGroupRow({
 							{group.id}
 						</span>
 						<CopyToClipboard text={group.id} onCopy={() => notifier.show(`Copied`, 'Copied to clipboard', 5000)}>
-							<CButton size="sm" title="Copy group id" className="p-0 px-1">
+							<Button size="sm" title="Copy group id" className="p-0 px-1">
 								<FontAwesomeIcon icon={faCopy} color="#000" />
-							</CButton>
+							</Button>
 						</CopyToClipboard>
 					</div>
 				</div>
 				<div className="grid-cell">
 					<CButtonGroup>
-						<CButton onClick={deleteGroup2} title="Delete group">
+						<Button onClick={deleteGroup2} title="Delete group">
 							<FontAwesomeIcon icon={faTrash} />
-						</CButton>
+						</Button>
 					</CButtonGroup>
 				</div>
 			</div>
@@ -296,9 +297,9 @@ const SurfaceRow = observer(function SurfaceRow({
 				<div className="surface-id-row">
 					<span className="surface-id">{surface.id}</span>
 					<CopyToClipboard text={surface.id} onCopy={() => notifier.show(`Copied`, 'Copied to clipboard', 5000)}>
-						<CButton size="sm" title="Copy surface id" className="p-0 px-1">
+						<Button size="sm" title="Copy surface id" className="p-0 px-1">
 							<FontAwesomeIcon icon={faCopy} color="#000" />
-						</CButton>
+						</Button>
 					</CopyToClipboard>
 					<span className={classNames('surface-status', { 'surface-disabled': surfaceDisabled })}>
 						{surfaceDisabled ? 'Disabled' : surface.isConnected ? surface.location || 'Local' : 'Offline'}
@@ -310,23 +311,22 @@ const SurfaceRow = observer(function SurfaceRow({
 					<CButtonGroup className="no-break">
 						{surface.integrationType === 'emulator' && (
 							<>
-								<CButton
+								<LinkButtonExternal
 									href={makeAbsolutePath(`/emulator/${surface.id.substring(9)}`)}
-									target="_blank"
 									title="Open Emulator"
 								>
 									<FontAwesomeIcon icon={faFolderOpen} />
-								</CButton>
-								<CButton onClick={deleteEmulator2} title="Delete Emulator">
+								</LinkButtonExternal>
+								<Button onClick={deleteEmulator2} title="Delete Emulator">
 									<FontAwesomeIcon icon={faTrash} />
-								</CButton>
+								</Button>
 							</>
 						)}
 					</CButtonGroup>
 				) : (
-					<CButton onClick={forgetSurface2} title="Forget">
+					<Button onClick={forgetSurface2} title="Forget">
 						<FontAwesomeIcon icon={faTrash} />
-					</CButton>
+					</Button>
 				)}
 			</div>
 		</div>

--- a/webui/src/Surfaces/KnownSurfacesTable.tsx
+++ b/webui/src/Surfaces/KnownSurfacesTable.tsx
@@ -1,4 +1,3 @@
-import { CButtonGroup } from '@coreui/react'
 import { faCircleUp, faCopy, faFolderOpen, faPowerOff, faSearch, faTrash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import classNames from 'classnames'
@@ -6,7 +5,7 @@ import { observer } from 'mobx-react-lite'
 import { useCallback, useContext, useRef } from 'react'
 import CopyToClipboard from 'react-copy-to-clipboard'
 import type { ClientDevicesListItem, ClientSurfaceItem } from '@companion-app/shared/Model/Surfaces.js'
-import { Button, LinkButtonExternal } from '~/Components/Button'
+import { Button, ButtonGroup, LinkButtonExternal } from '~/Components/Button'
 import { GenericConfirmModal, type GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
 import { NonIdealState } from '~/Components/NonIdealState.js'
 import { WindowLinkOpen } from '~/Helpers/Window.js'
@@ -195,11 +194,11 @@ const ManualGroupRow = observer(function ManualGroupRow({
 					</div>
 				</div>
 				<div className="grid-cell">
-					<CButtonGroup>
+					<ButtonGroup>
 						<Button onClick={deleteGroup2} title="Delete group">
 							<FontAwesomeIcon icon={faTrash} />
 						</Button>
-					</CButtonGroup>
+					</ButtonGroup>
 				</div>
 			</div>
 			{(group.surfaces || []).map((surface, i, arr) => (
@@ -308,7 +307,7 @@ const SurfaceRow = observer(function SurfaceRow({
 			</div>
 			<div className="grid-cell">
 				{surface.isConnected ? (
-					<CButtonGroup className="no-break">
+					<ButtonGroup className="no-break">
 						{surface.integrationType === 'emulator' && (
 							<>
 								<LinkButtonExternal
@@ -322,7 +321,7 @@ const SurfaceRow = observer(function SurfaceRow({
 								</Button>
 							</>
 						)}
-					</CButtonGroup>
+					</ButtonGroup>
 				) : (
 					<Button onClick={forgetSurface2} title="Forget">
 						<FontAwesomeIcon icon={faTrash} />

--- a/webui/src/Surfaces/KnownSurfacesTable.tsx
+++ b/webui/src/Surfaces/KnownSurfacesTable.tsx
@@ -163,7 +163,7 @@ const ManualGroupRow = observer(function ManualGroupRow({
 	const handleGroupClick = useCallback(
 		(e: React.MouseEvent) => {
 			// Don't trigger row click if clicking on input field or buttons
-			if ((e.target as HTMLElement).closest('input, button')) {
+			if ((e.target as HTMLElement).closest('input, button, a, [role="button"]')) {
 				return
 			}
 			selectItem(group.id)

--- a/webui/src/Surfaces/MainSurfacesPage.tsx
+++ b/webui/src/Surfaces/MainSurfacesPage.tsx
@@ -93,7 +93,7 @@ export const MainSurfacesPage = observer(function MainSurfacesPage(): React.JSX.
 				className={`primary-panel ${showPrimaryPanel ? 'd-flex' : 'd-none'} flex-column-layout`}
 			>
 				<div className="fixed-header">
-					<h4 className="btn-inline">
+					<h4 className="button-inline">
 						Surfaces
 						<ContextHelpButton action="/user-guide/config/surfaces">
 							Use the table, below to configure currently-known surfaces and groups.

--- a/webui/src/Surfaces/MainSurfacesPage.tsx
+++ b/webui/src/Surfaces/MainSurfacesPage.tsx
@@ -1,4 +1,4 @@
-import { CButton, CButtonGroup, CCallout, CCol, CRow } from '@coreui/react'
+import { CButtonGroup, CCallout, CCol, CRow } from '@coreui/react'
 import { faAdd, faCog, faSync } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useMutation } from '@tanstack/react-query'
@@ -6,6 +6,7 @@ import { Outlet, useMatchRoute, useNavigate } from '@tanstack/react-router'
 import { observer } from 'mobx-react-lite'
 import { useCallback, useRef, useState } from 'react'
 import { StaticAlert } from '~/Components/Alert'
+import { Button } from '~/Components/Button'
 import { useTwoPanelMode } from '~/Hooks/useLayoutMode'
 import { useShowSecondaryPanel } from '~/Hooks/useShowSecondaryPanel'
 import { ContextHelpButton } from '~/Layout/PanelIcons'
@@ -120,25 +121,25 @@ export const MainSurfacesPage = observer(function MainSurfacesPage(): React.JSX.
 					)}
 
 					<CButtonGroup size="sm">
-						<CButton color="warning" onClick={refreshUSB}>
+						<Button color="warning" onClick={refreshUSB}>
 							<FontAwesomeIcon icon={faSync} spin={rescanUsbMutation.isPending} />
 							{rescanUsbMutation.isPending ? ' Checking for new surfaces...' : ' Rescan USB'}
-						</CButton>
-						<CButton color="primary" onClick={addEmulator}>
+						</Button>
+						<Button color="primary" onClick={addEmulator}>
 							<FontAwesomeIcon icon={faAdd} /> Add Emulator
-						</CButton>
-						<CButton color="secondary" onClick={addGroup}>
+						</Button>
+						<Button color="secondary" onClick={addGroup}>
 							<FontAwesomeIcon icon={faAdd} /> Add Group
-						</CButton>
+						</Button>
 					</CButtonGroup>
 
 					<AddSurfaceGroupModal ref={addGroupModalRef} />
 					<AddEmulatorModal ref={addEmulatorModalRef} />
 
 					{!twoPanelMode && (
-						<CButton color="info" className="float-end" size="sm" onClick={handleShowSettings}>
+						<Button color="info" className="float-end" size="sm" onClick={handleShowSettings}>
 							<FontAwesomeIcon icon={faCog} /> Show Settings
-						</CButton>
+						</Button>
 					)}
 				</div>
 

--- a/webui/src/Surfaces/MainSurfacesPage.tsx
+++ b/webui/src/Surfaces/MainSurfacesPage.tsx
@@ -1,4 +1,4 @@
-import { CButtonGroup, CCallout, CCol, CRow } from '@coreui/react'
+import { CCallout, CCol, CRow } from '@coreui/react'
 import { faAdd, faCog, faSync } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useMutation } from '@tanstack/react-query'
@@ -6,7 +6,7 @@ import { Outlet, useMatchRoute, useNavigate } from '@tanstack/react-router'
 import { observer } from 'mobx-react-lite'
 import { useCallback, useRef, useState } from 'react'
 import { StaticAlert } from '~/Components/Alert'
-import { Button } from '~/Components/Button'
+import { Button, ButtonGroup } from '~/Components/Button'
 import { useTwoPanelMode } from '~/Hooks/useLayoutMode'
 import { useShowSecondaryPanel } from '~/Hooks/useShowSecondaryPanel'
 import { ContextHelpButton } from '~/Layout/PanelIcons'
@@ -120,18 +120,18 @@ export const MainSurfacesPage = observer(function MainSurfacesPage(): React.JSX.
 						</StaticAlert>
 					)}
 
-					<CButtonGroup size="sm">
-						<Button color="warning" onClick={refreshUSB}>
+					<ButtonGroup>
+						<Button color="warning" size="sm" onClick={refreshUSB}>
 							<FontAwesomeIcon icon={faSync} spin={rescanUsbMutation.isPending} />
 							{rescanUsbMutation.isPending ? ' Checking for new surfaces...' : ' Rescan USB'}
 						</Button>
-						<Button color="primary" onClick={addEmulator}>
+						<Button color="primary" size="sm" onClick={addEmulator}>
 							<FontAwesomeIcon icon={faAdd} /> Add Emulator
 						</Button>
-						<Button color="secondary" onClick={addGroup}>
+						<Button color="secondary" size="sm" onClick={addGroup}>
 							<FontAwesomeIcon icon={faAdd} /> Add Group
 						</Button>
-					</CButtonGroup>
+					</ButtonGroup>
 
 					<AddSurfaceGroupModal ref={addGroupModalRef} />
 					<AddEmulatorModal ref={addEmulatorModalRef} />

--- a/webui/src/Surfaces/Remote/EditPanel.tsx
+++ b/webui/src/Surfaces/Remote/EditPanel.tsx
@@ -1,4 +1,4 @@
-import { CButton, CCol, CFormInput, CFormLabel, CFormText } from '@coreui/react'
+import { CCol, CFormInput, CFormLabel, CFormText } from '@coreui/react'
 import { useForm } from '@tanstack/react-form'
 import { useNavigate } from '@tanstack/react-router'
 import { observer } from 'mobx-react-lite'
@@ -7,6 +7,7 @@ import type { JsonValue } from 'type-fest'
 import type { OutboundSurfaceInfo } from '@companion-app/shared/Model/Surfaces.js'
 import { validateInputValue } from '@companion-app/shared/ValidateInputValue.js'
 import { StaticAlert } from '~/Components/Alert'
+import { Button } from '~/Components/Button.js'
 import { useTwoPanelMode } from '~/Hooks/useLayoutMode'
 import { CloseButton } from '~/Layout/PanelIcons'
 import { trpc, useMutationExt } from '~/Resources/TRPC'
@@ -179,18 +180,18 @@ const SurfaceEditPanelContent = observer<SurfaceEditPanelContentProps>(function 
 						<CCol sm={12}>
 							<div className="flex flex-row">
 								<div className="grow">
-									<CButton
+									<Button
 										color="success"
 										className="me-md-1"
 										disabled={!isDirty || !isValid || isSubmitting}
 										type="submit"
 									>
 										Save {isSubmitting ? '...' : ''}
-									</CButton>
+									</Button>
 
-									<CButton color="secondary" onClick={handleCancel} disabled={isSubmitting}>
+									<Button color="secondary" onClick={handleCancel} disabled={isSubmitting}>
 										Cancel
-									</CButton>
+									</Button>
 								</div>
 							</div>
 						</CCol>

--- a/webui/src/Surfaces/Remote/EditPanel.tsx
+++ b/webui/src/Surfaces/Remote/EditPanel.tsx
@@ -189,7 +189,7 @@ const SurfaceEditPanelContent = observer<SurfaceEditPanelContentProps>(function 
 										Save {isSubmitting ? '...' : ''}
 									</Button>
 
-									<Button color="secondary" onClick={handleCancel} disabled={isSubmitting}>
+									<Button type="button" color="secondary" onClick={handleCancel} disabled={isSubmitting}>
 										Cancel
 									</Button>
 								</div>

--- a/webui/src/Surfaces/Remote/RemoteSurfaces/AddRemoteSurfaceButton.tsx
+++ b/webui/src/Surfaces/Remote/RemoteSurfaces/AddRemoteSurfaceButton.tsx
@@ -70,7 +70,7 @@ function AddRemoteSurfacePopoverButton({ instanceId, label }: { instanceId: stri
 	}, [addOutboundMutation, instanceId, navigate, notifier])
 
 	return (
-		<Button onMouseDown={addCallback} color="secondary" title={`Add ${label}`} style={{ textAlign: 'left' }}>
+		<Button onMouseDown={addCallback} color="secondary" title={`Add ${label}`}>
 			{label}
 		</Button>
 	)

--- a/webui/src/Surfaces/Remote/RemoteSurfaces/AddRemoteSurfaceButton.tsx
+++ b/webui/src/Surfaces/Remote/RemoteSurfaces/AddRemoteSurfaceButton.tsx
@@ -1,9 +1,10 @@
-import { CButton, CButtonGroup, CPopover } from '@coreui/react'
+import { CButtonGroup, CPopover } from '@coreui/react'
 import { faPlus } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useNavigate } from '@tanstack/react-router'
 import { observer } from 'mobx-react-lite'
 import { useCallback, useContext } from 'react'
+import { Button } from '~/Components/Button.js'
 import type { DropdownChoiceInt } from '~/Components/DropdownChoices.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC'
 import { useComputed } from '~/Resources/util'
@@ -36,9 +37,9 @@ export const AddRemoteSurfaceButton = observer(function AddRemoteSurfaceButton()
 			placement="bottom"
 			style={{ backgroundColor: 'white' }}
 		>
-			<CButton color="primary" size="sm" title="Add Remote Surface Connection" disabled={sortedInstances.length === 0}>
+			<Button color="primary" size="sm" title="Add Remote Surface Connection" disabled={sortedInstances.length === 0}>
 				<FontAwesomeIcon icon={faPlus} /> Add Remote Surface Connection
-			</CButton>
+			</Button>
 		</CPopover>
 	)
 })
@@ -69,9 +70,9 @@ function AddRemoteSurfacePopoverButton({ instanceId, label }: { instanceId: stri
 	}, [addOutboundMutation, instanceId, navigate, notifier])
 
 	return (
-		<CButton onMouseDown={addCallback} color="secondary" title={`Add ${label}`} style={{ textAlign: 'left' }}>
+		<Button onMouseDown={addCallback} color="secondary" title={`Add ${label}`} style={{ textAlign: 'left' }}>
 			{label}
-		</CButton>
+		</Button>
 	)
 }
 

--- a/webui/src/Surfaces/Remote/RemoteSurfaces/AddRemoteSurfaceButton.tsx
+++ b/webui/src/Surfaces/Remote/RemoteSurfaces/AddRemoteSurfaceButton.tsx
@@ -1,10 +1,10 @@
-import { CButtonGroup, CPopover } from '@coreui/react'
+import { CPopover } from '@coreui/react'
 import { faPlus } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useNavigate } from '@tanstack/react-router'
 import { observer } from 'mobx-react-lite'
 import { useCallback, useContext } from 'react'
-import { Button } from '~/Components/Button.js'
+import { Button, ButtonGroup } from '~/Components/Button.js'
 import type { DropdownChoiceInt } from '~/Components/DropdownChoices.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC'
 import { useComputed } from '~/Resources/util'
@@ -84,7 +84,7 @@ const AddRemoteSurfacePopoverContent = observer(function AddRemoteSurfacePopover
 	return (
 		<>
 			{/* Note: the popover closing due to focus loss stops mouseup/click events propagating */}
-			<CButtonGroup vertical>
+			<ButtonGroup vertical>
 				{sortedInstances.map((instance) => (
 					<AddRemoteSurfacePopoverButton
 						key={instance.value}
@@ -92,7 +92,7 @@ const AddRemoteSurfacePopoverContent = observer(function AddRemoteSurfacePopover
 						label={instance.label}
 					/>
 				))}
-			</CButtonGroup>
+			</ButtonGroup>
 		</>
 	)
 })

--- a/webui/src/Surfaces/Remote/RemoteSurfaces/RemoteSurfaceTableRow.tsx
+++ b/webui/src/Surfaces/Remote/RemoteSurfaces/RemoteSurfaceTableRow.tsx
@@ -1,9 +1,9 @@
-import { CButton } from '@coreui/react'
 import { faTrash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
 import { useCallback, useContext } from 'react'
 import type { OutboundSurfaceInfo } from '@companion-app/shared/Model/Surfaces.js'
+import { Button } from '~/Components/Button.js'
 import { SwitchInputField } from '~/Components/SwitchInputField.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC.js'
 import { RootAppStoreContext } from '~/Stores/RootAppStore.js'
@@ -82,9 +82,9 @@ export const RemoteSurfaceTableRow = observer(function RemoteSurfaceTableRow({
 					tooltip={isEnabled ? `Disable surface connection` : `Enable surface connection`}
 				/>
 
-				<CButton onClick={doDelete} title="Delete" className="p-1">
+				<Button onClick={doDelete} title="Delete" className="p-1">
 					<FontAwesomeIcon icon={faTrash} />
-				</CButton>
+				</Button>
 			</div>
 		</div>
 	)

--- a/webui/src/Surfaces/Remote/RemoteSurfaces/RemoteSurfacesList.tsx
+++ b/webui/src/Surfaces/Remote/RemoteSurfaces/RemoteSurfacesList.tsx
@@ -1,4 +1,3 @@
-import { CButtonGroup } from '@coreui/react'
 import { faLayerGroup, faPlug } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useNavigate } from '@tanstack/react-router'
@@ -6,7 +5,7 @@ import { observer } from 'mobx-react-lite'
 import { useCallback, useContext, useRef } from 'react'
 import type { OutboundSurfaceCollection, OutboundSurfaceInfo } from '@companion-app/shared/Model/Surfaces.js'
 import { stringifyError } from '@companion-app/shared/Stringify.js'
-import { Button } from '~/Components/Button'
+import { Button, ButtonGroup } from '~/Components/Button'
 import { CollectionsNestingTable } from '~/Components/CollectionsNestingTable/CollectionsNestingTable.js'
 import { GenericConfirmModal, type GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
 import { NonIdealState } from '~/Components/NonIdealState.js'
@@ -71,7 +70,7 @@ export const RemoteSurfacesList = observer(function RemoteSurfacesList({
 
 				<GenericConfirmModal ref={confirmModalRef} />
 
-				<CButtonGroup size="sm" className="connection-group-actions mb-2">
+				<ButtonGroup className="connection-group-actions mb-2">
 					<AddRemoteSurfaceButton />
 					<Button
 						color="warning"
@@ -82,7 +81,7 @@ export const RemoteSurfacesList = observer(function RemoteSurfacesList({
 						Discover Remote Surfaces
 					</Button>
 					<CreateCollectionButton />
-				</CButtonGroup>
+				</ButtonGroup>
 			</div>
 
 			<div className="connections-list-table-container scrollable-content">

--- a/webui/src/Surfaces/Remote/RemoteSurfaces/RemoteSurfacesList.tsx
+++ b/webui/src/Surfaces/Remote/RemoteSurfaces/RemoteSurfacesList.tsx
@@ -1,4 +1,4 @@
-import { CButton, CButtonGroup } from '@coreui/react'
+import { CButtonGroup } from '@coreui/react'
 import { faLayerGroup, faPlug } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useNavigate } from '@tanstack/react-router'
@@ -6,6 +6,7 @@ import { observer } from 'mobx-react-lite'
 import { useCallback, useContext, useRef } from 'react'
 import type { OutboundSurfaceCollection, OutboundSurfaceInfo } from '@companion-app/shared/Model/Surfaces.js'
 import { stringifyError } from '@companion-app/shared/Stringify.js'
+import { Button } from '~/Components/Button'
 import { CollectionsNestingTable } from '~/Components/CollectionsNestingTable/CollectionsNestingTable.js'
 import { GenericConfirmModal, type GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
 import { NonIdealState } from '~/Components/NonIdealState.js'
@@ -72,14 +73,14 @@ export const RemoteSurfacesList = observer(function RemoteSurfacesList({
 
 				<CButtonGroup size="sm" className="connection-group-actions mb-2">
 					<AddRemoteSurfaceButton />
-					<CButton
+					<Button
 						color="warning"
 						className="d-xl-none"
 						onClick={() => void navigate({ to: '/surfaces/remote/discover' })}
 					>
 						<FontAwesomeIcon icon={faPlug} className="me-1" />
 						Discover Remote Surfaces
-					</CButton>
+					</Button>
 					<CreateCollectionButton />
 				</CButtonGroup>
 			</div>
@@ -157,8 +158,8 @@ function CreateCollectionButton() {
 	}, [createMutation])
 
 	return (
-		<CButton color="info" size="sm" onClick={doCreateCollection}>
+		<Button color="info" size="sm" onClick={doCreateCollection}>
 			<FontAwesomeIcon icon={faLayerGroup} /> Create Collection
-		</CButton>
+		</Button>
 	)
 }

--- a/webui/src/TabletView/ConfigurePanel.tsx
+++ b/webui/src/TabletView/ConfigurePanel.tsx
@@ -1,8 +1,9 @@
-import { CButton, CCol, CForm, CFormInput, CRow } from '@coreui/react'
+import { CCol, CForm, CFormInput, CRow } from '@coreui/react'
 import { faCog, faExpand } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useState } from 'react'
 import type { UserConfigGridSize } from '@companion-app/shared/Model/UserConfigModel.js'
+import { Button } from '~/Components/Button'
 import { CheckboxInputFieldWithLabel } from '~/Components/CheckboxInputField'
 import { PreventDefaultHandler, useMountEffect } from '~/Resources/util.js'
 
@@ -30,9 +31,9 @@ export function ConfigurePanel({ updateQueryUrl, query, gridSize }: ConfigurePan
 			<CCol sm={12}>
 				<h3>
 					Configure Buttons View
-					<CButton className="close-config" onClick={() => setShow(false)} title="Close">
+					<Button className="close-config" onClick={() => setShow(false)} title="Close">
 						<FontAwesomeIcon icon={faCog} />
-					</CButton>
+					</Button>
 				</h3>
 				<CForm onSubmit={PreventDefaultHandler}>
 					<CRow>
@@ -115,7 +116,7 @@ export function ConfigurePanel({ updateQueryUrl, query, gridSize }: ConfigurePan
 		<CRow className="header">
 			<CCol xs={12}>
 				{(!fullscreen || !query['noconfigure']) && !query['nofullscreen'] && (
-					<CButton
+					<Button
 						onClick={() => {
 							document.documentElement.requestFullscreen().catch((err) => {
 								console.error('Error attempting to enable full-screen mode:', err)
@@ -125,12 +126,12 @@ export function ConfigurePanel({ updateQueryUrl, query, gridSize }: ConfigurePan
 						title="Fullscreen"
 					>
 						<FontAwesomeIcon icon={faExpand} />
-					</CButton>
+					</Button>
 				)}
 				{!query['noconfigure'] && (
-					<CButton className="open-config" onClick={() => setShow(true)} title="Configure">
+					<Button className="open-config" onClick={() => setShow(true)} title="Configure">
 						<FontAwesomeIcon icon={faCog} />
-					</CButton>
+					</Button>
 				)}
 			</CCol>
 		</CRow>

--- a/webui/src/Triggers/EditPanel.tsx
+++ b/webui/src/Triggers/EditPanel.tsx
@@ -1,9 +1,10 @@
-import { CButton, CCol, CForm, CFormLabel, CInputGroup } from '@coreui/react'
+import { CCol, CForm, CFormLabel, CInputGroup } from '@coreui/react'
 import { useCallback, useRef } from 'react'
 import type { JsonValue } from 'type-fest'
 import { EntityModelType, FeedbackEntitySubType } from '@companion-app/shared/Model/EntityModel.js'
 import type { TriggerModel, TriggerOptions } from '@companion-app/shared/Model/TriggerModel.js'
 import { StaticAlert } from '~/Components/Alert.js'
+import { Button } from '~/Components/Button'
 import { GenericConfirmModal, type GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
 import { InlineHelpIcon } from '~/Components/InlineHelp.js'
 import { TextInputField } from '~/Components/TextInputField.js'
@@ -184,8 +185,8 @@ function TestActionsButton({ controlId, hidden }: { controlId: string; hidden: b
 		testActionsMutation.mutateAsync({ controlId }).catch((e) => console.error(`Hot press failed: ${e}`))
 	}, [testActionsMutation, controlId])
 	return (
-		<CButton color="warning" hidden={hidden} onMouseDown={hotPressDown}>
+		<Button color="warning" hidden={hidden} onMouseDown={hotPressDown}>
 			Test actions
-		</CButton>
+		</Button>
 	)
 }

--- a/webui/src/Triggers/EventEditor.tsx
+++ b/webui/src/Triggers/EventEditor.tsx
@@ -1,4 +1,4 @@
-import { CButtonGroup, CCol, CForm } from '@coreui/react'
+import { CCol, CForm } from '@coreui/react'
 import {
 	faClone,
 	faCompressArrowsAlt,
@@ -16,7 +16,7 @@ import { getEmptyImage } from 'react-dnd-html5-backend'
 import type { JsonValue } from 'type-fest'
 import type { EventInstance } from '@companion-app/shared/Model/EventModel.js'
 import { optionsObjectToExpressionOptions, type ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
-import { Button } from '~/Components/Button'
+import { Button, ButtonGroup } from '~/Components/Button'
 import { GenericConfirmModal, type GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
 import { SwitchInputField } from '~/Components/SwitchInputField.js'
 import { TextInputField } from '~/Components/TextInputField.js'
@@ -66,20 +66,18 @@ export const TriggerEventEditor = observer(function TriggerEventEditor({
 			<h4 className="mt-3">
 				{heading}
 				{events.length > 1 && (
-					<CButtonGroup className="right">
-						<CButtonGroup>
-							{panelCollapseHelper.canExpandAll() && (
-								<Button size="sm" onClick={panelCollapseHelper.setAllExpanded} title="Expand all events">
-									<FontAwesomeIcon icon={faExpandArrowsAlt} />
-								</Button>
-							)}
-							{panelCollapseHelper.canCollapseAll() && (
-								<Button size="sm" onClick={panelCollapseHelper.setAllCollapsed} title="Collapse all events">
-									<FontAwesomeIcon icon={faCompressArrowsAlt} />
-								</Button>
-							)}
-						</CButtonGroup>
-					</CButtonGroup>
+					<ButtonGroup className="right">
+						{panelCollapseHelper.canExpandAll() && (
+							<Button size="sm" onClick={panelCollapseHelper.setAllExpanded} title="Expand all events">
+								<FontAwesomeIcon icon={faExpandArrowsAlt} />
+							</Button>
+						)}
+						{panelCollapseHelper.canCollapseAll() && (
+							<Button size="sm" onClick={panelCollapseHelper.setAllCollapsed} title="Collapse all events">
+								<FontAwesomeIcon icon={faCompressArrowsAlt} />
+							</Button>
+						)}
+					</ButtonGroup>
 				)}
 			</h4>
 
@@ -374,7 +372,7 @@ const EventEditor = observer(function EventEditor({
 				</div>
 
 				<div className="cell-controls">
-					<CButtonGroup className="me-1">
+					<ButtonGroup className="me-1">
 						{canSetHeadline && !headlineExpanded && (
 							<Button size="sm" onClick={doEditHeadline} title="Set headline">
 								<FontAwesomeIcon icon={faPencil} />
@@ -406,7 +404,7 @@ const EventEditor = observer(function EventEditor({
 								/>
 							</>
 						)}
-					</CButtonGroup>
+					</ButtonGroup>
 				</div>
 			</div>
 

--- a/webui/src/Triggers/EventEditor.tsx
+++ b/webui/src/Triggers/EventEditor.tsx
@@ -1,4 +1,4 @@
-import { CButton, CButtonGroup, CCol, CForm } from '@coreui/react'
+import { CButtonGroup, CCol, CForm } from '@coreui/react'
 import {
 	faClone,
 	faCompressArrowsAlt,
@@ -16,6 +16,7 @@ import { getEmptyImage } from 'react-dnd-html5-backend'
 import type { JsonValue } from 'type-fest'
 import type { EventInstance } from '@companion-app/shared/Model/EventModel.js'
 import { optionsObjectToExpressionOptions, type ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
+import { Button } from '~/Components/Button'
 import { GenericConfirmModal, type GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
 import { SwitchInputField } from '~/Components/SwitchInputField.js'
 import { TextInputField } from '~/Components/TextInputField.js'
@@ -68,14 +69,14 @@ export const TriggerEventEditor = observer(function TriggerEventEditor({
 					<CButtonGroup className="right">
 						<CButtonGroup>
 							{panelCollapseHelper.canExpandAll() && (
-								<CButton size="sm" onClick={panelCollapseHelper.setAllExpanded} title="Expand all events">
+								<Button size="sm" onClick={panelCollapseHelper.setAllExpanded} title="Expand all events">
 									<FontAwesomeIcon icon={faExpandArrowsAlt} />
-								</CButton>
+								</Button>
 							)}
 							{panelCollapseHelper.canCollapseAll() && (
-								<CButton size="sm" onClick={panelCollapseHelper.setAllCollapsed} title="Collapse all events">
+								<Button size="sm" onClick={panelCollapseHelper.setAllCollapsed} title="Collapse all events">
 									<FontAwesomeIcon icon={faCompressArrowsAlt} />
-								</CButton>
+								</Button>
 							)}
 						</CButtonGroup>
 					</CButtonGroup>
@@ -375,25 +376,25 @@ const EventEditor = observer(function EventEditor({
 				<div className="cell-controls">
 					<CButtonGroup className="me-1">
 						{canSetHeadline && !headlineExpanded && (
-							<CButton size="sm" onClick={doEditHeadline} title="Set headline">
+							<Button size="sm" onClick={doEditHeadline} title="Set headline">
 								<FontAwesomeIcon icon={faPencil} />
-							</CButton>
+							</Button>
 						)}
 						{isCollapsed ? (
-							<CButton size="sm" onClick={doExpand} title="Expand event view">
+							<Button size="sm" onClick={doExpand} title="Expand event view">
 								<FontAwesomeIcon icon={faExpandArrowsAlt} />
-							</CButton>
+							</Button>
 						) : (
-							<CButton size="sm" onClick={doCollapse} title="Collapse event view">
+							<Button size="sm" onClick={doCollapse} title="Collapse event view">
 								<FontAwesomeIcon icon={faCompressArrowsAlt} />
-							</CButton>
+							</Button>
 						)}
-						<CButton size="sm" onClick={service.performDuplicate} title="Duplicate event">
+						<Button size="sm" onClick={service.performDuplicate} title="Duplicate event">
 							<FontAwesomeIcon icon={faClone} />
-						</CButton>
-						<CButton size="sm" onClick={service.performDelete} title="Remove event">
+						</Button>
+						<Button size="sm" onClick={service.performDelete} title="Remove event">
 							<FontAwesomeIcon icon={faTrash} />
-						</CButton>
+						</Button>
 						{!!service.setEnabled && (
 							<>
 								&nbsp;

--- a/webui/src/Triggers/Page.tsx
+++ b/webui/src/Triggers/Page.tsx
@@ -1,4 +1,4 @@
-import { CButton, CButtonGroup, CCol, CFormInput, CInputGroup, CRow } from '@coreui/react'
+import { CButtonGroup, CCol, CFormInput, CInputGroup, CRow } from '@coreui/react'
 import {
 	faAdd,
 	faClone,
@@ -20,6 +20,7 @@ import sanitizeHtml from 'sanitize-html'
 import { CreateTriggerControlId, ParseControlId } from '@companion-app/shared/ControlId.js'
 import type { ClientTriggerData, TriggerCollection } from '@companion-app/shared/Model/TriggerModel.js'
 import { stringifyError } from '@companion-app/shared/Stringify.js'
+import { Button, LinkButtonExternal } from '~/Components/Button'
 import { CollectionsNestingTable } from '~/Components/CollectionsNestingTable/CollectionsNestingTable'
 import { ConfirmExportModal, type ConfirmExportModalRef } from '~/Components/ConfirmExportModal.js'
 import { GenericConfirmModal, type GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
@@ -137,15 +138,15 @@ export const TriggersPage = observer(function Triggers() {
 
 						<div className="mb-2">
 							<CButtonGroup>
-								<CButton color="primary" onClick={doAddNew} size="sm">
+								<Button color="primary" onClick={doAddNew} size="sm">
 									<FontAwesomeIcon icon={faAdd} /> Add Trigger
-								</CButton>
+								</Button>
 								<CreateCollectionButton />
 							</CButtonGroup>
 
-							<CButton color="secondary" className="right" size="sm" onClick={showExportModal}>
+							<Button color="secondary" className="right" size="sm" onClick={showExportModal}>
 								<FontAwesomeIcon icon={faFileExport} /> Export all
-							</CButton>
+							</Button>
 						</div>
 
 						<CInputGroup className="variables-table-filter mt-2">
@@ -156,9 +157,9 @@ export const TriggersPage = observer(function Triggers() {
 								value={filter}
 								style={{ fontSize: '1.2em' }}
 							/>
-							<CButton color="danger" onClick={clearFilter}>
+							<Button color="danger" onClick={clearFilter}>
 								<FontAwesomeIcon icon={faTimes} />
-							</CButton>
+							</Button>
 						</CInputGroup>
 					</div>
 
@@ -318,20 +319,19 @@ const TriggersTableRow = observer(function TriggersTableRow2({ item }: TriggersT
 						}
 					/>
 
-					<CButton
+					<LinkButtonExternal
 						color="white"
 						href={makeAbsolutePath(`/int/export/triggers/single/${item.id}`)}
-						target="_blank"
 						title="Export"
 					>
 						<FontAwesomeIcon icon={faDownload} />
-					</CButton>
-					<CButton color="white" onClick={doClone} title="Clone">
+					</LinkButtonExternal>
+					<Button color="white" onClick={doClone} title="Clone">
 						<FontAwesomeIcon icon={faClone} />
-					</CButton>
-					<CButton color="gray" onClick={doDelete} title="Delete">
+					</Button>
+					<Button color="gray" onClick={doDelete} title="Delete">
 						<FontAwesomeIcon icon={faTrash} />
-					</CButton>
+					</Button>
 				</CButtonGroup>
 			</div>
 		</div>
@@ -348,9 +348,9 @@ function CreateCollectionButton() {
 	}, [createMutation])
 
 	return (
-		<CButton color="info" size="sm" onClick={doCreateCollection}>
+		<Button color="info" size="sm" onClick={doCreateCollection}>
 			<FontAwesomeIcon icon={faLayerGroup} /> Create Collection
-		</CButton>
+		</Button>
 	)
 }
 

--- a/webui/src/Triggers/Page.tsx
+++ b/webui/src/Triggers/Page.tsx
@@ -127,7 +127,7 @@ export const TriggersPage = observer(function Triggers() {
 			<CCol xs={twoPanelMode ? 6 : 12} className={classnames('primary-panel', showPrimaryPanel ? 'd-block' : 'd-none')}>
 				<div className="flex-column-layout">
 					<div className="fixed-header">
-						<h4 className="btn-inline">
+						<h4 className="button-inline">
 							Triggers
 							<ContextHelpButton action="/user-guide/config/triggers" />
 						</h4>
@@ -157,7 +157,7 @@ export const TriggersPage = observer(function Triggers() {
 								value={filter}
 								style={{ fontSize: '1.2em' }}
 							/>
-							<Button color="danger" onClick={clearFilter}>
+							<Button color="primary" onClick={clearFilter}>
 								<FontAwesomeIcon icon={faTimes} />
 							</Button>
 						</CInputGroup>
@@ -319,17 +319,13 @@ const TriggersTableRow = observer(function TriggersTableRow2({ item }: TriggersT
 						}
 					/>
 
-					<LinkButtonExternal
-						color="white"
-						href={makeAbsolutePath(`/int/export/triggers/single/${item.id}`)}
-						title="Export"
-					>
+					<LinkButtonExternal href={makeAbsolutePath(`/int/export/triggers/single/${item.id}`)} title="Export">
 						<FontAwesomeIcon icon={faDownload} />
 					</LinkButtonExternal>
-					<Button color="white" onClick={doClone} title="Clone">
+					<Button onClick={doClone} title="Clone">
 						<FontAwesomeIcon icon={faClone} />
 					</Button>
-					<Button color="gray" onClick={doDelete} title="Delete">
+					<Button onClick={doDelete} title="Delete">
 						<FontAwesomeIcon icon={faTrash} />
 					</Button>
 				</ButtonGroup>

--- a/webui/src/Triggers/Page.tsx
+++ b/webui/src/Triggers/Page.tsx
@@ -1,4 +1,4 @@
-import { CButtonGroup, CCol, CFormInput, CInputGroup, CRow } from '@coreui/react'
+import { CCol, CFormInput, CInputGroup, CRow } from '@coreui/react'
 import {
 	faAdd,
 	faClone,
@@ -20,7 +20,7 @@ import sanitizeHtml from 'sanitize-html'
 import { CreateTriggerControlId, ParseControlId } from '@companion-app/shared/ControlId.js'
 import type { ClientTriggerData, TriggerCollection } from '@companion-app/shared/Model/TriggerModel.js'
 import { stringifyError } from '@companion-app/shared/Stringify.js'
-import { Button, LinkButtonExternal } from '~/Components/Button'
+import { Button, ButtonGroup, LinkButtonExternal } from '~/Components/Button'
 import { CollectionsNestingTable } from '~/Components/CollectionsNestingTable/CollectionsNestingTable'
 import { ConfirmExportModal, type ConfirmExportModalRef } from '~/Components/ConfirmExportModal.js'
 import { GenericConfirmModal, type GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
@@ -137,12 +137,12 @@ export const TriggersPage = observer(function Triggers() {
 						</p>
 
 						<div className="mb-2">
-							<CButtonGroup>
+							<ButtonGroup>
 								<Button color="primary" onClick={doAddNew} size="sm">
 									<FontAwesomeIcon icon={faAdd} /> Add Trigger
 								</Button>
 								<CreateCollectionButton />
-							</CButtonGroup>
+							</ButtonGroup>
 
 							<Button color="secondary" className="right" size="sm" onClick={showExportModal}>
 								<FontAwesomeIcon icon={faFileExport} /> Export all
@@ -309,7 +309,7 @@ const TriggersTableRow = observer(function TriggersTableRow2({ item }: TriggersT
 				{item.lastExecuted ? <small>Last run: {dayjs(item.lastExecuted).format(tableDateFormat)}</small> : ''}
 			</div>
 			<div className="action-buttons w-auto">
-				<CButtonGroup className="ms-1">
+				<ButtonGroup className="ms-1">
 					<SwitchInputField
 						value={item.enabled}
 						setValue={doEnableDisable}
@@ -332,7 +332,7 @@ const TriggersTableRow = observer(function TriggersTableRow2({ item }: TriggersT
 					<Button color="gray" onClick={doDelete} title="Delete">
 						<FontAwesomeIcon icon={faTrash} />
 					</Button>
-				</CButtonGroup>
+				</ButtonGroup>
 			</div>
 		</div>
 	)

--- a/webui/src/Triggers/Page.tsx
+++ b/webui/src/Triggers/Page.tsx
@@ -157,7 +157,12 @@ export const TriggersPage = observer(function Triggers() {
 								value={filter}
 								style={{ fontSize: '1.2em' }}
 							/>
-							<Button color="primary" onClick={clearFilter}>
+							<Button
+								color="primary"
+								onClick={clearFilter}
+								aria-label="Clear search filter"
+								title="Clear search filter"
+							>
 								<FontAwesomeIcon icon={faTimes} />
 							</Button>
 						</CInputGroup>

--- a/webui/src/UserConfig/BackupRuleEditor.tsx
+++ b/webui/src/UserConfig/BackupRuleEditor.tsx
@@ -1,10 +1,11 @@
-import { CButton, CCol, CForm, CFormLabel, CInputGroup } from '@coreui/react'
+import { CCol, CForm, CFormLabel, CInputGroup } from '@coreui/react'
 import { faTrash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
 import { useCallback, useContext } from 'react'
 import type { BackupRulesConfig, PreviousBackupInfo } from '@companion-app/shared/Model/UserConfigModel.js'
 import { StaticAlert } from '~/Components/Alert.js'
+import { Button } from '~/Components/Button'
 import { SimpleDropdownInputField } from '~/Components/DropdownInputFieldSimple.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC.js'
 import { NumberInputField } from '../Components/NumberInputField.js'
@@ -63,9 +64,9 @@ const PreviousBackupRow = observer(function PreviousBackupRow({ backup, ruleId }
 				</small>
 			</td>
 			<td className="no-wrap" style={{ verticalAlign: 'middle' }}>
-				<CButton color="danger" size="sm" onClick={deleteBackup} title="Delete backup">
+				<Button color="danger" size="sm" onClick={deleteBackup} title="Delete backup">
 					<FontAwesomeIcon icon={faTrash} />
-				</CButton>
+				</Button>
 			</td>
 		</tr>
 	)
@@ -120,9 +121,9 @@ export const BackupRuleEditor = observer(function BackupRuleEditor({ ruleId }: B
 			<CCol className={`fieldtype-textinput`} sm={8}>
 				<CInputGroup>
 					<TextInputField value={rule.name} setValue={(value) => updateField('name', value)} />
-					<CButton color="warning" onClick={runNow}>
+					<Button color="warning" onClick={runNow}>
 						Run Now
-					</CButton>
+					</Button>
 				</CInputGroup>
 			</CCol>
 

--- a/webui/src/UserConfig/Components/Common.tsx
+++ b/webui/src/UserConfig/Components/Common.tsx
@@ -1,7 +1,7 @@
-import { CButton } from '@coreui/react'
 import { faUndo } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import type { UserConfigModel } from '@companion-app/shared/Model/UserConfigModel.js'
+import { Button } from '~/Components/Button.js'
 
 export interface UserConfigProps {
 	config: UserConfigModel
@@ -17,8 +17,8 @@ interface ResetButtonProps {
 
 export function ResetButton({ userConfig, field }: ResetButtonProps): React.JSX.Element {
 	return (
-		<CButton onClick={() => userConfig.resetValue(field)} title="Reset to default">
+		<Button onClick={() => userConfig.resetValue(field)} title="Reset to default">
 			<FontAwesomeIcon icon={faUndo} />
-		</CButton>
+		</Button>
 	)
 }

--- a/webui/src/UserConfig/Sections/ArtnetProtocol.tsx
+++ b/webui/src/UserConfig/Sections/ArtnetProtocol.tsx
@@ -1,30 +1,25 @@
-import { CButton } from '@coreui/react'
 import { faFileImport } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { LinkButtonExternal } from '~/Components/Button'
 import { makeAbsolutePath } from '~/Resources/util'
 
 export function ArtnetProtocol(): React.JSX.Element {
 	return (
 		<>
 			<div className="my-3">
-				<CButton
-					color="success"
-					href={makeAbsolutePath('/Bitfocus_Companion_v20.d4')}
-					target="_blank"
-					rel="noopener noreferrer"
-				>
+				<LinkButtonExternal color="success" href={makeAbsolutePath('/Bitfocus_Companion_v20.d4')}>
 					<FontAwesomeIcon icon={faFileImport} /> Download Avolites Fixture file (v2.0)
-				</CButton>
+				</LinkButtonExternal>
 			</div>
 			<div className="my-3">
-				<CButton color="success" href={makeAbsolutePath('/bitfocus@companion_v2.0@00.xml')} target="_blank">
+				<LinkButtonExternal color="success" href={makeAbsolutePath('/bitfocus@companion_v2.0@00.xml')}>
 					<FontAwesomeIcon icon={faFileImport} /> Download GrandMA2 Fixture file (v2.0)
-				</CButton>
+				</LinkButtonExternal>
 			</div>
 			<div className="my-3">
-				<CButton color="success" href={makeAbsolutePath('/Bitfocus Companion Fixture.v3f')} target="_blank">
+				<LinkButtonExternal color="success" href={makeAbsolutePath('/Bitfocus Companion Fixture.v3f')}>
 					<FontAwesomeIcon icon={faFileImport} /> Download Vista Fixture file (v2.0)
-				</CButton>
+				</LinkButtonExternal>
 			</div>
 		</>
 	)

--- a/webui/src/UserConfig/Sections/DataCollection.tsx
+++ b/webui/src/UserConfig/Sections/DataCollection.tsx
@@ -1,6 +1,6 @@
-import { CButton } from '@coreui/react'
 import { observer } from 'mobx-react-lite'
 import { useState } from 'react'
+import { Button } from '~/Components/Button.js'
 import type { UserConfigProps } from '../Components/Common.js'
 import { UserConfigHeadingRow } from '../Components/UserConfigHeadingRow.js'
 import { UserConfigSwitchRow } from '../Components/UserConfigSwitchRow.js'
@@ -35,9 +35,9 @@ export const DataCollectionConfig = observer(function DataCollectionConfig(props
 			<tr>
 				<td>View data being collected</td>
 				<td className="text-end">
-					<CButton color="primary" size="sm" onClick={() => setShowModal(true)} className="uc-button">
+					<Button color="primary" size="sm" onClick={() => setShowModal(true)} className="uc-button">
 						View Data
-					</CButton>
+					</Button>
 				</td>
 				<td></td>
 			</tr>

--- a/webui/src/UserConfig/Sections/GridConfig.tsx
+++ b/webui/src/UserConfig/Sections/GridConfig.tsx
@@ -1,8 +1,9 @@
-import { CButton, CCol, CForm, CFormLabel, CModal, CModalBody, CModalFooter, CModalHeader } from '@coreui/react'
+import { CCol, CForm, CFormLabel, CModal, CModalBody, CModalFooter, CModalHeader } from '@coreui/react'
 import { observer } from 'mobx-react-lite'
 import React, { useCallback, useContext, useEffect, useImperativeHandle, useRef, useState } from 'react'
 import type { UserConfigGridSize } from '@companion-app/shared/Model/UserConfigModel.js'
 import { StaticAlert } from '~/Components/Alert.js'
+import { Button } from '~/Components/Button.js'
 import { NumberInputField } from '~/Components/NumberInputField.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC.js'
 import { RootAppStoreContext } from '~/Stores/RootAppStore.js'
@@ -32,9 +33,9 @@ export const GridConfigRows = observer(function GridConfigRows(props: GridConfig
 							{props.config.gridSize.maxRow - props.config.gridSize.minRow + 1} rows x{' '}
 							{props.config.gridSize.maxColumn - props.config.gridSize.minColumn + 1} columns
 						</div>
-						<CButton onClick={editGridSize} color="secondary" size="sm" style={{ marginTop: 4 }}>
+						<Button onClick={editGridSize} color="secondary" size="sm" style={{ marginTop: 4 }}>
 							Edit size
-						</CButton>
+						</Button>
 					</>
 				}
 			/>
@@ -231,12 +232,12 @@ export const GridSizeModal = observer<object, GridSizeModalRef>(
 					)}
 				</CModalBody>
 				<CModalFooter>
-					<CButton color="secondary" onClick={doClose}>
+					<Button color="secondary" onClick={doClose}>
 						Cancel
-					</CButton>
-					<CButton ref={buttonRef} color="primary" onClick={doAction}>
+					</Button>
+					<Button ref={buttonRef} color="primary" onClick={doAction}>
 						Save
-					</CButton>
+					</Button>
 				</CModalFooter>
 			</CModal>
 		)

--- a/webui/src/UserConfig/Sections/GridConfig.tsx
+++ b/webui/src/UserConfig/Sections/GridConfig.tsx
@@ -33,7 +33,7 @@ export const GridConfigRows = observer(function GridConfigRows(props: GridConfig
 							{props.config.gridSize.maxRow - props.config.gridSize.minRow + 1} rows x{' '}
 							{props.config.gridSize.maxColumn - props.config.gridSize.minColumn + 1} columns
 						</div>
-						<Button onClick={editGridSize} color="secondary" size="sm" style={{ marginTop: 4 }}>
+						<Button onClick={editGridSize} color="secondary" size="sm" className="mt-1">
 							Edit size
 						</Button>
 					</>

--- a/webui/src/UserConfig/Sections/HttpsConfig.tsx
+++ b/webui/src/UserConfig/Sections/HttpsConfig.tsx
@@ -1,9 +1,10 @@
-import { CButton, CDropdown, CDropdownItem, CDropdownMenu, CDropdownToggle } from '@coreui/react'
+import { CDropdown, CDropdownItem, CDropdownMenu, CDropdownToggle } from '@coreui/react'
 import { faSync, faTrash, faUndo } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
 import { useCallback } from 'react'
 import { StaticAlert } from '~/Components/Alert.js'
+import { Button } from '~/Components/Button'
 import { trpc, useMutationExt } from '~/Resources/TRPC.js'
 import type { UserConfigProps } from '../Components/Common.js'
 import { UserConfigHeadingRow } from '../Components/UserConfigHeadingRow.js'
@@ -72,9 +73,9 @@ export const HttpsConfig = observer(function HttpsConfig(props: UserConfigProps)
 							</CDropdown>
 						</td>
 						<td>
-							<CButton onClick={() => props.resetValue('https_cert_type')} title="Reset to default">
+							<Button onClick={() => props.resetValue('https_cert_type')} title="Reset to default">
 								<FontAwesomeIcon icon={faUndo} />
-							</CButton>
+							</Button>
 						</td>
 					</tr>
 
@@ -119,21 +120,21 @@ export const HttpsConfig = observer(function HttpsConfig(props: UserConfigProps)
 											<td>
 												{props.config.https_self_cert && props.config.https_self_cert.length > 0 ? (
 													<div className="my-3">
-														<CButton onClick={renewSslCertificate} color="success" className="mb-2">
+														<Button onClick={renewSslCertificate} color="success" className="mb-2">
 															<FontAwesomeIcon icon={faSync} />
 															&nbsp;Renew
-														</CButton>
+														</Button>
 														<br />
-														<CButton onClick={deleteSslCertificate} color="danger">
+														<Button onClick={deleteSslCertificate} color="danger">
 															<FontAwesomeIcon icon={faTrash} />
 															&nbsp;Delete
-														</CButton>
+														</Button>
 													</div>
 												) : (
-													<CButton onClick={createSslCertificate} color="success">
+													<Button onClick={createSslCertificate} color="success">
 														<FontAwesomeIcon icon={faSync} />
 														&nbsp;Generate
-													</CButton>
+													</Button>
 												)}
 											</td>
 											<td>&nbsp;</td>

--- a/webui/src/UserConfig/backups.tsx
+++ b/webui/src/UserConfig/backups.tsx
@@ -1,4 +1,4 @@
-import { CButtonGroup, CCol, CRow } from '@coreui/react'
+import { CCol, CRow } from '@coreui/react'
 import { faAdd, faSort, faTrash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Outlet, useMatchRoute, useNavigate } from '@tanstack/react-router'
@@ -8,7 +8,7 @@ import { observer } from 'mobx-react-lite'
 import { useCallback, useContext, useRef } from 'react'
 import { useDrag, useDrop } from 'react-dnd'
 import type { BackupRulesConfig } from '@companion-app/shared/Model/UserConfigModel.js'
-import { Button } from '~/Components/Button'
+import { Button, ButtonGroup } from '~/Components/Button'
 import { SwitchInputField } from '~/Components/SwitchInputField.js'
 import { ContextHelpButton } from '~/Layout/PanelIcons.js'
 import { checkDragState, type DragState } from '~/Resources/DragAndDrop.js'
@@ -69,11 +69,11 @@ export const SettingsBackupsPage = observer(function UserConfig() {
 						</div>
 
 						<div className="mb-2">
-							<CButtonGroup>
+							<ButtonGroup>
 								<Button color="primary" onClick={doAddNew} size="sm">
 									<FontAwesomeIcon icon={faAdd} /> Add Backup Rule
 								</Button>
-							</CButtonGroup>
+							</ButtonGroup>
 						</div>
 					</div>
 
@@ -238,7 +238,7 @@ function BackupsTableRow({ rule, editRule, moveRule }: BackupsTableRowProps) {
 				{rule.lastRan ? <small>Last run: {dayjs(rule.lastRan).format('MM/DD HH:mm:ss')}</small> : ''}
 			</td>
 			<td className="action-buttons">
-				<CButtonGroup className="ms-2">
+				<ButtonGroup className="ms-2">
 					<SwitchInputField
 						value={rule.enabled}
 						setValue={doEnableDisable}
@@ -248,7 +248,7 @@ function BackupsTableRow({ rule, editRule, moveRule }: BackupsTableRowProps) {
 					<Button color="gray" onClick={doDelete} title="Delete">
 						<FontAwesomeIcon icon={faTrash} />
 					</Button>
-				</CButtonGroup>
+				</ButtonGroup>
 			</td>
 		</tr>
 	)

--- a/webui/src/UserConfig/backups.tsx
+++ b/webui/src/UserConfig/backups.tsx
@@ -57,7 +57,7 @@ export const SettingsBackupsPage = observer(function UserConfig() {
 					<div className="fixed-header">
 						<div className="d-flex justify-content-between">
 							<div>
-								<h4 className="btn-inline">
+								<h4 className="button-inline">
 									Settings - Backups
 									<ContextHelpButton action="/user-guide/config/settings#backups">
 										Companion can back itself up on a schedule to multiple directories if desired. These backups can be
@@ -245,7 +245,7 @@ function BackupsTableRow({ rule, editRule, moveRule }: BackupsTableRowProps) {
 						tooltip={rule.enabled ? 'Disable rule' : 'Enable rule'}
 					/>
 
-					<Button color="gray" onClick={doDelete} title="Delete">
+					<Button onClick={doDelete} title="Delete">
 						<FontAwesomeIcon icon={faTrash} />
 					</Button>
 				</ButtonGroup>

--- a/webui/src/UserConfig/backups.tsx
+++ b/webui/src/UserConfig/backups.tsx
@@ -1,4 +1,4 @@
-import { CButton, CButtonGroup, CCol, CRow } from '@coreui/react'
+import { CButtonGroup, CCol, CRow } from '@coreui/react'
 import { faAdd, faSort, faTrash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Outlet, useMatchRoute, useNavigate } from '@tanstack/react-router'
@@ -8,6 +8,7 @@ import { observer } from 'mobx-react-lite'
 import { useCallback, useContext, useRef } from 'react'
 import { useDrag, useDrop } from 'react-dnd'
 import type { BackupRulesConfig } from '@companion-app/shared/Model/UserConfigModel.js'
+import { Button } from '~/Components/Button'
 import { SwitchInputField } from '~/Components/SwitchInputField.js'
 import { ContextHelpButton } from '~/Layout/PanelIcons.js'
 import { checkDragState, type DragState } from '~/Resources/DragAndDrop.js'
@@ -69,9 +70,9 @@ export const SettingsBackupsPage = observer(function UserConfig() {
 
 						<div className="mb-2">
 							<CButtonGroup>
-								<CButton color="primary" onClick={doAddNew} size="sm">
+								<Button color="primary" onClick={doAddNew} size="sm">
 									<FontAwesomeIcon icon={faAdd} /> Add Backup Rule
-								</CButton>
+								</Button>
 							</CButtonGroup>
 						</div>
 					</div>
@@ -244,9 +245,9 @@ function BackupsTableRow({ rule, editRule, moveRule }: BackupsTableRowProps) {
 						tooltip={rule.enabled ? 'Disable rule' : 'Enable rule'}
 					/>
 
-					<CButton color="gray" onClick={doDelete} title="Delete">
+					<Button color="gray" onClick={doDelete} title="Delete">
 						<FontAwesomeIcon icon={faTrash} />
-					</CButton>
+					</Button>
 				</CButtonGroup>
 			</td>
 		</tr>

--- a/webui/src/UserConfig/protocols.tsx
+++ b/webui/src/UserConfig/protocols.tsx
@@ -28,7 +28,7 @@ export const SettingsProtocolsPage = memo(function UserConfig() {
 					<div className="fixed-header">
 						<div className="d-flex justify-content-between">
 							<div>
-								<h4 className="btn-inline">
+								<h4 className="button-inline">
 									Settings - Protocols
 									<ContextHelpButton action="/user-guide/config/settings#protocols" />
 								</h4>

--- a/webui/src/Variables/CustomVariablesList.tsx
+++ b/webui/src/Variables/CustomVariablesList.tsx
@@ -94,7 +94,7 @@ export const CustomVariablesListPage = observer(function CustomVariablesList() {
 
 			<PanelCollapseHelperProvider storageId="custom_variables" knownPanelIds={allVariableNames}>
 				<div>
-					<h4 className="btn-inline">
+					<h4 className="button-inline">
 						Custom Variables
 						<ContextHelpButton action="/user-guide/config/variables#custom-variables" />
 					</h4>
@@ -125,7 +125,7 @@ export const CustomVariablesListPage = observer(function CustomVariablesList() {
 						value={filter}
 						style={{ fontSize: '1.2em' }}
 					/>
-					<Button color="danger" onClick={clearFilter}>
+					<Button color="primary" onClick={clearFilter}>
 						<FontAwesomeIcon icon={faTimes} />
 					</Button>
 				</CInputGroup>

--- a/webui/src/Variables/CustomVariablesList.tsx
+++ b/webui/src/Variables/CustomVariablesList.tsx
@@ -1,4 +1,4 @@
-import { CButtonGroup, CForm, CFormInput, CInputGroup } from '@coreui/react'
+import { CForm, CFormInput, CInputGroup } from '@coreui/react'
 import {
 	faArrowLeft,
 	faCompressArrowsAlt,
@@ -12,7 +12,7 @@ import { observer } from 'mobx-react-lite'
 import { useCallback, useContext, useRef, useState } from 'react'
 import { isCustomVariableValid } from '@companion-app/shared/CustomVariable.js'
 import type { CustomVariableDefinition } from '@companion-app/shared/Model/CustomVariableModel.js'
-import { Button, LinkButton } from '~/Components/Button'
+import { Button, ButtonGroup, LinkButton } from '~/Components/Button'
 import {
 	CollectionsNestingTable,
 	UNGROUPED_PANEL_ID,
@@ -102,19 +102,19 @@ export const CustomVariablesListPage = observer(function CustomVariablesList() {
 						Here you can create some variables which you can define the values of, and update with actions
 					</p>
 
-					<CButtonGroup size="sm">
-						<LinkButton color="primary" to="/variables">
+					<ButtonGroup>
+						<LinkButton color="primary" size="sm" to="/variables">
 							<FontAwesomeIcon icon={faArrowLeft} />
 							&nbsp; Go back
 						</LinkButton>
-						<Button color="secondary" disabled>
+						<Button color="secondary" size="sm" disabled>
 							Custom Variables
 						</Button>
 						<CreateCollectionButton />
 						{(customVariables.customVariables.size > 0 || customVariables.customVariableCollections.size > 0) && (
 							<ExpandCollapseButtons />
 						)}
-					</CButtonGroup>
+					</ButtonGroup>
 				</div>
 
 				<CInputGroup className="variables-table-filter">
@@ -184,6 +184,7 @@ const ExpandCollapseButtons = observer(function ExpandCollapseButtons() {
 			{panelCollapseHelper.canExpandAll(null, rootPanels) && (
 				<Button
 					color="secondary"
+					size="sm"
 					onClick={() => panelCollapseHelper.setAllExpanded(null, rootPanels)}
 					title="Expand all"
 				>
@@ -193,6 +194,7 @@ const ExpandCollapseButtons = observer(function ExpandCollapseButtons() {
 			{panelCollapseHelper.canCollapseAll(null, rootPanels) && (
 				<Button
 					color="secondary"
+					size="sm"
 					onClick={() => panelCollapseHelper.setAllCollapsed(null, rootPanels)}
 					title="Collapse all"
 				>

--- a/webui/src/Variables/CustomVariablesList.tsx
+++ b/webui/src/Variables/CustomVariablesList.tsx
@@ -1,4 +1,4 @@
-import { CButton, CButtonGroup, CForm, CFormInput, CInputGroup } from '@coreui/react'
+import { CButtonGroup, CForm, CFormInput, CInputGroup } from '@coreui/react'
 import {
 	faArrowLeft,
 	faCompressArrowsAlt,
@@ -8,11 +8,11 @@ import {
 	faTimes,
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { Link } from '@tanstack/react-router'
 import { observer } from 'mobx-react-lite'
 import { useCallback, useContext, useRef, useState } from 'react'
 import { isCustomVariableValid } from '@companion-app/shared/CustomVariable.js'
 import type { CustomVariableDefinition } from '@companion-app/shared/Model/CustomVariableModel.js'
+import { Button, LinkButton } from '~/Components/Button'
 import {
 	CollectionsNestingTable,
 	UNGROUPED_PANEL_ID,
@@ -103,13 +103,13 @@ export const CustomVariablesListPage = observer(function CustomVariablesList() {
 					</p>
 
 					<CButtonGroup size="sm">
-						<CButton color="primary" as={Link} to="/variables">
+						<LinkButton color="primary" to="/variables">
 							<FontAwesomeIcon icon={faArrowLeft} />
 							&nbsp; Go back
-						</CButton>
-						<CButton color="secondary" disabled>
+						</LinkButton>
+						<Button color="secondary" disabled>
 							Custom Variables
-						</CButton>
+						</Button>
 						<CreateCollectionButton />
 						{(customVariables.customVariables.size > 0 || customVariables.customVariableCollections.size > 0) && (
 							<ExpandCollapseButtons />
@@ -125,9 +125,9 @@ export const CustomVariablesListPage = observer(function CustomVariablesList() {
 						value={filter}
 						style={{ fontSize: '1.2em' }}
 					/>
-					<CButton color="danger" onClick={clearFilter}>
+					<Button color="danger" onClick={clearFilter}>
 						<FontAwesomeIcon icon={faTimes} />
-					</CButton>
+					</Button>
 				</CInputGroup>
 
 				<div className="variables-table-scroller ">
@@ -182,22 +182,22 @@ const ExpandCollapseButtons = observer(function ExpandCollapseButtons() {
 	return (
 		<>
 			{panelCollapseHelper.canExpandAll(null, rootPanels) && (
-				<CButton
+				<Button
 					color="secondary"
 					onClick={() => panelCollapseHelper.setAllExpanded(null, rootPanels)}
 					title="Expand all"
 				>
 					<FontAwesomeIcon icon={faExpandArrowsAlt} /> Expand All
-				</CButton>
+				</Button>
 			)}
 			{panelCollapseHelper.canCollapseAll(null, rootPanels) && (
-				<CButton
+				<Button
 					color="secondary"
 					onClick={() => panelCollapseHelper.setAllCollapsed(null, rootPanels)}
 					title="Collapse all"
 				>
 					<FontAwesomeIcon icon={faCompressArrowsAlt} /> Collapse All
-				</CButton>
+				</Button>
 			)}
 		</>
 	)
@@ -247,9 +247,9 @@ function AddVariablePanel() {
 					onChange={(e) => setNewName(e.currentTarget.value)}
 					placeholder="variableName"
 				/>
-				<CButton color="primary" onClick={doCreateNew} disabled={!isCustomVariableValid(newName)}>
+				<Button color="primary" onClick={doCreateNew} disabled={!isCustomVariableValid(newName)}>
 					Add
-				</CButton>
+				</Button>
 			</CInputGroup>
 		</CForm>
 	)
@@ -265,8 +265,8 @@ function CreateCollectionButton() {
 	}, [createMutation])
 
 	return (
-		<CButton color="info" size="sm" onClick={doCreateCollection}>
+		<Button color="info" size="sm" onClick={doCreateCollection}>
 			<FontAwesomeIcon icon={faLayerGroup} /> Create Collection
-		</CButton>
+		</Button>
 	)
 }

--- a/webui/src/Variables/CustomVariablesList.tsx
+++ b/webui/src/Variables/CustomVariablesList.tsx
@@ -125,7 +125,7 @@ export const CustomVariablesListPage = observer(function CustomVariablesList() {
 						value={filter}
 						style={{ fontSize: '1.2em' }}
 					/>
-					<Button color="primary" onClick={clearFilter}>
+					<Button color="primary" onClick={clearFilter} aria-label="Clear search filter" title="Clear search filter">
 						<FontAwesomeIcon icon={faTimes} />
 					</Button>
 				</CInputGroup>

--- a/webui/src/Variables/CustomVariablesListRow.tsx
+++ b/webui/src/Variables/CustomVariablesListRow.tsx
@@ -1,10 +1,11 @@
-import { CButton, CButtonGroup, CCol, CForm, CFormLabel, CRow } from '@coreui/react'
+import { CButtonGroup, CCol, CForm, CFormLabel, CRow } from '@coreui/react'
 import { faCompressArrowsAlt, faCopy, faExpandArrowsAlt, faTrash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import classNames from 'classnames'
 import { observer } from 'mobx-react-lite'
 import { useCallback } from 'react'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
+import { Button } from '~/Components/Button.js'
 import { CheckboxInputField } from '~/Components/CheckboxInputField.js'
 import { InlineHelpIcon } from '~/Components/InlineHelp'
 import { TextInputField } from '~/Components/TextInputField.js'
@@ -44,9 +45,9 @@ export const CustomVariableRow = observer(function CustomVariableRow({ info }: C
 				<div className={classNames('cell-header-item', !isCollapsed && 'span-2')}>
 					<span className="variable-style">$({fullname})</span>
 					<CopyToClipboard text={`$(${fullname})`} onCopy={customVariablesApi.onCopied}>
-						<CButton size="sm" title="Copy variable name">
+						<Button size="sm" title="Copy variable name">
 							<FontAwesomeIcon icon={faCopy} color="#d50215" />
-						</CButton>
+						</Button>
 					</CopyToClipboard>
 				</div>
 				{isCollapsed && (
@@ -57,18 +58,18 @@ export const CustomVariableRow = observer(function CustomVariableRow({ info }: C
 				<div className="cell-header-item">
 					<CButtonGroup style={{ float: 'inline-end' }}>
 						{isCollapsed ? (
-							<CButton onClick={doExpand} size="sm" title="Expand variable view">
+							<Button onClick={doExpand} size="sm" title="Expand variable view">
 								<FontAwesomeIcon icon={faExpandArrowsAlt} />
-							</CButton>
+							</Button>
 						) : (
-							<CButton onClick={doCollapse} size="sm" title="Collapse variable view">
+							<Button onClick={doCollapse} size="sm" title="Collapse variable view">
 								<FontAwesomeIcon icon={faCompressArrowsAlt} />
-							</CButton>
+							</Button>
 						)}
 
-						<CButton onClick={() => customVariablesApi.doDelete(info.id)} size="sm" title="Delete custom variable">
+						<Button onClick={() => customVariablesApi.doDelete(info.id)} size="sm" title="Delete custom variable">
 							<FontAwesomeIcon icon={faTrash} />
-						</CButton>
+						</Button>
 					</CButtonGroup>
 				</div>
 			</div>

--- a/webui/src/Variables/CustomVariablesListRow.tsx
+++ b/webui/src/Variables/CustomVariablesListRow.tsx
@@ -1,11 +1,11 @@
-import { CButtonGroup, CCol, CForm, CFormLabel, CRow } from '@coreui/react'
+import { CCol, CForm, CFormLabel, CRow } from '@coreui/react'
 import { faCompressArrowsAlt, faCopy, faExpandArrowsAlt, faTrash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import classNames from 'classnames'
 import { observer } from 'mobx-react-lite'
 import { useCallback } from 'react'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
-import { Button } from '~/Components/Button.js'
+import { Button, ButtonGroup } from '~/Components/Button.js'
 import { CheckboxInputField } from '~/Components/CheckboxInputField.js'
 import { InlineHelpIcon } from '~/Components/InlineHelp'
 import { TextInputField } from '~/Components/TextInputField.js'
@@ -56,7 +56,7 @@ export const CustomVariableRow = observer(function CustomVariableRow({ info }: C
 					</div>
 				)}
 				<div className="cell-header-item">
-					<CButtonGroup style={{ float: 'inline-end' }}>
+					<ButtonGroup className="float-end">
 						{isCollapsed ? (
 							<Button onClick={doExpand} size="sm" title="Expand variable view">
 								<FontAwesomeIcon icon={faExpandArrowsAlt} />
@@ -70,7 +70,7 @@ export const CustomVariableRow = observer(function CustomVariableRow({ info }: C
 						<Button onClick={() => customVariablesApi.doDelete(info.id)} size="sm" title="Delete custom variable">
 							<FontAwesomeIcon icon={faTrash} />
 						</Button>
-					</CButtonGroup>
+					</ButtonGroup>
 				</div>
 			</div>
 			{isCollapsed ? (

--- a/webui/src/Variables/ExpressionVariables/Page.tsx
+++ b/webui/src/Variables/ExpressionVariables/Page.tsx
@@ -131,7 +131,7 @@ export const ExpressionVariablesPage = observer(function ExpressionVariablesPage
 			<GenericConfirmModal ref={confirmModalRef} />
 
 			<CCol xs={12} xl={6} className={`primary-panel ${showPrimaryPanel ? '' : 'd-xl-block d-none'}`}>
-				<h4 className="btn-inline">
+				<h4 className="button-inline">
 					Expression Variables
 					<ContextHelpButton action="/user-guide/config/variables#expression-variables" />
 				</h4>
@@ -157,7 +157,7 @@ export const ExpressionVariablesPage = observer(function ExpressionVariablesPage
 							value={filter}
 							style={{ fontSize: '1.2em' }}
 						/>
-						<Button color="danger" onClick={clearFilter}>
+						<Button color="primary" onClick={clearFilter}>
 							<FontAwesomeIcon icon={faTimes} />
 						</Button>
 					</CInputGroup>
@@ -275,10 +275,10 @@ const ExpressionVariableTableRow = observer(function ExpressionVariableTableRow2
 
 			<div className="action-buttons w-auto">
 				<ButtonGroup>
-					<Button color="white" onClick={doClone} title="Clone">
+					<Button onClick={doClone} title="Clone">
 						<FontAwesomeIcon icon={faClone} />
 					</Button>
-					<Button color="gray" onClick={doDelete} title="Delete">
+					<Button onClick={doDelete} title="Delete">
 						<FontAwesomeIcon icon={faTrash} />
 					</Button>
 				</ButtonGroup>

--- a/webui/src/Variables/ExpressionVariables/Page.tsx
+++ b/webui/src/Variables/ExpressionVariables/Page.tsx
@@ -1,4 +1,4 @@
-import { CButton, CButtonGroup, CCol, CFormInput, CInputGroup, CRow } from '@coreui/react'
+import { CButtonGroup, CCol, CFormInput, CInputGroup, CRow } from '@coreui/react'
 import {
 	faAdd,
 	faArrowLeft,
@@ -10,7 +10,7 @@ import {
 	faTrash,
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { Link, Outlet, useMatchRoute, useNavigate } from '@tanstack/react-router'
+import { Outlet, useMatchRoute, useNavigate } from '@tanstack/react-router'
 import { observer } from 'mobx-react-lite'
 import { useCallback, useContext, useRef, useState } from 'react'
 import CopyToClipboard from 'react-copy-to-clipboard'
@@ -19,6 +19,7 @@ import type {
 	ClientExpressionVariableData,
 	ExpressionVariableCollection,
 } from '@companion-app/shared/Model/ExpressionVariableModel.js'
+import { Button, LinkButton } from '~/Components/Button'
 import { CollectionsNestingTable } from '~/Components/CollectionsNestingTable/CollectionsNestingTable'
 import { GenericConfirmModal, type GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
 import { NonIdealState } from '~/Components/NonIdealState.js'
@@ -138,13 +139,13 @@ export const ExpressionVariablesPage = observer(function ExpressionVariablesPage
 
 				<div className="mb-2">
 					<CButtonGroup>
-						<CButton color="primary" as={Link} to="/variables" size="sm">
+						<LinkButton color="primary" to="/variables" size="sm">
 							<FontAwesomeIcon icon={faArrowLeft} />
 							&nbsp; Go back
-						</CButton>
-						<CButton color="warning" onClick={doAddNew} size="sm">
+						</LinkButton>
+						<Button color="warning" onClick={doAddNew} size="sm">
 							<FontAwesomeIcon icon={faAdd} /> Add Expression Variable
-						</CButton>
+						</Button>
 						<CreateCollectionButton />
 					</CButtonGroup>
 
@@ -156,9 +157,9 @@ export const ExpressionVariablesPage = observer(function ExpressionVariablesPage
 							value={filter}
 							style={{ fontSize: '1.2em' }}
 						/>
-						<CButton color="danger" onClick={clearFilter}>
+						<Button color="danger" onClick={clearFilter}>
 							<FontAwesomeIcon icon={faTimes} />
-						</CButton>
+						</Button>
 					</CInputGroup>
 				</div>
 
@@ -260,9 +261,9 @@ const ExpressionVariableTableRow = observer(function ExpressionVariableTableRow2
 					<span className="variable-style">
 						{fullname}
 						<CopyToClipboard text={fullname} onCopy={onCopied}>
-							<CButton size="sm" title="Copy variable name">
+							<Button size="sm" title="Copy variable name">
 								<FontAwesomeIcon icon={faCopy} color="#d50215" />
-							</CButton>
+							</Button>
 						</CopyToClipboard>
 					</span>
 				) : (
@@ -274,12 +275,12 @@ const ExpressionVariableTableRow = observer(function ExpressionVariableTableRow2
 
 			<div className="action-buttons w-auto">
 				<CButtonGroup>
-					<CButton color="white" onClick={doClone} title="Clone">
+					<Button color="white" onClick={doClone} title="Clone">
 						<FontAwesomeIcon icon={faClone} />
-					</CButton>
-					<CButton color="gray" onClick={doDelete} title="Delete">
+					</Button>
+					<Button color="gray" onClick={doDelete} title="Delete">
 						<FontAwesomeIcon icon={faTrash} />
-					</CButton>
+					</Button>
 				</CButtonGroup>
 			</div>
 		</div>
@@ -296,9 +297,9 @@ function CreateCollectionButton() {
 	}, [createMutation])
 
 	return (
-		<CButton color="info" size="sm" onClick={doCreateCollection}>
+		<Button color="info" size="sm" onClick={doCreateCollection}>
 			<FontAwesomeIcon icon={faLayerGroup} /> Create Collection
-		</CButton>
+		</Button>
 	)
 }
 

--- a/webui/src/Variables/ExpressionVariables/Page.tsx
+++ b/webui/src/Variables/ExpressionVariables/Page.tsx
@@ -1,4 +1,4 @@
-import { CButtonGroup, CCol, CFormInput, CInputGroup, CRow } from '@coreui/react'
+import { CCol, CFormInput, CInputGroup, CRow } from '@coreui/react'
 import {
 	faAdd,
 	faArrowLeft,
@@ -19,7 +19,7 @@ import type {
 	ClientExpressionVariableData,
 	ExpressionVariableCollection,
 } from '@companion-app/shared/Model/ExpressionVariableModel.js'
-import { Button, LinkButton } from '~/Components/Button'
+import { Button, ButtonGroup, LinkButton } from '~/Components/Button'
 import { CollectionsNestingTable } from '~/Components/CollectionsNestingTable/CollectionsNestingTable'
 import { GenericConfirmModal, type GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
 import { NonIdealState } from '~/Components/NonIdealState.js'
@@ -138,7 +138,7 @@ export const ExpressionVariablesPage = observer(function ExpressionVariablesPage
 				<p className="mb-2">Here you can create some variables from live computed expressions</p>
 
 				<div className="mb-2">
-					<CButtonGroup>
+					<ButtonGroup>
 						<LinkButton color="primary" to="/variables" size="sm">
 							<FontAwesomeIcon icon={faArrowLeft} />
 							&nbsp; Go back
@@ -147,7 +147,7 @@ export const ExpressionVariablesPage = observer(function ExpressionVariablesPage
 							<FontAwesomeIcon icon={faAdd} /> Add Expression Variable
 						</Button>
 						<CreateCollectionButton />
-					</CButtonGroup>
+					</ButtonGroup>
 
 					<CInputGroup className="variables-table-filter mt-2">
 						<CFormInput
@@ -274,14 +274,14 @@ const ExpressionVariableTableRow = observer(function ExpressionVariableTableRow2
 			</div>
 
 			<div className="action-buttons w-auto">
-				<CButtonGroup>
+				<ButtonGroup>
 					<Button color="white" onClick={doClone} title="Clone">
 						<FontAwesomeIcon icon={faClone} />
 					</Button>
 					<Button color="gray" onClick={doDelete} title="Delete">
 						<FontAwesomeIcon icon={faTrash} />
 					</Button>
-				</CButtonGroup>
+				</ButtonGroup>
 			</div>
 		</div>
 	)

--- a/webui/src/Variables/ExpressionVariables/Page.tsx
+++ b/webui/src/Variables/ExpressionVariables/Page.tsx
@@ -157,7 +157,7 @@ export const ExpressionVariablesPage = observer(function ExpressionVariablesPage
 							value={filter}
 							style={{ fontSize: '1.2em' }}
 						/>
-						<Button color="primary" onClick={clearFilter}>
+						<Button color="primary" onClick={clearFilter} aria-label="Clear search filter" title="Clear search filter">
 							<FontAwesomeIcon icon={faTimes} />
 						</Button>
 					</CInputGroup>

--- a/webui/src/Variables/index.tsx
+++ b/webui/src/Variables/index.tsx
@@ -85,7 +85,7 @@ export const ConnectionVariablesPage = observer(function VariablesConnectionList
 		<CRow>
 			<CCol xs={12} className="flex-column-layout">
 				<div className="fixed-header">
-					<h4 className="btn-inline">
+					<h4 className="button-inline">
 						Variables
 						<ContextHelpButton action="/user-guide/config/variables" />
 					</h4>

--- a/webui/src/Variables/index.tsx
+++ b/webui/src/Variables/index.tsx
@@ -1,11 +1,11 @@
-import { CButtonGroup, CCol, CRow } from '@coreui/react'
+import { CCol, CRow } from '@coreui/react'
 import { faArrowLeft, faArrowRight, faDollarSign, faSquareRootVariable } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useNavigate, useParams } from '@tanstack/react-router'
 import { observer } from 'mobx-react-lite'
 import { memo, useCallback, useContext } from 'react'
 import type { ClientConnectionConfig } from '@companion-app/shared/Model/Connections.js'
-import { Button, LinkButton } from '~/Components/Button'
+import { Button, ButtonGroup, LinkButton } from '~/Components/Button'
 import { CollapsibleTree, type CollapsibleTreeHeaderProps } from '~/Components/CollapsibleTree/CollapsibleTree.js'
 import {
 	useConnectionLeafTree,
@@ -136,15 +136,15 @@ export function VariablesListPage(): React.JSX.Element {
 		<div className="variables-panel">
 			<div>
 				<h4 style={{ marginBottom: '0.8rem' }}>Variables</h4>
-				<CButtonGroup size="sm">
-					<LinkButton color="primary" to="/variables">
+				<ButtonGroup>
+					<LinkButton color="primary" size="sm" to="/variables">
 						<FontAwesomeIcon icon={faArrowLeft} />
 						&nbsp; Go back
 					</LinkButton>
-					<Button color="secondary" disabled>
+					<Button color="secondary" size="sm" disabled>
 						{label}
 					</Button>
-				</CButtonGroup>
+				</ButtonGroup>
 			</div>
 
 			<VariablesTable label={label} />

--- a/webui/src/Variables/index.tsx
+++ b/webui/src/Variables/index.tsx
@@ -1,10 +1,11 @@
-import { CButton, CButtonGroup, CCol, CRow } from '@coreui/react'
+import { CButtonGroup, CCol, CRow } from '@coreui/react'
 import { faArrowLeft, faArrowRight, faDollarSign, faSquareRootVariable } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { Link, useNavigate, useParams } from '@tanstack/react-router'
+import { useNavigate, useParams } from '@tanstack/react-router'
 import { observer } from 'mobx-react-lite'
 import { memo, useCallback, useContext } from 'react'
 import type { ClientConnectionConfig } from '@companion-app/shared/Model/Connections.js'
+import { Button, LinkButton } from '~/Components/Button'
 import { CollapsibleTree, type CollapsibleTreeHeaderProps } from '~/Components/CollapsibleTree/CollapsibleTree.js'
 import {
 	useConnectionLeafTree,
@@ -96,17 +97,17 @@ export const ConnectionVariablesPage = observer(function VariablesConnectionList
 
 				<div className="scrollable-content">
 					<div className="variables-category-grid" style={{ gridTemplateColumns: 'repeat(2, 1fr)' }}>
-						<CButton color="info" as={Link} to="/variables/custom" className="mb-3">
+						<LinkButton color="info" to="/variables/custom" className="mb-3">
 							<h6 className="mb-0 py-1">
 								<FontAwesomeIcon icon={faDollarSign} className="me-1" />
 								Custom Variables
 							</h6>
-						</CButton>
-						<CButton color="info" as={Link} to="/variables/expression" className="mb-3">
+						</LinkButton>
+						<LinkButton color="info" to="/variables/expression" className="mb-3">
 							<h6 className="mb-0 py-1">
 								<FontAwesomeIcon icon={faSquareRootVariable} className="me-1" /> Expression Variables
 							</h6>
-						</CButton>
+						</LinkButton>
 					</div>
 
 					<CollapsibleTree
@@ -136,13 +137,13 @@ export function VariablesListPage(): React.JSX.Element {
 			<div>
 				<h4 style={{ marginBottom: '0.8rem' }}>Variables</h4>
 				<CButtonGroup size="sm">
-					<CButton color="primary" as={Link} to="/variables">
+					<LinkButton color="primary" to="/variables">
 						<FontAwesomeIcon icon={faArrowLeft} />
 						&nbsp; Go back
-					</CButton>
-					<CButton color="secondary" disabled>
+					</LinkButton>
+					<Button color="secondary" disabled>
 						{label}
-					</CButton>
+					</Button>
 				</CButtonGroup>
 			</div>
 

--- a/webui/src/Wizard/index.tsx
+++ b/webui/src/Wizard/index.tsx
@@ -1,8 +1,9 @@
-import { CButton, CForm, CModal, CModalBody, CModalFooter, CModalHeader } from '@coreui/react'
+import { CForm, CModal, CModalBody, CModalFooter, CModalHeader } from '@coreui/react'
 import { toJS } from 'mobx'
 import { useCallback, useContext, useEffect, useState } from 'react'
 import type { UserConfigModel } from '@companion-app/shared/Model/UserConfigModel.js'
 import { StaticAlert } from '~/Components/Alert.js'
+import { Button } from '~/Components/Button'
 import { trpc, useMutationExt } from '~/Resources/TRPC.js'
 import { makeAbsolutePath } from '~/Resources/util.js'
 import { RootAppStoreContext } from '~/Stores/RootAppStore.js'
@@ -132,23 +133,23 @@ export function WizardModal(): React.JSX.Element {
 	switch (currentStep) {
 		case applyStep:
 			nextButton = (
-				<CButton color="primary" onClick={doSave}>
+				<Button color="primary" onClick={doSave}>
 					Apply
-				</CButton>
+				</Button>
 			)
 			break
 		case maxSteps:
 			nextButton = (
-				<CButton color="primary" onClick={doClose}>
+				<Button color="primary" onClick={doClose}>
 					Finish
-				</CButton>
+				</Button>
 			)
 			break
 		default:
 			nextButton = (
-				<CButton color="primary" onClick={doNextStep}>
+				<Button color="primary" onClick={doNextStep}>
 					Next
-				</CButton>
+				</Button>
 			)
 	}
 
@@ -202,13 +203,13 @@ export function WizardModal(): React.JSX.Element {
 				</CModalBody>
 				<CModalFooter>
 					{currentStep <= applyStep && (
-						<CButton color="secondary" onClick={doClose}>
+						<Button color="secondary" onClick={doClose}>
 							Cancel
-						</CButton>
+						</Button>
 					)}
-					<CButton color="secondary" disabled={currentStep === 1} onClick={doPrevStep}>
+					<Button color="secondary" disabled={currentStep === 1} onClick={doPrevStep}>
 						Previous
-					</CButton>
+					</Button>
 					{nextButton}
 				</CModalFooter>
 			</CForm>

--- a/webui/src/scss/_button-edit.scss
+++ b/webui/src/scss/_button-edit.scss
@@ -58,7 +58,7 @@
 }
 
 .flex-form {
-	& > div:not(.btn-group) {
+	& > div:not(.button-group) {
 		// column
 		margin-bottom: 10px;
 	}
@@ -431,7 +431,7 @@
 		text-overflow: ellipsis;
 	}
 
-	.btn-group-vertical {
+	.button-group-vertical {
 		width: 100%;
 	}
 

--- a/webui/src/scss/_button-edit.scss
+++ b/webui/src/scss/_button-edit.scss
@@ -406,8 +406,8 @@
 				white-space: nowrap;
 				padding: 0 0.25rem;
 
-				.btn {
-					--cui-btn-padding-x: 0.15rem;
+				.button {
+					--btn-padding-x: 0.15rem;
 				}
 			}
 		}
@@ -424,7 +424,7 @@
 	max-width: 300px;
 	width: 300px;
 
-	.btn {
+	.button {
 		width: 100%;
 
 		white-space: nowrap;

--- a/webui/src/scss/_button-grid.scss
+++ b/webui/src/scss/_button-grid.scss
@@ -98,13 +98,6 @@
 	border-radius: 8px;
 	// min-height: 250px;  instead, set min-height in tsx to match button-sizes.
 }
-.button-grid-header {
-	.btn-right {
-		float: right;
-		// margin-top: 10px;
-		margin-left: 3px;
-	}
-}
 
 .button-infinite-grid {
 	height: 100%; // needed to get the scrollbar.

--- a/webui/src/scss/_collections-nesting-table.scss
+++ b/webui/src/scss/_collections-nesting-table.scss
@@ -46,8 +46,8 @@
 			// the following is applied to the text. The buttons need more specific selectors
 			color: var(--cui-disabled);
 
-			.btn {
-				--cui-btn-color: var(--cui-disabled);
+			.button {
+				--btn-color: var(--cui-disabled);
 			}
 		}
 	}
@@ -86,7 +86,7 @@
 			}
 		}
 
-		.btn-link {
+		.button-link {
 			padding: 0 6px;
 			color: #666;
 

--- a/webui/src/scss/_common.scss
+++ b/webui/src/scss/_common.scss
@@ -170,34 +170,6 @@ code {
 	border-bottom-right-radius: 0;
 }
 
-.btn-danger {
-	background-color: $primary;
-}
-
-.btn-danger:hover {
-	background-color: color.adjust($primary, $lightness: -5%, $space: hsl);
-	color: #eee;
-	animation: blinker 0.3s linear infinite;
-}
-
-.btn-danger:disabled {
-	color: rgba(255, 255, 255, 0.8);
-}
-
-.btn-success:disabled {
-	color: rgba(255, 255, 255, 0.9);
-}
-
-.btn-info:disabled {
-	color: rgba(255, 255, 255, 0.9);
-}
-
-@keyframes blinker {
-	50% {
-		opacity: 0.8;
-	}
-}
-
 .c-app {
 	color: #222;
 }

--- a/webui/src/scss/_common.scss
+++ b/webui/src/scss/_common.scss
@@ -11,7 +11,7 @@ h4 {
 	// make compact
 	width: 1px;
 
-	.btn {
+	.button {
 		text-transform: uppercase;
 
 		padding: 4px;
@@ -21,7 +21,7 @@ h4 {
 		}
 	}
 
-	.btn-primary.disabled {
+	.button-primary.disabled {
 		opacity: 0.5;
 	}
 }
@@ -36,18 +36,18 @@ legend {
 	.button-group {
 		float: right;
 	}
-	.btn {
+	.button {
 		float: right;
 	}
 }
 
-// special case, mainly for context help buttons: add btn-inline to the <h4> or <h5> element to prevent buttons from floating right
-h4.btn-inline,
-h5.btn-inline {
+// special case, mainly for context help buttons: add button-inline to the <h4> or <h5> element to prevent buttons from floating right
+h4.button-inline,
+h5.button-inline {
 	display: flex;
 
 	.context-help-button,
-	.btn,
+	.button,
 	.button-group {
 		display: inline-flex;
 		align-items: center;
@@ -137,7 +137,7 @@ th {
 			opacity: 1;
 		}
 
-		&.btn-secondary {
+		&.button-secondary {
 			background-color: white;
 			color: black;
 		}
@@ -224,29 +224,6 @@ code {
 	}
 }
 
-.btn-secondary {
-	background-color: color.adjust($secondary, $lightness: 15%, $space: hsl);
-}
-.btn-danger,
-.btn-success,
-.btn-info {
-	color: #fff;
-}
-
-.btn-success:hover {
-	color: #fff;
-}
-
-.btn.disabled.with-tooltip {
-	cursor: inherit;
-	pointer-events: inherit;
-}
-
-.btn-white.disabled {
-	opacity: 0.4;
-	border-color: transparent;
-}
-
 .text-right {
 	text-align: right;
 }
@@ -297,10 +274,6 @@ code {
 
 .noBorder td {
 	border: none;
-}
-
-.btn-undefined:disabled {
-	border-color: transparent;
 }
 
 .nav-item {
@@ -397,7 +370,7 @@ svg.pad-left {
 	.expression-toggle-button {
 		justify-self: flex-end;
 
-		.btn {
+		.button {
 			height: 100%;
 			width: 3em;
 		}

--- a/webui/src/scss/_common.scss
+++ b/webui/src/scss/_common.scss
@@ -33,7 +33,7 @@ h4 {
 h4,
 h5,
 legend {
-	.btn-group {
+	.button-group {
 		float: right;
 	}
 	.btn {
@@ -48,7 +48,7 @@ h5.btn-inline {
 
 	.context-help-button,
 	.btn,
-	.btn-group {
+	.button-group {
 		display: inline-flex;
 		align-items: center;
 		padding-left: 0.75em;
@@ -79,7 +79,7 @@ h5.btn-inline {
 	}
 }
 
-.btn-group {
+.button-group {
 	// do not set "overflow: hidden;" globally! if needed put it in an appropriate scope. If set here it prevents dropdown menus!
 	&.margin-bottom {
 		margin-bottom: 1rem;

--- a/webui/src/scss/_layout.scss
+++ b/webui/src/scss/_layout.scss
@@ -136,7 +136,7 @@ form.row > * {
 	--menu-hover-color: #fff;
 	--menu-hover-bg: var(--cui-info);
 	color: var(--menu-color); // this may not affect anything
-	//overflow: visible; // uncomment this if unscoped .btn-group defined in _common.scss needs to make overflow hidden
+	//overflow: visible; // uncomment this if unscoped .button-group defined in _common.scss needs to make overflow hidden
 
 	// note: <CDropdownToggle color="primary"...> set a group of color properties. Here we extend or override as needed.
 	.help-toggle {

--- a/webui/src/scss/_layout.scss
+++ b/webui/src/scss/_layout.scss
@@ -617,7 +617,7 @@ $panel-header-button-color: color.adjust($panel-header-color, $lightness: +10%);
 .context-help-button-btn {
 	border: 0;
 	border-radius: 100%;
-	--cui-btn-color: #{$panel-header-button-color}; // the circle is the foreground; the "?" is transparent
+	--btn-color: #{$panel-header-button-color}; // the circle is the foreground; the "?" is transparent
 	background-color: white;
 }
 

--- a/webui/src/scss/_log.scss
+++ b/webui/src/scss/_log.scss
@@ -7,7 +7,7 @@
 	.log-debug-buttons {
 		padding: 0 20px;
 
-		.btn-group {
+		.button-group {
 			margin-right: 10px;
 		}
 	}

--- a/webui/src/scss/_log.scss
+++ b/webui/src/scss/_log.scss
@@ -4,14 +4,6 @@
 	height: 100%;
 	overflow: hidden;
 
-	.log-debug-buttons {
-		padding: 0 20px;
-
-		.button-group {
-			margin-right: 10px;
-		}
-	}
-
 	.log-panel {
 		margin-top: 10px;
 		font-size: 0.85em;

--- a/webui/src/scss/_presets.scss
+++ b/webui/src/scss/_presets.scss
@@ -1,6 +1,5 @@
 @use '@coreui/coreui/scss/coreui'; // not strictly necessary, but it allows us to clarify the origin of mixins
 
-.preset-category-grid,
 .variables-category-grid {
 	display: grid;
 
@@ -22,13 +21,5 @@
 
 	@include coreui.media-breakpoint-down('sm') {
 		grid-template-columns: 1fr;
-	}
-
-	.btn {
-		align-content: center;
-	}
-
-	.btn-block {
-		margin-top: 0;
 	}
 }

--- a/webui/src/scss/_surfaces.scss
+++ b/webui/src/scss/_surfaces.scss
@@ -118,7 +118,7 @@
 			justify-content: flex-end;
 			white-space: nowrap;
 
-			.btn {
+			.button {
 				text-transform: uppercase;
 				padding: 4px;
 
@@ -127,7 +127,7 @@
 				}
 			}
 
-			.btn-primary.disabled {
+			.button-primary.disabled {
 				opacity: 0.5;
 			}
 		}

--- a/webui/src/scss/_tablet.scss
+++ b/webui/src/scss/_tablet.scss
@@ -23,8 +23,8 @@
 		margin: 0 auto;
 	}
 
-	.btn.open-config,
-	.btn.close-config {
+	.button.open-config,
+	.button.close-config {
 		float: right;
 	}
 
@@ -45,7 +45,7 @@
 		margin: 10px 0 10px;
 	}
 
-	.btn {
+	.button {
 		margin: 0 5px;
 		color: #d69e2e;
 		border: 1px solid #d69e2e;
@@ -67,7 +67,7 @@
 				padding: 0 25px;
 			}
 
-			.btn {
+			.button {
 				float: right;
 			}
 		}

--- a/webui/src/scss/components/_button.scss
+++ b/webui/src/scss/components/_button.scss
@@ -1,947 +1,788 @@
-@use 'sass:color';
+// ---- Base ----
 
-// .btn{
-//     --cui-btn-padding-x: .75rem;
-//     --cui-btn-padding-y: .375rem;
-//     --cui-btn-font-family: ;
-//     --cui-btn-font-size: .9rem;
-//     --cui-btn-font-weight: 400;
-//     --cui-btn-line-height: 1.5;
-//     --cui-btn-color: var(--cui-body-color);
-//     --cui-btn-bg: transparent;
-//     --cui-btn-border-width: var(--cui-border-width);
-//     --cui-btn-border-color: transparent;
-//     --cui-btn-border-radius: var(--cui-border-radius);
-//     --cui-btn-hover-border-color: transparent;
-//     --cui-btn-box-shadow: inset 0 1px 0 rgba(255, 255, 255, .15), 0 1px 1px rgba(8, 10, 12, .075);
-//     --cui-btn-disabled-opacity: .65;
-//     --cui-btn-focus-box-shadow: 0 0 0 .25rem rgba(var(--cui-btn-focus-shadow-rgb), .5);
-//     display:inline-block;
-//     padding:var(--cui-btn-padding-y) var(--cui-btn-padding-x);
-//     font-family:var(--cui-btn-font-family);
-//     font-size:var(--cui-btn-font-size);
-//     font-weight:var(--cui-btn-font-weight);
-//     line-height:var(--cui-btn-line-height);
-//     color:var(--cui-btn-color);
-//     text-align:center;
-//     text-decoration:none;
-//     vertical-align:middle;
-//     cursor:pointer;
-//     user-select:none;
-//     border:var(--cui-btn-border-width) solid var(--cui-btn-border-color);
-//     border-radius:var(--cui-btn-border-radius);
-//     background-color:var(--cui-btn-bg);
-//     transition:color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out
-// }
-// @media(prefers-reduced-motion:reduce){
-//     .btn{
-//         transition:none
-//     }
-// }
-// .btn:hover{
-//     color:var(--cui-btn-hover-color);
-//     background-color:var(--cui-btn-hover-bg);
-//     border-color:var(--cui-btn-hover-border-color)
-// }
-// .btn-check+.btn:hover{
-//     color:var(--cui-btn-color);
-//     background-color:var(--cui-btn-bg);
-//     border-color:var(--cui-btn-border-color)
-// }
-// .btn:focus-visible{
-//     color:var(--cui-btn-hover-color);
-//     background-color:var(--cui-btn-hover-bg);
-//     border-color:var(--cui-btn-hover-border-color);
-//     outline:0;
-//     box-shadow:var(--cui-btn-focus-box-shadow)
-// }
-// .btn-check:focus-visible+.btn{
-//     border-color:var(--cui-btn-hover-border-color);
-//     outline:0;
-//     box-shadow:var(--cui-btn-focus-box-shadow)
-// }
-// .btn-check:checked+.btn,:not(.btn-check)+.btn:active,.btn:first-child:active,.btn.active,.btn.show{
-//     color:var(--cui-btn-active-color);
-//     background-color:var(--cui-btn-active-bg);
-//     border-color:var(--cui-btn-active-border-color)
-// }
-// .btn-check:checked+.btn:focus-visible,:not(.btn-check)+.btn:active:focus-visible,.btn:first-child:active:focus-visible,.btn.active:focus-visible,.btn.show:focus-visible{
-//     box-shadow:var(--cui-btn-focus-box-shadow)
-// }
-// .btn-check:checked:focus-visible+.btn{
-//     box-shadow:var(--cui-btn-focus-box-shadow)
-// }
-// .btn:disabled,.btn.disabled,fieldset:disabled .btn{
-//     color:var(--cui-btn-disabled-color);
-//     pointer-events:none;
-//     background-color:var(--cui-btn-disabled-bg);
-//     border-color:var(--cui-btn-disabled-border-color);
-//     opacity:var(--cui-btn-disabled-opacity)
-// }
-// .btn-ghost{
-//     --cui-btn-color: var(--cui-secondary-color);
-//     --cui-btn-border-color: transparent;
-//     --cui-btn-active-color: var(--cui-body-color);
-//     --cui-btn-active-bg: var(--cui-tertiary-bg);
-//     --cui-btn-active-border-color: var(--cui-tertiary-bg);
-//     --cui-btn-disabled-color: var(--cui-secondary-color);
-//     --cui-btn-disabled-border-color: transparent;
-//     --cui-btn-hover-color: var(--cui-body-color);
-//     --cui-btn-hover-bg: var(--cui-tertiary-bg);
-//     --cui-btn-hover-border-color: var(--cui-tertiary-bg);
-//     --cui-btn-focus-box-shadow: 0 0 0 .25rem rgba(var(--cui-tertiary-bg-rgb), .5)
-// }
-// .btn-outline{
-//     --cui-btn-color: var(--cui-secondary-color);
-//     --cui-btn-border-color: var(--cui-border-color);
-//     --cui-btn-active-color: var(--cui-body-color);
-//     --cui-btn-active-bg: var(--cui-tertiary-bg);
-//     --cui-btn-active-border-color: var(--cui-border-color);
-//     --cui-btn-disabled-color: var(--cui-secondary-color);
-//     --cui-btn-disabled-border-color: var(--cui-border-color);
-//     --cui-btn-hover-color: var(--cui-body-color);
-//     --cui-btn-hover-bg: var(--cui-tertiary-bg);
-//     --cui-btn-hover-border-color: var(--cui-border-color);
-//     --cui-btn-focus-box-shadow: 0 0 0 .25rem rgba(var(--cui-tertiary-bg-rgb), .5)
-// }
-// .btn-transparent{
-//     --cui-btn-active-border-color: transparent;
-//     --cui-btn-disabled-border-color: transparent;
-//     --cui-btn-hover-border-color: transparent
-// }
-// .btn-primary{
-//     --cui-btn-color: #fff;
-//     --cui-btn-bg: #d50215;
-//     --cui-btn-border-color: #d50215;
-//     --cui-btn-hover-color: #fff;
-//     --cui-btn-hover-bg: rgb(181.05, 1.7, 17.85);
-//     --cui-btn-hover-border-color: rgb(170.4, 1.6, 16.8);
-//     --cui-btn-focus-shadow-rgb: 219.3, 39.95, 56.1;
-//     --cui-btn-active-color: #fff;
-//     --cui-btn-active-bg: rgb(170.4, 1.6, 16.8);
-//     --cui-btn-active-border-color: rgb(159.75, 1.5, 15.75);
-//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
-//     --cui-btn-disabled-color: #fff;
-//     --cui-btn-disabled-bg: #d50215;
-//     --cui-btn-disabled-border-color: #d50215
-// }
-// .btn-secondary{
-//     --cui-btn-color: #080a0c;
-//     --cui-btn-bg: #ccc;
-//     --cui-btn-border-color: #ccc;
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-hover-bg: rgb(211.65, 211.65, 211.65);
-//     --cui-btn-hover-border-color: rgb(209.1, 209.1, 209.1);
-//     --cui-btn-focus-shadow-rgb: 174.6, 174.9, 175.2;
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-active-bg: rgb(214.2, 214.2, 214.2);
-//     --cui-btn-active-border-color: rgb(209.1, 209.1, 209.1);
-//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
-//     --cui-btn-disabled-color: #080a0c;
-//     --cui-btn-disabled-bg: #ccc;
-//     --cui-btn-disabled-border-color: #ccc
-// }
-// .btn-success{
-//     --cui-btn-color: #080a0c;
-//     --cui-btn-bg: #1b9e3e;
-//     --cui-btn-border-color: #1b9e3e;
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-hover-bg: rgb(61.2, 172.55, 90.95);
-//     --cui-btn-hover-border-color: rgb(49.8, 167.7, 81.3);
-//     --cui-btn-focus-shadow-rgb: 24.15, 135.8, 54.5;
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-active-bg: rgb(72.6, 177.4, 100.6);
-//     --cui-btn-active-border-color: rgb(49.8, 167.7, 81.3);
-//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
-//     --cui-btn-disabled-color: #080a0c;
-//     --cui-btn-disabled-bg: #1b9e3e;
-//     --cui-btn-disabled-border-color: #1b9e3e
-// }
-// .btn-info{
-//     --cui-btn-color: #080a0c;
-//     --cui-btn-bg: #39f;
-//     --cui-btn-border-color: #39f;
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-hover-bg: rgb(81.6, 168.3, 255);
-//     --cui-btn-hover-border-color: rgb(71.4, 163.2, 255);
-//     --cui-btn-focus-shadow-rgb: 44.55, 131.55, 218.55;
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-active-bg: rgb(91.8, 173.4, 255);
-//     --cui-btn-active-border-color: rgb(71.4, 163.2, 255);
-//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
-//     --cui-btn-disabled-color: #080a0c;
-//     --cui-btn-disabled-bg: #39f;
-//     --cui-btn-disabled-border-color: #39f
-// }
-// .btn-warning{
-//     --cui-btn-color: #080a0c;
-//     --cui-btn-bg: #f9b115;
-//     --cui-btn-border-color: #f9b115;
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-hover-bg: rgb(249.9, 188.7, 56.1);
-//     --cui-btn-hover-border-color: rgb(249.6, 184.8, 44.4);
-//     --cui-btn-focus-shadow-rgb: 212.85, 151.95, 19.65;
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-active-bg: rgb(250.2, 192.6, 67.8);
-//     --cui-btn-active-border-color: rgb(249.6, 184.8, 44.4);
-//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
-//     --cui-btn-disabled-color: #080a0c;
-//     --cui-btn-disabled-bg: #f9b115;
-//     --cui-btn-disabled-border-color: #f9b115
-// }
-// .btn-danger{
-//     --cui-btn-color: #080a0c;
-//     --cui-btn-bg: #e55353;
-//     --cui-btn-border-color: #e55353;
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-hover-bg: rgb(232.9, 108.8, 108.8);
-//     --cui-btn-hover-border-color: rgb(231.6, 100.2, 100.2);
-//     --cui-btn-focus-shadow-rgb: 195.85, 72.05, 72.35;
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-active-bg: rgb(234.2, 117.4, 117.4);
-//     --cui-btn-active-border-color: rgb(231.6, 100.2, 100.2);
-//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
-//     --cui-btn-disabled-color: #080a0c;
-//     --cui-btn-disabled-bg: #e55353;
-//     --cui-btn-disabled-border-color: #e55353
-// }
-// .btn-light{
-//     --cui-btn-color: #080a0c;
-//     --cui-btn-bg: #e9e9e9;
-//     --cui-btn-border-color: #e9e9e9;
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-hover-bg: rgb(198.05, 198.05, 198.05);
-//     --cui-btn-hover-border-color: rgb(186.4, 186.4, 186.4);
-//     --cui-btn-focus-shadow-rgb: 199.25, 199.55, 199.85;
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-active-bg: rgb(186.4, 186.4, 186.4);
-//     --cui-btn-active-border-color: rgb(174.75, 174.75, 174.75);
-//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
-//     --cui-btn-disabled-color: #080a0c;
-//     --cui-btn-disabled-bg: #e9e9e9;
-//     --cui-btn-disabled-border-color: #e9e9e9
-// }
-// .btn-dark{
-//     --cui-btn-color: #fff;
-//     --cui-btn-bg: #212631;
-//     --cui-btn-border-color: #212631;
-//     --cui-btn-hover-color: #fff;
-//     --cui-btn-hover-bg: rgb(66.3, 70.55, 79.9);
-//     --cui-btn-hover-border-color: rgb(55.2, 59.7, 69.6);
-//     --cui-btn-focus-shadow-rgb: 66.3, 70.55, 79.9;
-//     --cui-btn-active-color: #fff;
-//     --cui-btn-active-bg: rgb(77.4, 81.4, 90.2);
-//     --cui-btn-active-border-color: rgb(55.2, 59.7, 69.6);
-//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
-//     --cui-btn-disabled-color: #fff;
-//     --cui-btn-disabled-bg: #212631;
-//     --cui-btn-disabled-border-color: #212631
-// }
-// .btn-outline-primary{
-//     --cui-btn-color: #d50215;
-//     --cui-btn-border-color: #d50215;
-//     --cui-btn-hover-color: #fff;
-//     --cui-btn-hover-bg: #d50215;
-//     --cui-btn-hover-border-color: #d50215;
-//     --cui-btn-focus-shadow-rgb: 213, 2, 21;
-//     --cui-btn-active-color: #fff;
-//     --cui-btn-active-bg: #d50215;
-//     --cui-btn-active-border-color: #d50215;
-//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
-//     --cui-btn-disabled-color: #d50215;
-//     --cui-btn-disabled-bg: transparent;
-//     --cui-btn-disabled-border-color: #d50215;
-//     --cui-gradient: none
-// }
-// .btn-outline-secondary{
-//     --cui-btn-color: #ccc;
-//     --cui-btn-border-color: #ccc;
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-hover-bg: #ccc;
-//     --cui-btn-hover-border-color: #ccc;
-//     --cui-btn-focus-shadow-rgb: 204, 204, 204;
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-active-bg: #ccc;
-//     --cui-btn-active-border-color: #ccc;
-//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
-//     --cui-btn-disabled-color: #ccc;
-//     --cui-btn-disabled-bg: transparent;
-//     --cui-btn-disabled-border-color: #ccc;
-//     --cui-gradient: none
-// }
-// .btn-outline-success{
-//     --cui-btn-color: #1b9e3e;
-//     --cui-btn-border-color: #1b9e3e;
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-hover-bg: #1b9e3e;
-//     --cui-btn-hover-border-color: #1b9e3e;
-//     --cui-btn-focus-shadow-rgb: 27, 158, 62;
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-active-bg: #1b9e3e;
-//     --cui-btn-active-border-color: #1b9e3e;
-//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
-//     --cui-btn-disabled-color: #1b9e3e;
-//     --cui-btn-disabled-bg: transparent;
-//     --cui-btn-disabled-border-color: #1b9e3e;
-//     --cui-gradient: none
-// }
-// .btn-outline-info{
-//     --cui-btn-color: #39f;
-//     --cui-btn-border-color: #39f;
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-hover-bg: #39f;
-//     --cui-btn-hover-border-color: #39f;
-//     --cui-btn-focus-shadow-rgb: 51, 153, 255;
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-active-bg: #39f;
-//     --cui-btn-active-border-color: #39f;
-//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
-//     --cui-btn-disabled-color: #39f;
-//     --cui-btn-disabled-bg: transparent;
-//     --cui-btn-disabled-border-color: #39f;
-//     --cui-gradient: none
-// }
-// .btn-outline-warning{
-//     --cui-btn-color: #f9b115;
-//     --cui-btn-border-color: #f9b115;
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-hover-bg: #f9b115;
-//     --cui-btn-hover-border-color: #f9b115;
-//     --cui-btn-focus-shadow-rgb: 249, 177, 21;
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-active-bg: #f9b115;
-//     --cui-btn-active-border-color: #f9b115;
-//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
-//     --cui-btn-disabled-color: #f9b115;
-//     --cui-btn-disabled-bg: transparent;
-//     --cui-btn-disabled-border-color: #f9b115;
-//     --cui-gradient: none
-// }
-// .btn-outline-danger{
-//     --cui-btn-color: #e55353;
-//     --cui-btn-border-color: #e55353;
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-hover-bg: #e55353;
-//     --cui-btn-hover-border-color: #e55353;
-//     --cui-btn-focus-shadow-rgb: 229, 83, 83;
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-active-bg: #e55353;
-//     --cui-btn-active-border-color: #e55353;
-//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
-//     --cui-btn-disabled-color: #e55353;
-//     --cui-btn-disabled-bg: transparent;
-//     --cui-btn-disabled-border-color: #e55353;
-//     --cui-gradient: none
-// }
-// .btn-outline-light{
-//     --cui-btn-color: #e9e9e9;
-//     --cui-btn-border-color: #e9e9e9;
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-hover-bg: #e9e9e9;
-//     --cui-btn-hover-border-color: #e9e9e9;
-//     --cui-btn-focus-shadow-rgb: 233, 233, 233;
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-active-bg: #e9e9e9;
-//     --cui-btn-active-border-color: #e9e9e9;
-//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
-//     --cui-btn-disabled-color: #e9e9e9;
-//     --cui-btn-disabled-bg: transparent;
-//     --cui-btn-disabled-border-color: #e9e9e9;
-//     --cui-gradient: none
-// }
-// .btn-outline-dark{
-//     --cui-btn-color: #212631;
-//     --cui-btn-border-color: #212631;
-//     --cui-btn-hover-color: #fff;
-//     --cui-btn-hover-bg: #212631;
-//     --cui-btn-hover-border-color: #212631;
-//     --cui-btn-focus-shadow-rgb: 33, 38, 49;
-//     --cui-btn-active-color: #fff;
-//     --cui-btn-active-bg: #212631;
-//     --cui-btn-active-border-color: #212631;
-//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
-//     --cui-btn-disabled-color: #212631;
-//     --cui-btn-disabled-bg: transparent;
-//     --cui-btn-disabled-border-color: #212631;
-//     --cui-gradient: none
-// }
-// .btn-ghost-primary{
-//     --cui-btn-color: #d50215;
-//     --cui-btn-border-color: transparent;
-//     --cui-btn-hover-bg: #d50215;
-//     --cui-btn-hover-border-color: #d50215;
-//     --cui-btn-hover-color: #fff;
-//     --cui-btn-active-bg: #d50215;
-//     --cui-btn-active-border-color: #d50215;
-//     --cui-btn-active-color: #fff;
-//     --cui-btn-disabled-color: #d50215;
-//     --cui-btn-disabled-bg: transparent;
-//     --cui-btn-disabled-border-color: transparent
-// }
-// .btn-ghost-secondary{
-//     --cui-btn-color: #ccc;
-//     --cui-btn-border-color: transparent;
-//     --cui-btn-hover-bg: #ccc;
-//     --cui-btn-hover-border-color: #ccc;
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-active-bg: #ccc;
-//     --cui-btn-active-border-color: #ccc;
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-disabled-color: #ccc;
-//     --cui-btn-disabled-bg: transparent;
-//     --cui-btn-disabled-border-color: transparent
-// }
-// .btn-ghost-success{
-//     --cui-btn-color: #1b9e3e;
-//     --cui-btn-border-color: transparent;
-//     --cui-btn-hover-bg: #1b9e3e;
-//     --cui-btn-hover-border-color: #1b9e3e;
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-active-bg: #1b9e3e;
-//     --cui-btn-active-border-color: #1b9e3e;
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-disabled-color: #1b9e3e;
-//     --cui-btn-disabled-bg: transparent;
-//     --cui-btn-disabled-border-color: transparent
-// }
-// .btn-ghost-info{
-//     --cui-btn-color: #39f;
-//     --cui-btn-border-color: transparent;
-//     --cui-btn-hover-bg: #39f;
-//     --cui-btn-hover-border-color: #39f;
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-active-bg: #39f;
-//     --cui-btn-active-border-color: #39f;
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-disabled-color: #39f;
-//     --cui-btn-disabled-bg: transparent;
-//     --cui-btn-disabled-border-color: transparent
-// }
-// .btn-ghost-warning{
-//     --cui-btn-color: #f9b115;
-//     --cui-btn-border-color: transparent;
-//     --cui-btn-hover-bg: #f9b115;
-//     --cui-btn-hover-border-color: #f9b115;
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-active-bg: #f9b115;
-//     --cui-btn-active-border-color: #f9b115;
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-disabled-color: #f9b115;
-//     --cui-btn-disabled-bg: transparent;
-//     --cui-btn-disabled-border-color: transparent
-// }
-// .btn-ghost-danger{
-//     --cui-btn-color: #e55353;
-//     --cui-btn-border-color: transparent;
-//     --cui-btn-hover-bg: #e55353;
-//     --cui-btn-hover-border-color: #e55353;
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-active-bg: #e55353;
-//     --cui-btn-active-border-color: #e55353;
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-disabled-color: #e55353;
-//     --cui-btn-disabled-bg: transparent;
-//     --cui-btn-disabled-border-color: transparent
-// }
-// .btn-ghost-light{
-//     --cui-btn-color: #e9e9e9;
-//     --cui-btn-border-color: transparent;
-//     --cui-btn-hover-bg: #e9e9e9;
-//     --cui-btn-hover-border-color: #e9e9e9;
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-active-bg: #e9e9e9;
-//     --cui-btn-active-border-color: #e9e9e9;
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-disabled-color: #e9e9e9;
-//     --cui-btn-disabled-bg: transparent;
-//     --cui-btn-disabled-border-color: transparent
-// }
-// .btn-ghost-dark{
-//     --cui-btn-color: #212631;
-//     --cui-btn-border-color: transparent;
-//     --cui-btn-hover-bg: #212631;
-//     --cui-btn-hover-border-color: #212631;
-//     --cui-btn-hover-color: #fff;
-//     --cui-btn-active-bg: #212631;
-//     --cui-btn-active-border-color: #212631;
-//     --cui-btn-active-color: #fff;
-//     --cui-btn-disabled-color: #212631;
-//     --cui-btn-disabled-bg: transparent;
-//     --cui-btn-disabled-border-color: transparent
-// }
-// .btn-link{
-//     --cui-btn-font-weight: 400;
-//     --cui-btn-color: var(--cui-link-color);
-//     --cui-btn-bg: transparent;
-//     --cui-btn-border-color: transparent;
-//     --cui-btn-hover-color: var(--cui-link-hover-color);
-//     --cui-btn-hover-border-color: transparent;
-//     --cui-btn-active-border-color: transparent;
-//     --cui-btn-disabled-color: #6d7d9c;
-//     --cui-btn-disabled-border-color: transparent;
-//     --cui-btn-box-shadow: none;
-//     --cui-btn-focus-shadow-rgb: 219.3, 39.95, 56.1;
-//     text-decoration:underline
-// }
-// .btn-link:focus-visible{
-//     color:var(--cui-btn-color)
-// }
-// .btn-lg,.btn-group-lg>.btn{
-//     --cui-btn-padding-y: .5rem;
-//     --cui-btn-padding-x: 1rem;
-//     --cui-btn-font-size: 1.25rem;
-//     --cui-btn-border-radius: var(--cui-border-radius-lg)
-// }
-// .btn-sm,.btn-group-sm>.btn{
-//     --cui-btn-padding-y: .25rem;
-//     --cui-btn-padding-x: .5rem;
-//     --cui-btn-font-size: .75rem;
-//     --cui-btn-border-radius: var(--cui-border-radius-sm)
-// }
-// [data-coreui-theme=dark] .btn-primary{
-//     --cui-btn-color: #fff;
-//     --cui-btn-bg: rgb(202.45, 12.55, 29.65);
-//     --cui-btn-border-color: rgb(202.45, 12.55, 29.65);
-//     --cui-btn-hover-color: #fff;
-//     --cui-btn-hover-bg: rgb(172.0825, 10.6675, 25.2025);
-//     --cui-btn-hover-border-color: rgb(161.96, 10.04, 23.72);
-//     --cui-btn-focus-shadow-rgb: 210.3325, 48.9175, 63.4525;
-//     --cui-btn-active-color: #fff;
-//     --cui-btn-active-bg: rgb(161.96, 10.04, 23.72);
-//     --cui-btn-active-border-color: rgb(151.8375, 9.4125, 22.2375);
-//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
-//     --cui-btn-disabled-color: #fff;
-//     --cui-btn-disabled-bg: rgb(202.45, 12.55, 29.65);
-//     --cui-btn-disabled-border-color: rgb(202.45, 12.55, 29.65)
-// }
-// [data-coreui-theme=dark] .btn-secondary{
-//     --cui-btn-color: #080a0c;
-//     --cui-btn-bg: #ccc;
-//     --cui-btn-border-color: #ccc;
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-hover-bg: rgb(211.65, 211.65, 211.65);
-//     --cui-btn-hover-border-color: rgb(209.1, 209.1, 209.1);
-//     --cui-btn-focus-shadow-rgb: 174.6, 174.9, 175.2;
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-active-bg: rgb(214.2, 214.2, 214.2);
-//     --cui-btn-active-border-color: rgb(209.1, 209.1, 209.1);
-//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
-//     --cui-btn-disabled-color: #080a0c;
-//     --cui-btn-disabled-bg: #ccc;
-//     --cui-btn-disabled-border-color: #ccc
-// }
-// [data-coreui-theme=dark] .btn-success{
-//     --cui-btn-color: #080a0c;
-//     --cui-btn-bg: rgb(33.55, 151.45, 65.05);
-//     --cui-btn-border-color: rgb(33.55, 151.45, 65.05);
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-hover-bg: rgb(66.7675, 166.9825, 93.5425);
-//     --cui-btn-hover-border-color: rgb(55.695, 161.805, 84.045);
-//     --cui-btn-focus-shadow-rgb: 29.7175, 130.2325, 57.0925;
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-active-bg: rgb(77.84, 172.16, 103.04);
-//     --cui-btn-active-border-color: rgb(55.695, 161.805, 84.045);
-//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
-//     --cui-btn-disabled-color: #080a0c;
-//     --cui-btn-disabled-bg: rgb(33.55, 151.45, 65.05);
-//     --cui-btn-disabled-border-color: rgb(33.55, 151.45, 65.05)
-// }
-// [data-coreui-theme=dark] .btn-info{
-//     --cui-btn-color: #080a0c;
-//     --cui-btn-bg: rgb(61.2, 153, 244.8);
-//     --cui-btn-border-color: rgb(61.2, 153, 244.8);
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-hover-bg: rgb(90.27, 168.3, 246.33);
-//     --cui-btn-hover-border-color: rgb(80.58, 163.2, 245.82);
-//     --cui-btn-focus-shadow-rgb: 53.22, 131.55, 209.88;
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-active-bg: rgb(99.96, 173.4, 246.84);
-//     --cui-btn-active-border-color: rgb(80.58, 163.2, 245.82);
-//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
-//     --cui-btn-disabled-color: #080a0c;
-//     --cui-btn-disabled-bg: rgb(61.2, 153, 244.8);
-//     --cui-btn-disabled-border-color: rgb(61.2, 153, 244.8)
-// }
-// [data-coreui-theme=dark] .btn-warning{
-//     --cui-btn-color: #080a0c;
-//     --cui-btn-bg: rgb(237.6, 172.8, 32.4);
-//     --cui-btn-border-color: rgb(237.6, 172.8, 32.4);
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-hover-bg: rgb(240.21, 185.13, 65.79);
-//     --cui-btn-hover-border-color: rgb(239.34, 181.02, 54.66);
-//     --cui-btn-focus-shadow-rgb: 203.16, 148.38, 29.34;
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-active-bg: rgb(241.08, 189.24, 76.92);
-//     --cui-btn-active-border-color: rgb(239.34, 181.02, 54.66);
-//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
-//     --cui-btn-disabled-color: #080a0c;
-//     --cui-btn-disabled-bg: rgb(237.6, 172.8, 32.4);
-//     --cui-btn-disabled-border-color: rgb(237.6, 172.8, 32.4)
-// }
-// [data-coreui-theme=dark] .btn-danger{
-//     --cui-btn-color: #080a0c;
-//     --cui-btn-bg: rgb(221.7, 90.3, 90.3);
-//     --cui-btn-border-color: rgb(221.7, 90.3, 90.3);
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-hover-bg: rgb(226.695, 115.005, 115.005);
-//     --cui-btn-hover-border-color: rgb(225.03, 106.77, 106.77);
-//     --cui-btn-focus-shadow-rgb: 189.645, 78.255, 78.555;
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-active-bg: rgb(228.36, 123.24, 123.24);
-//     --cui-btn-active-border-color: rgb(225.03, 106.77, 106.77);
-//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
-//     --cui-btn-disabled-color: #080a0c;
-//     --cui-btn-disabled-bg: rgb(221.7, 90.3, 90.3);
-//     --cui-btn-disabled-border-color: rgb(221.7, 90.3, 90.3)
-// }
-// [data-coreui-theme=dark] .btn-light{
-//     --cui-btn-color: #080a0c;
-//     --cui-btn-bg: #e9e9e9;
-//     --cui-btn-border-color: #e9e9e9;
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-hover-bg: rgb(236.3, 236.3, 236.3);
-//     --cui-btn-hover-border-color: rgb(235.2, 235.2, 235.2);
-//     --cui-btn-focus-shadow-rgb: 199.25, 199.55, 199.85;
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-active-bg: rgb(237.4, 237.4, 237.4);
-//     --cui-btn-active-border-color: rgb(235.2, 235.2, 235.2);
-//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
-//     --cui-btn-disabled-color: #080a0c;
-//     --cui-btn-disabled-bg: #e9e9e9;
-//     --cui-btn-disabled-border-color: #e9e9e9
-// }
-// [data-coreui-theme=dark] .btn-dark{
-//     --cui-btn-color: #fff;
-//     --cui-btn-bg: #212631;
-//     --cui-btn-border-color: #212631;
-//     --cui-btn-hover-color: #fff;
-//     --cui-btn-hover-bg: rgb(28.05, 32.3, 41.65);
-//     --cui-btn-hover-border-color: rgb(26.4, 30.4, 39.2);
-//     --cui-btn-focus-shadow-rgb: 66.3, 70.55, 79.9;
-//     --cui-btn-active-color: #fff;
-//     --cui-btn-active-bg: rgb(26.4, 30.4, 39.2);
-//     --cui-btn-active-border-color: rgb(24.75, 28.5, 36.75);
-//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
-//     --cui-btn-disabled-color: #fff;
-//     --cui-btn-disabled-bg: #212631;
-//     --cui-btn-disabled-border-color: #212631
-// }
-// [data-coreui-theme=dark] .btn-outline-primary{
-//     --cui-btn-color: rgb(202.45, 12.55, 29.65);
-//     --cui-btn-border-color: rgb(202.45, 12.55, 29.65);
-//     --cui-btn-hover-color: #fff;
-//     --cui-btn-hover-bg: rgb(202.45, 12.55, 29.65);
-//     --cui-btn-hover-border-color: rgb(202.45, 12.55, 29.65);
-//     --cui-btn-focus-shadow-rgb: 202.45, 12.55, 29.65;
-//     --cui-btn-active-color: #fff;
-//     --cui-btn-active-bg: rgb(202.45, 12.55, 29.65);
-//     --cui-btn-active-border-color: rgb(202.45, 12.55, 29.65);
-//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
-//     --cui-btn-disabled-color: rgb(202.45, 12.55, 29.65);
-//     --cui-btn-disabled-bg: transparent;
-//     --cui-btn-disabled-border-color: rgb(202.45, 12.55, 29.65);
-//     --cui-gradient: none
-// }
-// [data-coreui-theme=dark] .btn-outline-secondary{
-//     --cui-btn-color: #ccc;
-//     --cui-btn-border-color: #ccc;
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-hover-bg: #ccc;
-//     --cui-btn-hover-border-color: #ccc;
-//     --cui-btn-focus-shadow-rgb: 204, 204, 204;
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-active-bg: #ccc;
-//     --cui-btn-active-border-color: #ccc;
-//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
-//     --cui-btn-disabled-color: #ccc;
-//     --cui-btn-disabled-bg: transparent;
-//     --cui-btn-disabled-border-color: #ccc;
-//     --cui-gradient: none
-// }
-// [data-coreui-theme=dark] .btn-outline-success{
-//     --cui-btn-color: rgb(33.55, 151.45, 65.05);
-//     --cui-btn-border-color: rgb(33.55, 151.45, 65.05);
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-hover-bg: rgb(33.55, 151.45, 65.05);
-//     --cui-btn-hover-border-color: rgb(33.55, 151.45, 65.05);
-//     --cui-btn-focus-shadow-rgb: 33.55, 151.45, 65.05;
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-active-bg: rgb(33.55, 151.45, 65.05);
-//     --cui-btn-active-border-color: rgb(33.55, 151.45, 65.05);
-//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
-//     --cui-btn-disabled-color: rgb(33.55, 151.45, 65.05);
-//     --cui-btn-disabled-bg: transparent;
-//     --cui-btn-disabled-border-color: rgb(33.55, 151.45, 65.05);
-//     --cui-gradient: none
-// }
-// [data-coreui-theme=dark] .btn-outline-info{
-//     --cui-btn-color: rgb(61.2, 153, 244.8);
-//     --cui-btn-border-color: rgb(61.2, 153, 244.8);
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-hover-bg: rgb(61.2, 153, 244.8);
-//     --cui-btn-hover-border-color: rgb(61.2, 153, 244.8);
-//     --cui-btn-focus-shadow-rgb: 61.2, 153, 244.8;
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-active-bg: rgb(61.2, 153, 244.8);
-//     --cui-btn-active-border-color: rgb(61.2, 153, 244.8);
-//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
-//     --cui-btn-disabled-color: rgb(61.2, 153, 244.8);
-//     --cui-btn-disabled-bg: transparent;
-//     --cui-btn-disabled-border-color: rgb(61.2, 153, 244.8);
-//     --cui-gradient: none
-// }
-// [data-coreui-theme=dark] .btn-outline-warning{
-//     --cui-btn-color: rgb(237.6, 172.8, 32.4);
-//     --cui-btn-border-color: rgb(237.6, 172.8, 32.4);
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-hover-bg: rgb(237.6, 172.8, 32.4);
-//     --cui-btn-hover-border-color: rgb(237.6, 172.8, 32.4);
-//     --cui-btn-focus-shadow-rgb: 237.6, 172.8, 32.4;
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-active-bg: rgb(237.6, 172.8, 32.4);
-//     --cui-btn-active-border-color: rgb(237.6, 172.8, 32.4);
-//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
-//     --cui-btn-disabled-color: rgb(237.6, 172.8, 32.4);
-//     --cui-btn-disabled-bg: transparent;
-//     --cui-btn-disabled-border-color: rgb(237.6, 172.8, 32.4);
-//     --cui-gradient: none
-// }
-// [data-coreui-theme=dark] .btn-outline-danger{
-//     --cui-btn-color: rgb(221.7, 90.3, 90.3);
-//     --cui-btn-border-color: rgb(221.7, 90.3, 90.3);
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-hover-bg: rgb(221.7, 90.3, 90.3);
-//     --cui-btn-hover-border-color: rgb(221.7, 90.3, 90.3);
-//     --cui-btn-focus-shadow-rgb: 221.7, 90.3, 90.3;
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-active-bg: rgb(221.7, 90.3, 90.3);
-//     --cui-btn-active-border-color: rgb(221.7, 90.3, 90.3);
-//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
-//     --cui-btn-disabled-color: rgb(221.7, 90.3, 90.3);
-//     --cui-btn-disabled-bg: transparent;
-//     --cui-btn-disabled-border-color: rgb(221.7, 90.3, 90.3);
-//     --cui-gradient: none
-// }
-// [data-coreui-theme=dark] .btn-outline-light{
-//     --cui-btn-color: #e9e9e9;
-//     --cui-btn-border-color: #e9e9e9;
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-hover-bg: #e9e9e9;
-//     --cui-btn-hover-border-color: #e9e9e9;
-//     --cui-btn-focus-shadow-rgb: 233, 233, 233;
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-active-bg: #e9e9e9;
-//     --cui-btn-active-border-color: #e9e9e9;
-//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
-//     --cui-btn-disabled-color: #e9e9e9;
-//     --cui-btn-disabled-bg: transparent;
-//     --cui-btn-disabled-border-color: #e9e9e9;
-//     --cui-gradient: none
-// }
-// [data-coreui-theme=dark] .btn-outline-dark{
-//     --cui-btn-color: #212631;
-//     --cui-btn-border-color: #212631;
-//     --cui-btn-hover-color: #fff;
-//     --cui-btn-hover-bg: #212631;
-//     --cui-btn-hover-border-color: #212631;
-//     --cui-btn-focus-shadow-rgb: 33, 38, 49;
-//     --cui-btn-active-color: #fff;
-//     --cui-btn-active-bg: #212631;
-//     --cui-btn-active-border-color: #212631;
-//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
-//     --cui-btn-disabled-color: #212631;
-//     --cui-btn-disabled-bg: transparent;
-//     --cui-btn-disabled-border-color: #212631;
-//     --cui-gradient: none
-// }
-// [data-coreui-theme=dark] .btn-ghost-primary{
-//     --cui-btn-color: rgb(202.45, 12.55, 29.65);
-//     --cui-btn-border-color: transparent;
-//     --cui-btn-hover-bg: rgb(202.45, 12.55, 29.65);
-//     --cui-btn-hover-border-color: rgb(202.45, 12.55, 29.65);
-//     --cui-btn-hover-color: #fff;
-//     --cui-btn-active-bg: rgb(202.45, 12.55, 29.65);
-//     --cui-btn-active-border-color: rgb(202.45, 12.55, 29.65);
-//     --cui-btn-active-color: #fff;
-//     --cui-btn-disabled-color: rgb(202.45, 12.55, 29.65);
-//     --cui-btn-disabled-bg: transparent;
-//     --cui-btn-disabled-border-color: transparent
-// }
-// [data-coreui-theme=dark] .btn-ghost-secondary{
-//     --cui-btn-color: #ccc;
-//     --cui-btn-border-color: transparent;
-//     --cui-btn-hover-bg: #ccc;
-//     --cui-btn-hover-border-color: #ccc;
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-active-bg: #ccc;
-//     --cui-btn-active-border-color: #ccc;
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-disabled-color: #ccc;
-//     --cui-btn-disabled-bg: transparent;
-//     --cui-btn-disabled-border-color: transparent
-// }
-// [data-coreui-theme=dark] .btn-ghost-success{
-//     --cui-btn-color: rgb(33.55, 151.45, 65.05);
-//     --cui-btn-border-color: transparent;
-//     --cui-btn-hover-bg: rgb(33.55, 151.45, 65.05);
-//     --cui-btn-hover-border-color: rgb(33.55, 151.45, 65.05);
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-active-bg: rgb(33.55, 151.45, 65.05);
-//     --cui-btn-active-border-color: rgb(33.55, 151.45, 65.05);
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-disabled-color: rgb(33.55, 151.45, 65.05);
-//     --cui-btn-disabled-bg: transparent;
-//     --cui-btn-disabled-border-color: transparent
-// }
-// [data-coreui-theme=dark] .btn-ghost-info{
-//     --cui-btn-color: rgb(61.2, 153, 244.8);
-//     --cui-btn-border-color: transparent;
-//     --cui-btn-hover-bg: rgb(61.2, 153, 244.8);
-//     --cui-btn-hover-border-color: rgb(61.2, 153, 244.8);
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-active-bg: rgb(61.2, 153, 244.8);
-//     --cui-btn-active-border-color: rgb(61.2, 153, 244.8);
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-disabled-color: rgb(61.2, 153, 244.8);
-//     --cui-btn-disabled-bg: transparent;
-//     --cui-btn-disabled-border-color: transparent
-// }
-// [data-coreui-theme=dark] .btn-ghost-warning{
-//     --cui-btn-color: rgb(237.6, 172.8, 32.4);
-//     --cui-btn-border-color: transparent;
-//     --cui-btn-hover-bg: rgb(237.6, 172.8, 32.4);
-//     --cui-btn-hover-border-color: rgb(237.6, 172.8, 32.4);
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-active-bg: rgb(237.6, 172.8, 32.4);
-//     --cui-btn-active-border-color: rgb(237.6, 172.8, 32.4);
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-disabled-color: rgb(237.6, 172.8, 32.4);
-//     --cui-btn-disabled-bg: transparent;
-//     --cui-btn-disabled-border-color: transparent
-// }
-// [data-coreui-theme=dark] .btn-ghost-danger{
-//     --cui-btn-color: rgb(221.7, 90.3, 90.3);
-//     --cui-btn-border-color: transparent;
-//     --cui-btn-hover-bg: rgb(221.7, 90.3, 90.3);
-//     --cui-btn-hover-border-color: rgb(221.7, 90.3, 90.3);
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-active-bg: rgb(221.7, 90.3, 90.3);
-//     --cui-btn-active-border-color: rgb(221.7, 90.3, 90.3);
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-disabled-color: rgb(221.7, 90.3, 90.3);
-//     --cui-btn-disabled-bg: transparent;
-//     --cui-btn-disabled-border-color: transparent
-// }
-// [data-coreui-theme=dark] .btn-ghost-light{
-//     --cui-btn-color: #e9e9e9;
-//     --cui-btn-border-color: transparent;
-//     --cui-btn-hover-bg: #e9e9e9;
-//     --cui-btn-hover-border-color: #e9e9e9;
-//     --cui-btn-hover-color: #080a0c;
-//     --cui-btn-active-bg: #e9e9e9;
-//     --cui-btn-active-border-color: #e9e9e9;
-//     --cui-btn-active-color: #080a0c;
-//     --cui-btn-disabled-color: #e9e9e9;
-//     --cui-btn-disabled-bg: transparent;
-//     --cui-btn-disabled-border-color: transparent
-// }
-// [data-coreui-theme=dark] .btn-ghost-dark{
-//     --cui-btn-color: #212631;
-//     --cui-btn-border-color: transparent;
-//     --cui-btn-hover-bg: #212631;
-//     --cui-btn-hover-border-color: #212631;
-//     --cui-btn-hover-color: #fff;
-//     --cui-btn-active-bg: #212631;
-//     --cui-btn-active-border-color: #212631;
-//     --cui-btn-active-color: #fff;
-//     --cui-btn-disabled-color: #212631;
-//     --cui-btn-disabled-bg: transparent;
-//     --cui-btn-disabled-border-color: transparent
-// }
-// .fade{
-//     transition:opacity .15s linear
-// }
-// @media(prefers-reduced-motion:reduce){
-//     .fade{
-//         transition:none
-//     }
-// }
+.button {
+	--btn-padding-x: 0.75rem;
+	--btn-padding-y: 0.375rem;
+	--btn-font-size: 0.9rem;
+	--btn-font-weight: 400;
+	--btn-line-height: 1.5;
+	--btn-border-width: 1px;
+	--btn-border-radius: 0.375rem;
+	--btn-disabled-opacity: 0.65;
+	--btn-focus-shadow-rgb: 213, 2, 21;
 
-// .btn-close{
-//     --cui-btn-close-color: #080a0c;
-//     --cui-btn-close-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23080a0c'%3e%3cpath d='M.293.293a1 1 0 0 1 1.414 0L8 6.586 14.293.293a1 1 0 1 1 1.414 1.414L9.414 8l6.293 6.293a1 1 0 0 1-1.414 1.414L8 9.414l-6.293 6.293a1 1 0 0 1-1.414-1.414L6.586 8 .293 1.707a1 1 0 0 1 0-1.414'/%3e%3c/svg%3e");
-//     --cui-btn-close-opacity: .5;
-//     --cui-btn-close-hover-opacity: .75;
-//     --cui-btn-close-focus-shadow: 0 0 0 .25rem rgba(213, 2, 21, .25);
-//     --cui-btn-close-focus-opacity: 1;
-//     --cui-btn-close-disabled-opacity: .25;
-//     box-sizing:content-box;
-//     width:1em;
-//     height:1em;
-//     padding:.25em;
-//     color:var(--cui-btn-close-color);
-//     background:transparent var(--cui-btn-close-bg) center/1em auto no-repeat;
-//     filter:var(--cui-btn-close-filter);
-//     border:0;
-//     border-radius:.375rem;
-//     opacity:var(--cui-btn-close-opacity)
-// }
-// .btn-close:hover{
-//     color:var(--cui-btn-close-color);
-//     text-decoration:none;
-//     opacity:var(--cui-btn-close-hover-opacity)
-// }
-// .btn-close:focus{
-//     outline:0;
-//     box-shadow:var(--cui-btn-close-focus-shadow);
-//     opacity:var(--cui-btn-close-focus-opacity)
-// }
-// .btn-close:disabled,.btn-close.disabled{
-//     pointer-events:none;
-//     user-select:none;
-//     opacity:var(--cui-btn-close-disabled-opacity)
-// }
-// .btn-close-white{
-//     --cui-btn-close-filter: invert(1) grayscale(100%) brightness(200%)
-// }
-// :root,[data-coreui-theme=light]{
-//     --cui-btn-close-filter:
-// }
-// [data-coreui-theme=dark]{
-//     --cui-btn-close-filter: invert(1) grayscale(100%) brightness(200%)
-// }
+	// defaults — overridden by color variants below
+	--btn-color: inherit;
+	--btn-bg: transparent;
+	--btn-border-color: transparent;
+	--btn-hover-color: inherit;
+	--btn-hover-bg: transparent;
+	--btn-hover-border-color: transparent;
+	--btn-active-color: inherit;
+	--btn-active-bg: transparent;
+	--btn-active-border-color: transparent;
+	--btn-disabled-color: inherit;
+	--btn-disabled-bg: transparent;
+	--btn-disabled-border-color: transparent;
 
-// .input-group .btn{
-//     position:relative;
-//     z-index:2
-// }
-// .input-group .btn:focus{
-//     z-index:5
-// }
+	display: inline-block;
+	padding: var(--btn-padding-y) var(--btn-padding-x);
+	font-size: var(--btn-font-size);
+	font-weight: var(--btn-font-weight);
+	line-height: var(--btn-line-height);
+	color: var(--btn-color);
+	text-align: center;
+	text-decoration: none;
+	vertical-align: middle;
+	cursor: pointer;
+	user-select: none;
+	border: var(--btn-border-width) solid var(--btn-border-color);
+	border-radius: var(--btn-border-radius);
+	background-color: var(--btn-bg);
+	transition:
+		color 0.15s ease-in-out,
+		background-color 0.15s ease-in-out,
+		border-color 0.15s ease-in-out,
+		box-shadow 0.15s ease-in-out;
 
-.btn-danger {
-	// TODO - this should really update the variables
-	background-color: rgba(180, 0, 0, 1);
+	@media (prefers-reduced-motion: reduce) {
+		transition: none;
+	}
+
+	&:hover {
+		color: var(--btn-hover-color);
+		background-color: var(--btn-hover-bg);
+		border-color: var(--btn-hover-border-color);
+	}
+
+	&:focus-visible {
+		color: var(--btn-hover-color);
+		background-color: var(--btn-hover-bg);
+		border-color: var(--btn-hover-border-color);
+		outline: 0;
+		box-shadow: 0 0 0 0.25rem rgba(var(--btn-focus-shadow-rgb), 0.5);
+	}
+
+	&:active,
+	&:not([disabled]):active,
+	&.active {
+		color: var(--btn-active-color);
+		background-color: var(--btn-active-bg);
+		border-color: var(--btn-active-border-color);
+	}
+
+	&:active:focus-visible,
+	&:not([disabled]):active:focus-visible,
+	&.active:focus-visible {
+		box-shadow: 0 0 0 0.25rem rgba(var(--btn-focus-shadow-rgb), 0.5);
+	}
+
+	&:disabled,
+	&.disabled,
+	&[aria-disabled='true'] {
+		color: var(--btn-disabled-color);
+		pointer-events: none;
+		background-color: var(--btn-disabled-bg);
+		border-color: var(--btn-disabled-border-color);
+		opacity: var(--btn-disabled-opacity);
+	}
 }
 
-.btn-danger:hover {
-	// TODO - this should really use the variables
-	background-color: color.adjust(rgba(180, 0, 0, 1), $lightness: -5%, $space: hsl);
-	color: #eee;
-	animation: blinker 0.4s linear infinite;
+// ---- Special states ----
+
+.button.disabled.with-tooltip {
+	cursor: inherit;
+	pointer-events: inherit;
 }
 
-.btn-danger:disabled {
-	color: rgba(255, 255, 255, 0.8);
+// ---- Size modifiers ----
+
+.button-sm {
+	--btn-padding-y: 0.25rem;
+	--btn-padding-x: 0.5rem;
+	--btn-font-size: 0.75rem;
+	--btn-border-radius: 0.25rem;
 }
 
-.btn-success:disabled {
-	color: rgba(255, 255, 255, 0.9);
+.button-lg {
+	--btn-padding-y: 0.5rem;
+	--btn-padding-x: 1rem;
+	--btn-font-size: 1.25rem;
+	--btn-border-radius: 0.5rem;
 }
 
-.btn-info:disabled {
-	color: rgba(255, 255, 255, 0.9);
+// ---- Solid color variants ----
+
+.button-primary {
+	--btn-color: #fff;
+	--btn-bg: #d50215;
+	--btn-border-color: #d50215;
+	--btn-hover-color: #fff;
+	--btn-hover-bg: rgb(181, 2, 18);
+	--btn-hover-border-color: rgb(170, 2, 17);
+	--btn-focus-shadow-rgb: 219, 40, 56;
+	--btn-active-color: #fff;
+	--btn-active-bg: rgb(170, 2, 17);
+	--btn-active-border-color: rgb(160, 2, 16);
+	--btn-disabled-color: #fff;
+	--btn-disabled-bg: #d50215;
+	--btn-disabled-border-color: #d50215;
 }
+
+.button-secondary {
+	--btn-color: #080a0c;
+	--btn-bg: #f2f2f2;
+	--btn-border-color: #ccc;
+	--btn-hover-color: #080a0c;
+	--btn-hover-bg: rgb(212, 212, 212);
+	--btn-hover-border-color: rgb(209, 209, 209);
+	--btn-focus-shadow-rgb: 175, 175, 175;
+	--btn-active-color: #080a0c;
+	--btn-active-bg: rgb(214, 214, 214);
+	--btn-active-border-color: rgb(209, 209, 209);
+	--btn-disabled-color: #080a0c;
+	--btn-disabled-bg: #ccc;
+	--btn-disabled-border-color: #ccc;
+}
+
+.button-success {
+	--btn-color: #fff;
+	--btn-bg: #1b9e3e;
+	--btn-border-color: #1b9e3e;
+	--btn-hover-color: #fff;
+	--btn-hover-bg: rgb(61, 173, 91);
+	--btn-hover-border-color: rgb(50, 168, 81);
+	--btn-focus-shadow-rgb: 24, 136, 55;
+	--btn-active-color: #080a0c;
+	--btn-active-bg: rgb(73, 177, 101);
+	--btn-active-border-color: rgb(50, 168, 81);
+	--btn-disabled-color: rgba(255, 255, 255, 0.9);
+	--btn-disabled-bg: #1b9e3e;
+	--btn-disabled-border-color: #1b9e3e;
+}
+
+.button-info {
+	--btn-color: #fff;
+	--btn-bg: #39f;
+	--btn-border-color: #39f;
+	--btn-hover-color: #080a0c;
+	--btn-hover-bg: rgb(82, 168, 255);
+	--btn-hover-border-color: rgb(71, 163, 255);
+	--btn-focus-shadow-rgb: 45, 132, 219;
+	--btn-active-color: #080a0c;
+	--btn-active-bg: rgb(92, 173, 255);
+	--btn-active-border-color: rgb(71, 163, 255);
+	--btn-disabled-color: rgba(255, 255, 255, 0.9);
+	--btn-disabled-bg: #39f;
+	--btn-disabled-border-color: #39f;
+}
+
+.button-warning {
+	--btn-color: #080a0c;
+	--btn-bg: #f9b115;
+	--btn-border-color: #f9b115;
+	--btn-hover-color: #080a0c;
+	--btn-hover-bg: rgb(250, 189, 56);
+	--btn-hover-border-color: rgb(250, 185, 44);
+	--btn-focus-shadow-rgb: 213, 152, 20;
+	--btn-active-color: #080a0c;
+	--btn-active-bg: rgb(250, 193, 68);
+	--btn-active-border-color: rgb(250, 185, 44);
+	--btn-disabled-color: #080a0c;
+	--btn-disabled-bg: #f9b115;
+	--btn-disabled-border-color: #f9b115;
+}
+
+.button-danger {
+	--btn-color: #fff;
+	--btn-bg: rgb(180, 0, 0);
+	--btn-border-color: rgb(180, 0, 0);
+	--btn-hover-color: #eee;
+	--btn-hover-bg: rgb(155, 0, 0);
+	--btn-hover-border-color: rgb(145, 0, 0);
+	--btn-focus-shadow-rgb: 196, 72, 72;
+	--btn-active-color: #fff;
+	--btn-active-bg: rgb(140, 0, 0);
+	--btn-active-border-color: rgb(130, 0, 0);
+	--btn-disabled-color: rgba(255, 255, 255, 0.8);
+	--btn-disabled-bg: rgb(180, 0, 0);
+	--btn-disabled-border-color: rgb(180, 0, 0);
+
+	&:hover {
+		animation: blinker 0.4s linear infinite;
+	}
+}
+
+.button-light {
+	--btn-color: #080a0c;
+	--btn-bg: #e9e9e9;
+	--btn-border-color: #e9e9e9;
+	--btn-hover-color: #080a0c;
+	--btn-hover-bg: rgb(198, 198, 198);
+	--btn-hover-border-color: rgb(186, 186, 186);
+	--btn-focus-shadow-rgb: 199, 200, 200;
+	--btn-active-color: #080a0c;
+	--btn-active-bg: rgb(186, 186, 186);
+	--btn-active-border-color: rgb(175, 175, 175);
+	--btn-disabled-color: #080a0c;
+	--btn-disabled-bg: #e9e9e9;
+	--btn-disabled-border-color: #e9e9e9;
+}
+
+.button-dark {
+	--btn-color: #fff;
+	--btn-bg: #212631;
+	--btn-border-color: #212631;
+	--btn-hover-color: #fff;
+	--btn-hover-bg: rgb(66, 71, 80);
+	--btn-hover-border-color: rgb(55, 60, 70);
+	--btn-focus-shadow-rgb: 66, 71, 80;
+	--btn-active-color: #fff;
+	--btn-active-bg: rgb(77, 81, 90);
+	--btn-active-border-color: rgb(55, 60, 70);
+	--btn-disabled-color: #fff;
+	--btn-disabled-bg: #212631;
+	--btn-disabled-border-color: #212631;
+}
+
+.button-gray {
+	--btn-color: #fff;
+	--btn-bg: #6c757d;
+	--btn-border-color: #6c757d;
+	--btn-hover-color: #fff;
+	--btn-hover-bg: #5c636a;
+	--btn-hover-border-color: #565e64;
+	--btn-focus-shadow-rgb: 108, 117, 125;
+	--btn-active-color: #fff;
+	--btn-active-bg: #565e64;
+	--btn-active-border-color: #51585e;
+	--btn-disabled-color: #fff;
+	--btn-disabled-bg: #6c757d;
+	--btn-disabled-border-color: #6c757d;
+}
+
+.button-white {
+	--btn-color: #080a0c;
+	--btn-bg: #fff;
+	--btn-border-color: #dee2e6;
+	--btn-hover-color: #080a0c;
+	--btn-hover-bg: #e9ecef;
+	--btn-hover-border-color: #dee2e6;
+	--btn-focus-shadow-rgb: 222, 226, 230;
+	--btn-active-color: #080a0c;
+	--btn-active-bg: #dde0e3;
+	--btn-active-border-color: #d0d5d8;
+	--btn-disabled-color: #080a0c;
+	--btn-disabled-bg: #fff;
+	--btn-disabled-border-color: #dee2e6;
+}
+
+.button-disabled {
+	--btn-color: #6c757d;
+	--btn-bg: #e9ecef;
+	--btn-border-color: #dee2e6;
+	--btn-hover-color: #6c757d;
+	--btn-hover-bg: #e9ecef;
+	--btn-hover-border-color: #dee2e6;
+	--btn-focus-shadow-rgb: 108, 117, 125;
+	--btn-active-color: #6c757d;
+	--btn-active-bg: #e9ecef;
+	--btn-active-border-color: #dee2e6;
+	--btn-disabled-color: #6c757d;
+	--btn-disabled-bg: #e9ecef;
+	--btn-disabled-border-color: #dee2e6;
+}
+
+.button-link {
+	--btn-color: #d50215;
+	--btn-bg: transparent;
+	--btn-border-color: transparent;
+	--btn-hover-color: #aa0111;
+	--btn-hover-border-color: transparent;
+	--btn-active-border-color: transparent;
+	--btn-disabled-color: #6d7d9c;
+	--btn-disabled-border-color: transparent;
+	text-decoration: underline;
+
+	&:focus-visible {
+		color: var(--btn-color);
+	}
+}
+
+// ---- Outline variant ----
+
+.button-outline {
+	--btn-color: #6d7d9c;
+	--btn-bg: transparent;
+	--btn-border-color: #dee2e6;
+	--btn-hover-color: currentColor;
+	--btn-hover-bg: rgba(0, 0, 0, 0.05);
+	--btn-hover-border-color: #dee2e6;
+	--btn-active-color: currentColor;
+	--btn-active-bg: rgba(0, 0, 0, 0.05);
+	--btn-active-border-color: #dee2e6;
+	--btn-disabled-color: #6d7d9c;
+	--btn-disabled-bg: transparent;
+	--btn-disabled-border-color: #dee2e6;
+}
+
+.button-outline-primary {
+	--btn-color: #d50215;
+	--btn-bg: transparent;
+	--btn-border-color: #d50215;
+	--btn-hover-color: #fff;
+	--btn-hover-bg: #d50215;
+	--btn-hover-border-color: #d50215;
+	--btn-focus-shadow-rgb: 213, 2, 21;
+	--btn-active-color: #fff;
+	--btn-active-bg: #d50215;
+	--btn-active-border-color: #d50215;
+	--btn-disabled-color: #d50215;
+	--btn-disabled-bg: transparent;
+	--btn-disabled-border-color: #d50215;
+}
+
+.button-outline-secondary {
+	--btn-color: #ccc;
+	--btn-bg: transparent;
+	--btn-border-color: #ccc;
+	--btn-hover-color: #080a0c;
+	--btn-hover-bg: #ccc;
+	--btn-hover-border-color: #ccc;
+	--btn-focus-shadow-rgb: 204, 204, 204;
+	--btn-active-color: #080a0c;
+	--btn-active-bg: #ccc;
+	--btn-active-border-color: #ccc;
+	--btn-disabled-color: #ccc;
+	--btn-disabled-bg: transparent;
+	--btn-disabled-border-color: #ccc;
+}
+
+.button-outline-success {
+	--btn-color: #1b9e3e;
+	--btn-bg: transparent;
+	--btn-border-color: #1b9e3e;
+	--btn-hover-color: #080a0c;
+	--btn-hover-bg: #1b9e3e;
+	--btn-hover-border-color: #1b9e3e;
+	--btn-focus-shadow-rgb: 27, 158, 62;
+	--btn-active-color: #080a0c;
+	--btn-active-bg: #1b9e3e;
+	--btn-active-border-color: #1b9e3e;
+	--btn-disabled-color: #1b9e3e;
+	--btn-disabled-bg: transparent;
+	--btn-disabled-border-color: #1b9e3e;
+}
+
+.button-outline-info {
+	--btn-color: #39f;
+	--btn-bg: transparent;
+	--btn-border-color: #39f;
+	--btn-hover-color: #080a0c;
+	--btn-hover-bg: #39f;
+	--btn-hover-border-color: #39f;
+	--btn-focus-shadow-rgb: 51, 153, 255;
+	--btn-active-color: #080a0c;
+	--btn-active-bg: #39f;
+	--btn-active-border-color: #39f;
+	--btn-disabled-color: #39f;
+	--btn-disabled-bg: transparent;
+	--btn-disabled-border-color: #39f;
+}
+
+.button-outline-warning {
+	--btn-color: #f9b115;
+	--btn-bg: transparent;
+	--btn-border-color: #f9b115;
+	--btn-hover-color: #080a0c;
+	--btn-hover-bg: #f9b115;
+	--btn-hover-border-color: #f9b115;
+	--btn-focus-shadow-rgb: 249, 177, 21;
+	--btn-active-color: #080a0c;
+	--btn-active-bg: #f9b115;
+	--btn-active-border-color: #f9b115;
+	--btn-disabled-color: #f9b115;
+	--btn-disabled-bg: transparent;
+	--btn-disabled-border-color: #f9b115;
+}
+
+.button-outline-danger {
+	--btn-color: rgb(180, 0, 0);
+	--btn-bg: transparent;
+	--btn-border-color: rgb(180, 0, 0);
+	--btn-hover-color: #fff;
+	--btn-hover-bg: rgb(180, 0, 0);
+	--btn-hover-border-color: rgb(180, 0, 0);
+	--btn-focus-shadow-rgb: 180, 0, 0;
+	--btn-active-color: #fff;
+	--btn-active-bg: rgb(180, 0, 0);
+	--btn-active-border-color: rgb(180, 0, 0);
+	--btn-disabled-color: rgb(180, 0, 0);
+	--btn-disabled-bg: transparent;
+	--btn-disabled-border-color: rgb(180, 0, 0);
+}
+
+.button-outline-light {
+	--btn-color: #e9e9e9;
+	--btn-bg: transparent;
+	--btn-border-color: #e9e9e9;
+	--btn-hover-color: #080a0c;
+	--btn-hover-bg: #e9e9e9;
+	--btn-hover-border-color: #e9e9e9;
+	--btn-focus-shadow-rgb: 233, 233, 233;
+	--btn-active-color: #080a0c;
+	--btn-active-bg: #e9e9e9;
+	--btn-active-border-color: #e9e9e9;
+	--btn-disabled-color: #e9e9e9;
+	--btn-disabled-bg: transparent;
+	--btn-disabled-border-color: #e9e9e9;
+}
+
+.button-outline-dark {
+	--btn-color: #212631;
+	--btn-bg: transparent;
+	--btn-border-color: #212631;
+	--btn-hover-color: #fff;
+	--btn-hover-bg: #212631;
+	--btn-hover-border-color: #212631;
+	--btn-focus-shadow-rgb: 33, 38, 49;
+	--btn-active-color: #fff;
+	--btn-active-bg: #212631;
+	--btn-active-border-color: #212631;
+	--btn-disabled-color: #212631;
+	--btn-disabled-bg: transparent;
+	--btn-disabled-border-color: #212631;
+}
+
+// ---- Ghost variant ----
+
+.button-ghost {
+	--btn-color: #6d7d9c;
+	--btn-bg: transparent;
+	--btn-border-color: transparent;
+	--btn-hover-color: currentColor;
+	--btn-hover-bg: rgba(0, 0, 0, 0.05);
+	--btn-hover-border-color: rgba(0, 0, 0, 0.05);
+	--btn-active-color: currentColor;
+	--btn-active-bg: rgba(0, 0, 0, 0.08);
+	--btn-active-border-color: rgba(0, 0, 0, 0.08);
+	--btn-disabled-color: #6d7d9c;
+	--btn-disabled-bg: transparent;
+	--btn-disabled-border-color: transparent;
+}
+
+.button-ghost-primary {
+	--btn-color: #d50215;
+	--btn-bg: transparent;
+	--btn-border-color: transparent;
+	--btn-hover-color: #fff;
+	--btn-hover-bg: #d50215;
+	--btn-hover-border-color: #d50215;
+	--btn-active-color: #fff;
+	--btn-active-bg: #d50215;
+	--btn-active-border-color: #d50215;
+	--btn-disabled-color: #d50215;
+	--btn-disabled-bg: transparent;
+	--btn-disabled-border-color: transparent;
+}
+
+.button-ghost-secondary {
+	--btn-color: #ccc;
+	--btn-bg: transparent;
+	--btn-border-color: transparent;
+	--btn-hover-color: #080a0c;
+	--btn-hover-bg: #ccc;
+	--btn-hover-border-color: #ccc;
+	--btn-active-color: #080a0c;
+	--btn-active-bg: #ccc;
+	--btn-active-border-color: #ccc;
+	--btn-disabled-color: #ccc;
+	--btn-disabled-bg: transparent;
+	--btn-disabled-border-color: transparent;
+}
+
+.button-ghost-success {
+	--btn-color: #1b9e3e;
+	--btn-bg: transparent;
+	--btn-border-color: transparent;
+	--btn-hover-color: #080a0c;
+	--btn-hover-bg: #1b9e3e;
+	--btn-hover-border-color: #1b9e3e;
+	--btn-active-color: #080a0c;
+	--btn-active-bg: #1b9e3e;
+	--btn-active-border-color: #1b9e3e;
+	--btn-disabled-color: #1b9e3e;
+	--btn-disabled-bg: transparent;
+	--btn-disabled-border-color: transparent;
+}
+
+.button-ghost-info {
+	--btn-color: #39f;
+	--btn-bg: transparent;
+	--btn-border-color: transparent;
+	--btn-hover-color: #080a0c;
+	--btn-hover-bg: #39f;
+	--btn-hover-border-color: #39f;
+	--btn-active-color: #080a0c;
+	--btn-active-bg: #39f;
+	--btn-active-border-color: #39f;
+	--btn-disabled-color: #39f;
+	--btn-disabled-bg: transparent;
+	--btn-disabled-border-color: transparent;
+}
+
+.button-ghost-warning {
+	--btn-color: #f9b115;
+	--btn-bg: transparent;
+	--btn-border-color: transparent;
+	--btn-hover-color: #080a0c;
+	--btn-hover-bg: #f9b115;
+	--btn-hover-border-color: #f9b115;
+	--btn-active-color: #080a0c;
+	--btn-active-bg: #f9b115;
+	--btn-active-border-color: #f9b115;
+	--btn-disabled-color: #f9b115;
+	--btn-disabled-bg: transparent;
+	--btn-disabled-border-color: transparent;
+}
+
+.button-ghost-danger {
+	--btn-color: rgb(180, 0, 0);
+	--btn-bg: transparent;
+	--btn-border-color: transparent;
+	--btn-hover-color: #fff;
+	--btn-hover-bg: rgb(180, 0, 0);
+	--btn-hover-border-color: rgb(180, 0, 0);
+	--btn-active-color: #fff;
+	--btn-active-bg: rgb(180, 0, 0);
+	--btn-active-border-color: rgb(180, 0, 0);
+	--btn-disabled-color: rgb(180, 0, 0);
+	--btn-disabled-bg: transparent;
+	--btn-disabled-border-color: transparent;
+}
+
+.button-ghost-light {
+	--btn-color: #e9e9e9;
+	--btn-bg: transparent;
+	--btn-border-color: transparent;
+	--btn-hover-color: #080a0c;
+	--btn-hover-bg: #e9e9e9;
+	--btn-hover-border-color: #e9e9e9;
+	--btn-active-color: #080a0c;
+	--btn-active-bg: #e9e9e9;
+	--btn-active-border-color: #e9e9e9;
+	--btn-disabled-color: #e9e9e9;
+	--btn-disabled-bg: transparent;
+	--btn-disabled-border-color: transparent;
+}
+
+.button-ghost-dark {
+	--btn-color: #212631;
+	--btn-bg: transparent;
+	--btn-border-color: transparent;
+	--btn-hover-color: #fff;
+	--btn-hover-bg: #212631;
+	--btn-hover-border-color: #212631;
+	--btn-active-color: #fff;
+	--btn-active-bg: #212631;
+	--btn-active-border-color: #212631;
+	--btn-disabled-color: #212631;
+	--btn-disabled-bg: transparent;
+	--btn-disabled-border-color: transparent;
+}
+
+// ---- Dark mode overrides ----
+
+[data-coreui-theme='dark'] {
+	.button-primary {
+		--btn-bg: rgb(202, 13, 30);
+		--btn-border-color: rgb(202, 13, 30);
+		--btn-hover-bg: rgb(172, 11, 25);
+		--btn-hover-border-color: rgb(162, 10, 24);
+		--btn-focus-shadow-rgb: 210, 49, 63;
+		--btn-active-bg: rgb(162, 10, 24);
+		--btn-active-border-color: rgb(152, 9, 22);
+		--btn-disabled-bg: rgb(202, 13, 30);
+		--btn-disabled-border-color: rgb(202, 13, 30);
+	}
+
+	.button-success {
+		--btn-bg: rgb(34, 151, 65);
+		--btn-border-color: rgb(34, 151, 65);
+		--btn-hover-bg: rgb(67, 167, 94);
+		--btn-hover-border-color: rgb(56, 162, 84);
+		--btn-focus-shadow-rgb: 30, 130, 57;
+		--btn-active-bg: rgb(78, 172, 103);
+		--btn-active-border-color: rgb(56, 162, 84);
+		--btn-disabled-bg: rgb(34, 151, 65);
+		--btn-disabled-border-color: rgb(34, 151, 65);
+	}
+
+	.button-info {
+		--btn-bg: rgb(61, 153, 245);
+		--btn-border-color: rgb(61, 153, 245);
+		--btn-hover-bg: rgb(90, 168, 246);
+		--btn-hover-border-color: rgb(81, 163, 246);
+		--btn-focus-shadow-rgb: 53, 132, 210;
+		--btn-active-bg: rgb(100, 173, 247);
+		--btn-active-border-color: rgb(81, 163, 246);
+		--btn-disabled-bg: rgb(61, 153, 245);
+		--btn-disabled-border-color: rgb(61, 153, 245);
+	}
+
+	.button-warning {
+		--btn-bg: rgb(238, 173, 32);
+		--btn-border-color: rgb(238, 173, 32);
+		--btn-hover-bg: rgb(240, 185, 66);
+		--btn-hover-border-color: rgb(239, 181, 55);
+		--btn-focus-shadow-rgb: 203, 148, 29;
+		--btn-active-bg: rgb(241, 189, 77);
+		--btn-active-border-color: rgb(239, 181, 55);
+		--btn-disabled-bg: rgb(238, 173, 32);
+		--btn-disabled-border-color: rgb(238, 173, 32);
+	}
+
+	.button-danger {
+		--btn-color: #080a0c;
+		--btn-bg: rgb(222, 90, 90);
+		--btn-border-color: rgb(222, 90, 90);
+		--btn-hover-color: #080a0c;
+		--btn-hover-bg: rgb(227, 115, 115);
+		--btn-hover-border-color: rgb(225, 107, 107);
+		--btn-focus-shadow-rgb: 190, 78, 79;
+		--btn-active-color: #080a0c;
+		--btn-active-bg: rgb(228, 123, 123);
+		--btn-active-border-color: rgb(225, 107, 107);
+		--btn-disabled-color: #080a0c;
+		--btn-disabled-bg: rgb(222, 90, 90);
+		--btn-disabled-border-color: rgb(222, 90, 90);
+	}
+
+	.button-dark {
+		--btn-hover-bg: rgb(28, 32, 42);
+		--btn-hover-border-color: rgb(26, 30, 39);
+		--btn-active-bg: rgb(26, 30, 39);
+		--btn-active-border-color: rgb(25, 29, 37);
+	}
+
+	.button-light {
+		--btn-hover-bg: rgb(236, 236, 236);
+		--btn-hover-border-color: rgb(235, 235, 235);
+		--btn-active-bg: rgb(237, 237, 237);
+		--btn-active-border-color: rgb(235, 235, 235);
+	}
+
+	.button-outline-primary {
+		--btn-color: rgb(202, 13, 30);
+		--btn-border-color: rgb(202, 13, 30);
+		--btn-hover-bg: rgb(202, 13, 30);
+		--btn-hover-border-color: rgb(202, 13, 30);
+		--btn-focus-shadow-rgb: 202, 13, 30;
+		--btn-active-bg: rgb(202, 13, 30);
+		--btn-active-border-color: rgb(202, 13, 30);
+		--btn-disabled-color: rgb(202, 13, 30);
+		--btn-disabled-border-color: rgb(202, 13, 30);
+	}
+
+	.button-outline-success {
+		--btn-color: rgb(34, 151, 65);
+		--btn-border-color: rgb(34, 151, 65);
+		--btn-hover-bg: rgb(34, 151, 65);
+		--btn-hover-border-color: rgb(34, 151, 65);
+		--btn-focus-shadow-rgb: 34, 151, 65;
+		--btn-active-bg: rgb(34, 151, 65);
+		--btn-active-border-color: rgb(34, 151, 65);
+		--btn-disabled-color: rgb(34, 151, 65);
+		--btn-disabled-border-color: rgb(34, 151, 65);
+	}
+
+	.button-outline-info {
+		--btn-color: rgb(61, 153, 245);
+		--btn-border-color: rgb(61, 153, 245);
+		--btn-hover-bg: rgb(61, 153, 245);
+		--btn-hover-border-color: rgb(61, 153, 245);
+		--btn-focus-shadow-rgb: 61, 153, 245;
+		--btn-active-bg: rgb(61, 153, 245);
+		--btn-active-border-color: rgb(61, 153, 245);
+		--btn-disabled-color: rgb(61, 153, 245);
+		--btn-disabled-border-color: rgb(61, 153, 245);
+	}
+
+	.button-outline-warning {
+		--btn-color: rgb(238, 173, 32);
+		--btn-border-color: rgb(238, 173, 32);
+		--btn-hover-bg: rgb(238, 173, 32);
+		--btn-hover-border-color: rgb(238, 173, 32);
+		--btn-focus-shadow-rgb: 238, 173, 32;
+		--btn-active-bg: rgb(238, 173, 32);
+		--btn-active-border-color: rgb(238, 173, 32);
+		--btn-disabled-color: rgb(238, 173, 32);
+		--btn-disabled-border-color: rgb(238, 173, 32);
+	}
+
+	.button-outline-danger {
+		--btn-color: rgb(222, 90, 90);
+		--btn-border-color: rgb(222, 90, 90);
+		--btn-hover-color: #080a0c;
+		--btn-hover-bg: rgb(222, 90, 90);
+		--btn-hover-border-color: rgb(222, 90, 90);
+		--btn-focus-shadow-rgb: 222, 90, 90;
+		--btn-active-color: #080a0c;
+		--btn-active-bg: rgb(222, 90, 90);
+		--btn-active-border-color: rgb(222, 90, 90);
+		--btn-disabled-color: rgb(222, 90, 90);
+		--btn-disabled-border-color: rgb(222, 90, 90);
+	}
+
+	.button-ghost-primary {
+		--btn-color: rgb(202, 13, 30);
+		--btn-hover-bg: rgb(202, 13, 30);
+		--btn-hover-border-color: rgb(202, 13, 30);
+		--btn-active-bg: rgb(202, 13, 30);
+		--btn-active-border-color: rgb(202, 13, 30);
+		--btn-disabled-color: rgb(202, 13, 30);
+	}
+
+	.button-ghost-success {
+		--btn-color: rgb(34, 151, 65);
+		--btn-hover-bg: rgb(34, 151, 65);
+		--btn-hover-border-color: rgb(34, 151, 65);
+		--btn-active-bg: rgb(34, 151, 65);
+		--btn-active-border-color: rgb(34, 151, 65);
+		--btn-disabled-color: rgb(34, 151, 65);
+	}
+
+	.button-ghost-info {
+		--btn-color: rgb(61, 153, 245);
+		--btn-hover-bg: rgb(61, 153, 245);
+		--btn-hover-border-color: rgb(61, 153, 245);
+		--btn-active-bg: rgb(61, 153, 245);
+		--btn-active-border-color: rgb(61, 153, 245);
+		--btn-disabled-color: rgb(61, 153, 245);
+	}
+
+	.button-ghost-warning {
+		--btn-color: rgb(238, 173, 32);
+		--btn-hover-bg: rgb(238, 173, 32);
+		--btn-hover-border-color: rgb(238, 173, 32);
+		--btn-active-bg: rgb(238, 173, 32);
+		--btn-active-border-color: rgb(238, 173, 32);
+		--btn-disabled-color: rgb(238, 173, 32);
+	}
+
+	.button-ghost-danger {
+		--btn-color: rgb(222, 90, 90);
+		--btn-hover-color: #080a0c;
+		--btn-hover-bg: rgb(222, 90, 90);
+		--btn-hover-border-color: rgb(222, 90, 90);
+		--btn-active-color: #080a0c;
+		--btn-active-bg: rgb(222, 90, 90);
+		--btn-active-border-color: rgb(222, 90, 90);
+		--btn-disabled-color: rgb(222, 90, 90);
+	}
+}
+
+// ---- Animations ----
 
 @keyframes blinker {
 	50% {
@@ -949,7 +790,7 @@
 	}
 }
 
-// ----
+// ---- Button Group ----
 
 .button-group,
 .button-group-vertical {
@@ -957,7 +798,7 @@
 	display: inline-flex;
 	vertical-align: middle;
 
-	> .btn {
+	> .button {
 		position: relative;
 		flex: 1 1 auto;
 
@@ -971,17 +812,17 @@
 }
 
 .button-group {
-	border-radius: var(--cui-border-radius);
+	border-radius: 0.375rem;
 
-	> :not(:first-child) > .btn,
-	> .btn:not(:first-child) {
+	> :not(:first-child) > .button,
+	> .button:not(:first-child) {
 		border-start-start-radius: 0;
 		border-end-start-radius: 0;
-		border-inline-start-color: color-mix(in srgb, var(--cui-btn-bg, currentColor) 75%, black);
+		border-inline-start-color: color-mix(in srgb, var(--btn-bg, currentColor) 75%, black);
 	}
 
-	> :not(:last-child) > .btn,
-	> .btn:not(:last-child):not(.dropdown-toggle) {
+	> :not(:last-child) > .button,
+	> .button:not(:last-child):not(.dropdown-toggle) {
 		border-start-end-radius: 0;
 		border-end-end-radius: 0;
 		border-inline-end-width: 0;
@@ -993,20 +834,20 @@
 	align-items: flex-start;
 	justify-content: center;
 
-	> .btn,
+	> .button,
 	> .button-group {
 		width: 100%;
 	}
 
-	> :not(:first-child) > .btn,
-	> .btn:not(:first-child) {
+	> :not(:first-child) > .button,
+	> .button:not(:first-child) {
 		border-start-start-radius: 0;
 		border-start-end-radius: 0;
-		border-block-start-color: color-mix(in srgb, var(--cui-btn-bg, currentColor) 75%, black);
+		border-block-start-color: color-mix(in srgb, var(--btn-bg, currentColor) 75%, black);
 	}
 
-	> :not(:last-child) > .btn,
-	> .btn:not(:last-child) {
+	> :not(:last-child) > .button,
+	> .button:not(:last-child) {
 		border-end-start-radius: 0;
 		border-end-end-radius: 0;
 		border-block-end-width: 0;

--- a/webui/src/scss/components/_button.scss
+++ b/webui/src/scss/components/_button.scss
@@ -1,0 +1,61 @@
+.button-group,
+.button-group-vertical {
+	position: relative;
+	display: inline-flex;
+	vertical-align: middle;
+
+	> .btn {
+		position: relative;
+		flex: 1 1 auto;
+
+		&:hover,
+		&:focus,
+		&:active,
+		&.active {
+			z-index: 1;
+		}
+	}
+}
+
+.button-group {
+	border-radius: var(--cui-border-radius);
+
+	> :not(:first-child) > .btn,
+	> .btn:not(:first-child) {
+		border-start-start-radius: 0;
+		border-end-start-radius: 0;
+		border-inline-start-color: color-mix(in srgb, var(--cui-btn-bg, currentColor) 75%, black);
+	}
+
+	> :not(:last-child) > .btn,
+	> .btn:not(:last-child):not(.dropdown-toggle) {
+		border-start-end-radius: 0;
+		border-end-end-radius: 0;
+		border-inline-end-width: 0;
+	}
+}
+
+.button-group-vertical {
+	flex-direction: column;
+	align-items: flex-start;
+	justify-content: center;
+
+	> .btn,
+	> .button-group {
+		width: 100%;
+	}
+
+	> :not(:first-child) > .btn,
+	> .btn:not(:first-child) {
+		border-start-start-radius: 0;
+		border-start-end-radius: 0;
+		border-block-start-color: color-mix(in srgb, var(--cui-btn-bg, currentColor) 75%, black);
+	}
+
+	> :not(:last-child) > .btn,
+	> .btn:not(:last-child) {
+		border-end-start-radius: 0;
+		border-end-end-radius: 0;
+		border-block-end-width: 0;
+	}
+}

--- a/webui/src/scss/components/_button.scss
+++ b/webui/src/scss/components/_button.scss
@@ -1,3 +1,956 @@
+@use 'sass:color';
+
+// .btn{
+//     --cui-btn-padding-x: .75rem;
+//     --cui-btn-padding-y: .375rem;
+//     --cui-btn-font-family: ;
+//     --cui-btn-font-size: .9rem;
+//     --cui-btn-font-weight: 400;
+//     --cui-btn-line-height: 1.5;
+//     --cui-btn-color: var(--cui-body-color);
+//     --cui-btn-bg: transparent;
+//     --cui-btn-border-width: var(--cui-border-width);
+//     --cui-btn-border-color: transparent;
+//     --cui-btn-border-radius: var(--cui-border-radius);
+//     --cui-btn-hover-border-color: transparent;
+//     --cui-btn-box-shadow: inset 0 1px 0 rgba(255, 255, 255, .15), 0 1px 1px rgba(8, 10, 12, .075);
+//     --cui-btn-disabled-opacity: .65;
+//     --cui-btn-focus-box-shadow: 0 0 0 .25rem rgba(var(--cui-btn-focus-shadow-rgb), .5);
+//     display:inline-block;
+//     padding:var(--cui-btn-padding-y) var(--cui-btn-padding-x);
+//     font-family:var(--cui-btn-font-family);
+//     font-size:var(--cui-btn-font-size);
+//     font-weight:var(--cui-btn-font-weight);
+//     line-height:var(--cui-btn-line-height);
+//     color:var(--cui-btn-color);
+//     text-align:center;
+//     text-decoration:none;
+//     vertical-align:middle;
+//     cursor:pointer;
+//     user-select:none;
+//     border:var(--cui-btn-border-width) solid var(--cui-btn-border-color);
+//     border-radius:var(--cui-btn-border-radius);
+//     background-color:var(--cui-btn-bg);
+//     transition:color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out
+// }
+// @media(prefers-reduced-motion:reduce){
+//     .btn{
+//         transition:none
+//     }
+// }
+// .btn:hover{
+//     color:var(--cui-btn-hover-color);
+//     background-color:var(--cui-btn-hover-bg);
+//     border-color:var(--cui-btn-hover-border-color)
+// }
+// .btn-check+.btn:hover{
+//     color:var(--cui-btn-color);
+//     background-color:var(--cui-btn-bg);
+//     border-color:var(--cui-btn-border-color)
+// }
+// .btn:focus-visible{
+//     color:var(--cui-btn-hover-color);
+//     background-color:var(--cui-btn-hover-bg);
+//     border-color:var(--cui-btn-hover-border-color);
+//     outline:0;
+//     box-shadow:var(--cui-btn-focus-box-shadow)
+// }
+// .btn-check:focus-visible+.btn{
+//     border-color:var(--cui-btn-hover-border-color);
+//     outline:0;
+//     box-shadow:var(--cui-btn-focus-box-shadow)
+// }
+// .btn-check:checked+.btn,:not(.btn-check)+.btn:active,.btn:first-child:active,.btn.active,.btn.show{
+//     color:var(--cui-btn-active-color);
+//     background-color:var(--cui-btn-active-bg);
+//     border-color:var(--cui-btn-active-border-color)
+// }
+// .btn-check:checked+.btn:focus-visible,:not(.btn-check)+.btn:active:focus-visible,.btn:first-child:active:focus-visible,.btn.active:focus-visible,.btn.show:focus-visible{
+//     box-shadow:var(--cui-btn-focus-box-shadow)
+// }
+// .btn-check:checked:focus-visible+.btn{
+//     box-shadow:var(--cui-btn-focus-box-shadow)
+// }
+// .btn:disabled,.btn.disabled,fieldset:disabled .btn{
+//     color:var(--cui-btn-disabled-color);
+//     pointer-events:none;
+//     background-color:var(--cui-btn-disabled-bg);
+//     border-color:var(--cui-btn-disabled-border-color);
+//     opacity:var(--cui-btn-disabled-opacity)
+// }
+// .btn-ghost{
+//     --cui-btn-color: var(--cui-secondary-color);
+//     --cui-btn-border-color: transparent;
+//     --cui-btn-active-color: var(--cui-body-color);
+//     --cui-btn-active-bg: var(--cui-tertiary-bg);
+//     --cui-btn-active-border-color: var(--cui-tertiary-bg);
+//     --cui-btn-disabled-color: var(--cui-secondary-color);
+//     --cui-btn-disabled-border-color: transparent;
+//     --cui-btn-hover-color: var(--cui-body-color);
+//     --cui-btn-hover-bg: var(--cui-tertiary-bg);
+//     --cui-btn-hover-border-color: var(--cui-tertiary-bg);
+//     --cui-btn-focus-box-shadow: 0 0 0 .25rem rgba(var(--cui-tertiary-bg-rgb), .5)
+// }
+// .btn-outline{
+//     --cui-btn-color: var(--cui-secondary-color);
+//     --cui-btn-border-color: var(--cui-border-color);
+//     --cui-btn-active-color: var(--cui-body-color);
+//     --cui-btn-active-bg: var(--cui-tertiary-bg);
+//     --cui-btn-active-border-color: var(--cui-border-color);
+//     --cui-btn-disabled-color: var(--cui-secondary-color);
+//     --cui-btn-disabled-border-color: var(--cui-border-color);
+//     --cui-btn-hover-color: var(--cui-body-color);
+//     --cui-btn-hover-bg: var(--cui-tertiary-bg);
+//     --cui-btn-hover-border-color: var(--cui-border-color);
+//     --cui-btn-focus-box-shadow: 0 0 0 .25rem rgba(var(--cui-tertiary-bg-rgb), .5)
+// }
+// .btn-transparent{
+//     --cui-btn-active-border-color: transparent;
+//     --cui-btn-disabled-border-color: transparent;
+//     --cui-btn-hover-border-color: transparent
+// }
+// .btn-primary{
+//     --cui-btn-color: #fff;
+//     --cui-btn-bg: #d50215;
+//     --cui-btn-border-color: #d50215;
+//     --cui-btn-hover-color: #fff;
+//     --cui-btn-hover-bg: rgb(181.05, 1.7, 17.85);
+//     --cui-btn-hover-border-color: rgb(170.4, 1.6, 16.8);
+//     --cui-btn-focus-shadow-rgb: 219.3, 39.95, 56.1;
+//     --cui-btn-active-color: #fff;
+//     --cui-btn-active-bg: rgb(170.4, 1.6, 16.8);
+//     --cui-btn-active-border-color: rgb(159.75, 1.5, 15.75);
+//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
+//     --cui-btn-disabled-color: #fff;
+//     --cui-btn-disabled-bg: #d50215;
+//     --cui-btn-disabled-border-color: #d50215
+// }
+// .btn-secondary{
+//     --cui-btn-color: #080a0c;
+//     --cui-btn-bg: #ccc;
+//     --cui-btn-border-color: #ccc;
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-hover-bg: rgb(211.65, 211.65, 211.65);
+//     --cui-btn-hover-border-color: rgb(209.1, 209.1, 209.1);
+//     --cui-btn-focus-shadow-rgb: 174.6, 174.9, 175.2;
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-active-bg: rgb(214.2, 214.2, 214.2);
+//     --cui-btn-active-border-color: rgb(209.1, 209.1, 209.1);
+//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
+//     --cui-btn-disabled-color: #080a0c;
+//     --cui-btn-disabled-bg: #ccc;
+//     --cui-btn-disabled-border-color: #ccc
+// }
+// .btn-success{
+//     --cui-btn-color: #080a0c;
+//     --cui-btn-bg: #1b9e3e;
+//     --cui-btn-border-color: #1b9e3e;
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-hover-bg: rgb(61.2, 172.55, 90.95);
+//     --cui-btn-hover-border-color: rgb(49.8, 167.7, 81.3);
+//     --cui-btn-focus-shadow-rgb: 24.15, 135.8, 54.5;
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-active-bg: rgb(72.6, 177.4, 100.6);
+//     --cui-btn-active-border-color: rgb(49.8, 167.7, 81.3);
+//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
+//     --cui-btn-disabled-color: #080a0c;
+//     --cui-btn-disabled-bg: #1b9e3e;
+//     --cui-btn-disabled-border-color: #1b9e3e
+// }
+// .btn-info{
+//     --cui-btn-color: #080a0c;
+//     --cui-btn-bg: #39f;
+//     --cui-btn-border-color: #39f;
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-hover-bg: rgb(81.6, 168.3, 255);
+//     --cui-btn-hover-border-color: rgb(71.4, 163.2, 255);
+//     --cui-btn-focus-shadow-rgb: 44.55, 131.55, 218.55;
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-active-bg: rgb(91.8, 173.4, 255);
+//     --cui-btn-active-border-color: rgb(71.4, 163.2, 255);
+//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
+//     --cui-btn-disabled-color: #080a0c;
+//     --cui-btn-disabled-bg: #39f;
+//     --cui-btn-disabled-border-color: #39f
+// }
+// .btn-warning{
+//     --cui-btn-color: #080a0c;
+//     --cui-btn-bg: #f9b115;
+//     --cui-btn-border-color: #f9b115;
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-hover-bg: rgb(249.9, 188.7, 56.1);
+//     --cui-btn-hover-border-color: rgb(249.6, 184.8, 44.4);
+//     --cui-btn-focus-shadow-rgb: 212.85, 151.95, 19.65;
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-active-bg: rgb(250.2, 192.6, 67.8);
+//     --cui-btn-active-border-color: rgb(249.6, 184.8, 44.4);
+//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
+//     --cui-btn-disabled-color: #080a0c;
+//     --cui-btn-disabled-bg: #f9b115;
+//     --cui-btn-disabled-border-color: #f9b115
+// }
+// .btn-danger{
+//     --cui-btn-color: #080a0c;
+//     --cui-btn-bg: #e55353;
+//     --cui-btn-border-color: #e55353;
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-hover-bg: rgb(232.9, 108.8, 108.8);
+//     --cui-btn-hover-border-color: rgb(231.6, 100.2, 100.2);
+//     --cui-btn-focus-shadow-rgb: 195.85, 72.05, 72.35;
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-active-bg: rgb(234.2, 117.4, 117.4);
+//     --cui-btn-active-border-color: rgb(231.6, 100.2, 100.2);
+//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
+//     --cui-btn-disabled-color: #080a0c;
+//     --cui-btn-disabled-bg: #e55353;
+//     --cui-btn-disabled-border-color: #e55353
+// }
+// .btn-light{
+//     --cui-btn-color: #080a0c;
+//     --cui-btn-bg: #e9e9e9;
+//     --cui-btn-border-color: #e9e9e9;
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-hover-bg: rgb(198.05, 198.05, 198.05);
+//     --cui-btn-hover-border-color: rgb(186.4, 186.4, 186.4);
+//     --cui-btn-focus-shadow-rgb: 199.25, 199.55, 199.85;
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-active-bg: rgb(186.4, 186.4, 186.4);
+//     --cui-btn-active-border-color: rgb(174.75, 174.75, 174.75);
+//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
+//     --cui-btn-disabled-color: #080a0c;
+//     --cui-btn-disabled-bg: #e9e9e9;
+//     --cui-btn-disabled-border-color: #e9e9e9
+// }
+// .btn-dark{
+//     --cui-btn-color: #fff;
+//     --cui-btn-bg: #212631;
+//     --cui-btn-border-color: #212631;
+//     --cui-btn-hover-color: #fff;
+//     --cui-btn-hover-bg: rgb(66.3, 70.55, 79.9);
+//     --cui-btn-hover-border-color: rgb(55.2, 59.7, 69.6);
+//     --cui-btn-focus-shadow-rgb: 66.3, 70.55, 79.9;
+//     --cui-btn-active-color: #fff;
+//     --cui-btn-active-bg: rgb(77.4, 81.4, 90.2);
+//     --cui-btn-active-border-color: rgb(55.2, 59.7, 69.6);
+//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
+//     --cui-btn-disabled-color: #fff;
+//     --cui-btn-disabled-bg: #212631;
+//     --cui-btn-disabled-border-color: #212631
+// }
+// .btn-outline-primary{
+//     --cui-btn-color: #d50215;
+//     --cui-btn-border-color: #d50215;
+//     --cui-btn-hover-color: #fff;
+//     --cui-btn-hover-bg: #d50215;
+//     --cui-btn-hover-border-color: #d50215;
+//     --cui-btn-focus-shadow-rgb: 213, 2, 21;
+//     --cui-btn-active-color: #fff;
+//     --cui-btn-active-bg: #d50215;
+//     --cui-btn-active-border-color: #d50215;
+//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
+//     --cui-btn-disabled-color: #d50215;
+//     --cui-btn-disabled-bg: transparent;
+//     --cui-btn-disabled-border-color: #d50215;
+//     --cui-gradient: none
+// }
+// .btn-outline-secondary{
+//     --cui-btn-color: #ccc;
+//     --cui-btn-border-color: #ccc;
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-hover-bg: #ccc;
+//     --cui-btn-hover-border-color: #ccc;
+//     --cui-btn-focus-shadow-rgb: 204, 204, 204;
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-active-bg: #ccc;
+//     --cui-btn-active-border-color: #ccc;
+//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
+//     --cui-btn-disabled-color: #ccc;
+//     --cui-btn-disabled-bg: transparent;
+//     --cui-btn-disabled-border-color: #ccc;
+//     --cui-gradient: none
+// }
+// .btn-outline-success{
+//     --cui-btn-color: #1b9e3e;
+//     --cui-btn-border-color: #1b9e3e;
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-hover-bg: #1b9e3e;
+//     --cui-btn-hover-border-color: #1b9e3e;
+//     --cui-btn-focus-shadow-rgb: 27, 158, 62;
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-active-bg: #1b9e3e;
+//     --cui-btn-active-border-color: #1b9e3e;
+//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
+//     --cui-btn-disabled-color: #1b9e3e;
+//     --cui-btn-disabled-bg: transparent;
+//     --cui-btn-disabled-border-color: #1b9e3e;
+//     --cui-gradient: none
+// }
+// .btn-outline-info{
+//     --cui-btn-color: #39f;
+//     --cui-btn-border-color: #39f;
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-hover-bg: #39f;
+//     --cui-btn-hover-border-color: #39f;
+//     --cui-btn-focus-shadow-rgb: 51, 153, 255;
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-active-bg: #39f;
+//     --cui-btn-active-border-color: #39f;
+//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
+//     --cui-btn-disabled-color: #39f;
+//     --cui-btn-disabled-bg: transparent;
+//     --cui-btn-disabled-border-color: #39f;
+//     --cui-gradient: none
+// }
+// .btn-outline-warning{
+//     --cui-btn-color: #f9b115;
+//     --cui-btn-border-color: #f9b115;
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-hover-bg: #f9b115;
+//     --cui-btn-hover-border-color: #f9b115;
+//     --cui-btn-focus-shadow-rgb: 249, 177, 21;
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-active-bg: #f9b115;
+//     --cui-btn-active-border-color: #f9b115;
+//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
+//     --cui-btn-disabled-color: #f9b115;
+//     --cui-btn-disabled-bg: transparent;
+//     --cui-btn-disabled-border-color: #f9b115;
+//     --cui-gradient: none
+// }
+// .btn-outline-danger{
+//     --cui-btn-color: #e55353;
+//     --cui-btn-border-color: #e55353;
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-hover-bg: #e55353;
+//     --cui-btn-hover-border-color: #e55353;
+//     --cui-btn-focus-shadow-rgb: 229, 83, 83;
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-active-bg: #e55353;
+//     --cui-btn-active-border-color: #e55353;
+//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
+//     --cui-btn-disabled-color: #e55353;
+//     --cui-btn-disabled-bg: transparent;
+//     --cui-btn-disabled-border-color: #e55353;
+//     --cui-gradient: none
+// }
+// .btn-outline-light{
+//     --cui-btn-color: #e9e9e9;
+//     --cui-btn-border-color: #e9e9e9;
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-hover-bg: #e9e9e9;
+//     --cui-btn-hover-border-color: #e9e9e9;
+//     --cui-btn-focus-shadow-rgb: 233, 233, 233;
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-active-bg: #e9e9e9;
+//     --cui-btn-active-border-color: #e9e9e9;
+//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
+//     --cui-btn-disabled-color: #e9e9e9;
+//     --cui-btn-disabled-bg: transparent;
+//     --cui-btn-disabled-border-color: #e9e9e9;
+//     --cui-gradient: none
+// }
+// .btn-outline-dark{
+//     --cui-btn-color: #212631;
+//     --cui-btn-border-color: #212631;
+//     --cui-btn-hover-color: #fff;
+//     --cui-btn-hover-bg: #212631;
+//     --cui-btn-hover-border-color: #212631;
+//     --cui-btn-focus-shadow-rgb: 33, 38, 49;
+//     --cui-btn-active-color: #fff;
+//     --cui-btn-active-bg: #212631;
+//     --cui-btn-active-border-color: #212631;
+//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
+//     --cui-btn-disabled-color: #212631;
+//     --cui-btn-disabled-bg: transparent;
+//     --cui-btn-disabled-border-color: #212631;
+//     --cui-gradient: none
+// }
+// .btn-ghost-primary{
+//     --cui-btn-color: #d50215;
+//     --cui-btn-border-color: transparent;
+//     --cui-btn-hover-bg: #d50215;
+//     --cui-btn-hover-border-color: #d50215;
+//     --cui-btn-hover-color: #fff;
+//     --cui-btn-active-bg: #d50215;
+//     --cui-btn-active-border-color: #d50215;
+//     --cui-btn-active-color: #fff;
+//     --cui-btn-disabled-color: #d50215;
+//     --cui-btn-disabled-bg: transparent;
+//     --cui-btn-disabled-border-color: transparent
+// }
+// .btn-ghost-secondary{
+//     --cui-btn-color: #ccc;
+//     --cui-btn-border-color: transparent;
+//     --cui-btn-hover-bg: #ccc;
+//     --cui-btn-hover-border-color: #ccc;
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-active-bg: #ccc;
+//     --cui-btn-active-border-color: #ccc;
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-disabled-color: #ccc;
+//     --cui-btn-disabled-bg: transparent;
+//     --cui-btn-disabled-border-color: transparent
+// }
+// .btn-ghost-success{
+//     --cui-btn-color: #1b9e3e;
+//     --cui-btn-border-color: transparent;
+//     --cui-btn-hover-bg: #1b9e3e;
+//     --cui-btn-hover-border-color: #1b9e3e;
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-active-bg: #1b9e3e;
+//     --cui-btn-active-border-color: #1b9e3e;
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-disabled-color: #1b9e3e;
+//     --cui-btn-disabled-bg: transparent;
+//     --cui-btn-disabled-border-color: transparent
+// }
+// .btn-ghost-info{
+//     --cui-btn-color: #39f;
+//     --cui-btn-border-color: transparent;
+//     --cui-btn-hover-bg: #39f;
+//     --cui-btn-hover-border-color: #39f;
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-active-bg: #39f;
+//     --cui-btn-active-border-color: #39f;
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-disabled-color: #39f;
+//     --cui-btn-disabled-bg: transparent;
+//     --cui-btn-disabled-border-color: transparent
+// }
+// .btn-ghost-warning{
+//     --cui-btn-color: #f9b115;
+//     --cui-btn-border-color: transparent;
+//     --cui-btn-hover-bg: #f9b115;
+//     --cui-btn-hover-border-color: #f9b115;
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-active-bg: #f9b115;
+//     --cui-btn-active-border-color: #f9b115;
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-disabled-color: #f9b115;
+//     --cui-btn-disabled-bg: transparent;
+//     --cui-btn-disabled-border-color: transparent
+// }
+// .btn-ghost-danger{
+//     --cui-btn-color: #e55353;
+//     --cui-btn-border-color: transparent;
+//     --cui-btn-hover-bg: #e55353;
+//     --cui-btn-hover-border-color: #e55353;
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-active-bg: #e55353;
+//     --cui-btn-active-border-color: #e55353;
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-disabled-color: #e55353;
+//     --cui-btn-disabled-bg: transparent;
+//     --cui-btn-disabled-border-color: transparent
+// }
+// .btn-ghost-light{
+//     --cui-btn-color: #e9e9e9;
+//     --cui-btn-border-color: transparent;
+//     --cui-btn-hover-bg: #e9e9e9;
+//     --cui-btn-hover-border-color: #e9e9e9;
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-active-bg: #e9e9e9;
+//     --cui-btn-active-border-color: #e9e9e9;
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-disabled-color: #e9e9e9;
+//     --cui-btn-disabled-bg: transparent;
+//     --cui-btn-disabled-border-color: transparent
+// }
+// .btn-ghost-dark{
+//     --cui-btn-color: #212631;
+//     --cui-btn-border-color: transparent;
+//     --cui-btn-hover-bg: #212631;
+//     --cui-btn-hover-border-color: #212631;
+//     --cui-btn-hover-color: #fff;
+//     --cui-btn-active-bg: #212631;
+//     --cui-btn-active-border-color: #212631;
+//     --cui-btn-active-color: #fff;
+//     --cui-btn-disabled-color: #212631;
+//     --cui-btn-disabled-bg: transparent;
+//     --cui-btn-disabled-border-color: transparent
+// }
+// .btn-link{
+//     --cui-btn-font-weight: 400;
+//     --cui-btn-color: var(--cui-link-color);
+//     --cui-btn-bg: transparent;
+//     --cui-btn-border-color: transparent;
+//     --cui-btn-hover-color: var(--cui-link-hover-color);
+//     --cui-btn-hover-border-color: transparent;
+//     --cui-btn-active-border-color: transparent;
+//     --cui-btn-disabled-color: #6d7d9c;
+//     --cui-btn-disabled-border-color: transparent;
+//     --cui-btn-box-shadow: none;
+//     --cui-btn-focus-shadow-rgb: 219.3, 39.95, 56.1;
+//     text-decoration:underline
+// }
+// .btn-link:focus-visible{
+//     color:var(--cui-btn-color)
+// }
+// .btn-lg,.btn-group-lg>.btn{
+//     --cui-btn-padding-y: .5rem;
+//     --cui-btn-padding-x: 1rem;
+//     --cui-btn-font-size: 1.25rem;
+//     --cui-btn-border-radius: var(--cui-border-radius-lg)
+// }
+// .btn-sm,.btn-group-sm>.btn{
+//     --cui-btn-padding-y: .25rem;
+//     --cui-btn-padding-x: .5rem;
+//     --cui-btn-font-size: .75rem;
+//     --cui-btn-border-radius: var(--cui-border-radius-sm)
+// }
+// [data-coreui-theme=dark] .btn-primary{
+//     --cui-btn-color: #fff;
+//     --cui-btn-bg: rgb(202.45, 12.55, 29.65);
+//     --cui-btn-border-color: rgb(202.45, 12.55, 29.65);
+//     --cui-btn-hover-color: #fff;
+//     --cui-btn-hover-bg: rgb(172.0825, 10.6675, 25.2025);
+//     --cui-btn-hover-border-color: rgb(161.96, 10.04, 23.72);
+//     --cui-btn-focus-shadow-rgb: 210.3325, 48.9175, 63.4525;
+//     --cui-btn-active-color: #fff;
+//     --cui-btn-active-bg: rgb(161.96, 10.04, 23.72);
+//     --cui-btn-active-border-color: rgb(151.8375, 9.4125, 22.2375);
+//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
+//     --cui-btn-disabled-color: #fff;
+//     --cui-btn-disabled-bg: rgb(202.45, 12.55, 29.65);
+//     --cui-btn-disabled-border-color: rgb(202.45, 12.55, 29.65)
+// }
+// [data-coreui-theme=dark] .btn-secondary{
+//     --cui-btn-color: #080a0c;
+//     --cui-btn-bg: #ccc;
+//     --cui-btn-border-color: #ccc;
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-hover-bg: rgb(211.65, 211.65, 211.65);
+//     --cui-btn-hover-border-color: rgb(209.1, 209.1, 209.1);
+//     --cui-btn-focus-shadow-rgb: 174.6, 174.9, 175.2;
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-active-bg: rgb(214.2, 214.2, 214.2);
+//     --cui-btn-active-border-color: rgb(209.1, 209.1, 209.1);
+//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
+//     --cui-btn-disabled-color: #080a0c;
+//     --cui-btn-disabled-bg: #ccc;
+//     --cui-btn-disabled-border-color: #ccc
+// }
+// [data-coreui-theme=dark] .btn-success{
+//     --cui-btn-color: #080a0c;
+//     --cui-btn-bg: rgb(33.55, 151.45, 65.05);
+//     --cui-btn-border-color: rgb(33.55, 151.45, 65.05);
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-hover-bg: rgb(66.7675, 166.9825, 93.5425);
+//     --cui-btn-hover-border-color: rgb(55.695, 161.805, 84.045);
+//     --cui-btn-focus-shadow-rgb: 29.7175, 130.2325, 57.0925;
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-active-bg: rgb(77.84, 172.16, 103.04);
+//     --cui-btn-active-border-color: rgb(55.695, 161.805, 84.045);
+//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
+//     --cui-btn-disabled-color: #080a0c;
+//     --cui-btn-disabled-bg: rgb(33.55, 151.45, 65.05);
+//     --cui-btn-disabled-border-color: rgb(33.55, 151.45, 65.05)
+// }
+// [data-coreui-theme=dark] .btn-info{
+//     --cui-btn-color: #080a0c;
+//     --cui-btn-bg: rgb(61.2, 153, 244.8);
+//     --cui-btn-border-color: rgb(61.2, 153, 244.8);
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-hover-bg: rgb(90.27, 168.3, 246.33);
+//     --cui-btn-hover-border-color: rgb(80.58, 163.2, 245.82);
+//     --cui-btn-focus-shadow-rgb: 53.22, 131.55, 209.88;
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-active-bg: rgb(99.96, 173.4, 246.84);
+//     --cui-btn-active-border-color: rgb(80.58, 163.2, 245.82);
+//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
+//     --cui-btn-disabled-color: #080a0c;
+//     --cui-btn-disabled-bg: rgb(61.2, 153, 244.8);
+//     --cui-btn-disabled-border-color: rgb(61.2, 153, 244.8)
+// }
+// [data-coreui-theme=dark] .btn-warning{
+//     --cui-btn-color: #080a0c;
+//     --cui-btn-bg: rgb(237.6, 172.8, 32.4);
+//     --cui-btn-border-color: rgb(237.6, 172.8, 32.4);
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-hover-bg: rgb(240.21, 185.13, 65.79);
+//     --cui-btn-hover-border-color: rgb(239.34, 181.02, 54.66);
+//     --cui-btn-focus-shadow-rgb: 203.16, 148.38, 29.34;
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-active-bg: rgb(241.08, 189.24, 76.92);
+//     --cui-btn-active-border-color: rgb(239.34, 181.02, 54.66);
+//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
+//     --cui-btn-disabled-color: #080a0c;
+//     --cui-btn-disabled-bg: rgb(237.6, 172.8, 32.4);
+//     --cui-btn-disabled-border-color: rgb(237.6, 172.8, 32.4)
+// }
+// [data-coreui-theme=dark] .btn-danger{
+//     --cui-btn-color: #080a0c;
+//     --cui-btn-bg: rgb(221.7, 90.3, 90.3);
+//     --cui-btn-border-color: rgb(221.7, 90.3, 90.3);
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-hover-bg: rgb(226.695, 115.005, 115.005);
+//     --cui-btn-hover-border-color: rgb(225.03, 106.77, 106.77);
+//     --cui-btn-focus-shadow-rgb: 189.645, 78.255, 78.555;
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-active-bg: rgb(228.36, 123.24, 123.24);
+//     --cui-btn-active-border-color: rgb(225.03, 106.77, 106.77);
+//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
+//     --cui-btn-disabled-color: #080a0c;
+//     --cui-btn-disabled-bg: rgb(221.7, 90.3, 90.3);
+//     --cui-btn-disabled-border-color: rgb(221.7, 90.3, 90.3)
+// }
+// [data-coreui-theme=dark] .btn-light{
+//     --cui-btn-color: #080a0c;
+//     --cui-btn-bg: #e9e9e9;
+//     --cui-btn-border-color: #e9e9e9;
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-hover-bg: rgb(236.3, 236.3, 236.3);
+//     --cui-btn-hover-border-color: rgb(235.2, 235.2, 235.2);
+//     --cui-btn-focus-shadow-rgb: 199.25, 199.55, 199.85;
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-active-bg: rgb(237.4, 237.4, 237.4);
+//     --cui-btn-active-border-color: rgb(235.2, 235.2, 235.2);
+//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
+//     --cui-btn-disabled-color: #080a0c;
+//     --cui-btn-disabled-bg: #e9e9e9;
+//     --cui-btn-disabled-border-color: #e9e9e9
+// }
+// [data-coreui-theme=dark] .btn-dark{
+//     --cui-btn-color: #fff;
+//     --cui-btn-bg: #212631;
+//     --cui-btn-border-color: #212631;
+//     --cui-btn-hover-color: #fff;
+//     --cui-btn-hover-bg: rgb(28.05, 32.3, 41.65);
+//     --cui-btn-hover-border-color: rgb(26.4, 30.4, 39.2);
+//     --cui-btn-focus-shadow-rgb: 66.3, 70.55, 79.9;
+//     --cui-btn-active-color: #fff;
+//     --cui-btn-active-bg: rgb(26.4, 30.4, 39.2);
+//     --cui-btn-active-border-color: rgb(24.75, 28.5, 36.75);
+//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
+//     --cui-btn-disabled-color: #fff;
+//     --cui-btn-disabled-bg: #212631;
+//     --cui-btn-disabled-border-color: #212631
+// }
+// [data-coreui-theme=dark] .btn-outline-primary{
+//     --cui-btn-color: rgb(202.45, 12.55, 29.65);
+//     --cui-btn-border-color: rgb(202.45, 12.55, 29.65);
+//     --cui-btn-hover-color: #fff;
+//     --cui-btn-hover-bg: rgb(202.45, 12.55, 29.65);
+//     --cui-btn-hover-border-color: rgb(202.45, 12.55, 29.65);
+//     --cui-btn-focus-shadow-rgb: 202.45, 12.55, 29.65;
+//     --cui-btn-active-color: #fff;
+//     --cui-btn-active-bg: rgb(202.45, 12.55, 29.65);
+//     --cui-btn-active-border-color: rgb(202.45, 12.55, 29.65);
+//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
+//     --cui-btn-disabled-color: rgb(202.45, 12.55, 29.65);
+//     --cui-btn-disabled-bg: transparent;
+//     --cui-btn-disabled-border-color: rgb(202.45, 12.55, 29.65);
+//     --cui-gradient: none
+// }
+// [data-coreui-theme=dark] .btn-outline-secondary{
+//     --cui-btn-color: #ccc;
+//     --cui-btn-border-color: #ccc;
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-hover-bg: #ccc;
+//     --cui-btn-hover-border-color: #ccc;
+//     --cui-btn-focus-shadow-rgb: 204, 204, 204;
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-active-bg: #ccc;
+//     --cui-btn-active-border-color: #ccc;
+//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
+//     --cui-btn-disabled-color: #ccc;
+//     --cui-btn-disabled-bg: transparent;
+//     --cui-btn-disabled-border-color: #ccc;
+//     --cui-gradient: none
+// }
+// [data-coreui-theme=dark] .btn-outline-success{
+//     --cui-btn-color: rgb(33.55, 151.45, 65.05);
+//     --cui-btn-border-color: rgb(33.55, 151.45, 65.05);
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-hover-bg: rgb(33.55, 151.45, 65.05);
+//     --cui-btn-hover-border-color: rgb(33.55, 151.45, 65.05);
+//     --cui-btn-focus-shadow-rgb: 33.55, 151.45, 65.05;
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-active-bg: rgb(33.55, 151.45, 65.05);
+//     --cui-btn-active-border-color: rgb(33.55, 151.45, 65.05);
+//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
+//     --cui-btn-disabled-color: rgb(33.55, 151.45, 65.05);
+//     --cui-btn-disabled-bg: transparent;
+//     --cui-btn-disabled-border-color: rgb(33.55, 151.45, 65.05);
+//     --cui-gradient: none
+// }
+// [data-coreui-theme=dark] .btn-outline-info{
+//     --cui-btn-color: rgb(61.2, 153, 244.8);
+//     --cui-btn-border-color: rgb(61.2, 153, 244.8);
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-hover-bg: rgb(61.2, 153, 244.8);
+//     --cui-btn-hover-border-color: rgb(61.2, 153, 244.8);
+//     --cui-btn-focus-shadow-rgb: 61.2, 153, 244.8;
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-active-bg: rgb(61.2, 153, 244.8);
+//     --cui-btn-active-border-color: rgb(61.2, 153, 244.8);
+//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
+//     --cui-btn-disabled-color: rgb(61.2, 153, 244.8);
+//     --cui-btn-disabled-bg: transparent;
+//     --cui-btn-disabled-border-color: rgb(61.2, 153, 244.8);
+//     --cui-gradient: none
+// }
+// [data-coreui-theme=dark] .btn-outline-warning{
+//     --cui-btn-color: rgb(237.6, 172.8, 32.4);
+//     --cui-btn-border-color: rgb(237.6, 172.8, 32.4);
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-hover-bg: rgb(237.6, 172.8, 32.4);
+//     --cui-btn-hover-border-color: rgb(237.6, 172.8, 32.4);
+//     --cui-btn-focus-shadow-rgb: 237.6, 172.8, 32.4;
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-active-bg: rgb(237.6, 172.8, 32.4);
+//     --cui-btn-active-border-color: rgb(237.6, 172.8, 32.4);
+//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
+//     --cui-btn-disabled-color: rgb(237.6, 172.8, 32.4);
+//     --cui-btn-disabled-bg: transparent;
+//     --cui-btn-disabled-border-color: rgb(237.6, 172.8, 32.4);
+//     --cui-gradient: none
+// }
+// [data-coreui-theme=dark] .btn-outline-danger{
+//     --cui-btn-color: rgb(221.7, 90.3, 90.3);
+//     --cui-btn-border-color: rgb(221.7, 90.3, 90.3);
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-hover-bg: rgb(221.7, 90.3, 90.3);
+//     --cui-btn-hover-border-color: rgb(221.7, 90.3, 90.3);
+//     --cui-btn-focus-shadow-rgb: 221.7, 90.3, 90.3;
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-active-bg: rgb(221.7, 90.3, 90.3);
+//     --cui-btn-active-border-color: rgb(221.7, 90.3, 90.3);
+//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
+//     --cui-btn-disabled-color: rgb(221.7, 90.3, 90.3);
+//     --cui-btn-disabled-bg: transparent;
+//     --cui-btn-disabled-border-color: rgb(221.7, 90.3, 90.3);
+//     --cui-gradient: none
+// }
+// [data-coreui-theme=dark] .btn-outline-light{
+//     --cui-btn-color: #e9e9e9;
+//     --cui-btn-border-color: #e9e9e9;
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-hover-bg: #e9e9e9;
+//     --cui-btn-hover-border-color: #e9e9e9;
+//     --cui-btn-focus-shadow-rgb: 233, 233, 233;
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-active-bg: #e9e9e9;
+//     --cui-btn-active-border-color: #e9e9e9;
+//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
+//     --cui-btn-disabled-color: #e9e9e9;
+//     --cui-btn-disabled-bg: transparent;
+//     --cui-btn-disabled-border-color: #e9e9e9;
+//     --cui-gradient: none
+// }
+// [data-coreui-theme=dark] .btn-outline-dark{
+//     --cui-btn-color: #212631;
+//     --cui-btn-border-color: #212631;
+//     --cui-btn-hover-color: #fff;
+//     --cui-btn-hover-bg: #212631;
+//     --cui-btn-hover-border-color: #212631;
+//     --cui-btn-focus-shadow-rgb: 33, 38, 49;
+//     --cui-btn-active-color: #fff;
+//     --cui-btn-active-bg: #212631;
+//     --cui-btn-active-border-color: #212631;
+//     --cui-btn-active-shadow: inset 0 3px 5px rgba(8, 10, 12, .125);
+//     --cui-btn-disabled-color: #212631;
+//     --cui-btn-disabled-bg: transparent;
+//     --cui-btn-disabled-border-color: #212631;
+//     --cui-gradient: none
+// }
+// [data-coreui-theme=dark] .btn-ghost-primary{
+//     --cui-btn-color: rgb(202.45, 12.55, 29.65);
+//     --cui-btn-border-color: transparent;
+//     --cui-btn-hover-bg: rgb(202.45, 12.55, 29.65);
+//     --cui-btn-hover-border-color: rgb(202.45, 12.55, 29.65);
+//     --cui-btn-hover-color: #fff;
+//     --cui-btn-active-bg: rgb(202.45, 12.55, 29.65);
+//     --cui-btn-active-border-color: rgb(202.45, 12.55, 29.65);
+//     --cui-btn-active-color: #fff;
+//     --cui-btn-disabled-color: rgb(202.45, 12.55, 29.65);
+//     --cui-btn-disabled-bg: transparent;
+//     --cui-btn-disabled-border-color: transparent
+// }
+// [data-coreui-theme=dark] .btn-ghost-secondary{
+//     --cui-btn-color: #ccc;
+//     --cui-btn-border-color: transparent;
+//     --cui-btn-hover-bg: #ccc;
+//     --cui-btn-hover-border-color: #ccc;
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-active-bg: #ccc;
+//     --cui-btn-active-border-color: #ccc;
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-disabled-color: #ccc;
+//     --cui-btn-disabled-bg: transparent;
+//     --cui-btn-disabled-border-color: transparent
+// }
+// [data-coreui-theme=dark] .btn-ghost-success{
+//     --cui-btn-color: rgb(33.55, 151.45, 65.05);
+//     --cui-btn-border-color: transparent;
+//     --cui-btn-hover-bg: rgb(33.55, 151.45, 65.05);
+//     --cui-btn-hover-border-color: rgb(33.55, 151.45, 65.05);
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-active-bg: rgb(33.55, 151.45, 65.05);
+//     --cui-btn-active-border-color: rgb(33.55, 151.45, 65.05);
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-disabled-color: rgb(33.55, 151.45, 65.05);
+//     --cui-btn-disabled-bg: transparent;
+//     --cui-btn-disabled-border-color: transparent
+// }
+// [data-coreui-theme=dark] .btn-ghost-info{
+//     --cui-btn-color: rgb(61.2, 153, 244.8);
+//     --cui-btn-border-color: transparent;
+//     --cui-btn-hover-bg: rgb(61.2, 153, 244.8);
+//     --cui-btn-hover-border-color: rgb(61.2, 153, 244.8);
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-active-bg: rgb(61.2, 153, 244.8);
+//     --cui-btn-active-border-color: rgb(61.2, 153, 244.8);
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-disabled-color: rgb(61.2, 153, 244.8);
+//     --cui-btn-disabled-bg: transparent;
+//     --cui-btn-disabled-border-color: transparent
+// }
+// [data-coreui-theme=dark] .btn-ghost-warning{
+//     --cui-btn-color: rgb(237.6, 172.8, 32.4);
+//     --cui-btn-border-color: transparent;
+//     --cui-btn-hover-bg: rgb(237.6, 172.8, 32.4);
+//     --cui-btn-hover-border-color: rgb(237.6, 172.8, 32.4);
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-active-bg: rgb(237.6, 172.8, 32.4);
+//     --cui-btn-active-border-color: rgb(237.6, 172.8, 32.4);
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-disabled-color: rgb(237.6, 172.8, 32.4);
+//     --cui-btn-disabled-bg: transparent;
+//     --cui-btn-disabled-border-color: transparent
+// }
+// [data-coreui-theme=dark] .btn-ghost-danger{
+//     --cui-btn-color: rgb(221.7, 90.3, 90.3);
+//     --cui-btn-border-color: transparent;
+//     --cui-btn-hover-bg: rgb(221.7, 90.3, 90.3);
+//     --cui-btn-hover-border-color: rgb(221.7, 90.3, 90.3);
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-active-bg: rgb(221.7, 90.3, 90.3);
+//     --cui-btn-active-border-color: rgb(221.7, 90.3, 90.3);
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-disabled-color: rgb(221.7, 90.3, 90.3);
+//     --cui-btn-disabled-bg: transparent;
+//     --cui-btn-disabled-border-color: transparent
+// }
+// [data-coreui-theme=dark] .btn-ghost-light{
+//     --cui-btn-color: #e9e9e9;
+//     --cui-btn-border-color: transparent;
+//     --cui-btn-hover-bg: #e9e9e9;
+//     --cui-btn-hover-border-color: #e9e9e9;
+//     --cui-btn-hover-color: #080a0c;
+//     --cui-btn-active-bg: #e9e9e9;
+//     --cui-btn-active-border-color: #e9e9e9;
+//     --cui-btn-active-color: #080a0c;
+//     --cui-btn-disabled-color: #e9e9e9;
+//     --cui-btn-disabled-bg: transparent;
+//     --cui-btn-disabled-border-color: transparent
+// }
+// [data-coreui-theme=dark] .btn-ghost-dark{
+//     --cui-btn-color: #212631;
+//     --cui-btn-border-color: transparent;
+//     --cui-btn-hover-bg: #212631;
+//     --cui-btn-hover-border-color: #212631;
+//     --cui-btn-hover-color: #fff;
+//     --cui-btn-active-bg: #212631;
+//     --cui-btn-active-border-color: #212631;
+//     --cui-btn-active-color: #fff;
+//     --cui-btn-disabled-color: #212631;
+//     --cui-btn-disabled-bg: transparent;
+//     --cui-btn-disabled-border-color: transparent
+// }
+// .fade{
+//     transition:opacity .15s linear
+// }
+// @media(prefers-reduced-motion:reduce){
+//     .fade{
+//         transition:none
+//     }
+// }
+
+// .btn-close{
+//     --cui-btn-close-color: #080a0c;
+//     --cui-btn-close-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23080a0c'%3e%3cpath d='M.293.293a1 1 0 0 1 1.414 0L8 6.586 14.293.293a1 1 0 1 1 1.414 1.414L9.414 8l6.293 6.293a1 1 0 0 1-1.414 1.414L8 9.414l-6.293 6.293a1 1 0 0 1-1.414-1.414L6.586 8 .293 1.707a1 1 0 0 1 0-1.414'/%3e%3c/svg%3e");
+//     --cui-btn-close-opacity: .5;
+//     --cui-btn-close-hover-opacity: .75;
+//     --cui-btn-close-focus-shadow: 0 0 0 .25rem rgba(213, 2, 21, .25);
+//     --cui-btn-close-focus-opacity: 1;
+//     --cui-btn-close-disabled-opacity: .25;
+//     box-sizing:content-box;
+//     width:1em;
+//     height:1em;
+//     padding:.25em;
+//     color:var(--cui-btn-close-color);
+//     background:transparent var(--cui-btn-close-bg) center/1em auto no-repeat;
+//     filter:var(--cui-btn-close-filter);
+//     border:0;
+//     border-radius:.375rem;
+//     opacity:var(--cui-btn-close-opacity)
+// }
+// .btn-close:hover{
+//     color:var(--cui-btn-close-color);
+//     text-decoration:none;
+//     opacity:var(--cui-btn-close-hover-opacity)
+// }
+// .btn-close:focus{
+//     outline:0;
+//     box-shadow:var(--cui-btn-close-focus-shadow);
+//     opacity:var(--cui-btn-close-focus-opacity)
+// }
+// .btn-close:disabled,.btn-close.disabled{
+//     pointer-events:none;
+//     user-select:none;
+//     opacity:var(--cui-btn-close-disabled-opacity)
+// }
+// .btn-close-white{
+//     --cui-btn-close-filter: invert(1) grayscale(100%) brightness(200%)
+// }
+// :root,[data-coreui-theme=light]{
+//     --cui-btn-close-filter:
+// }
+// [data-coreui-theme=dark]{
+//     --cui-btn-close-filter: invert(1) grayscale(100%) brightness(200%)
+// }
+
+// .input-group .btn{
+//     position:relative;
+//     z-index:2
+// }
+// .input-group .btn:focus{
+//     z-index:5
+// }
+
+.btn-danger {
+	// TODO - this should really update the variables
+	background-color: rgba(180, 0, 0, 1);
+}
+
+.btn-danger:hover {
+	// TODO - this should really use the variables
+	background-color: color.adjust(rgba(180, 0, 0, 1), $lightness: -5%, $space: hsl);
+	color: #eee;
+	animation: blinker 0.4s linear infinite;
+}
+
+.btn-danger:disabled {
+	color: rgba(255, 255, 255, 0.8);
+}
+
+.btn-success:disabled {
+	color: rgba(255, 255, 255, 0.9);
+}
+
+.btn-info:disabled {
+	color: rgba(255, 255, 255, 0.9);
+}
+
+@keyframes blinker {
+	50% {
+		opacity: 0.8;
+	}
+}
+
+// ----
+
 .button-group,
 .button-group-vertical {
 	position: relative;


### PR DESCRIPTION
Continue #4172

Tackling the buttons this time. Probably starting to creep in some accidental style changes, but hard to spot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Unified button visuals and CSS class names across the app with a new custom button theme.

* **Refactor**
  * Swapped legacy third-party button primitives for a shared app button component everywhere, preserving behavior and layout.

* **New Features**
  * Added interactive Button component stories to Storybook for previewing variants and states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitfocus/companion/pull/4175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->