### PR TITLE
feat: rebuild page buttons to use elements for drawing

### DIFF
--- a/companion/lib/Controls/ControlTypes/Button/Layered.ts
+++ b/companion/lib/Controls/ControlTypes/Button/Layered.ts
@@ -269,6 +269,7 @@ export class ControlButtonLayered
 			elements,
 
 			style: 'button-layered',
+			drawType: 'button',
 		}
 
 		this.#lastDrawStyle = result

--- a/companion/lib/Controls/ControlTypes/Button/Preset.ts
+++ b/companion/lib/Controls/ControlTypes/Button/Preset.ts
@@ -266,6 +266,7 @@ export class ControlButtonPreset
 			button_status: this.button_status,
 
 			style: 'button-layered',
+			drawType: 'button',
 		}
 
 		this.#lastDrawStyle = result

--- a/companion/lib/Controls/ControlTypes/PageButton.ts
+++ b/companion/lib/Controls/ControlTypes/PageButton.ts
@@ -1,0 +1,162 @@
+import type { SomeButtonGraphicsElement } from '@companion-app/shared/Model/StyleLayersModel.js'
+import { type DrawStyleLayeredButtonModel } from '@companion-app/shared/Model/StyleModel.js'
+import { ConvertSomeButtonGraphicsElementForDrawing } from '../../Graphics/ConvertGraphicsElements.js'
+import { ElementConversionCache } from '../../Graphics/ElementConversionCache.js'
+import { ControlBase } from '../ControlBase.js'
+import type {
+	ControlWithoutActions,
+	ControlWithoutActionSets,
+	ControlWithoutEvents,
+	ControlWithoutLayeredStyle,
+	ControlWithoutOptions,
+	ControlWithoutPushed,
+} from '../IControlFragments.js'
+
+const emptyMap: ReadonlyMap<string, never> = new Map<string, never>()
+
+/**
+ * Class for some page button control.
+ *
+ * @author Håkon Nessjøen <haakon@bitfocus.io>
+ * @author Keith Rocheck <keith.rocheck@gmail.com>
+ * @author William Viker <william@bitfocus.io>
+ * @author Julian Waller <me@julusian.co.uk>
+ * @since 3.0.0
+ * @copyright 2022 Bitfocus AS
+ * @license
+ * This program is free software.
+ * You should have received a copy of the MIT licence as well as the Bitfocus
+ * Individual Contributor License Agreement for Companion along with
+ * this program.
+ */
+export abstract class ControlButtonPage<TJson>
+	extends ControlBase<TJson>
+	implements
+		ControlWithoutActions,
+		ControlWithoutLayeredStyle,
+		ControlWithoutEvents,
+		ControlWithoutActionSets,
+		ControlWithoutOptions,
+		ControlWithoutPushed
+{
+	readonly supportsActions = false
+	readonly supportsEntities = false
+	readonly supportsLayeredStyle = false
+	readonly supportsEvents = false
+	readonly supportsActionSets = false
+	readonly supportsOptions = false
+	readonly supportsPushed = false
+
+	/**
+	 * The variables referenced in the last draw. Whenever one of these changes, a redraw should be performed
+	 */
+	#lastDrawVariables: ReadonlySet<string> | null = null
+
+	/**
+	 * Cache for element conversion results (for future per-element caching optimization)
+	 */
+	readonly #elementConversionCache = new ElementConversionCache()
+
+	/**
+	 * Prepare this control for deletion
+	 */
+	destroy(): void {
+		this.#elementConversionCache.clear()
+		super.destroy()
+	}
+
+	/**
+	 * Get the complete style object of a button
+	 * @returns the processed style of the button
+	 */
+	#lastDrawStyle: DrawStyleLayeredButtonModel | null = null
+	getLastDrawStyle(): DrawStyleLayeredButtonModel | null {
+		return this.#lastDrawStyle
+	}
+
+	protected abstract getDrawElements(): {
+		drawType: DrawStyleLayeredButtonModel['drawType']
+		elements: SomeButtonGraphicsElement[]
+	}
+
+	/**
+	 * Get the complete style object of a button
+	 * @returns the processed style of the button
+	 */
+	async getDrawStyle(): Promise<DrawStyleLayeredButtonModel | null> {
+		const location = this.deps.pageStore.getLocationOfControlId(this.controlId)
+		const parser = this.deps.variableValues.createVariablesAndExpressionParser(location, null, null)
+
+		const { drawType, elements: rawElements } = this.getDrawElements()
+
+		// Compute the new drawing, using the element conversion cache for per-element caching
+		const { elements, usedVariables } = await ConvertSomeButtonGraphicsElementForDrawing(
+			this.deps.instance.definitions,
+			parser,
+			this.deps.graphics.renderPixelBuffers.bind(this.deps.graphics),
+			rawElements,
+			emptyMap,
+			true,
+			this.#elementConversionCache
+		)
+		this.#lastDrawVariables = usedVariables.size > 0 ? usedVariables : null
+
+		const result: DrawStyleLayeredButtonModel = {
+			pushed: false,
+			stepCurrent: 0,
+			stepCount: 0,
+			button_status: undefined,
+			action_running: undefined,
+
+			elements,
+
+			style: 'button-layered',
+			drawType: drawType,
+		}
+
+		this.#lastDrawStyle = result
+		return result
+	}
+
+	/**
+	 * Collect the connection ids, labels, and variables referenced by this control
+	 * @param foundConnectionIds - connection ids being referenced
+	 * @param foundConnectionLabels - connection labels being referenced
+	 * @param foundVariables - variables being referenced
+	 */
+	collectReferencedConnectionsAndVariables(
+		_foundConnectionIds: Set<string>,
+		_foundConnectionLabels: Set<string>,
+		_foundVariables: Set<string>
+	): void {
+		// Nothing being referenced
+	}
+
+	/**
+	 * Inform the control that it has been moved, and anything relying on its location must be invalidated
+	 */
+	triggerLocationHasChanged(): void {
+		// Ensure any dependencies on the location in the drawing are updated
+		this.#elementConversionCache.clear()
+		this.triggerRedraw()
+	}
+
+	renameVariables(_labelFrom: string, _labelTo: string): void {
+		// Nothing to do
+	}
+
+	/**
+	 * Propagate variable changes
+	 * @param allChangedVariables - variables with changes
+	 */
+	onVariablesChanged(allChangedVariables: ReadonlySet<string>): void {
+		if (!this.#lastDrawVariables) return
+		if (this.#lastDrawVariables.isDisjointFrom(allChangedVariables)) return
+
+		// Queue invalidation for cached elements that use any of the changed variables
+		this.#elementConversionCache.queueInvalidateVariables(allChangedVariables)
+
+		this.logger.silly('variable changed in button ' + this.controlId)
+		this.triggerRedraw()
+	}
+}

--- a/companion/lib/Controls/ControlTypes/PageDown.ts
+++ b/companion/lib/Controls/ControlTypes/PageDown.ts
@@ -1,15 +1,82 @@
 import type { PageDownButtonModel } from '@companion-app/shared/Model/ButtonModel.js'
-import type { DrawStyleModel } from '@companion-app/shared/Model/StyleModel.js'
-import { ControlBase } from '../ControlBase.js'
-import type { ControlDependencies } from '../ControlDependencies.js'
+import { exprExpr, exprVal } from '@companion-app/shared/Model/Options.js'
 import type {
-	ControlWithoutActions,
-	ControlWithoutActionSets,
-	ControlWithoutEvents,
-	ControlWithoutLayeredStyle,
-	ControlWithoutOptions,
-	ControlWithoutPushed,
-} from '../IControlFragments.js'
+	ButtonGraphicsBoxElement,
+	ButtonGraphicsGroupElement,
+	ButtonGraphicsLineElement,
+	ButtonGraphicsTextElement,
+	SomeButtonGraphicsElement,
+} from '@companion-app/shared/Model/StyleLayersModel.js'
+import {
+	ButtonGraphicsDecorationType,
+	ButtonGraphicsElementUsage,
+	ButtonGraphicsShowStatusIcons,
+} from '@companion-app/shared/Model/StyleModel.js'
+import type { ControlDependencies } from '../ControlDependencies.js'
+import { CreateElementOfType } from './Button/LayerDefaults.js'
+import { ControlButtonPage } from './PageButton.js'
+
+export const pageDownElements: SomeButtonGraphicsElement[] = [
+	{
+		type: 'canvas',
+		id: 'canvas',
+		name: 'Canvas',
+		decoration: exprVal(ButtonGraphicsDecorationType.None),
+		showStatusIcons: exprVal(ButtonGraphicsShowStatusIcons.None),
+		usage: ButtonGraphicsElementUsage.Automatic,
+	},
+	{
+		...(CreateElementOfType('box') as ButtonGraphicsBoxElement),
+		color: exprVal(0x0f0f0f), // Grey background
+	},
+
+	{
+		// Draw the arrow
+		...(CreateElementOfType('group') as ButtonGraphicsGroupElement),
+		enabled: exprExpr('!$(internal:_graphics_page_plusminus)'),
+		children: [
+			{
+				...(CreateElementOfType('line') as ButtonGraphicsLineElement),
+				fromX: exprVal(64),
+				fromY: exprVal(55),
+				toX: exprVal(50),
+				toY: exprVal(69),
+				borderColor: exprVal(0xffffff),
+				borderWidth: exprVal(2.5),
+			},
+			{
+				...(CreateElementOfType('line') as ButtonGraphicsLineElement),
+				fromX: exprVal(36),
+				fromY: exprVal(55),
+				toX: exprVal(50),
+				toY: exprVal(69),
+				borderColor: exprVal(0xffffff),
+				borderWidth: exprVal(2.5),
+			},
+		],
+	},
+
+	{
+		// Draw +/- if enabled
+		...(CreateElementOfType('text') as ButtonGraphicsTextElement),
+		enabled: exprExpr('$(internal:_graphics_page_plusminus)'),
+		text: exprExpr('$(internal:_graphics_page_direction_flipped") ? "+" : "–"'),
+		color: exprVal(0xffffff),
+		fontsize: exprVal('30'),
+		valign: exprVal('top'),
+		y: exprVal(50),
+		height: exprVal(50),
+	},
+
+	{
+		...(CreateElementOfType('text') as ButtonGraphicsTextElement),
+		text: exprVal('DOWN'),
+		color: exprVal(0xffc600), // Yellow color
+		fontsize: exprVal('16.5'),
+		valign: exprVal('bottom'),
+		height: exprVal(47),
+	},
+]
 
 /**
  * Class for a pagedown button control.
@@ -26,25 +93,8 @@ import type {
  * Individual Contributor License Agreement for Companion along with
  * this program.
  */
-export class ControlButtonPageDown
-	extends ControlBase<PageDownButtonModel>
-	implements
-		ControlWithoutActions,
-		ControlWithoutLayeredStyle,
-		ControlWithoutEvents,
-		ControlWithoutActionSets,
-		ControlWithoutOptions,
-		ControlWithoutPushed
-{
+export class ControlButtonPageDown extends ControlButtonPage<PageDownButtonModel> {
 	readonly type = 'pagedown'
-
-	readonly supportsActions = false
-	readonly supportsEntities = false
-	readonly supportsLayeredStyle = false
-	readonly supportsEvents = false
-	readonly supportsActionSets = false
-	readonly supportsOptions = false
-	readonly supportsPushed = false
 
 	/**
 	 * @param registry - the application core
@@ -69,35 +119,11 @@ export class ControlButtonPageDown
 		}
 	}
 
-	/**
-	 * Get the complete style object of a button
-	 * @returns the processed style of the button
-	 */
-	getLastDrawStyle(): DrawStyleModel {
+	protected getDrawElements(): ReturnType<ControlButtonPage<any>['getDrawElements']> {
 		return {
-			style: 'pagedown',
+			drawType: 'pagedown',
+			elements: pageDownElements,
 		}
-	}
-
-	/**
-	 * Collect the connection ids, labels, and variables referenced by this control
-	 * @param foundConnectionIds - connection ids being referenced
-	 * @param foundConnectionLabels - connection labels being referenced
-	 * @param foundVariables - variables being referenced
-	 */
-	collectReferencedConnectionsAndVariables(
-		_foundConnectionIds: Set<string>,
-		_foundConnectionLabels: Set<string>,
-		_foundVariables: Set<string>
-	): void {
-		// Nothing being referenced
-	}
-
-	/**
-	 * Inform the control that it has been moved, and anything relying on its location must be invalidated
-	 */
-	triggerLocationHasChanged(): void {
-		// Nothing to do
 	}
 
 	/**
@@ -120,12 +146,5 @@ export class ControlButtonPageDown
 		return {
 			type: this.type,
 		}
-	}
-
-	renameVariables(_labelFrom: string, _labelTo: string): void {
-		// Nothing to do
-	}
-	onVariablesChanged(_allChangedVariables: ReadonlySet<string>): void {
-		// Nothing to do
 	}
 }

--- a/companion/lib/Controls/ControlTypes/PageDown.ts
+++ b/companion/lib/Controls/ControlTypes/PageDown.ts
@@ -60,7 +60,7 @@ export const pageDownElements: SomeButtonGraphicsElement[] = [
 		// Draw +/- if enabled
 		...(CreateElementOfType('text') as ButtonGraphicsTextElement),
 		enabled: exprExpr('$(internal:_graphics_page_plusminus)'),
-		text: exprExpr('$(internal:_graphics_page_direction_flipped") ? "+" : "–"'),
+		text: exprExpr('$(internal:_graphics_page_direction_flipped) ? "+" : "–"'),
 		color: exprVal(0xffffff),
 		fontsize: exprVal('30'),
 		valign: exprVal('top'),

--- a/companion/lib/Controls/ControlTypes/PageNumber.ts
+++ b/companion/lib/Controls/ControlTypes/PageNumber.ts
@@ -1,5 +1,19 @@
 import type { PageNumberButtonModel } from '@companion-app/shared/Model/ButtonModel.js'
-import type { DrawStyleModel } from '@companion-app/shared/Model/StyleModel.js'
+import { exprExpr, exprVal } from '@companion-app/shared/Model/Options.js'
+import type {
+	ButtonGraphicsBoxElement,
+	ButtonGraphicsGroupElement,
+	ButtonGraphicsTextElement,
+	SomeButtonGraphicsElement,
+} from '@companion-app/shared/Model/StyleLayersModel.js'
+import {
+	ButtonGraphicsDecorationType,
+	ButtonGraphicsElementUsage,
+	ButtonGraphicsShowStatusIcons,
+	type DrawStyleLayeredButtonModel,
+} from '@companion-app/shared/Model/StyleModel.js'
+import { ConvertSomeButtonGraphicsElementForDrawing } from '../../Graphics/ConvertGraphicsElements.js'
+import { ElementConversionCache } from '../../Graphics/ElementConversionCache.js'
 import { ControlBase } from '../ControlBase.js'
 import type { ControlDependencies } from '../ControlDependencies.js'
 import type {
@@ -10,6 +24,63 @@ import type {
 	ControlWithoutOptions,
 	ControlWithoutPushed,
 } from '../IControlFragments.js'
+import { CreateElementOfType } from './Button/LayerDefaults.js'
+
+const emptyMap: ReadonlyMap<string, never> = new Map<string, never>()
+
+export const pageNumberElements: SomeButtonGraphicsElement[] = [
+	{
+		type: 'canvas',
+		id: 'canvas',
+		name: 'Canvas',
+		decoration: exprVal(ButtonGraphicsDecorationType.None),
+		showStatusIcons: exprVal(ButtonGraphicsShowStatusIcons.None),
+		usage: ButtonGraphicsElementUsage.Automatic,
+	},
+	{
+		...(CreateElementOfType('box') as ButtonGraphicsBoxElement),
+		color: exprVal(0x0f0f0f), // Grey background
+	},
+
+	{
+		// If page has a name
+		...(CreateElementOfType('group') as ButtonGraphicsGroupElement),
+		enabled: exprExpr('!!$(this:page_name) && toLowerCase($(this:page_name)) != "page" && $(this:page_name) != "$NA"'),
+		children: [
+			{
+				...(CreateElementOfType('text') as ButtonGraphicsTextElement),
+				text: exprVal('$(this:page_name)'),
+				color: exprVal(0xffffff),
+				fontsize: exprVal('30'),
+			},
+		],
+	},
+
+	{
+		// No name, default display
+		...(CreateElementOfType('group') as ButtonGraphicsGroupElement),
+		enabled: exprExpr('!$(this:page_name) || toLowerCase($(this:page_name)) == "page" || $(this:page_name) == "$NA"'),
+		children: [
+			{
+				...(CreateElementOfType('text') as ButtonGraphicsTextElement),
+				text: exprVal('PAGE'),
+				color: exprVal(0xffc600), // Yellow color
+				fontsize: exprVal('16.5'),
+				valign: exprVal('bottom'),
+				height: exprVal(40),
+			},
+			{
+				...(CreateElementOfType('text') as ButtonGraphicsTextElement),
+				text: exprExpr('getVariable("this:page") || "x"'),
+				color: exprVal(0xffffff),
+				fontsize: exprVal('30'),
+				valign: exprVal('top'),
+				y: exprVal(45),
+				height: exprVal(55),
+			},
+		],
+	},
+]
 
 /**
  * Class for a pagenum button control.
@@ -47,6 +118,16 @@ export class ControlButtonPageNumber
 	readonly supportsPushed = false
 
 	/**
+	 * The variables referenced in the last draw. Whenever one of these changes, a redraw should be performed
+	 */
+	#lastDrawVariables: ReadonlySet<string> | null = null
+
+	/**
+	 * Cache for element conversion results (for future per-element caching optimization)
+	 */
+	readonly #elementConversionCache = new ElementConversionCache()
+
+	/**
 	 * @param registry - the application core
 	 * @param controlId - id of the control
 	 * @param storage - persisted storage object
@@ -71,13 +152,57 @@ export class ControlButtonPageNumber
 	}
 
 	/**
+	 * Prepare this control for deletion
+	 */
+	destroy(): void {
+		this.#elementConversionCache.clear()
+		super.destroy()
+	}
+
+	/**
 	 * Get the complete style object of a button
 	 * @returns the processed style of the button
 	 */
-	getLastDrawStyle(): DrawStyleModel {
-		return {
-			style: 'pagenum',
+	#lastDrawStyle: DrawStyleLayeredButtonModel | null = null
+	getLastDrawStyle(): DrawStyleLayeredButtonModel | null {
+		return this.#lastDrawStyle
+	}
+
+	/**
+	 * Get the complete style object of a button
+	 * @returns the processed style of the button
+	 */
+	async getDrawStyle(): Promise<DrawStyleLayeredButtonModel | null> {
+		const location = this.deps.pageStore.getLocationOfControlId(this.controlId)
+		const parser = this.deps.variableValues.createVariablesAndExpressionParser(location, null, null)
+
+		// Compute the new drawing, using the element conversion cache for per-element caching
+		const { elements, usedVariables } = await ConvertSomeButtonGraphicsElementForDrawing(
+			this.deps.instance.definitions,
+			parser,
+			this.deps.graphics.renderPixelBuffers.bind(this.deps.graphics),
+			pageNumberElements,
+			emptyMap,
+			true,
+			this.#elementConversionCache
+		)
+		this.#lastDrawVariables = usedVariables.size > 0 ? usedVariables : null
+
+		const result: DrawStyleLayeredButtonModel = {
+			pushed: false,
+			stepCurrent: 0,
+			stepCount: 0,
+			button_status: undefined,
+			action_running: undefined,
+
+			elements,
+
+			style: 'button-layered',
+			drawType: 'pagenum',
 		}
+
+		this.#lastDrawStyle = result
+		return result
 	}
 
 	/**
@@ -98,7 +223,9 @@ export class ControlButtonPageNumber
 	 * Inform the control that it has been moved, and anything relying on its location must be invalidated
 	 */
 	triggerLocationHasChanged(): void {
-		// Nothing to do
+		// Ensure any dependencies on the location in the drawing are updated
+		this.#elementConversionCache.clear()
+		this.triggerRedraw()
 	}
 
 	/**
@@ -126,7 +253,18 @@ export class ControlButtonPageNumber
 	renameVariables(_labelFrom: string, _labelTo: string): void {
 		// Nothing to do
 	}
-	onVariablesChanged(_allChangedVariables: ReadonlySet<string>): void {
-		// Nothing to do
+	/**
+	 * Propagate variable changes
+	 * @param allChangedVariables - variables with changes
+	 */
+	onVariablesChanged(allChangedVariables: ReadonlySet<string>): void {
+		if (!this.#lastDrawVariables) return
+		if (this.#lastDrawVariables.isDisjointFrom(allChangedVariables)) return
+
+		// Queue invalidation for cached elements that use any of the changed variables
+		this.#elementConversionCache.queueInvalidateVariables(allChangedVariables)
+
+		this.logger.silly('variable changed in button ' + this.controlId)
+		this.triggerRedraw()
 	}
 }

--- a/companion/lib/Controls/ControlTypes/PageNumber.ts
+++ b/companion/lib/Controls/ControlTypes/PageNumber.ts
@@ -10,23 +10,10 @@ import {
 	ButtonGraphicsDecorationType,
 	ButtonGraphicsElementUsage,
 	ButtonGraphicsShowStatusIcons,
-	type DrawStyleLayeredButtonModel,
 } from '@companion-app/shared/Model/StyleModel.js'
-import { ConvertSomeButtonGraphicsElementForDrawing } from '../../Graphics/ConvertGraphicsElements.js'
-import { ElementConversionCache } from '../../Graphics/ElementConversionCache.js'
-import { ControlBase } from '../ControlBase.js'
 import type { ControlDependencies } from '../ControlDependencies.js'
-import type {
-	ControlWithoutActions,
-	ControlWithoutActionSets,
-	ControlWithoutEvents,
-	ControlWithoutLayeredStyle,
-	ControlWithoutOptions,
-	ControlWithoutPushed,
-} from '../IControlFragments.js'
 import { CreateElementOfType } from './Button/LayerDefaults.js'
-
-const emptyMap: ReadonlyMap<string, never> = new Map<string, never>()
+import { ControlButtonPage } from './PageButton.js'
 
 export const pageNumberElements: SomeButtonGraphicsElement[] = [
 	{
@@ -97,35 +84,8 @@ export const pageNumberElements: SomeButtonGraphicsElement[] = [
  * Individual Contributor License Agreement for Companion along with
  * this program.
  */
-export class ControlButtonPageNumber
-	extends ControlBase<PageNumberButtonModel>
-	implements
-		ControlWithoutActions,
-		ControlWithoutLayeredStyle,
-		ControlWithoutEvents,
-		ControlWithoutActionSets,
-		ControlWithoutOptions,
-		ControlWithoutPushed
-{
+export class ControlButtonPageNumber extends ControlButtonPage<PageNumberButtonModel> {
 	readonly type = 'pagenum'
-
-	readonly supportsActions = false
-	readonly supportsEntities = false
-	readonly supportsLayeredStyle = false
-	readonly supportsEvents = false
-	readonly supportsActionSets = false
-	readonly supportsOptions = false
-	readonly supportsPushed = false
-
-	/**
-	 * The variables referenced in the last draw. Whenever one of these changes, a redraw should be performed
-	 */
-	#lastDrawVariables: ReadonlySet<string> | null = null
-
-	/**
-	 * Cache for element conversion results (for future per-element caching optimization)
-	 */
-	readonly #elementConversionCache = new ElementConversionCache()
 
 	/**
 	 * @param registry - the application core
@@ -151,81 +111,11 @@ export class ControlButtonPageNumber
 		}
 	}
 
-	/**
-	 * Prepare this control for deletion
-	 */
-	destroy(): void {
-		this.#elementConversionCache.clear()
-		super.destroy()
-	}
-
-	/**
-	 * Get the complete style object of a button
-	 * @returns the processed style of the button
-	 */
-	#lastDrawStyle: DrawStyleLayeredButtonModel | null = null
-	getLastDrawStyle(): DrawStyleLayeredButtonModel | null {
-		return this.#lastDrawStyle
-	}
-
-	/**
-	 * Get the complete style object of a button
-	 * @returns the processed style of the button
-	 */
-	async getDrawStyle(): Promise<DrawStyleLayeredButtonModel | null> {
-		const location = this.deps.pageStore.getLocationOfControlId(this.controlId)
-		const parser = this.deps.variableValues.createVariablesAndExpressionParser(location, null, null)
-
-		// Compute the new drawing, using the element conversion cache for per-element caching
-		const { elements, usedVariables } = await ConvertSomeButtonGraphicsElementForDrawing(
-			this.deps.instance.definitions,
-			parser,
-			this.deps.graphics.renderPixelBuffers.bind(this.deps.graphics),
-			pageNumberElements,
-			emptyMap,
-			true,
-			this.#elementConversionCache
-		)
-		this.#lastDrawVariables = usedVariables.size > 0 ? usedVariables : null
-
-		const result: DrawStyleLayeredButtonModel = {
-			pushed: false,
-			stepCurrent: 0,
-			stepCount: 0,
-			button_status: undefined,
-			action_running: undefined,
-
-			elements,
-
-			style: 'button-layered',
+	protected getDrawElements(): ReturnType<ControlButtonPage<any>['getDrawElements']> {
+		return {
 			drawType: 'pagenum',
+			elements: pageNumberElements,
 		}
-
-		this.#lastDrawStyle = result
-		return result
-	}
-
-	/**
-	 * Collect the connection ids, labels, and variables referenced by this control
-	 * @param foundConnectionIds - connection ids being referenced
-	 * @param foundConnectionLabels - connection labels being referenced
-	 * @param foundVariables - variables being referenced
-	 */
-	collectReferencedConnectionsAndVariables(
-		_foundConnectionIds: Set<string>,
-		_foundConnectionLabels: Set<string>,
-		_foundVariables: Set<string>
-	): void {
-		// Nothing being referenced
-	}
-
-	/**
-	 * Inform the control that it has been moved, and anything relying on its location must be invalidated
-	 */
-	triggerLocationHasChanged(): void {
-		// Ensure any dependencies on the location in the drawing are updated
-		this.#elementConversionCache.clear()
-		this.triggerRedraw()
 	}
 
 	/**
@@ -248,23 +138,5 @@ export class ControlButtonPageNumber
 		return {
 			type: this.type,
 		}
-	}
-
-	renameVariables(_labelFrom: string, _labelTo: string): void {
-		// Nothing to do
-	}
-	/**
-	 * Propagate variable changes
-	 * @param allChangedVariables - variables with changes
-	 */
-	onVariablesChanged(allChangedVariables: ReadonlySet<string>): void {
-		if (!this.#lastDrawVariables) return
-		if (this.#lastDrawVariables.isDisjointFrom(allChangedVariables)) return
-
-		// Queue invalidation for cached elements that use any of the changed variables
-		this.#elementConversionCache.queueInvalidateVariables(allChangedVariables)
-
-		this.logger.silly('variable changed in button ' + this.controlId)
-		this.triggerRedraw()
 	}
 }

--- a/companion/lib/Controls/ControlTypes/PageUp.ts
+++ b/companion/lib/Controls/ControlTypes/PageUp.ts
@@ -60,7 +60,7 @@ export const pageUpElements: SomeButtonGraphicsElement[] = [
 		// Draw +/- if enabled
 		...(CreateElementOfType('text') as ButtonGraphicsTextElement),
 		enabled: exprExpr('$(internal:_graphics_page_plusminus)'),
-		text: exprExpr('$(internal:_graphics_page_direction_flipped") ? "–" : "+"'),
+		text: exprExpr('$(internal:_graphics_page_direction_flipped) ? "–" : "+"'),
 		color: exprVal(0xffffff),
 		fontsize: exprVal('30'),
 		valign: exprVal('bottom'),

--- a/companion/lib/Controls/ControlTypes/PageUp.ts
+++ b/companion/lib/Controls/ControlTypes/PageUp.ts
@@ -1,15 +1,82 @@
 import type { PageUpButtonModel } from '@companion-app/shared/Model/ButtonModel.js'
-import type { DrawStyleModel } from '@companion-app/shared/Model/StyleModel.js'
-import { ControlBase } from '../ControlBase.js'
-import type { ControlDependencies } from '../ControlDependencies.js'
+import { exprExpr, exprVal } from '@companion-app/shared/Model/Options.js'
 import type {
-	ControlWithoutActions,
-	ControlWithoutActionSets,
-	ControlWithoutEvents,
-	ControlWithoutLayeredStyle,
-	ControlWithoutOptions,
-	ControlWithoutPushed,
-} from '../IControlFragments.js'
+	ButtonGraphicsBoxElement,
+	ButtonGraphicsGroupElement,
+	ButtonGraphicsLineElement,
+	ButtonGraphicsTextElement,
+	SomeButtonGraphicsElement,
+} from '@companion-app/shared/Model/StyleLayersModel.js'
+import {
+	ButtonGraphicsDecorationType,
+	ButtonGraphicsElementUsage,
+	ButtonGraphicsShowStatusIcons,
+} from '@companion-app/shared/Model/StyleModel.js'
+import type { ControlDependencies } from '../ControlDependencies.js'
+import { CreateElementOfType } from './Button/LayerDefaults.js'
+import { ControlButtonPage } from './PageButton.js'
+
+export const pageUpElements: SomeButtonGraphicsElement[] = [
+	{
+		type: 'canvas',
+		id: 'canvas',
+		name: 'Canvas',
+		decoration: exprVal(ButtonGraphicsDecorationType.None),
+		showStatusIcons: exprVal(ButtonGraphicsShowStatusIcons.None),
+		usage: ButtonGraphicsElementUsage.Automatic,
+	},
+	{
+		...(CreateElementOfType('box') as ButtonGraphicsBoxElement),
+		color: exprVal(0x0f0f0f), // Grey background
+	},
+
+	{
+		// Draw the arrow
+		...(CreateElementOfType('group') as ButtonGraphicsGroupElement),
+		enabled: exprExpr('!$(internal:_graphics_page_plusminus)'),
+		children: [
+			{
+				...(CreateElementOfType('line') as ButtonGraphicsLineElement),
+				fromX: exprVal(64),
+				fromY: exprVal(42),
+				toX: exprVal(50),
+				toY: exprVal(28),
+				borderColor: exprVal(0xffffff),
+				borderWidth: exprVal(2.5),
+			},
+			{
+				...(CreateElementOfType('line') as ButtonGraphicsLineElement),
+				fromX: exprVal(36),
+				fromY: exprVal(42),
+				toX: exprVal(50),
+				toY: exprVal(28),
+				borderColor: exprVal(0xffffff),
+				borderWidth: exprVal(2.5),
+			},
+		],
+	},
+
+	{
+		// Draw +/- if enabled
+		...(CreateElementOfType('text') as ButtonGraphicsTextElement),
+		enabled: exprExpr('$(internal:_graphics_page_plusminus)'),
+		text: exprExpr('$(internal:_graphics_page_direction_flipped") ? "–" : "+"'),
+		color: exprVal(0xffffff),
+		fontsize: exprVal('30'),
+		valign: exprVal('bottom'),
+		height: exprVal(50),
+	},
+
+	{
+		...(CreateElementOfType('text') as ButtonGraphicsTextElement),
+		text: exprVal('UP'),
+		color: exprVal(0xffc600), // Yellow color
+		fontsize: exprVal('16.5'),
+		valign: exprVal('top'),
+		y: exprVal(53),
+		height: exprVal(47),
+	},
+]
 
 /**
  * Class for a pageup button control.
@@ -26,25 +93,8 @@ import type {
  * Individual Contributor License Agreement for Companion along with
  * this program.
  */
-export class ControlButtonPageUp
-	extends ControlBase<PageUpButtonModel>
-	implements
-		ControlWithoutActions,
-		ControlWithoutLayeredStyle,
-		ControlWithoutEvents,
-		ControlWithoutActionSets,
-		ControlWithoutOptions,
-		ControlWithoutPushed
-{
+export class ControlButtonPageUp extends ControlButtonPage<PageUpButtonModel> {
 	readonly type = 'pageup'
-
-	readonly supportsActions = false
-	readonly supportsEntities = false
-	readonly supportsLayeredStyle = false
-	readonly supportsEvents = false
-	readonly supportsActionSets = false
-	readonly supportsOptions = false
-	readonly supportsPushed = false
 
 	/**
 	 * @param registry - the application core
@@ -69,35 +119,11 @@ export class ControlButtonPageUp
 		}
 	}
 
-	/**
-	 * Get the complete style object of a button
-	 * @returns the processed style of the button
-	 */
-	getLastDrawStyle(): DrawStyleModel {
+	protected getDrawElements(): ReturnType<ControlButtonPage<any>['getDrawElements']> {
 		return {
-			style: 'pageup',
+			drawType: 'pageup',
+			elements: pageUpElements,
 		}
-	}
-
-	/**
-	 * Collect the connection ids, labels, and variables referenced by this control
-	 * @param foundConnectionIds - connection ids being referenced
-	 * @param foundConnectionLabels - connection labels being referenced
-	 * @param foundVariables - variables being referenced
-	 */
-	collectReferencedConnectionsAndVariables(
-		_foundConnectionIds: Set<string>,
-		_foundConnectionLabels: Set<string>,
-		_foundVariables: Set<string>
-	): void {
-		// Nothing being referenced
-	}
-
-	/**
-	 * Inform the control that it has been moved, and anything relying on its location must be invalidated
-	 */
-	triggerLocationHasChanged(): void {
-		// Nothing to do
 	}
 
 	/**
@@ -120,12 +146,5 @@ export class ControlButtonPageUp
 		return {
 			type: this.type,
 		}
-	}
-
-	renameVariables(_labelFrom: string, _labelTo: string): void {
-		// Nothing to do
-	}
-	onVariablesChanged(_allChangedVariables: ReadonlySet<string>): void {
-		// Nothing to do
 	}
 }

--- a/companion/lib/Graphics/Controller.ts
+++ b/companion/lib/Graphics/Controller.ts
@@ -303,8 +303,6 @@ export class GraphicsController extends EventEmitter<GraphicsControllerEvents> {
 
 					let render: ImageResult | undefined
 					if (location && locationIsInBounds && buttonStyle && buttonStyle.style) {
-						const pagename = this.#pageStore.getPageName(location.pageNumber)
-
 						let renderStyle: RendererDrawStyle | undefined
 						let cacheKey: string | undefined
 
@@ -333,15 +331,6 @@ export class GraphicsController extends EventEmitter<GraphicsControllerEvents> {
 									style: buttonStyle.style,
 									plusminus: this.#drawOptions.page_plusminus,
 									direction_flipped: this.#drawOptions.page_direction_flipped,
-								}
-								cacheKey = JSON.stringify(renderStyle)
-								break
-							}
-							case 'pagenum': {
-								renderStyle = {
-									style: 'pagenum',
-									pageNumber: location.pageNumber,
-									pageName: pagename,
 								}
 								cacheKey = JSON.stringify(renderStyle)
 								break
@@ -530,9 +519,13 @@ export class GraphicsController extends EventEmitter<GraphicsControllerEvents> {
 	/**
 	 * Draw a preview of a button
 	 */
-	async drawPreview(elements: SomeButtonGraphicsDrawElement[]): Promise<ImageResult> {
+	async drawPreview(
+		drawType: RendererButtonStyle['drawType'],
+		elements: SomeButtonGraphicsDrawElement[]
+	): Promise<ImageResult> {
 		const drawStyle: RendererButtonStyle = {
 			style: 'button-layered',
+			drawType,
 
 			elements: elements,
 

--- a/companion/lib/Graphics/Controller.ts
+++ b/companion/lib/Graphics/Controller.ts
@@ -325,8 +325,7 @@ export class GraphicsController extends EventEmitter<GraphicsControllerEvents> {
 
 								break
 							}
-							case 'pageup':
-							case 'pagedown': {
+							case 'pageup': {
 								renderStyle = {
 									style: buttonStyle.style,
 									plusminus: this.#drawOptions.page_plusminus,

--- a/companion/lib/Graphics/Controller.ts
+++ b/companion/lib/Graphics/Controller.ts
@@ -31,7 +31,6 @@ import type { SomeButtonGraphicsDrawElement } from '@companion-app/shared/Model/
 import type { DrawImageBuffer } from '@companion-app/shared/Model/StyleModel.js'
 import type { SurfaceRotation } from '@companion-app/shared/Model/Surfaces.js'
 import type { VariableValues } from '@companion-app/shared/Model/Variables.js'
-import { assertNever } from '@companion-module/base'
 import type { IControlStore } from '../Controls/IControlStore.js'
 import type { DataDatabase } from '../Data/Database.js'
 import type { DataUserConfig } from '../Data/UserConfig.js'
@@ -67,11 +66,6 @@ interface GraphicsControllerEvents {
 	resubscribeFeedbacks: []
 }
 
-interface GraphicsOptions extends ResolveButtonStylePropertiesConfig {
-	page_direction_flipped: boolean
-	page_plusminus: boolean
-}
-
 interface RenderArgumentsButton {
 	type: 'button'
 	location: ControlLocation
@@ -93,7 +87,7 @@ export class GraphicsController extends EventEmitter<GraphicsControllerEvents> {
 	/**
 	 * Cached UserConfig values that affect button rendering
 	 */
-	readonly #drawOptions: GraphicsOptions
+	readonly #drawOptions: ResolveButtonStylePropertiesConfig
 
 	/**
 	 * Current button renders cache
@@ -230,8 +224,6 @@ export class GraphicsController extends EventEmitter<GraphicsControllerEvents> {
 		this.setMaxListeners(0)
 
 		this.#drawOptions = {
-			page_direction_flipped: this.#userConfigController.getKey('page_direction_flipped'),
-			page_plusminus: this.#userConfigController.getKey('page_plusminus'),
 			remove_topbar: this.#userConfigController.getKey('remove_topbar'),
 			buttons_status_icons: this.#userConfigController.getKey('buttons_status_icons'),
 		}
@@ -303,64 +295,39 @@ export class GraphicsController extends EventEmitter<GraphicsControllerEvents> {
 
 					let render: ImageResult | undefined
 					if (location && locationIsInBounds && buttonStyle && buttonStyle.style) {
-						let renderStyle: RendererDrawStyle | undefined
-						let cacheKey: string | undefined
+						const showButtonConfig = resolveButtonStyleProperties(this.#drawOptions, buttonStyle.elements)
 
-						switch (buttonStyle.style) {
-							case 'button-layered': {
-								const showButtonConfig = resolveButtonStyleProperties(this.#drawOptions, buttonStyle.elements)
+						const renderStyle = {
+							...buttonStyle,
 
-								renderStyle = {
-									...buttonStyle,
-
-									...showButtonConfig,
-									location: showButtonConfig.show_topbar ? location : undefined, // Only needed if the topbar is shown
-								}
-
-								const cacheKeyObj: Record<string, any> = {
-									...renderStyle,
-									elements: collectContentHashes(buttonStyle.elements), // use hashes of elements for the key
-								}
-								cacheKey = JSON.stringify(cacheKeyObj)
-
-								break
-							}
-							case 'pageup': {
-								renderStyle = {
-									style: buttonStyle.style,
-									plusminus: this.#drawOptions.page_plusminus,
-									direction_flipped: this.#drawOptions.page_direction_flipped,
-								}
-								cacheKey = JSON.stringify(renderStyle)
-								break
-							}
-							default:
-								assertNever(buttonStyle)
-								break
+							...showButtonConfig,
+							location: showButtonConfig.show_topbar ? location : undefined, // Only needed if the topbar is shown
 						}
 
-						if (renderStyle && cacheKey) {
-							// Check if the image is already present in the render cache and if so, return it
-							render = this.#renderLRUCache.get(cacheKey)
+						const cacheKeyObj: Record<string, any> = {
+							...renderStyle,
+							elements: collectContentHashes(buttonStyle.elements), // use hashes of elements for the key
+						}
+						const cacheKey = JSON.stringify(cacheKeyObj)
 
-							if (!render) {
-								const { dataUrl, processedStyle } = await this.#executePoolDrawButtonImage(
+						// Check if the image is already present in the render cache and if so, return it
+						render = this.#renderLRUCache.get(cacheKey)
+
+						if (!render) {
+							const { dataUrl, processedStyle } = await this.#executePoolDrawButtonImage(
+								renderStyle,
+								CRASHED_WORKER_RETRY_COUNT
+							)
+							render = new ImageResult(dataUrl, processedStyle, async (width, height, rotation, format) =>
+								this.#executePoolDrawButtonBareImage(
 									renderStyle,
+									{ width, height, oversampling: 4 }, // TODO - dynamic oversampling?
+									rotation,
+									format,
 									CRASHED_WORKER_RETRY_COUNT
 								)
-								render = new ImageResult(dataUrl, processedStyle, async (width, height, rotation, format) =>
-									this.#executePoolDrawButtonBareImage(
-										renderStyle,
-										{ width, height, oversampling: 4 }, // TODO - dynamic oversampling?
-										rotation,
-										format,
-										CRASHED_WORKER_RETRY_COUNT
-									)
-								)
-								this.#renderLRUCache.set(cacheKey, render)
-							}
-						} else {
-							render = GraphicsRenderer.drawBlank({ width: 72, height: 72 }, !this.#drawOptions.remove_topbar, location)
+							)
+							this.#renderLRUCache.set(cacheKey, render)
 						}
 					} else {
 						render = GraphicsRenderer.drawBlank({ width: 72, height: 72 }, !this.#drawOptions.remove_topbar, location)
@@ -504,18 +471,6 @@ export class GraphicsController extends EventEmitter<GraphicsControllerEvents> {
 	}
 
 	/**
-	 * Redraw the page controls on every page
-	 */
-	invalidatePageControls(): void {
-		const allControls = this.controlsStore.getAllControls()
-		for (const control of allControls.values()) {
-			if (control.type === 'pageup' || control.type === 'pagedown') {
-				this.invalidateControl(control.controlId)
-			}
-		}
-	}
-
-	/**
 	 * Draw a preview of a button
 	 */
 	async drawPreview(
@@ -558,13 +513,7 @@ export class GraphicsController extends EventEmitter<GraphicsControllerEvents> {
 	 * @param value - the saved value
 	 */
 	updateUserConfig(key: string, value: boolean | number | string): void {
-		if (key == 'page_direction_flipped') {
-			this.#drawOptions.page_direction_flipped = !!value
-			this.invalidatePageControls()
-		} else if (key == 'page_plusminus') {
-			this.#drawOptions.page_plusminus = !!value
-			this.invalidatePageControls()
-		} else if (key == 'remove_topbar') {
+		if (key == 'remove_topbar') {
 			this.#drawOptions.remove_topbar = !!value
 			this.#logger.silly('Topbar removed')
 			// Delay redrawing to give connections a chance to adjust

--- a/companion/lib/Graphics/LayeredProcessedStyleGenerator.ts
+++ b/companion/lib/Graphics/LayeredProcessedStyleGenerator.ts
@@ -15,6 +15,11 @@ import type { ImageResultProcessedStyle } from './ImageResult.js'
 
 export class GraphicsLayeredProcessedStyleGenerator {
 	static Generate(drawStyle: DrawStyleLayeredButtonModel): ImageResultProcessedStyle {
+		if (drawStyle.drawType !== 'button') {
+			// Special case for backwards compatibility
+			return { type: drawStyle.drawType }
+		}
+
 		const canvasLayer = drawStyle.elements.find((e) => e.type === 'canvas')
 		const textLayer = GraphicsLayeredProcessedStyleGenerator.SelectLayerForUsage<ButtonGraphicsTextDrawElement>(
 			drawStyle.elements,

--- a/companion/lib/Graphics/Renderer.ts
+++ b/companion/lib/Graphics/Renderer.ts
@@ -26,10 +26,6 @@ import { Image } from './Image.js'
 import { ImageResult, type ImageResultProcessedStyle } from './ImageResult.js'
 import { GraphicsLayeredProcessedStyleGenerator } from './LayeredProcessedStyleGenerator.js'
 
-const colorButtonYellow = 'rgb(255, 198, 0)'
-const colorWhite = 'white'
-const colorDarkGrey = 'rgba(15, 15, 15, 1)'
-
 /**
  * Shared style for lock icon display
  */
@@ -54,21 +50,6 @@ export class GraphicsRenderer {
 
 	/** Static cache for text layout computations, shared across all Image instances */
 	static #textLayoutCache: TextLayoutCache = new QuickLRU({ maxSize: 5000 })
-
-	private static calculateTransforms(resolution: { width: number; height: number }) {
-		// Calculate some constants for drawing without reinventing the numbers
-		const drawScale = Math.min(resolution.width, resolution.height) / 72
-		const xOffset = (resolution.width - 72 * drawScale) / 2
-		const yOffset = (resolution.height - 72 * drawScale) / 2
-		const transformX = (x: number): number => xOffset + x * drawScale
-		const transformY = (y: number): number => yOffset + y * drawScale
-
-		return {
-			drawScale,
-			transformX,
-			transformY,
-		}
-	}
 
 	/**
 	 * Get a cached Image instance.
@@ -171,10 +152,7 @@ export class GraphicsRenderer {
 			dimensions[1],
 			resolution.oversampling,
 			async (img) => {
-				await GraphicsRenderer.#drawButtonImageInternal(img, drawStyle, {
-					width: dimensions[0],
-					height: dimensions[1],
-				})
+				await GraphicsRenderer.#drawButtonImageInternal(img, drawStyle)
 
 				return {
 					buffer: img.buffer(),
@@ -195,10 +173,7 @@ export class GraphicsRenderer {
 		processedStyle: ImageResultProcessedStyle
 	}> {
 		return GraphicsRenderer.#getCachedImage(72, 72, 4, async (img) => {
-			const processedStyle = await GraphicsRenderer.#drawButtonImageInternal(img, drawStyle, {
-				width: 72,
-				height: 72,
-			})
+			const processedStyle = await GraphicsRenderer.#drawButtonImageInternal(img, drawStyle)
 
 			return {
 				dataUrl: img.toDataURLSync(),
@@ -207,46 +182,15 @@ export class GraphicsRenderer {
 		})
 	}
 
-	static async #drawButtonImageInternal(
-		img: Image,
-		drawStyle: RendererDrawStyle,
-		resolution: { width: number; height: number }
-	): Promise<ImageResultProcessedStyle> {
+	static async #drawButtonImageInternal(img: Image, drawStyle: RendererDrawStyle): Promise<ImageResultProcessedStyle> {
 		// console.log('starting drawButtonImage '+ performance.now())
 		// console.time('drawButtonImage')
 
 		let processedStyle: ImageResultProcessedStyle
 
 		// Calculate some constants for drawing without reinventing the numbers
-		const { drawScale, transformX, transformY } = GraphicsRenderer.calculateTransforms(resolution)
 
-		// special button types
-		if (drawStyle.style == 'pageup') {
-			processedStyle = { type: 'pageup' }
-
-			img.fillColor(colorDarkGrey)
-
-			if (drawStyle.plusminus) {
-				img.drawTextLine(
-					transformX(31),
-					transformY(20),
-					drawStyle.direction_flipped ? '–' : '+',
-					colorWhite,
-					18 * drawScale
-				)
-			} else {
-				img.drawPath(
-					[
-						[transformX(46), transformY(30)],
-						[transformX(36), transformY(20)],
-						[transformX(26), transformY(30)],
-					],
-					{ color: colorWhite, width: 2 }
-				) // Arrow up path
-			}
-
-			img.drawTextLineAligned(transformX(36), transformY(39), 'UP', colorButtonYellow, 10 * drawScale, 'center', 'top')
-		} else if (drawStyle.style === 'button-layered') {
+		if (drawStyle.style === 'button-layered') {
 			processedStyle = GraphicsLayeredProcessedStyleGenerator.Generate(drawStyle)
 
 			await GraphicsLayeredButtonRenderer.draw(img, drawStyle, emptySet, null, {

--- a/companion/lib/Graphics/Renderer.ts
+++ b/companion/lib/Graphics/Renderer.ts
@@ -279,47 +279,6 @@ export class GraphicsRenderer {
 				'center',
 				'top'
 			)
-		} else if (drawStyle.style == 'pagenum') {
-			processedStyle = { type: 'pagenum' }
-
-			img.fillColor(colorDarkGrey)
-
-			if (drawStyle.pageNumber <= 0) {
-				// Preview (no location)
-				img.drawTextLineAligned(
-					transformX(36),
-					transformY(18),
-					'PAGE',
-					colorButtonYellow,
-					10 * drawScale,
-					'center',
-					'top'
-				)
-				img.drawTextLineAligned(transformX(36), transformY(32), 'x', colorWhite, 18 * drawScale, 'center', 'top')
-			} else if (!drawStyle.pageName || drawStyle.pageName.toLowerCase() == 'page') {
-				img.drawTextLine(transformX(23), transformY(18), 'PAGE', colorButtonYellow, 10 * drawScale)
-				img.drawTextLineAligned(
-					transformX(36),
-					transformY(32),
-					'' + drawStyle.pageNumber,
-					colorWhite,
-					18 * drawScale,
-					'center',
-					'top'
-				)
-			} else {
-				img.drawAlignedText(
-					0,
-					0,
-					img.width,
-					img.height,
-					drawStyle.pageName,
-					colorWhite,
-					18 * drawScale,
-					'center',
-					'center'
-				)
-			}
 		} else if (drawStyle.style === 'button-layered') {
 			processedStyle = GraphicsLayeredProcessedStyleGenerator.Generate(drawStyle)
 

--- a/companion/lib/Graphics/Renderer.ts
+++ b/companion/lib/Graphics/Renderer.ts
@@ -246,39 +246,6 @@ export class GraphicsRenderer {
 			}
 
 			img.drawTextLineAligned(transformX(36), transformY(39), 'UP', colorButtonYellow, 10 * drawScale, 'center', 'top')
-		} else if (drawStyle.style == 'pagedown') {
-			processedStyle = { type: 'pagedown' }
-
-			img.fillColor(colorDarkGrey)
-
-			if (drawStyle.plusminus) {
-				img.drawTextLine(
-					transformX(31),
-					transformY(36),
-					drawStyle.direction_flipped ? '+' : '–',
-					colorWhite,
-					18 * drawScale
-				)
-			} else {
-				img.drawPath(
-					[
-						[transformX(46), transformY(40)],
-						[transformX(36), transformY(50)],
-						[transformX(26), transformY(40)],
-					],
-					{ color: colorWhite, width: 2 }
-				) // Arrow down path
-			}
-
-			img.drawTextLineAligned(
-				transformX(36),
-				transformY(23),
-				'DOWN',
-				colorButtonYellow,
-				10 * drawScale,
-				'center',
-				'top'
-			)
 		} else if (drawStyle.style === 'button-layered') {
 			processedStyle = GraphicsLayeredProcessedStyleGenerator.Generate(drawStyle)
 

--- a/companion/lib/ImportExport/Controller.ts
+++ b/companion/lib/ImportExport/Controller.ts
@@ -29,6 +29,7 @@ import { assertNever } from '@companion-app/shared/Util.js'
 import type { ControlsController } from '../Controls/Controller.js'
 import { pageDownElements } from '../Controls/ControlTypes/PageDown.js'
 import { pageNumberElements } from '../Controls/ControlTypes/PageNumber.js'
+import { pageUpElements } from '../Controls/ControlTypes/PageUp.js'
 import type { DataDatabase } from '../Data/Database.js'
 import { upgradeImport } from '../Data/Upgrade.js'
 import type { DataUserConfig } from '../Data/UserConfig.js'
@@ -374,8 +375,7 @@ export class ImportExportController {
 							break
 						case 'pageup':
 							drawType = 'pageup'
-							// TODO
-							rawElements = structuredClone(pageNumberElements)
+							rawElements = structuredClone(pageUpElements)
 							break
 						case 'pagedown':
 							drawType = 'pagedown'

--- a/companion/lib/ImportExport/Controller.ts
+++ b/companion/lib/ImportExport/Controller.ts
@@ -27,6 +27,7 @@ import type { RendererButtonStyle } from '@companion-app/shared/Model/Render.js'
 import type { SomeButtonGraphicsElement } from '@companion-app/shared/Model/StyleLayersModel.js'
 import { assertNever } from '@companion-app/shared/Util.js'
 import type { ControlsController } from '../Controls/Controller.js'
+import { pageDownElements } from '../Controls/ControlTypes/PageDown.js'
 import { pageNumberElements } from '../Controls/ControlTypes/PageNumber.js'
 import type { DataDatabase } from '../Data/Database.js'
 import { upgradeImport } from '../Data/Upgrade.js'
@@ -378,8 +379,7 @@ export class ImportExportController {
 							break
 						case 'pagedown':
 							drawType = 'pagedown'
-							// TODO
-							rawElements = structuredClone(pageNumberElements)
+							rawElements = structuredClone(pageDownElements)
 							break
 						default:
 							assertNever(controlObjLayered)

--- a/companion/lib/ImportExport/Controller.ts
+++ b/companion/lib/ImportExport/Controller.ts
@@ -14,7 +14,7 @@ import path from 'node:path'
 import type express from 'express'
 import workerPool from 'workerpool'
 import z from 'zod'
-import type { LayeredButtonModel } from '@companion-app/shared/Model/ButtonModel.js'
+import type { SomeButtonModel } from '@companion-app/shared/Model/ButtonModel.js'
 import type { ExportFullv6, ExportPageContentv6 } from '@companion-app/shared/Model/ExportModel.js'
 import {
 	zodClientImportOrResetSelection,
@@ -23,7 +23,11 @@ import {
 	type ClientPageInfo,
 	type ImportOrResetType,
 } from '@companion-app/shared/Model/ImportExport.js'
+import type { RendererButtonStyle } from '@companion-app/shared/Model/Render.js'
+import type { SomeButtonGraphicsElement } from '@companion-app/shared/Model/StyleLayersModel.js'
+import { assertNever } from '@companion-app/shared/Util.js'
 import type { ControlsController } from '../Controls/Controller.js'
+import { pageNumberElements } from '../Controls/ControlTypes/PageNumber.js'
 import type { DataDatabase } from '../Data/Database.js'
 import { upgradeImport } from '../Data/Upgrade.js'
 import type { DataUserConfig } from '../Data/UserConfig.js'
@@ -354,7 +358,33 @@ export class ImportExportController {
 					const controlObj = importPage.controls?.[input.location.row]?.[input.location.column]
 					if (!controlObj) return null
 
-					const controlObjLayered = controlObj as LayeredButtonModel
+					const controlObjLayered = controlObj as SomeButtonModel
+
+					let drawType: RendererButtonStyle['drawType']
+					let rawElements: SomeButtonGraphicsElement[]
+					switch (controlObjLayered.type) {
+						case 'button-layered':
+							drawType = 'button'
+							rawElements = controlObjLayered.style.layers
+							break
+						case 'pagenum':
+							drawType = 'pagenum'
+							rawElements = structuredClone(pageNumberElements)
+							break
+						case 'pageup':
+							drawType = 'pageup'
+							// TODO
+							rawElements = structuredClone(pageNumberElements)
+							break
+						case 'pagedown':
+							drawType = 'pagedown'
+							// TODO
+							rawElements = structuredClone(pageNumberElements)
+							break
+						default:
+							assertNever(controlObjLayered)
+							return null
+					}
 
 					const parser = this.#variablesController.values.createVariablesAndExpressionParser(null, null, null)
 
@@ -363,13 +393,13 @@ export class ImportExportController {
 						this.#instancesController.definitions,
 						parser,
 						this.#graphicsController.renderPixelBuffers.bind(this.#graphicsController),
-						controlObjLayered.style.layers,
+						rawElements,
 						new Map(),
 						true,
 						null
 					)
 
-					const res = await this.#graphicsController.drawPreview(elements)
+					const res = await this.#graphicsController.drawPreview(drawType, elements)
 					return res?.style ? (res?.asDataUrl ?? null) : null
 				}),
 

--- a/companion/lib/Internal/System.ts
+++ b/companion/lib/Internal/System.ts
@@ -132,6 +132,10 @@ export class InternalSystem extends EventEmitter<InternalModuleFragmentEvents> i
 			() => {
 				const values: VariableValues = {
 					installation_name: this.#userConfigController.getKey('installName'),
+
+					// Some internal values needed for the drawing
+					_graphics_page_plusminus: !!this.#userConfigController.getKey('page_plusminus'),
+					_graphics_page_direction_flipped: !!this.#userConfigController.getKey('page_direction_flipped'),
 				}
 
 				this.emit('setVariables', values)

--- a/companion/lib/Page/Controller.ts
+++ b/companion/lib/Page/Controller.ts
@@ -116,7 +116,7 @@ export class PageController extends EventEmitter<PageControllerEvents> {
 				.mutation(({ input }) => {
 					this.#logger.silly(`trpc: pages:setName ${input.pageNumber}: ${input.name}`)
 
-					this.setPageName(input.pageNumber, input.name, true)
+					this.setPageName(input.pageNumber, input.name)
 				}),
 
 			remove: publicProcedure
@@ -398,10 +398,9 @@ export class PageController extends EventEmitter<PageControllerEvents> {
 	 * Reset a page to defaults and empty
 	 * Note: Controls will be orphaned if not explicitly deleted by the caller
 	 * @param pageNumber - the page id
-	 * @param [redraw = true] - <code>true</code> if the graphics should invalidate
 	 * @returns ControlIds referenced on the page
 	 */
-	resetPage(pageNumber: number, redraw = true): string[] {
+	resetPage(pageNumber: number): string[] {
 		this.#logger.silly('Reset page ' + pageNumber)
 
 		// Fetch the page and ensure it exists
@@ -428,9 +427,8 @@ export class PageController extends EventEmitter<PageControllerEvents> {
 		this.#store._resetPageControls(pageNumber)
 
 		// Reset page name using the store
-		const newPageInfo = this.#store._setPageName(pageNumber, 'PAGE')
+		this.#store._setPageName(pageNumber, 'PAGE')
 
-		if (redraw && newPageInfo) this.#invalidatePageNumberControls(pageNumber, newPageInfo)
 		this.emit('clientUpdate', {
 			type: 'update',
 			updatedOrder: null,
@@ -500,19 +498,16 @@ export class PageController extends EventEmitter<PageControllerEvents> {
 	 * Set/update a page
 	 * @param pageNumber - the page id
 	 * @param name - the page object containing the name
-	 * @param redraw - <code>true</code> if the graphics should invalidate
 	 */
-	setPageName(pageNumber: number, name: string, redraw = true): void {
+	setPageName(pageNumber: number, name: string): void {
 		const pageInfo = this.#store.getPageInfo(pageNumber)
 		if (!pageInfo) {
 			throw new Error('Page must be created before it can be imported to')
 		}
 
-		const newPageInfo = this.#store._setPageName(pageNumber, name)
+		this.#store._setPageName(pageNumber, name)
 
 		this.#logger.silly('Set page ' + pageNumber + ' to ', name)
-
-		if (redraw && newPageInfo) this.#invalidatePageNumberControls(pageNumber, newPageInfo)
 
 		this.emit('clientUpdate', {
 			type: 'update',
@@ -526,26 +521,6 @@ export class PageController extends EventEmitter<PageControllerEvents> {
 				},
 			],
 		})
-	}
-
-	/**
-	 * Redraw the page number control on the specified page
-	 */
-	#invalidatePageNumberControls(pageNumber: number, pageInfo: PageModel): void {
-		if (!pageInfo?.controls) return
-
-		for (const [row, rowObj] of Object.entries(pageInfo.controls)) {
-			for (const [column, controlId] of Object.entries(rowObj)) {
-				const control = this.#controlsController.getControl(controlId)
-				if (control && control.type === 'pagenum') {
-					this.#graphicsController.invalidateButton({
-						pageNumber: Number(pageNumber),
-						column: Number(column),
-						row: Number(row),
-					})
-				}
-			}
-		}
 	}
 
 	/**

--- a/shared-lib/lib/Graphics/ButtonDecorationRenderer.ts
+++ b/shared-lib/lib/Graphics/ButtonDecorationRenderer.ts
@@ -13,7 +13,7 @@ export class ButtonDecorationRenderer {
 
 	static drawStatusBar(
 		img: ImageBase<any>,
-		drawStyle: Omit<RendererButtonStyle, 'style' | 'show_topbar' | 'show_status_icons' | 'elements'>,
+		drawStyle: Omit<RendererButtonStyle, 'style' | 'drawType' | 'show_topbar' | 'show_status_icons' | 'elements'>,
 		topBarBounds: DrawBounds,
 		emptyButton: boolean
 	): void {

--- a/shared-lib/lib/Model/Render.ts
+++ b/shared-lib/lib/Model/Render.ts
@@ -1,16 +1,10 @@
 import type { ControlLocation } from './Common.js'
 import type { DrawStyleLayeredButtonModel } from './StyleModel.js'
 
-export type RendererDrawStyle = RendererButtonStyle | RendererPageUpDownStyle
+export type RendererDrawStyle = RendererButtonStyle
 
 export interface RendererButtonStyle extends DrawStyleLayeredButtonModel {
 	show_topbar: boolean
 	show_status_icons: boolean
 	location: ControlLocation | undefined
-}
-
-export interface RendererPageUpDownStyle {
-	style: 'pageup'
-	plusminus: boolean
-	direction_flipped: boolean
 }

--- a/shared-lib/lib/Model/Render.ts
+++ b/shared-lib/lib/Model/Render.ts
@@ -1,7 +1,7 @@
 import type { ControlLocation } from './Common.js'
 import type { DrawStyleLayeredButtonModel } from './StyleModel.js'
 
-export type RendererDrawStyle = RendererButtonStyle | RendererPageUpDownStyle | RendererPageNumStyle
+export type RendererDrawStyle = RendererButtonStyle | RendererPageUpDownStyle
 
 export interface RendererButtonStyle extends DrawStyleLayeredButtonModel {
 	show_topbar: boolean
@@ -13,10 +13,4 @@ export interface RendererPageUpDownStyle {
 	style: 'pageup' | 'pagedown'
 	plusminus: boolean
 	direction_flipped: boolean
-}
-
-export interface RendererPageNumStyle {
-	style: 'pagenum'
-	pageNumber: number
-	pageName: string | undefined
 }

--- a/shared-lib/lib/Model/Render.ts
+++ b/shared-lib/lib/Model/Render.ts
@@ -10,7 +10,7 @@ export interface RendererButtonStyle extends DrawStyleLayeredButtonModel {
 }
 
 export interface RendererPageUpDownStyle {
-	style: 'pageup' | 'pagedown'
+	style: 'pageup'
 	plusminus: boolean
 	direction_flipped: boolean
 }

--- a/shared-lib/lib/Model/StyleModel.ts
+++ b/shared-lib/lib/Model/StyleModel.ts
@@ -1,11 +1,7 @@
 import type { CompanionAlignment, CompanionTextSize } from '@companion-module/base'
 import type { SomeButtonGraphicsDrawElement } from './StyleLayersModel.js'
 
-export type DrawStyleModel =
-	| {
-			style: 'pageup'
-	  }
-	| DrawStyleLayeredButtonModel
+export type DrawStyleModel = DrawStyleLayeredButtonModel
 
 export interface DrawStyleButtonStateProps {
 	pushed: boolean

--- a/shared-lib/lib/Model/StyleModel.ts
+++ b/shared-lib/lib/Model/StyleModel.ts
@@ -3,7 +3,7 @@ import type { SomeButtonGraphicsDrawElement } from './StyleLayersModel.js'
 
 export type DrawStyleModel =
 	| {
-			style: 'pageup' | 'pagedown'
+			style: 'pageup'
 	  }
 	| DrawStyleLayeredButtonModel
 

--- a/shared-lib/lib/Model/StyleModel.ts
+++ b/shared-lib/lib/Model/StyleModel.ts
@@ -3,7 +3,7 @@ import type { SomeButtonGraphicsDrawElement } from './StyleLayersModel.js'
 
 export type DrawStyleModel =
 	| {
-			style: 'pageup' | 'pagedown' | 'pagenum'
+			style: 'pageup' | 'pagedown'
 	  }
 	| DrawStyleLayeredButtonModel
 
@@ -19,6 +19,7 @@ export interface DrawStyleButtonStateProps {
 
 export interface DrawStyleLayeredButtonModel extends DrawStyleButtonStateProps {
 	style: 'button-layered'
+	drawType: 'button' | 'pagenum' | 'pageup' | 'pagedown'
 
 	elements: SomeButtonGraphicsDrawElement[]
 }

--- a/webui/src/Buttons/EditButton/LayeredButtonEditor/Preview/DrawStyleParser.tsx
+++ b/webui/src/Buttons/EditButton/LayeredButtonEditor/Preview/DrawStyleParser.tsx
@@ -298,6 +298,7 @@ class LayeredButtonDrawStyleParser {
 			// Emit the new elements
 			this.#changed({
 				style: 'button-layered',
+				drawType: 'button',
 
 				elements,
 


### PR DESCRIPTION
Removes the special drawing paths, utilising the element system instead.

This fixes an issue with imports, where they arent showing these buttons.  
But this is primarily to simplify (one drawing flow) and in the future allow users to 'explode' these buttons into an editable form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Page-related buttons (page up/down/number) now provide unified, declarative rendering data so previews and exports reflect their specific draw type.
* **Chores**
  * Consolidated button rendering and preview paths for more consistent visuals and simpler maintenance.
* **Bug Fixes**
  * Renaming pages no longer triggers unnecessary redraws of page controls, reducing flicker and work during updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitfocus/companion/pull/4182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->