### PR TITLE
fix: OSC press command example

### DIFF
--- a/docs/user-guide/5_remote-control/osc-control.md
+++ b/docs/user-guide/5_remote-control/osc-control.md
@@ -39,7 +39,7 @@ Remote triggering can be done by sending OSC commands to port `12321` (the port 
 
 ## Examples
 
-Press row 0, column 5 on page 1 down and hold  
+Press the button at row 0, column 5 on page 1 and release immediately  
 `/location/1/0/5/press`
 
 Change button background color of row 0, column 5 on page 1 to red  

--- a/webui/src/UserConfig/Sections/OscProtocol.tsx
+++ b/webui/src/UserConfig/Sections/OscProtocol.tsx
@@ -102,7 +102,7 @@ export const OscProtocol = observer(function OscProtocol() {
 			</p>
 
 			<p>
-				Press row 0, column 5 on page 1 down and hold
+				Press the button at row 0, column 5 on page 1 and release immediately
 				<br />
 				<code>/location/1/0/5/press</code>
 			</p>


### PR DESCRIPTION
The example was implying that, when you use `/press` on a location over OSC, it would press and then hold down the button, when in reality it presses and then immediately releases the button (`/down` presses and holds down the button).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated OSC control docs to clarify that the `/location/<page>/<row>/<column>/press` command performs an immediate press-and-release (no hold).
* **Documentation**
  * Updated in-app OSC protocol examples/descriptions to match the press-and-release semantics for button commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitfocus/companion/pull/4185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->