### PR TITLE
feat: lazy render buttons

### DIFF
--- a/companion/lib/Cloud/Controller.ts
+++ b/companion/lib/Cloud/Controller.ts
@@ -3,7 +3,7 @@ import isEqual from 'fast-deep-equal'
 import nodeMachineId from 'node-machine-id'
 import { v4 } from 'uuid'
 import z from 'zod'
-import { xyToOldBankIndex } from '@companion-app/shared/ControlId.js'
+import { formatLocation, xyToOldBankIndex } from '@companion-app/shared/ControlId.js'
 import { CloudRegionState } from '@companion-app/shared/Model/Cloud.js'
 import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
 import { stringifyError } from '@companion-app/shared/Stringify.js'
@@ -16,6 +16,7 @@ import type { ImageResult } from '../Graphics/ImageResult.js'
 import LogController from '../Log/Controller.js'
 import type { IPageStore } from '../Page/Store.js'
 import type { AppInfo } from '../Registry.js'
+import { ImageWriteQueue } from '../Resources/ImageWriteQueue.js'
 import { delay } from '../Resources/Util.js'
 import { publicProcedure, router, toIterable } from '../UI/TRPC.js'
 import { CloudRegion, RegionInfo } from './Region.js'
@@ -104,6 +105,8 @@ export class CloudController {
 	 * The initialized region handlers
 	 */
 	#regionInstances: { [region: string]: CloudRegion } = {}
+
+	readonly #updateBankQueue: ImageWriteQueue<string, [ControlLocation, ImageResult]>
 	/**
 	 * The state object for the UI
 	 */
@@ -139,6 +142,31 @@ export class CloudController {
 		this.pageStore = pageStore
 
 		this.#uiEvents.setMaxListeners(0)
+
+		this.#updateBankQueue = new ImageWriteQueue(
+			this.#logger,
+			async (_locationId: string, location: ControlLocation, render: ImageResult) => {
+				if (!this.state.cloudActive) return
+
+				const bank = xyToOldBankIndex(location.column, location.row)
+				const updateId = v4()
+				const png64 = await render.drawDataUrl()
+				for (const region of Object.values(this.#regionInstances)) {
+					region.socketTransmit('companion-banks:' + this.state.uuid, {
+						updateId,
+						type: 'single',
+						location,
+						p: this.protocolVersion,
+						page: location.pageNumber, // backwards compatibility, remove in release
+						bank, // backwards compatibility, remove in release
+						data: {
+							// Provide the default render as the best we can do
+							png64,
+						},
+					})
+				}
+			}
+		)
 
 		this.data = this.#dbTable.getOrDefault('auth', {
 			token: '',
@@ -180,8 +208,6 @@ export class CloudController {
 		setInterval(this.#timerTick.bind(this), 1000)
 
 		this.#graphics.on('button_drawn', this.#updateBank.bind(this))
-
-		this.#updateAllBanks()
 
 		this.pageStore.on('pageDataChanged', this.#handlePageNameUpdate.bind(this))
 	}
@@ -303,8 +329,8 @@ export class CloudController {
 	 * Get the current bank database
 	 * @returns the bank database
 	 */
-	getBanks(): object[] {
-		const retval = []
+	async getBanks(): Promise<object[]> {
+		const items: Array<Promise<object>> = []
 
 		for (const controlId of this.controls.getAllControls().keys()) {
 			const location = this.pageStore.getLocationOfControlId(controlId)
@@ -321,22 +347,23 @@ export class CloudController {
 			}
 
 			const render = this.#graphics.getCachedRender(location)
-
 			const bankIndex = xyToOldBankIndex(location.column, location.row)
 
-			retval.push({
-				location,
-				bank: bankIndex, // backwards compatibility, TODO: remove in release
-				page: location.pageNumber, // backwards compatibility, remove in release
-				p: this.protocolVersion,
-				data: {
-					// Provide the default render as the best we can do
-					png64: render?.asDataUrl,
-				},
-			})
+			items.push(
+				(render ? render.drawDataUrl() : Promise.resolve(undefined)).then((png64) => ({
+					location,
+					bank: bankIndex, // backwards compatibility, TODO: remove in release
+					page: location.pageNumber, // backwards compatibility, remove in release
+					p: this.protocolVersion,
+					data: {
+						// Provide the default render as the best we can do
+						png64,
+					},
+				}))
+			)
 		}
 
-		return retval
+		return Promise.all(items)
 	}
 
 	/**
@@ -711,46 +738,12 @@ export class CloudController {
 	}
 
 	/**
-	 * Get copies of all the current bank styles
-	 */
-	#updateAllBanks(): void {
-		const updateId = v4()
-		const data = this.getBanks()
-		for (let region in this.#regionInstances) {
-			if (!!this.#regionInstances[region]?.socketTransmit) {
-				this.#regionInstances[region].socketTransmit('companion-banks:' + this.state.uuid, {
-					updateId,
-					type: 'full',
-					data,
-				})
-			}
-		}
-	}
-
-	/**
 	 * Store and transmit an updated bank style
 	 * @param location - the location of the control
 	 * @param render
 	 */
 	#updateBank(location: ControlLocation, render: ImageResult): void {
-		const bank = xyToOldBankIndex(location.column, location.row)
-		const updateId = v4()
-		for (let region in this.#regionInstances) {
-			if (!!this.#regionInstances[region]?.socketTransmit) {
-				this.#regionInstances[region].socketTransmit('companion-banks:' + this.state.uuid, {
-					updateId,
-					type: 'single',
-					location,
-					p: this.protocolVersion,
-					page: location.pageNumber, // backwards compatibility, remove in release
-					bank, // backwards compatibility, remove in release
-					data: {
-						// Provide the default render as the best we can do
-						png64: render.asDataUrl,
-					},
-				})
-			}
-		}
+		this.#updateBankQueue.queue(formatLocation(location), location, render)
 	}
 }
 

--- a/companion/lib/Cloud/Region.ts
+++ b/companion/lib/Cloud/Region.ts
@@ -96,7 +96,7 @@ export class CloudRegion {
 	/**
 	 * Process a <code>getBanks</code> call from a remote client
 	 */
-	async #clientGetBanks(): Promise<object> {
+	async #clientGetBanks(): Promise<object[]> {
 		this.#logger.silly('Client requested getBanks()')
 		return this.#cloud.getBanks()
 	}
@@ -436,7 +436,7 @@ export class CloudRegion {
 		if (!this.#socket) throw new Error('No socket')
 		await this.#socket.transmitPublish('companion-banks:' + this.#cloud.state.uuid, {
 			type: 'full',
-			data: this.#cloud.getBanks(),
+			data: await this.#cloud.getBanks(),
 		})
 	}
 

--- a/companion/lib/Graphics/Controller.ts
+++ b/companion/lib/Graphics/Controller.ts
@@ -260,7 +260,7 @@ export class GraphicsController extends EventEmitter<GraphicsControllerEvents> {
 								this.#renderLRUCache.set(cacheKey, render)
 							}
 						} else {
-							render = GraphicsRenderer.drawBlank({ width: 72, height: 72 }, !this.#drawOptions.remove_topbar, null)
+							render = GraphicsRenderer.drawBlank(!this.#drawOptions.remove_topbar, null)
 						}
 
 						this.emit('presetDrawn', args.controlId, render)
@@ -308,7 +308,7 @@ export class GraphicsController extends EventEmitter<GraphicsControllerEvents> {
 							this.#renderLRUCache.set(cacheKey, render)
 						}
 					} else {
-						render = GraphicsRenderer.drawBlank({ width: 72, height: 72 }, !this.#drawOptions.remove_topbar, location)
+						render = GraphicsRenderer.drawBlank(!this.#drawOptions.remove_topbar, location)
 					}
 
 					if (location && locationIsInBounds) {
@@ -417,11 +417,7 @@ export class GraphicsController extends EventEmitter<GraphicsControllerEvents> {
 					column,
 				}
 
-				const blankRender = GraphicsRenderer.drawBlank(
-					{ width: 72, height: 72 },
-					!this.#drawOptions.remove_topbar,
-					location
-				)
+				const blankRender = GraphicsRenderer.drawBlank(!this.#drawOptions.remove_topbar, location)
 
 				this.#updateCacheWithRender(location, blankRender)
 				this.emit('button_drawn', location, blankRender)
@@ -590,7 +586,7 @@ export class GraphicsController extends EventEmitter<GraphicsControllerEvents> {
 		const render = this.#renderCache.get(location.pageNumber)?.get(location.row)?.get(location.column)
 		if (render) return render
 
-		return GraphicsRenderer.drawBlank({ width: 72, height: 72 }, !this.#drawOptions.remove_topbar, location)
+		return GraphicsRenderer.drawBlank(!this.#drawOptions.remove_topbar, location)
 	}
 
 	/**
@@ -617,16 +613,7 @@ export class GraphicsController extends EventEmitter<GraphicsControllerEvents> {
 	): Promise<ImageResult> {
 		const processedStyle = GraphicsLayeredProcessedStyleGenerator.Generate(drawStyle)
 
-		const dataUrlResolution = { width: 72, height: 72, oversampling: 4 } // Default values
-		const { dataUrl } = await this.#executePoolDrawButtonImageDataUrl(
-			drawStyle,
-			dataUrlResolution,
-			null,
-			CRASHED_WORKER_RETRY_COUNT
-		)
-
 		return new ImageResult(
-			dataUrl,
 			processedStyle,
 			async (width, height, rotation, format) =>
 				this.#executePoolDrawButtonImageBuffer(
@@ -634,6 +621,13 @@ export class GraphicsController extends EventEmitter<GraphicsControllerEvents> {
 					{ width, height, oversampling: 4 }, // TODO - dynamic oversampling?
 					rotation,
 					format,
+					CRASHED_WORKER_RETRY_COUNT
+				),
+			async (width, height, rotation) =>
+				this.#executePoolDrawButtonImageDataUrl(
+					drawStyle,
+					{ width, height, oversampling: 4 }, // Default values
+					rotation,
 					CRASHED_WORKER_RETRY_COUNT
 				),
 			drawElements,
@@ -650,9 +644,7 @@ export class GraphicsController extends EventEmitter<GraphicsControllerEvents> {
 		resolution: { width: number; height: number; oversampling: number },
 		rotation: SurfaceRotation | null,
 		remainingAttempts: number
-	): Promise<{
-		dataUrl: string
-	}> {
+	): Promise<string> {
 		return this.#poolExec('drawButtonImageDataUrl', [drawStyle, resolution, rotation], remainingAttempts)
 	}
 

--- a/companion/lib/Graphics/ImageResult.ts
+++ b/companion/lib/Graphics/ImageResult.ts
@@ -2,6 +2,7 @@ import type * as imageRs from '@julusian/image-rs'
 import type { HorizontalAlignment, VerticalAlignment } from '@companion-app/shared/Graphics/Util.js'
 import type { SomeButtonGraphicsDrawElement } from '@companion-app/shared/Model/StyleLayersModel.js'
 import type { SurfaceRotation } from '@companion-app/shared/Model/Surfaces.js'
+import { lazy } from '../Resources/Util.js'
 
 export interface ImageResultProcessedStyle {
 	type: 'button' | 'pagenum' | 'pageup' | 'pagedown'
@@ -31,12 +32,13 @@ export type ImageResultNativeDrawFn = (
 	format: imageRs.PixelFormat
 ) => Promise<Uint8Array>
 
-export class ImageResult {
-	/**
-	 * Image data-url for webui clients
-	 */
-	readonly #dataUrl: string
+export type ImageResultDataUrlDrawFn = (
+	width: number,
+	height: number,
+	rotation: SurfaceRotation | null
+) => Promise<string>
 
+export class ImageResult {
 	/**
 	 * Image draw style
 	 */
@@ -44,6 +46,7 @@ export class ImageResult {
 
 	readonly #drawNativeCache = new Map<string, Promise<Uint8Array>>()
 	readonly #drawNative: ImageResultNativeDrawFn
+	readonly #dataUrl: () => Promise<string>
 
 	/**
 	 * Last updated time
@@ -63,26 +66,19 @@ export class ImageResult {
 	readonly referencedLocations: ReadonlySet<string>
 
 	constructor(
-		dataUrl: string,
 		style: ImageResultProcessedStyle | null,
 		drawNative: ImageResultNativeDrawFn,
+		drawDataUrl: ImageResultDataUrlDrawFn,
 		drawElements: readonly SomeButtonGraphicsDrawElement[] | null = null,
 		referencedLocations: ReadonlySet<string> = new Set()
 	) {
-		this.#dataUrl = dataUrl
 		this.style = style
 		this.#drawNative = drawNative
 		this.drawElements = drawElements
+		this.#dataUrl = lazy(async () => drawDataUrl(72, 72, null)) // Default values for backwards compatibility
 		this.referencedLocations = referencedLocations
 
 		this.updated = Date.now()
-	}
-
-	/**
-	 * Get the image as a data url which can be used by a web base client
-	 */
-	get asDataUrl(): string {
-		return this.#dataUrl
 	}
 
 	get bgcolor(): number {
@@ -107,5 +103,13 @@ export class ImageResult {
 		const newBuffer = this.#drawNative(width, height, rotation, format)
 		this.#drawNativeCache.set(cacheKey, newBuffer)
 		return newBuffer
+	}
+
+	/**
+	 * Get the image as a png data url for web and similar clients
+	 * This caches the result between calls, and is safe to call multiple times
+	 */
+	async drawDataUrl(): Promise<string> {
+		return this.#dataUrl()
 	}
 }

--- a/companion/lib/Graphics/Renderer.ts
+++ b/companion/lib/Graphics/Renderer.ts
@@ -83,29 +83,26 @@ export class GraphicsRenderer {
 	/**
 	 * Draw the image for an empty button
 	 */
-	static drawBlank(
-		resolution: { width: number; height: number },
-		showTopbar: boolean,
-		location: ControlLocation | null
-	): ImageResult {
-		// let now = performance.now()
-		// console.log('starting drawBlank ' + now, 'time elapsed since last start ' + (now - lastDraw))
-		// lastDraw = now
-		// console.time('drawBlankImage')
-
-		return GraphicsRenderer.#getCachedImage(resolution.width, resolution.height, 2, (img) => {
-			// console.timeEnd('drawBlankImage')
-			GraphicsRenderer.#drawBlankImage(img, showTopbar, location)
-
-			return new ImageResult(img.toDataURLSync(), null, async (width, height, rotation, format) => {
+	static drawBlank(showTopbar: boolean, location: ControlLocation | null): ImageResult {
+		return new ImageResult(
+			null,
+			async (width, height, rotation, format) => {
 				const dimensions = rotateResolution(width, height, rotation)
 				return GraphicsRenderer.#getCachedImage(dimensions[0], dimensions[1], 4, async (img) => {
 					GraphicsRenderer.#drawBlankImage(img, showTopbar, location)
 
 					return this.#RotateAndConvertImage(img, width, height, rotation, format)
 				})
-			})
-		})
+			},
+			async (width, height, rotation) => {
+				const dimensions = rotateResolution(width, height, rotation)
+				return GraphicsRenderer.#getCachedImage(dimensions[0], dimensions[1], 2, (img) => {
+					GraphicsRenderer.#drawBlankImage(img, showTopbar, location)
+
+					return img.toDataURLSync()
+				})
+			}
+		)
 	}
 
 	static #drawBlankImage(img: Image, showTopbar: boolean, location: ControlLocation | null) {
@@ -174,9 +171,7 @@ export class GraphicsRenderer {
 		drawStyle: RendererDrawStyle,
 		resolution: { width: number; height: number; oversampling: number },
 		rotation: SurfaceRotation | null
-	): Promise<{
-		dataUrl: string
-	}> {
+	): Promise<string> {
 		const dimensions = rotateResolution(resolution.width, resolution.height, rotation)
 
 		return GraphicsRenderer.#getCachedImage(dimensions[0], dimensions[1], resolution.oversampling, async (img) => {
@@ -185,9 +180,7 @@ export class GraphicsRenderer {
 				y: 0,
 			})
 
-			return {
-				dataUrl: img.toDataURLSync(),
-			}
+			return img.toDataURLSync()
 		})
 	}
 
@@ -266,28 +259,35 @@ export class GraphicsRenderer {
 	 * @param height Height of the image
 	 */
 	static drawLockIcon(): ImageResult {
-		return new ImageResult('', LOCK_ICON_STYLE, async (width, height, rotation, format) => {
-			const dimensions = rotateResolution(width, height, rotation)
-			return GraphicsRenderer.#getCachedImage(dimensions[0], dimensions[1], 4, async (img) => {
-				// Fill with black background
-				img.fillColor('rgb(0, 0, 0)')
+		return new ImageResult(
+			LOCK_ICON_STYLE,
+			async (width, height, rotation, format) => {
+				const dimensions = rotateResolution(width, height, rotation)
+				return GraphicsRenderer.#getCachedImage(dimensions[0], dimensions[1], 4, async (img) => {
+					// Fill with black background
+					img.fillColor('rgb(0, 0, 0)')
 
-				// Draw a centered padlock unicode character in light grey
-				img.drawAlignedText(
-					0,
-					0,
-					width,
-					height,
-					'🔒',
-					'rgb(200, 200, 200)',
-					Math.floor(height * 0.6),
-					'center',
-					'center'
-				)
+					// Draw a centered padlock unicode character in light grey
+					img.drawAlignedText(
+						0,
+						0,
+						dimensions[0],
+						dimensions[1],
+						'🔒',
+						'rgb(200, 200, 200)',
+						Math.floor(dimensions[1] * 0.6),
+						'center',
+						'center'
+					)
 
-				return this.#RotateAndConvertImage(img, width, height, rotation, format)
-			})
-		})
+					return this.#RotateAndConvertImage(img, width, height, rotation, format)
+				})
+			},
+			async () => {
+				// data-url of this image is never used
+				return ''
+			}
+		)
 	}
 
 	/**

--- a/companion/lib/ImportExport/Controller.ts
+++ b/companion/lib/ImportExport/Controller.ts
@@ -402,7 +402,8 @@ export class ImportExportController {
 					)
 
 					const res = await this.#graphicsController.drawPreview(drawType, elements)
-					return res?.style ? (res?.asDataUrl ?? null) : null
+					if (!res?.style) return null
+					return await res.drawDataUrl()
 				}),
 
 			importSinglePage: publicProcedure

--- a/companion/lib/Preview/Graphics.ts
+++ b/companion/lib/Preview/Graphics.ts
@@ -15,6 +15,7 @@ import type { ImageResult } from '../Graphics/ImageResult.js'
 import { ParseLocationString } from '../Internal/Util.js'
 import LogController from '../Log/Controller.js'
 import type { IPageStore } from '../Page/Store.js'
+import { ImageWriteQueue } from '../Resources/ImageWriteQueue.js'
 import { publicProcedure, router, toIterable } from '../UI/TRPC.js'
 
 export const zodLocation: z.ZodSchema<ControlLocation> = z.object({
@@ -59,6 +60,9 @@ export class PreviewGraphics {
 
 	readonly #renderEvents = new EventEmitter<PreviewRenderEvents>()
 
+	readonly #updateButtonQueue: ImageWriteQueue<string, [ControlLocation, string | null, ImageResult]>
+	readonly #recheckQueue: ImageWriteQueue<string, [string, ControlLocation]>
+
 	constructor(
 		graphicsController: GraphicsController,
 		pageStore: IPageStore,
@@ -69,6 +73,43 @@ export class PreviewGraphics {
 		this.#pageStore = pageStore
 		this.#controlsController = controlsController
 		this.#controlEvents = controlEvents
+
+		this.#updateButtonQueue = new ImageWriteQueue(
+			this.#logger,
+			async (locationId: string, location: ControlLocation, controlId: string | null, render: ImageResult) => {
+				if (controlId && this.#renderEvents.listenerCount(`controlId:${controlId}`) > 0) {
+					this.#renderEvents.emit(`controlId:${controlId}`, await render.drawDataUrl())
+				}
+
+				if (this.#renderEvents.listenerCount(`location:${locationId}`) > 0) {
+					this.#renderEvents.emit(`location:${locationId}`, {
+						image: await render.drawDataUrl(),
+						isUsed: !!render.style,
+					})
+				}
+
+				for (const previewSession of this.#buttonReferencePreviews.values()) {
+					if (!previewSession.resolvedLocation) continue
+					if (previewSession.resolvedLocation.pageNumber != location.pageNumber) continue
+					if (previewSession.resolvedLocation.row != location.row) continue
+					if (previewSession.resolvedLocation.column != location.column) continue
+
+					this.#renderEvents.emit(`reference:${previewSession.id}`, await render.drawDataUrl())
+				}
+			}
+		)
+
+		this.#recheckQueue = new ImageWriteQueue(
+			this.#logger,
+			async (_sessionId: string, sessionId: string, resolvedLocation: ControlLocation) => {
+				if (this.#renderEvents.listenerCount(`reference:${sessionId}`) == 0) return
+
+				const dataUrl = await this.#graphicsController
+					.getCachedRenderOrGeneratePlaceholder(resolvedLocation)
+					.drawDataUrl()
+				this.#renderEvents.emit(`reference:${sessionId}`, dataUrl)
+			}
+		)
 
 		this.#graphicsController.on('button_drawn', this.#updateButton.bind(this))
 		this.#renderEvents.setMaxListeners(0)
@@ -90,7 +131,8 @@ export class PreviewGraphics {
 					const changes = toIterable(self.#renderEvents, `location:${locationId}`, signal)
 
 					const render = self.#graphicsController.getCachedRenderOrGeneratePlaceholder(location)
-					yield { image: render.asDataUrl, isUsed: !!render.style } satisfies WrappedImage
+					const dataUrl = await render.drawDataUrl()
+					yield { image: dataUrl, isUsed: !!render.style } satisfies WrappedImage
 
 					for await (const [image] of changes) {
 						yield image
@@ -111,7 +153,7 @@ export class PreviewGraphics {
 					// Send the preview image shortly after
 					const location = self.#pageStore.getLocationOfControlId(controlId)
 					const originalImg = location ? self.#graphicsController.getCachedRenderOrGeneratePlaceholder(location) : null
-					yield originalImg?.asDataUrl ?? null
+					yield originalImg ? await originalImg.drawDataUrl() : null
 
 					for await (const [image] of changes) {
 						yield image
@@ -143,11 +185,11 @@ export class PreviewGraphics {
 
 						// Send the preview image shortly after
 						const initialRender = control.lastRender
-						yield initialRender?.asDataUrl ?? null
+						yield initialRender ? await initialRender.drawDataUrl() : null
 
 						for await (const [controlId, render] of changes) {
 							if (controlId !== control.controlId) continue
-							yield render?.asDataUrl ?? null
+							yield render ? await render.drawDataUrl() : null
 						}
 					} finally {
 						if (control.removeRenderSubscriberAndCheckEmpty(sessionId)) {
@@ -195,7 +237,7 @@ export class PreviewGraphics {
 
 						// Emit the initial image
 						yield resolvedLocation
-							? self.#graphicsController.getCachedRenderOrGeneratePlaceholder(resolvedLocation).asDataUrl
+							? await self.#graphicsController.getCachedRenderOrGeneratePlaceholder(resolvedLocation).drawDataUrl()
 							: null
 
 						for await (const [image] of changes) {
@@ -213,26 +255,8 @@ export class PreviewGraphics {
 	 * Send a button update to the UIs
 	 */
 	#updateButton(location: ControlLocation, render: ImageResult): void {
-		// Push the updated render to any clients viewing a preview of a control
 		const controlId = this.#pageStore.getControlIdAt(location)
-		if (controlId) {
-			this.#renderEvents.emit(`controlId:${controlId}`, render.asDataUrl)
-		}
-
-		this.#renderEvents.emit(`location:${getLocationSubId(location)}`, {
-			image: render.asDataUrl,
-			isUsed: !!render.style,
-		})
-
-		// Lookup any sessions
-		for (const previewSession of this.#buttonReferencePreviews.values()) {
-			if (!previewSession.resolvedLocation) continue
-			if (previewSession.resolvedLocation.pageNumber != location.pageNumber) continue
-			if (previewSession.resolvedLocation.row != location.row) continue
-			if (previewSession.resolvedLocation.column != location.column) continue
-
-			this.#renderEvents.emit(`reference:${previewSession.id}`, render.asDataUrl)
-		}
+		this.#updateButtonQueue.queue(getLocationSubId(location), location, controlId, render)
 	}
 
 	onControlIdsLocationChanged(controlIds: string[]): void {
@@ -294,10 +318,7 @@ export class PreviewGraphics {
 			)
 				return
 
-			this.#renderEvents.emit(
-				`reference:${previewSession.id}`,
-				this.#graphicsController.getCachedRenderOrGeneratePlaceholder(resolvedLocation).asDataUrl
-			)
+			this.#recheckQueue.queue(previewSession.id, previewSession.id, resolvedLocation)
 		} catch (e) {
 			this.#logger.error(`Error while rechecking preview session for control ${previewSession.controlId}: ${e}`)
 		}

--- a/companion/lib/Resources/Util.ts
+++ b/companion/lib/Resources/Util.ts
@@ -332,7 +332,7 @@ export function isPackaged(): boolean {
  * @param fn Function to compute the value
  * @returns Function that returns the computed value, only computed once
  */
-export function lazy<T>(fn: () => T): () => T | undefined {
+export function lazy<T>(fn: () => T): () => T {
 	let value: T | undefined
 	let valueSet = false
 
@@ -341,6 +341,6 @@ export function lazy<T>(fn: () => T): () => T | undefined {
 			value = fn()
 			valueSet = true
 		}
-		return value
+		return value as T
 	}
 }

--- a/companion/lib/Surface/Controller.ts
+++ b/companion/lib/Surface/Controller.ts
@@ -615,7 +615,7 @@ export class SurfaceController extends EventEmitter<SurfaceControllerEvents> {
 
 				const changes = toIterable(self.#updateEvents, 'emulatorImages', signal)
 
-				yield { images: surface.panel.latestImages(), clearCache: true }
+				yield { images: await surface.panel.latestImages(), clearCache: true }
 
 				for await (const [changeId, changeData, clearCache] of changes) {
 					if (changeId === input.id) yield { images: changeData, clearCache }

--- a/companion/lib/Surface/IP/ElgatoEmulator.ts
+++ b/companion/lib/Surface/IP/ElgatoEmulator.ts
@@ -15,7 +15,9 @@ import debounceFn from 'debounce-fn'
 import isEqual from 'fast-deep-equal'
 import type { EmulatorConfig, EmulatorImage, EmulatorLockedState } from '@companion-app/shared/Model/Common.js'
 import type { CompanionSurfaceConfigField, GridSize } from '@companion-app/shared/Model/Surfaces.js'
+import type { ImageResult } from '../../Graphics/ImageResult.js'
 import LogController from '../../Log/Controller.js'
+import { ImageWriteQueue } from '../../Resources/ImageWriteQueue.js'
 import { LockConfigFields, OffsetConfigFields, RotationConfigField } from '../CommonConfigFields.js'
 import type { DrawButtonItem, SurfacePanel, SurfacePanelEvents, SurfacePanelInfo } from '../Types.js'
 
@@ -88,9 +90,11 @@ export class SurfaceIPElgatoEmulator extends EventEmitter<SurfacePanelEvents> im
 
 	#lastLockedState: EmulatorLockedState | false = false
 
-	readonly #pendingBufferUpdates = new Map<string, [number, number]>()
+	readonly #pendingBufferUpdates = new Map<string, [x: number, y: number, buffer: string | false]>()
 
-	#imageCache = new Map<string, string>()
+	#imageCache = new Map<string, ImageResult>()
+
+	readonly #drawQueue: ImageWriteQueue<string, [DrawButtonItem]>
 
 	readonly info: SurfacePanelInfo
 
@@ -98,12 +102,8 @@ export class SurfaceIPElgatoEmulator extends EventEmitter<SurfacePanelEvents> im
 		() => {
 			if (this.#pendingBufferUpdates.size > 0) {
 				const newImages: EmulatorImage[] = []
-				for (const [x, y] of this.#pendingBufferUpdates.values()) {
-					newImages.push({
-						x,
-						y,
-						buffer: this.#imageCache.get(getCacheKey(x, y)) ?? false,
-					})
+				for (const [x, y, buffer] of this.#pendingBufferUpdates.values()) {
+					newImages.push({ x, y, buffer })
 				}
 
 				this.#pendingBufferUpdates.clear()
@@ -136,6 +136,19 @@ export class SurfaceIPElgatoEmulator extends EventEmitter<SurfacePanelEvents> im
 		}
 
 		this.#logger.debug('Adding Elgato Streamdeck Emulator')
+
+		this.#drawQueue = new ImageWriteQueue(this.#logger, async (key: string, item: DrawButtonItem) => {
+			if (this.#events.listenerCount('emulatorImages') === 0) return
+
+			const dataUrl = await item.defaultRender.drawDataUrl()
+			if (this.#imageCache.get(key) !== item.defaultRender) return // Discard render if the cache has already moved on
+			if (!dataUrl) {
+				this.#logger.verbose('draw call had no data-url')
+				return
+			}
+			this.#pendingBufferUpdates.set(key, [item.x, item.y, dataUrl])
+			this.#emitChanged()
+		})
 	}
 
 	get gridSize(): GridSize {
@@ -149,15 +162,17 @@ export class SurfaceIPElgatoEmulator extends EventEmitter<SurfacePanelEvents> im
 		return this.#lastSentConfigJson
 	}
 
-	latestImages(): EmulatorImage[] {
+	async latestImages(): Promise<EmulatorImage[]> {
 		const images: EmulatorImage[] = []
 
 		for (let y = 0; y < this.gridSize.rows; y++) {
 			for (let x = 0; x < this.gridSize.columns; x++) {
+				const key = getCacheKey(x, y)
+				const render = this.#imageCache.get(key)
 				images.push({
 					x,
 					y,
-					buffer: this.#imageCache.get(getCacheKey(x, y)) ?? false,
+					buffer: render ? await render.drawDataUrl() : false,
 				})
 			}
 		}
@@ -189,10 +204,12 @@ export class SurfaceIPElgatoEmulator extends EventEmitter<SurfacePanelEvents> im
 		if (config.emulator_columns !== oldSize.columns || config.emulator_rows !== oldSize.rows) {
 			// Clear the cache to ensure no bleed
 			this.#imageCache.clear()
+			this.#pendingBufferUpdates.clear()
 
+			// Tell the client of empty images for the old size
 			for (let y = 0; y < oldSize.rows; y++) {
 				for (let x = 0; x < oldSize.columns; x++) {
-					this.#trackChanged(x, y)
+					this.#pendingBufferUpdates.set(`${x}/${y}`, [x, y, false])
 				}
 			}
 
@@ -229,23 +246,8 @@ export class SurfaceIPElgatoEmulator extends EventEmitter<SurfacePanelEvents> im
 		const size = this.gridSize
 		if (item.x < 0 || item.y < 0 || item.x >= size.columns || item.y >= size.rows) return
 
-		const dataUrl = item.defaultRender.asDataUrl
-		if (!dataUrl) {
-			this.#logger.verbose('draw call had no data-url')
-			return
-		}
-
-		this.#imageCache.set(getCacheKey(item.x, item.y), dataUrl)
-
-		this.#trackChanged(item.x, item.y)
-		this.#emitChanged()
-	}
-
-	/**
-	 * Track the pending changes
-	 */
-	#trackChanged(x: number, y: number): void {
-		this.#pendingBufferUpdates.set(`${x}/${y}`, [x, y])
+		this.#imageCache.set(getCacheKey(item.x, item.y), item.defaultRender)
+		this.#drawQueue.queue(getCacheKey(item.x, item.y), item)
 	}
 
 	clearDeck(): void {
@@ -253,6 +255,7 @@ export class SurfaceIPElgatoEmulator extends EventEmitter<SurfacePanelEvents> im
 
 		// clear all images
 		this.#imageCache.clear()
+		this.#pendingBufferUpdates.clear()
 
 		if (this.#events.listenerCount('emulatorImages') > 0) {
 			this.#events.emit('emulatorImages', this.#emulatorId, [], true)

--- a/companion/test/Graphics/ConvertGraphicsElements.test.ts
+++ b/companion/test/Graphics/ConvertGraphicsElements.test.ts
@@ -208,7 +208,13 @@ function createMockImageResult(
 	drawElements: SomeButtonGraphicsDrawElement[] = [],
 	referencedLocations: ReadonlySet<string> = new Set()
 ): ImageResult {
-	return new ImageResult('', null, async () => Buffer.alloc(0), drawElements, referencedLocations)
+	return new ImageResult(
+		null,
+		async () => Buffer.alloc(0),
+		async () => '',
+		drawElements,
+		referencedLocations
+	)
 }
 
 /**

--- a/companion/test/Service/Satellite/SatelliteRenderUtil.test.ts
+++ b/companion/test/Service/Satellite/SatelliteRenderUtil.test.ts
@@ -5,9 +5,10 @@ import type { SatelliteControlStylePreset } from '../../../lib/Service/Satellite
 
 function makeImage(
 	style: ImageResultProcessedStyle | null,
-	drawNative = vi.fn().mockResolvedValue(new Uint8Array(0))
+	drawNative = vi.fn().mockResolvedValue(new Uint8Array(0)),
+	drawDataUrl = vi.fn().mockResolvedValue('')
 ): ImageResult {
-	return new ImageResult('', style, drawNative)
+	return new ImageResult(style, drawNative, drawDataUrl)
 }
 
 describe('buildSatelliteStyleArgs', () => {


### PR DESCRIPTION
Closes #4008

Currently, whenever a button invalidates we re-render the png data-url for that button (unless we get a cache hit). This render gets used for the webui, emulator and cloud. If none of those pull that render, it goes unused.
For many systems, which are left running a streamdeck without the webui open, or the webui looking at a different page, this results in a lot of unnecessary button renders.
In 5.0, the streamdeck/surface bitmaps are rendered lazily due to not knowing the needed resolutions up front, so this makes the data-url flow consistent with that.

This PR avoids that cost by deferring the rendering of this data-url until it is first wanted.  
As a consequence, it does mean that the first use of it will take a little longer to load as it has to be rendered instead of being pre-renderer. But as these are async requests maybe a little more delay is fine and not really noticable? 

I do not yet know if this is a good compromise, there is still a chance I will change my mind on this (perhaps even after merging)


----

For comparison with a very small config on my dev machine, primarily with 2 flashing buttons.
Before: CPU: 0.7%, memory ~700mb
After: CPU: 0.1%, memory ~400mb (increases to 700mb once I open the button view

So it does appear to have a measurable performance improvement.

Opening the button grid view has always had a delay before things render (perhaps becasue I'm in dev mode), so I cant say whether it feels any slower


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Image rendering is now lazy and asynchronous to reduce blocking and improve responsiveness.
  * Bank, preview, and emulator surface updates use queued, debounced pipelines for smoother, more reliable image updates.
  * Image data URLs are generated on demand, lowering startup work, memory churn, and improving update consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->