### PR TITLE
fix: Stop tracking special expressions that don't refer to any variables after their values have been computed

### DIFF
--- a/companion/lib/Controls/Entities/EntitySpecialExpressionManager.ts
+++ b/companion/lib/Controls/Entities/EntitySpecialExpressionManager.ts
@@ -12,24 +12,42 @@ import type {
 	SpecialExpressions,
 	UpdateSpecialExpressionValuesFn,
 } from './SpecialExpressions.js'
-import type { StoreResult } from './Types.js'
 
 export type CreateVariablesAndExpressionParser = (
 	overrideVariableValues: VariableValues | null
 ) => VariablesAndExpressionParser
 
 interface EntityWrapper {
+	/**
+	 * The entity containing the special expression being tracked.
+	 */
 	readonly entity: WeakRef<ControlEntityInstance>
-	needsProcessing: boolean
-	lastReferencedVariableIds: ReadonlySet<string> | null
+
+	/**
+	 * If null, then the pertinent special expression is in need of initial
+	 * computation or subsequent recomputation, and so the set of variables it
+	 * uses is unknown.
+	 *
+	 * Otherwise the special expression *has* been computed, that computed value
+	 * has been recorded, and the special expression depends upon this *nonempty*
+	 * set of variables.
+	 *
+	 * No wrapper is tracked for a special expression that has been computed that
+	 * depends upon no variables.
+	 */
+	referencedVariableIds: null | ReadonlySet<string>
+}
+
+type SpecialExpressionComputation<Expression extends SpecialExpression> = {
+	referencedVariableIds: EntityWrapper['referencedVariableIds']
+	computedValue: SpecialExpressions[Expression]
 }
 
 type ComputeSpecialExpressionValueFn<Expression extends SpecialExpression> = (
 	entity: ControlEntityInstance,
-	wrapper: EntityWrapper,
 	parser: VariablesAndExpressionParser,
 	logger: Logger
-) => SpecialExpressions[Expression]
+) => SpecialExpressionComputation<Expression>
 
 type EvaluationResult<T> = { variableIds: ReadonlySet<string> } & (
 	| { ok: true; value: T }
@@ -56,31 +74,25 @@ function evaluateBoolean(
 			}
 }
 
-function ComputeIsInverted(
+const ComputeIsInverted: ComputeSpecialExpressionValueFn<'isInverted'> = (
 	entity: ControlEntityInstance,
-	wrapper: EntityWrapper,
 	parser: VariablesAndExpressionParser,
 	logger: Logger
-): boolean {
-	let isInverted: boolean
-
+): SpecialExpressionComputation<'isInverted'> => {
 	const isInvertedExpression = entity.rawIsInverted
 	if (!isInvertedExpression || !isExpressionOrValue(isInvertedExpression)) {
-		isInverted = false
-
-		wrapper.lastReferencedVariableIds = null
-	} else {
-		const result = evaluateBoolean(isInvertedExpression, parser)
-		if (result.ok) {
-			isInverted = result.value
-		} else {
-			logger.warn(`Failed to parse boolean expression: ${result.error}`)
-			isInverted = false
-		}
-		wrapper.lastReferencedVariableIds = result.variableIds
+		return { referencedVariableIds: null, computedValue: false }
 	}
 
-	return isInverted
+	const result = evaluateBoolean(isInvertedExpression, parser)
+	let isInverted: boolean
+	if (result.ok) {
+		isInverted = result.value
+	} else {
+		logger.warn(`Failed to parse boolean expression: ${result.error}`)
+		isInverted = false
+	}
+	return { referencedVariableIds: result.variableIds, computedValue: isInverted }
 }
 
 function evaluateString(
@@ -108,16 +120,14 @@ function evaluateString(
 			}
 }
 
-function ComputeStoreResult(
+const ComputeStoreResult: ComputeSpecialExpressionValueFn<'storeResult'> = (
 	entity: ControlEntityInstance,
-	wrapper: EntityWrapper,
 	parser: VariablesAndExpressionParser,
 	logger: Logger
-): StoreResult | undefined {
+): SpecialExpressionComputation<'storeResult'> => {
 	const rawStoreResult = entity.rawStoreResult
 	if (rawStoreResult === undefined) {
-		wrapper.lastReferencedVariableIds = null
-		return undefined
+		return { referencedVariableIds: null, computedValue: undefined }
 	}
 
 	const variableNameResult = evaluateString(rawStoreResult.variableName, parser)
@@ -140,21 +150,23 @@ function ComputeStoreResult(
 			location = ''
 		}
 
-		wrapper.lastReferencedVariableIds = locationResult.variableIds.union(variableNameResult.variableIds)
-
 		return {
-			type: 'local-variable',
-			location,
-			variableName,
+			referencedVariableIds: locationResult.variableIds.union(variableNameResult.variableIds),
+			computedValue: {
+				type: 'local-variable',
+				location,
+				variableName,
+			},
 		}
 	}
 
-	wrapper.lastReferencedVariableIds = variableNameResult.variableIds
-
 	return {
-		type: 'custom-variable',
-		variableName,
-		createIfNotExists: rawStoreResult.createIfNotExists,
+		referencedVariableIds: variableNameResult.variableIds,
+		computedValue: {
+			type: 'custom-variable',
+			variableName,
+			createIfNotExists: rawStoreResult.createIfNotExists,
+		},
 	}
 }
 
@@ -210,7 +222,7 @@ export class EntityPoolSpecialExpressionManager {
 
 			const parser = this.#createVariablesAndExpressionParser(null)
 
-			for (const specialExpression of Object.values(this.#specialExpressions)) {
+			for (const [type, specialExpression] of Object.entries(this.#specialExpressions)) {
 				// Skip a special expression when no entities track it.
 				const entities = specialExpression.entities
 				if (entities.size === 0) continue
@@ -227,16 +239,23 @@ export class EntityPoolSpecialExpressionManager {
 						continue
 					}
 
-					// Check if processing is needed
-					if (!wrapper.needsProcessing) continue
+					// Check whether referenced variables have already been computed
+					if (wrapper.referencedVariableIds) continue
+
+					const { referencedVariableIds, computedValue } = computeNewValueFn(entity, parser, logger)
+					if (!referencedVariableIds || referencedVariableIds.size === 0) {
+						// Do not track a special expression that refers to no variables.
+						logger.silly(`Stopped tracking ${entity.id}/${type} as it refers to no variables`)
+						entities.delete(entity.id)
+					} else {
+						wrapper.referencedVariableIds = referencedVariableIds
+					}
 
 					updatedValues.set(entity.id, {
 						entityId: entity.id,
 						controlId: this.#controlId,
-						value: computeNewValueFn(entity, wrapper, parser, logger),
+						value: computedValue,
 					})
-
-					wrapper.needsProcessing = false
 				}
 
 				// Propagate the updates if needed
@@ -276,11 +295,10 @@ export class EntityPoolSpecialExpressionManager {
 		// This may replace an existing entity, if so it needs to restart the process
 		entities.set(entity.id, {
 			entity: new WeakRef(entity),
-			needsProcessing: true,
-			lastReferencedVariableIds: null,
+			referencedVariableIds: null,
 		})
 
-		logger.silly(`Queued entity ${entity.id} for processing`)
+		logger.silly(`Queued entity ${entity.id}/${expression} for processing`)
 
 		this.#debounceProcessPending()
 	}
@@ -306,20 +324,16 @@ export class EntityPoolSpecialExpressionManager {
 		for (const { entities } of Object.values(this.#specialExpressions)) {
 			for (const wrapper of entities.values()) {
 				// Check if already queued for processing
-				if (wrapper.needsProcessing) continue
+				const referencedVariableIds = wrapper.referencedVariableIds
+				if (!referencedVariableIds) continue
 
-				if (!wrapper.lastReferencedVariableIds || wrapper.lastReferencedVariableIds.size === 0) {
-					// No variables to check, nothing to do
-					continue
-				}
-
-				if (variableIds.isDisjointFrom(wrapper.lastReferencedVariableIds)) {
+				if (variableIds.isDisjointFrom(referencedVariableIds)) {
 					// No variables changed that we care about, nothing to do
 					continue
 				}
 
 				// The entity needs re-processing
-				wrapper.needsProcessing = true
+				wrapper.referencedVariableIds = null
 				anyInvalidated = true
 			}
 		}

--- a/companion/lib/Controls/Entities/EntitySpecialExpressionManager.ts
+++ b/companion/lib/Controls/Entities/EntitySpecialExpressionManager.ts
@@ -181,7 +181,7 @@ export class EntityPoolSpecialExpressionManager {
 	readonly #createVariablesAndExpressionParser: CreateVariablesAndExpressionParser
 	#destroyed = false
 
-	readonly #specialExpressions: {
+	private readonly specialExpressions: {
 		readonly [Expression in SpecialExpression]: {
 			readonly entities: Map<string, EntityWrapper>
 			readonly computeNewValueFn: ComputeSpecialExpressionValueFn<Expression>
@@ -200,7 +200,7 @@ export class EntityPoolSpecialExpressionManager {
 		this.#controlId = controlId
 		this.#createVariablesAndExpressionParser = createVariablesAndExpressionParser
 
-		this.#specialExpressions = {
+		this.specialExpressions = {
 			isInverted: {
 				entities: new Map(),
 				computeNewValueFn: ComputeIsInverted,
@@ -222,7 +222,7 @@ export class EntityPoolSpecialExpressionManager {
 
 			const parser = this.#createVariablesAndExpressionParser(null)
 
-			for (const [type, specialExpression] of Object.entries(this.#specialExpressions)) {
+			for (const [type, specialExpression] of Object.entries(this.specialExpressions)) {
 				// Skip a special expression when no entities track it.
 				const entities = specialExpression.entities
 				if (entities.size === 0) continue
@@ -279,7 +279,7 @@ export class EntityPoolSpecialExpressionManager {
 	destroy(): void {
 		this.#destroyed = true
 		this.#debounceProcessPending.cancel()
-		for (const { entities } of Object.values(this.#specialExpressions)) {
+		for (const { entities } of Object.values(this.specialExpressions)) {
 			entities.clear()
 		}
 	}
@@ -290,7 +290,7 @@ export class EntityPoolSpecialExpressionManager {
 	 * value of any variables it depends upon, change.
 	 */
 	trackEntity(entity: ControlEntityInstance, expression: SpecialExpression): void {
-		const { entities, logger } = this.#specialExpressions[expression]
+		const { entities, logger } = this.specialExpressions[expression]
 
 		// This may replace an existing entity, if so it needs to restart the process
 		entities.set(entity.id, {
@@ -308,7 +308,7 @@ export class EntityPoolSpecialExpressionManager {
 	 * processing of those special expressions to compute their new values.
 	 */
 	forgetEntity(entityId: string): void {
-		for (const { entities } of Object.values(this.#specialExpressions)) {
+		for (const { entities } of Object.values(this.specialExpressions)) {
 			entities.delete(entityId)
 		}
 	}
@@ -321,7 +321,7 @@ export class EntityPoolSpecialExpressionManager {
 		if (this.#destroyed) return
 
 		let anyInvalidated = false
-		for (const { entities } of Object.values(this.#specialExpressions)) {
+		for (const { entities } of Object.values(this.specialExpressions)) {
 			for (const wrapper of entities.values()) {
 				// Check if already queued for processing
 				const referencedVariableIds = wrapper.referencedVariableIds

--- a/companion/test/Controls/Entities/EntitySpecialExpressionManager.test.ts
+++ b/companion/test/Controls/Entities/EntitySpecialExpressionManager.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../../../lib/Controls/Entities/EntitySpecialExpressionManager.js'
 import type {
 	NewSpecialExpressionValue,
+	SpecialExpression,
 	UpdateSpecialExpressionValuesFn,
 } from '../../../lib/Controls/Entities/SpecialExpressions.js'
 import { VariablesAndExpressionParser } from '../../../lib/Variables/VariablesAndExpressionParser.js'
@@ -203,6 +204,323 @@ describe('EntityPoolSpecialExpressionManager', () => {
 				])
 			)
 			expect(mockUpdateStoreResultFn).not.toHaveBeenCalled()
+		})
+	})
+
+	describe('entity wrapper referencedVariableIds state transitions', () => {
+		it('nonexpression isInverted', () => {
+			const mockEntity = createMockFeedbackEntity('entity-niner', { isExpression: false, value: true })
+
+			// Bracket-literal access evades access restrictions, for testing.  Don't
+			// try this at home, kids!
+			const {
+				isInverted: { entities },
+			} = manager['specialExpressions']
+
+			const maybeWrapper = () => entities.get('entity-niner')
+
+			// Initially no wrapper.
+			expect(maybeWrapper()).toBe(undefined)
+
+			// Start tracking.
+			manager.trackEntity(mockEntity, 'isInverted')
+
+			// Now a wrapper, with not-yet-computed referencedVariableIds.
+			let w = maybeWrapper()
+			expect(w).not.toBe(undefined)
+			const wrapper = w!
+			expect(wrapper.referencedVariableIds).toBe(null)
+
+			expect(mockUpdateIsInvertedFn).not.toHaveBeenCalled()
+
+			while (vi.getTimerCount() > 0) {
+				vi.advanceTimersToNextTimer()
+
+				w = maybeWrapper()
+				if (w !== undefined) {
+					expect(w).toBe(wrapper)
+					expect(w.referencedVariableIds).toBe(null)
+
+					expect(mockUpdateIsInvertedFn).not.toHaveBeenCalled()
+					continue // still not computed, keep going
+				}
+
+				expect(entities.size).toBe(0)
+				break
+			}
+
+			expect(mockVariablesParser.executeExpression).not.toHaveBeenCalled()
+			expect(mockVariablesParser.parseVariables).not.toHaveBeenCalled()
+			expect(mockUpdateIsInvertedFn).toHaveBeenCalledExactlyOnceWith(
+				new Map<string, NewSpecialExpressionValue<'isInverted'>>([
+					[
+						'entity-niner',
+						{
+							entityId: 'entity-niner',
+							controlId: 'control-1',
+							value: true,
+						},
+					],
+				])
+			)
+		})
+
+		it('isInverted expression no variables', () => {
+			const mockEntity = createMockFeedbackEntity('entity-lion', { isExpression: true, value: 'this is an expression' })
+
+			// Bracket-literal access evades access restrictions, for testing.  Don't
+			// try this at home, kids!
+			const {
+				isInverted: { entities },
+			} = manager['specialExpressions']
+
+			const maybeWrapper = () => entities.get('entity-lion')
+
+			// Initially no wrapper.
+			expect(maybeWrapper()).toBe(undefined)
+
+			// Start tracking.
+			manager.trackEntity(mockEntity, 'isInverted')
+
+			expect(mockVariablesParser.executeExpression).not.toHaveBeenCalled()
+
+			mockParseExpressionResult = {
+				ok: true,
+				value: false,
+				variableIds: new Set<string>(),
+			}
+
+			// Now a wrapper, with not-yet-computed referencedVariableIds.
+			let w = maybeWrapper()
+			expect(w).not.toBe(undefined)
+			const wrapper = w!
+			expect(wrapper.referencedVariableIds).toBe(null)
+
+			expect(mockUpdateIsInvertedFn).not.toHaveBeenCalled()
+
+			while (vi.getTimerCount() > 0) {
+				vi.advanceTimersToNextTimer()
+
+				w = maybeWrapper()
+				if (w !== undefined) {
+					expect(w).toBe(wrapper)
+					expect(w.referencedVariableIds).toBe(null)
+
+					expect(mockUpdateIsInvertedFn).not.toHaveBeenCalled()
+					continue // still not computed, keep going
+				}
+
+				expect(entities.size).toBe(0)
+				break
+			}
+
+			expect(mockVariablesParser.parseVariables).not.toHaveBeenCalled()
+			expect(mockVariablesParser.executeExpression).toHaveBeenCalledExactlyOnceWith('this is an expression', 'boolean')
+			expect(mockUpdateIsInvertedFn).toHaveBeenCalledExactlyOnceWith(
+				new Map<string, NewSpecialExpressionValue<'isInverted'>>([
+					[
+						'entity-lion',
+						{
+							entityId: 'entity-lion',
+							controlId: 'control-1',
+							value: false,
+						},
+					],
+				])
+			)
+		})
+
+		it('isInverted expression with a variable', () => {
+			const mockEntity = createMockFeedbackEntity('entity-tiger', { isExpression: true, value: 'also an expression' })
+
+			// Bracket-literal access evades access restrictions, for testing.  Don't
+			// try this at home, kids!
+			const {
+				isInverted: { entities },
+			} = manager['specialExpressions']
+
+			const maybeWrapper = () => entities.get('entity-tiger')
+
+			// Initially no wrapper.
+			expect(maybeWrapper()).toBe(undefined)
+
+			// Start tracking.
+			manager.trackEntity(mockEntity, 'isInverted')
+
+			expect(mockVariablesParser.executeExpression).not.toHaveBeenCalled()
+
+			mockParseExpressionResult = {
+				ok: true,
+				value: false,
+				variableIds: new Set<string>(['custom:DeadBeef']),
+			}
+
+			// Now a wrapper, with not-yet-computed referencedVariableIds.
+			let w = maybeWrapper()
+			expect(w).not.toBe(undefined)
+			const wrapper = w!
+			expect(wrapper.referencedVariableIds).toBe(null)
+
+			expect(mockUpdateIsInvertedFn).not.toHaveBeenCalled()
+
+			while (vi.getTimerCount() > 0) {
+				vi.advanceTimersToNextTimer()
+
+				w = maybeWrapper()
+				expect(w).toBe(wrapper)
+
+				if (wrapper.referencedVariableIds === null) {
+					expect(mockUpdateIsInvertedFn).not.toHaveBeenCalled()
+					continue // still not computed, keep going
+				}
+
+				expect(wrapper.referencedVariableIds.size).toBe(1)
+				expect(wrapper.referencedVariableIds.has('custom:DeadBeef')).toBe(true)
+				break
+			}
+
+			expect(mockVariablesParser.parseVariables).not.toHaveBeenCalled()
+			expect(mockVariablesParser.executeExpression).toHaveBeenCalledExactlyOnceWith('also an expression', 'boolean')
+			expect(mockUpdateIsInvertedFn).toHaveBeenCalledExactlyOnceWith(
+				new Map<string, NewSpecialExpressionValue<'isInverted'>>([
+					[
+						'entity-tiger',
+						{
+							entityId: 'entity-tiger',
+							controlId: 'control-1',
+							value: false,
+						},
+					],
+				])
+			)
+		})
+
+		it('isInverted expression without variable, storeResult nonexpression with variable', () => {
+			const mockFeedbackEntity = createMockFeedbackEntity('entity-batman', {
+				isExpression: true,
+				value: 'mucho expression',
+			})
+			const mockActionEntity = createMockActionEntity('entity-robin', {
+				type: 'custom-variable',
+				variableName: {
+					isExpression: false,
+					value: 'my variable name string',
+				},
+				createIfNotExists: true,
+			})
+
+			// Bracket-literal access evades access restrictions, for testing.  Don't
+			// try this at home, kids!
+			const {
+				isInverted: { entities: isInvertedEntities },
+				storeResult: { entities: storeResultEntities },
+			} = manager['specialExpressions']
+
+			const maybeIsInvertedWrapper = () => isInvertedEntities.get('entity-batman')
+			const maybeStoreResultWrapper = () => storeResultEntities.get('entity-robin')
+
+			// Initially no wrappers.
+			expect(maybeIsInvertedWrapper()).toBe(undefined)
+			expect(maybeStoreResultWrapper()).toBe(undefined)
+
+			// Start tracking.
+			manager.trackEntity(mockFeedbackEntity, 'isInverted')
+			expect(isInvertedEntities.size).toBe(1)
+			manager.trackEntity(mockActionEntity, 'storeResult')
+			expect(storeResultEntities.size).toBe(1)
+
+			expect(mockVariablesParser.executeExpression).not.toHaveBeenCalled()
+			expect(mockVariablesParser.parseVariables).not.toHaveBeenCalled()
+
+			mockParseExpressionResult = {
+				ok: true,
+				value: true,
+				variableIds: new Set<string>(),
+			}
+			mockParseVariablesResult = {
+				text: 'custom:variable-name',
+				variableIds: new Set<string>(['custom:BeefCafe']),
+			}
+
+			// Now a wrapper, with not-yet-computed referencedVariableIds.
+			let isInvertedW = maybeIsInvertedWrapper()
+			expect(isInvertedW).not.toBe(undefined)
+			const isInvertedWrapper = isInvertedW!
+			expect(isInvertedWrapper.referencedVariableIds).toBe(null)
+
+			let storeResultW = maybeStoreResultWrapper()
+			expect(storeResultW).not.toBe(undefined)
+			const storeResultWrapper = storeResultW!
+			expect(storeResultWrapper.referencedVariableIds).toBe(null)
+
+			expect(mockUpdateIsInvertedFn).not.toHaveBeenCalled()
+			expect(mockUpdateStoreResultFn).not.toHaveBeenCalled()
+
+			while (vi.getTimerCount() > 0) {
+				vi.advanceTimersToNextTimer()
+
+				isInvertedW = maybeIsInvertedWrapper()
+				storeResultW = maybeStoreResultWrapper()
+
+				// Recorded, no calculations completed.
+				if (
+					isInvertedW &&
+					storeResultW &&
+					isInvertedW.referencedVariableIds === null &&
+					storeResultW.referencedVariableIds === null
+				) {
+					expect(mockUpdateIsInvertedFn).not.toHaveBeenCalled()
+					expect(mockUpdateStoreResultFn).not.toHaveBeenCalled()
+					continue
+				}
+
+				// Calculations completed, update functions called (or not)
+				if (isInvertedW === undefined && storeResultW && storeResultW.referencedVariableIds) {
+					expect(storeResultW).toBe(storeResultWrapper)
+					expect(storeResultW.referencedVariableIds.values().toArray()).toEqual(['custom:BeefCafe'])
+					break
+				}
+
+				// Unexpected state.
+				expect('unexpected state').toBe(`
+isInvertedW=${isInvertedW}, isInvertedW.referencedVariableIds=${isInvertedW?.referencedVariableIds?.values().toArray()}
+storeResultW=${storeResultW}, storeResultW.referencedVariableIds=${storeResultW?.referencedVariableIds?.values().toArray()}
+`)
+			}
+
+			expect(isInvertedEntities.size).toBe(0)
+			expect(mockVariablesParser.executeExpression).toHaveBeenCalledExactlyOnceWith('mucho expression', 'boolean')
+			expect(mockUpdateIsInvertedFn).toHaveBeenCalledExactlyOnceWith(
+				new Map<string, NewSpecialExpressionValue<'isInverted'>>([
+					[
+						'entity-batman',
+						{
+							entityId: 'entity-batman',
+							controlId: 'control-1',
+							value: true,
+						},
+					],
+				])
+			)
+
+			expect(storeResultEntities.size).toBe(1)
+			expect(mockVariablesParser.parseVariables).toHaveBeenCalledExactlyOnceWith('my variable name string')
+			expect(mockUpdateStoreResultFn).toHaveBeenCalledExactlyOnceWith(
+				new Map<string, NewSpecialExpressionValue<'storeResult'>>([
+					[
+						'entity-robin',
+						{
+							entityId: 'entity-robin',
+							controlId: 'control-1',
+							value: {
+								type: 'custom-variable',
+								variableName: 'custom:variable-name',
+								createIfNotExists: true,
+							},
+						},
+					],
+				])
+			)
 		})
 	})
 


### PR DESCRIPTION
This is a followup optimization after #4065.

The value of a special expression only changes if the value of a variable it depends upon changes.  A special expression that refers to no variables, can never change.  Therefore, there's no need to keep tracking such expression to recompute it as variables change value.

Before this change, it looks like every single feedback was being continually tracked for `isInverted` special expressions, for all time, and same now for all actions for `storeResult` as of that feature landing.  This will minimize the former to exactly those feedbacks containing an `isInverted` that depends upon a variable, and the latter to only those actions that depend upon a variable -- the least tracking possible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved special-expression tracking and recomputation to reduce unnecessary work, speed up updates, and make lifecycle behavior more predictable.
* **Tests**
  * Added focused tests validating lifecycle state transitions and timed recomputation, ensuring expression evaluation and update notifications occur reliably and only once when expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitfocus/companion/pull/4193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->