### PR TITLE
refactor: `$(this:*)` variable definition cleanups

### DIFF
--- a/companion/lib/Variables/Values.ts
+++ b/companion/lib/Variables/Values.ts
@@ -12,6 +12,7 @@
 import EventEmitter from 'node:events'
 import z from 'zod'
 import { formatLocation } from '@companion-app/shared/ControlId.js'
+import type { ThisLocationVariable } from '@companion-app/shared/ControlLocation.js'
 import { BANNED_PROPS } from '@companion-app/shared/Expression/ExpressionResolve.js'
 import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
 import {
@@ -30,6 +31,51 @@ import { VariablesBlinker } from './VariablesBlinker.js'
 export interface VariablesValuesEvents {
 	variables_changed: [changed: ReadonlySet<string>, connection_labels: ReadonlySet<string>]
 	local_variables_changed: [changed: ReadonlySet<string>, fromControlId: string]
+}
+
+const ThisLocationVariables: Record<
+	ThisLocationVariable,
+	(location: ControlLocation | null | undefined) => VariableValue
+> = {
+	'this:page': (location) => location?.pageNumber,
+	'this:column': (location) => location?.column,
+	'this:row': (location) => location?.row,
+	'this:location': (location) => (location ? formatLocation(location) : undefined),
+
+	// The remaining variables simply delegate to internally-defined variables.
+	'this:page_name': (location) =>
+		location ? `$(internal:page_number_${location.pageNumber}_name)` : VARIABLE_UNKNOWN_VALUE,
+	'this:active': (location) =>
+		location
+			? `$(internal:b_active_${location.pageNumber}_${location.row}_${location.column})`
+			: VARIABLE_UNKNOWN_VALUE,
+
+	'this:step': (location) =>
+		location ? `$(internal:b_step_${location.pageNumber}_${location.row}_${location.column})` : VARIABLE_UNKNOWN_VALUE,
+	'this:step_count': (location) =>
+		location
+			? `$(internal:b_step_count_${location.pageNumber}_${location.row}_${location.column})`
+			: VARIABLE_UNKNOWN_VALUE,
+
+	'this:actions_running': (location) =>
+		location
+			? `$(internal:b_actions_running_${location.pageNumber}_${location.row}_${location.column})`
+			: VARIABLE_UNKNOWN_VALUE,
+
+	'this:button_status': (location) =>
+		location
+			? `$(internal:b_status_${location.pageNumber}_${location.row}_${location.column})`
+			: VARIABLE_UNKNOWN_VALUE,
+}
+
+const ThisLocationVariablesSet: ReadonlySet<string> = new Set(Object.keys(ThisLocationVariables))
+
+export function InjectedVariablesForLocation(controlLocation: ControlLocation | null | undefined): VariablesCache {
+	const injectedVariables: VariablesCache = new Map()
+	for (const [variableId, computeVariable] of Object.entries(ThisLocationVariables)) {
+		injectedVariables.set(`$(${variableId})`, computeVariable(controlLocation))
+	}
+	return injectedVariables
 }
 
 export class VariablesValues extends EventEmitter<VariablesValuesEvents> {
@@ -64,8 +110,7 @@ export class VariablesValues extends EventEmitter<VariablesValuesEvents> {
 		localValues: ControlEntityInstance[] | null,
 		overrideVariableValues: VariableValues | null
 	): VariablesAndExpressionParser {
-		const thisValues: VariablesCache = new Map()
-		this.addInjectedVariablesForLocation(thisValues, controlLocation)
+		const thisValues = InjectedVariablesForLocation(controlLocation)
 
 		return new VariablesAndExpressionParser(
 			this.#blinker,
@@ -175,65 +220,8 @@ export class VariablesValues extends EventEmitter<VariablesValuesEvents> {
 		}
 	}
 
-	/**
-	 * Variables to inject based on location
-	 */
-	addInjectedVariablesForLocation(values: VariablesCache, location: ControlLocation | null | undefined): void {
-		values.set('$(this:page)', location?.pageNumber)
-		values.set('$(this:column)', location?.column)
-		values.set('$(this:row)', location?.row)
-		values.set('$(this:location)', location ? formatLocation(location) : undefined)
-
-		// Reactivity happens for these because of references to the inner variables
-		values.set(
-			'$(this:page_name)',
-			location ? `$(internal:page_number_${location.pageNumber}_name)` : VARIABLE_UNKNOWN_VALUE
-		)
-		values.set(
-			'$(this:active)',
-			location
-				? `$(internal:b_active_${location.pageNumber}_${location.row}_${location.column})`
-				: VARIABLE_UNKNOWN_VALUE
-		)
-		values.set(
-			'$(this:step)',
-			location ? `$(internal:b_step_${location.pageNumber}_${location.row}_${location.column})` : VARIABLE_UNKNOWN_VALUE
-		)
-		values.set(
-			'$(this:step_count)',
-			location
-				? `$(internal:b_step_count_${location.pageNumber}_${location.row}_${location.column})`
-				: VARIABLE_UNKNOWN_VALUE
-		)
-
-		values.set(
-			'$(this:actions_running)',
-			location
-				? `$(internal:b_actions_running_${location.pageNumber}_${location.row}_${location.column})`
-				: VARIABLE_UNKNOWN_VALUE
-		)
-		values.set(
-			'$(this:button_status)',
-			location
-				? `$(internal:b_status_${location.pageNumber}_${location.row}_${location.column})`
-				: VARIABLE_UNKNOWN_VALUE
-		)
-	}
-
 	triggerLocationVariablesChange(controlId: string): void {
-		const newValues: VariablesCache = new Map()
-		this.addInjectedVariablesForLocation(newValues, { pageNumber: 1, row: 1, column: 1 }) // Fake location, we don't need it
-
-		const changedVariableIds = new Set<string>()
-		for (const variableId of newValues.keys()) {
-			// Strip off the wrapper
-			if (variableId.startsWith('$(') && variableId.endsWith(')')) {
-				changedVariableIds.add(variableId.substring(2, variableId.length - 1))
-			}
-		}
-		if (changedVariableIds.size > 0) {
-			this.emit('local_variables_changed', changedVariableIds, controlId)
-		}
+		this.emit('local_variables_changed', ThisLocationVariablesSet, controlId)
 	}
 }
 

--- a/companion/test/Variables/Values.test.ts
+++ b/companion/test/Variables/Values.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { BANNED_PROPS } from '@companion-app/shared/Expression/ExpressionResolve.js'
 import { VARIABLE_UNKNOWN_VALUE } from '@companion-app/shared/Variables.js'
 import type { VariablesCache } from '../../lib/Variables/Util.js'
-import { VariablesValues, type VariableValueEntry } from '../../lib/Variables/Values.js'
+import { InjectedVariablesForLocation, VariablesValues, type VariableValueEntry } from '../../lib/Variables/Values.js'
 
 describe('VariablesValues', () => {
 	let values: VariablesValues
@@ -319,10 +319,9 @@ describe('VariablesValues', () => {
 		})
 	})
 
-	describe('addInjectedVariablesForLocation', () => {
+	describe('InjectedVariablesForLocation', () => {
 		test('sets all ten $(this:*) keys for a valid location', () => {
-			const cache: VariablesCache = new Map()
-			values.addInjectedVariablesForLocation(cache, { pageNumber: 2, row: 3, column: 4 })
+			const cache: VariablesCache = InjectedVariablesForLocation({ pageNumber: 2, row: 3, column: 4 })
 			const expectedKeys = [
 				'$(this:page)',
 				'$(this:column)',
@@ -341,22 +340,19 @@ describe('VariablesValues', () => {
 		})
 
 		test('sets page, row, and column to the correct numeric values', () => {
-			const cache: VariablesCache = new Map()
-			values.addInjectedVariablesForLocation(cache, { pageNumber: 5, row: 2, column: 7 })
+			const cache: VariablesCache = InjectedVariablesForLocation({ pageNumber: 5, row: 2, column: 7 })
 			expect(cache.get('$(this:page)')).toBe(5)
 			expect(cache.get('$(this:row)')).toBe(2)
 			expect(cache.get('$(this:column)')).toBe(7)
 		})
 
 		test('sets $(this:page_name) to the correct $(internal:page_number_N_name) reference', () => {
-			const cache: VariablesCache = new Map()
-			values.addInjectedVariablesForLocation(cache, { pageNumber: 3, row: 1, column: 2 })
+			const cache: VariablesCache = InjectedVariablesForLocation({ pageNumber: 3, row: 1, column: 2 })
 			expect(cache.get('$(this:page_name)')).toBe('$(internal:page_number_3_name)')
 		})
 
 		test('sets button dynamic variables to the correct $(internal:b_*) reference strings', () => {
-			const cache: VariablesCache = new Map()
-			values.addInjectedVariablesForLocation(cache, { pageNumber: 2, row: 4, column: 6 })
+			const cache: VariablesCache = InjectedVariablesForLocation({ pageNumber: 2, row: 4, column: 6 })
 			expect(cache.get('$(this:active)')).toBe('$(internal:b_active_2_4_6)')
 			expect(cache.get('$(this:step)')).toBe('$(internal:b_step_2_4_6)')
 			expect(cache.get('$(this:step_count)')).toBe('$(internal:b_step_count_2_4_6)')
@@ -364,36 +360,26 @@ describe('VariablesValues', () => {
 			expect(cache.get('$(this:button_status)')).toBe('$(internal:b_status_2_4_6)')
 		})
 
-		test('null location: primitive this:* variables are undefined', () => {
-			const cache: VariablesCache = new Map()
-			values.addInjectedVariablesForLocation(cache, null)
+		test.each([[null], [undefined]])('$0 location: primitive this:* variables are undefined', (controlLocation) => {
+			const cache: VariablesCache = InjectedVariablesForLocation(controlLocation)
 			expect(cache.get('$(this:page)')).toBeUndefined()
 			expect(cache.get('$(this:row)')).toBeUndefined()
 			expect(cache.get('$(this:column)')).toBeUndefined()
 			expect(cache.get('$(this:location)')).toBeUndefined()
 		})
 
-		test('null location: complex this:* variables resolve to VARIABLE_UNKNOWN_VALUE', () => {
-			const cache: VariablesCache = new Map()
-			values.addInjectedVariablesForLocation(cache, null)
-			expect(cache.get('$(this:page_name)')).toBe(VARIABLE_UNKNOWN_VALUE)
-			expect(cache.get('$(this:active)')).toBe(VARIABLE_UNKNOWN_VALUE)
-			expect(cache.get('$(this:step)')).toBe(VARIABLE_UNKNOWN_VALUE)
-			expect(cache.get('$(this:step_count)')).toBe(VARIABLE_UNKNOWN_VALUE)
-			expect(cache.get('$(this:actions_running)')).toBe(VARIABLE_UNKNOWN_VALUE)
-			expect(cache.get('$(this:button_status)')).toBe(VARIABLE_UNKNOWN_VALUE)
-		})
-
-		test('undefined location produces identical results to null', () => {
-			const cacheNull: VariablesCache = new Map()
-			const cacheUndef: VariablesCache = new Map()
-			values.addInjectedVariablesForLocation(cacheNull, null)
-			values.addInjectedVariablesForLocation(cacheUndef, undefined)
-			expect(cacheUndef.size).toBe(cacheNull.size)
-			for (const [key, val] of cacheNull) {
-				expect(cacheUndef.get(key)).toEqual(val)
+		test.each([[null], [undefined]])(
+			'$0 location: complex this:* variables resolve to VARIABLE_UNKNOWN_VALUE',
+			(controlLocation) => {
+				const cache: VariablesCache = InjectedVariablesForLocation(controlLocation)
+				expect(cache.get('$(this:page_name)')).toBe(VARIABLE_UNKNOWN_VALUE)
+				expect(cache.get('$(this:active)')).toBe(VARIABLE_UNKNOWN_VALUE)
+				expect(cache.get('$(this:step)')).toBe(VARIABLE_UNKNOWN_VALUE)
+				expect(cache.get('$(this:step_count)')).toBe(VARIABLE_UNKNOWN_VALUE)
+				expect(cache.get('$(this:actions_running)')).toBe(VARIABLE_UNKNOWN_VALUE)
+				expect(cache.get('$(this:button_status)')).toBe(VARIABLE_UNKNOWN_VALUE)
 			}
-		})
+		)
 	})
 
 	describe('triggerLocationVariablesChange', () => {

--- a/shared-lib/lib/ControlLocation.ts
+++ b/shared-lib/lib/ControlLocation.ts
@@ -10,3 +10,15 @@ export const ControlLocationOption = {
 	default: '$(this:page)/$(this:row)/$(this:column)',
 	useVariables: CompanionFieldVariablesSupport.InternalParser,
 } as const satisfies CompanionInputFieldTextInputExtended
+
+export type ThisLocationVariable =
+	| 'this:page'
+	| 'this:column'
+	| 'this:row'
+	| 'this:location'
+	| 'this:page_name'
+	| 'this:active'
+	| 'this:step'
+	| 'this:step_count'
+	| 'this:actions_running'
+	| 'this:button_status'

--- a/webui/package.json
+++ b/webui/package.json
@@ -102,6 +102,7 @@
     "jsdom": "^29.1.1",
     "monaco-editor": "^0.55.1",
     "storybook": "^10.4.1",
+    "type-testing": "^0.2.0",
     "vitest": "^4.1.7"
   }
 }

--- a/webui/src/Controls/LocalVariablesStore.tsx
+++ b/webui/src/Controls/LocalVariablesStore.tsx
@@ -2,6 +2,8 @@ import { useQuery } from '@tanstack/react-query'
 import { action, makeObservable, observable } from 'mobx'
 import { computedFn } from 'mobx-utils'
 import { useEffect, useMemo } from 'react'
+import type { Equal, Expect } from 'type-testing'
+import type { ThisLocationVariable } from '@companion-app/shared/ControlLocation.js'
 import { EntityModelType, type SomeEntityModel } from '@companion-app/shared/Model/EntityModel.js'
 import type { VariableValue, VariableValues } from '@companion-app/shared/Model/Variables.js'
 import type { DropdownChoiceInt } from '~/Components/DropdownChoices.js'
@@ -90,7 +92,7 @@ export function useLocalVariablesStore(
 	return store
 }
 
-export const ControlLocalVariables: DropdownChoiceInt[] = [
+export const ControlLocalVariables = [
 	{
 		value: 'this:page',
 		label: 'This page',
@@ -131,7 +133,12 @@ export const ControlLocalVariables: DropdownChoiceInt[] = [
 		value: 'this:page_name',
 		label: 'This page name',
 	},
-]
+] as const satisfies DropdownChoiceInt[]
+
+// @ts-expect-error Type used only to assert a type condition
+type _VerifyControlVariablesDropdownIsComplete = Expect<
+	Equal<(typeof ControlLocalVariables)[number]['value'], ThisLocationVariable>
+>
 
 export const ControlWithInternalLocalVariables: DropdownChoiceInt[] = [
 	...ControlLocalVariables,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1837,6 +1837,7 @@ __metadata:
     storybook: "npm:^10.4.1"
     terser: "npm:^5.48.0"
     type-fest: "npm:^5.6.0"
+    type-testing: "npm:^0.2.0"
     typescript: "npm:~6.0.3"
     use-deep-compare: "npm:^1.3.0"
     usehooks-ts: "npm:^3.1.1"
@@ -24487,6 +24488,13 @@ __metadata:
     media-typer: "npm:0.3.0"
     mime-types: "npm:~2.1.24"
   checksum: 10c0/a23daeb538591b7efbd61ecf06b6feb2501b683ffdc9a19c74ef5baba362b4347e42f1b4ed81f5882a8c96a3bfff7f93ce3ffaf0cbbc879b532b04c97a55db9d
+  languageName: node
+  linkType: hard
+
+"type-testing@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "type-testing@npm:0.2.0"
+  checksum: 10c0/7d4f9891bc31516a6b3ccf2278290da0c0c78a637cb0b4fe7b1a3c755a17d95530fc97ffd9af4e48cbee6073d9ed0ef3b0396916c44a6304d17da50103fed9a6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This feels much cleaner to me than creating injected variables just to enumerate their keys.  (I had much of it written before any of the revs in #4192 were landed.)

It feels like it would not be terribly difficult to move static definition of these variables, with lazy computation of them, directly into variables parsing code.  Then you'd just update the parser on the new control location, only -- and it would handle notifying about the relevant variables changing value.  That would be a more extensive change than this minor simplification tho.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined how location-based "this:*" variables are provided and now always emit full local-variable updates for consistency.

* **Chores**
  * Added stronger compile-time validation to ensure local-variable dropdown options are complete and stable.

* **Tests**
  * Updated tests to use the new provisioning approach and explicitly cover null/undefined location behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitfocus/companion/pull/4200?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->