### PR TITLE
feat: add notes to control editors #760

### DIFF
--- a/companion/lib/Controls/ControlTypes/Button/Layered.ts
+++ b/companion/lib/Controls/ControlTypes/Button/Layered.ts
@@ -147,6 +147,7 @@ export class ControlButtonLayered
 			...structuredClone(ButtonControlBase.DefaultOptions),
 			rotaryActions: false,
 			canModifyStyleInApis: false,
+			notes: '',
 		}
 
 		if (!storage) {

--- a/companion/lib/Controls/ControlTypes/ExpressionVariable.ts
+++ b/companion/lib/Controls/ControlTypes/ExpressionVariable.ts
@@ -69,6 +69,7 @@ export class ControlExpressionVariable
 		variableName: '',
 		description: 'An expression variable',
 		sortOrder: 0,
+		notes: '',
 	}
 
 	/**

--- a/companion/lib/Controls/ControlTypes/Triggers/Trigger.ts
+++ b/companion/lib/Controls/ControlTypes/Triggers/Trigger.ts
@@ -75,6 +75,7 @@ export class ControlTrigger
 		name: 'New Trigger',
 		enabled: false,
 		sortOrder: 0,
+		notes: '',
 	}
 
 	/**

--- a/companion/lib/Data/Upgrades/v12tov13.ts
+++ b/companion/lib/Data/Upgrades/v12tov13.ts
@@ -62,6 +62,7 @@ function convertControlToLayered(control: NormalButtonModel, defaultNoTopBar: bo
 		options: {
 			...(control.options as Complete<NormalButtonOptions>),
 			canModifyStyleInApis: true, // Backwards compatibility
+			notes: '',
 		} satisfies Complete<LayeredButtonOptions>,
 		localVariables: control.localVariables,
 		steps: control.steps,

--- a/shared-lib/lib/Model/ButtonModel.ts
+++ b/shared-lib/lib/Model/ButtonModel.ts
@@ -59,6 +59,7 @@ export type ButtonOptionsBase = {
 export type LayeredButtonOptions = ButtonOptionsBase & {
 	rotaryActions: boolean
 	canModifyStyleInApis: boolean
+	notes?: string
 }
 
 export type ButtonStatus = 'good' | 'warning' | 'error'

--- a/shared-lib/lib/Model/ExpressionVariableModel.ts
+++ b/shared-lib/lib/Model/ExpressionVariableModel.ts
@@ -18,6 +18,7 @@ export type ExpressionVariableOptions = {
 	description: string
 	sortOrder: number
 	collectionId?: string
+	notes?: string
 }
 
 export interface ClientExpressionVariableData extends ExpressionVariableOptions {

--- a/shared-lib/lib/Model/TriggerModel.ts
+++ b/shared-lib/lib/Model/TriggerModel.ts
@@ -19,6 +19,7 @@ export type TriggerOptions = {
 	enabled: boolean
 	sortOrder: number
 	collectionId?: string
+	notes?: string
 }
 
 export interface ClientTriggerData extends TriggerOptions {

--- a/webui/src/Buttons/EditButton/EditButton.tsx
+++ b/webui/src/Buttons/EditButton/EditButton.tsx
@@ -6,6 +6,7 @@ import { StaticAlert } from '~/Components/Alert.js'
 import { ButtonPreviewBase } from '~/Components/ButtonPreview.js'
 import { GenericConfirmModal, type GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
 import { Grid } from '~/Components/Grid'
+import { ControlNotesEditor } from '~/Controls/ControlNotesEditor.js'
 import { useButtonImageForControlId } from '~/Hooks/useButtonImageForControlId.js'
 import { useControlConfig } from '~/Hooks/useControlConfig.js'
 import { MyErrorBoundary } from '~/Resources/Error.js'
@@ -98,16 +99,24 @@ const EditButtonContent = observer(function EditButton({
 }: EditButtonContentProps) {
 	return (
 		<>
-			<Grid.Col sm={12}>
-				<ButtonPreviewBase fixedSize preview={previewImage} right={true} className="button-zero-display-height" />
-
-				<ControlClearButton location={location} resetModalRef={resetModalRef} />
-				<MyErrorBoundary>
+			<div className="d-flex gap-2">
+				<div className="flex-grow-1 min-w-0 d-flex flex-column gap-1">
+					<div className="d-flex flex-wrap align-items-center gap-1">
+						<ControlClearButton location={location} resetModalRef={resetModalRef} />
+						<MyErrorBoundary>
+							{config.type === 'button-layered' && (
+								<ControlHotPressButtons location={location} showRotaries={config.options.rotaryActions} />
+							)}
+						</MyErrorBoundary>
+					</div>
 					{config.type === 'button-layered' && (
-						<ControlHotPressButtons location={location} showRotaries={config.options.rotaryActions} />
+						<MyErrorBoundary>
+							<ControlNotesEditor controlId={controlId} notes={config.options.notes} className="w-100 mt-1" />
+						</MyErrorBoundary>
 					)}
-				</MyErrorBoundary>
-			</Grid.Col>
+				</div>
+				<ButtonPreviewBase fixedSize preview={previewImage} />
+			</div>
 
 			{config.type === 'pageup' && (
 				<>

--- a/webui/src/Buttons/EditButton/LayeredButtonEditor/LayeredButtonEditor.tsx
+++ b/webui/src/Buttons/EditButton/LayeredButtonEditor/LayeredButtonEditor.tsx
@@ -55,14 +55,7 @@ export const LayeredButtonEditor = observer(function LayeredButtonEditor({
 	const localVariablesStore = useLocalVariablesStore(controlId, config.localVariables)
 
 	return (
-		<div
-			className="grow flex flex-column"
-			style={{
-				marginTop: '50px', // HACK: this is a bit silly, but is needed to avoid clipping the preview
-				// Once we have a 'notes' section, that can occupy the space this creates and avoid this issue for us.
-				minHeight: '0',
-			}}
-		>
+		<div className="grow flex flex-column min-h-0">
 			{runtimeProps && (
 				<MyErrorBoundary>
 					<ButtonEditorTabs

--- a/webui/src/Controls/ControlNotesEditor.tsx
+++ b/webui/src/Controls/ControlNotesEditor.tsx
@@ -1,0 +1,35 @@
+import { useCallback } from 'react'
+import { TextInputFieldSimple } from '~/Components/TextInputField.js'
+import { trpc, useMutationExt } from '~/Resources/TRPC.js'
+
+interface ControlNotesEditorProps {
+	controlId: string
+	notes: string | undefined
+	className?: string
+	id?: string
+}
+
+export function ControlNotesEditor({ controlId, notes, className, id }: ControlNotesEditorProps): React.JSX.Element {
+	const setOptionsFieldMutation = useMutationExt(trpc.controls.setOptionsField.mutationOptions())
+
+	const setNotes = useCallback(
+		(value: string) => {
+			setOptionsFieldMutation.mutateAsync({ controlId, key: 'notes', value }).catch((e) => {
+				console.error('Failed to set notes:', e)
+			})
+		},
+		[setOptionsFieldMutation, controlId]
+	)
+
+	return (
+		<TextInputFieldSimple
+			id={id}
+			value={notes ?? ''}
+			setValue={setNotes}
+			placeholder="Notes..."
+			multiline
+			tooltip="Internal notes for this control"
+			className={className}
+		/>
+	)
+}

--- a/webui/src/Triggers/EditPanel.tsx
+++ b/webui/src/Triggers/EditPanel.tsx
@@ -9,6 +9,7 @@ import { GenericConfirmModal, type GenericConfirmModalRef } from '~/Components/G
 import { Grid } from '~/Components/Grid'
 import { InlineHelpIcon } from '~/Components/InlineHelp.js'
 import { TextInputFieldSimple } from '~/Components/TextInputField.js'
+import { ControlNotesEditor } from '~/Controls/ControlNotesEditor.js'
 import { ControlEntitiesEditor } from '~/Controls/EntitiesEditor.js'
 import { LocalVariablesEditor } from '~/Controls/LocalVariablesEditor.js'
 import { useControlConfig } from '~/Hooks/useControlConfig.js'
@@ -67,6 +68,10 @@ function TriggerPanelContent({ config, controlId }: TriggerPanelContentProps): R
 		<>
 			<MyErrorBoundary>
 				<TriggerConfig options={config.options} controlId={controlId} />
+			</MyErrorBoundary>
+
+			<MyErrorBoundary>
+				<ControlNotesEditor controlId={controlId} notes={config.options.notes} />
 			</MyErrorBoundary>
 
 			<MyErrorBoundary>

--- a/webui/src/Variables/ExpressionVariables/EditPanel.tsx
+++ b/webui/src/Variables/ExpressionVariables/EditPanel.tsx
@@ -24,6 +24,7 @@ import { EntityManageChildGroups } from '~/Controls/Components/EntityChildGroup'
 import { EntityCommonCells } from '~/Controls/Components/EntityCommonCells'
 import { EntityEditorContextProvider, useEntityEditorContext } from '~/Controls/Components/EntityEditorContext.js'
 import { EditableEntityList } from '~/Controls/Components/EntityList'
+import { ControlNotesEditor } from '~/Controls/ControlNotesEditor.js'
 import { useLocalVariablesStore, type LocalVariablesStore } from '~/Controls/LocalVariablesStore'
 import { findAllEntityIdsDeep } from '~/Controls/Util.js'
 import { PanelCollapseHelperProvider } from '~/Helpers/CollapseHelper.js'
@@ -129,6 +130,7 @@ function ExpressionVariableConfig({ controlId, options }: ExpressionVariableConf
 
 	const nameFieldId = useId()
 	const descriptionFieldId = useId()
+	const notesFieldId = useId()
 
 	return (
 		<Grid.Col sm={12} className="p-0">
@@ -153,6 +155,13 @@ function ExpressionVariableConfig({ controlId, options }: ExpressionVariableConf
 				</FormLabel>
 				<Grid.Col xs={8}>
 					<TextInputFieldSimple id={descriptionFieldId} setValue={setDescription} value={options.description} />
+				</Grid.Col>
+
+				<FormLabel htmlFor={notesFieldId} className="col-sm-4 col-form-label col-form-label-sm">
+					Notes
+				</FormLabel>
+				<Grid.Col xs={8}>
+					<ControlNotesEditor id={notesFieldId} controlId={controlId} notes={options.notes} className="mb-2" />
 				</Grid.Col>
 			</Form>
 		</Grid.Col>

--- a/webui/src/scss/_common.scss
+++ b/webui/src/scss/_common.scss
@@ -336,3 +336,10 @@ svg.pad-left {
 		}
 	}
 }
+
+.min-h-0 {
+	min-height: 0;
+}
+.min-w-0 {
+	min-width: 0;
+}


### PR DESCRIPTION
Simple multiline text field, for all control types

<img width="768" height="298" alt="image" src="https://github.com/user-attachments/assets/2bd22f94-7624-4c15-86d6-8cb798088e98" />
<img width="768" height="348" alt="image" src="https://github.com/user-attachments/assets/6a8b2dad-11ba-4b1f-9af2-050fbe2cf675" />
<img width="768" height="348" alt="image" src="https://github.com/user-attachments/assets/9191063e-c623-4fc5-95d3-7866eb46e0d5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notes support to buttons (layered), triggers, and expression variables. Users can now add and edit custom notes for these control types to enhance documentation and organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitfocus/companion/pull/4202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->