### PR TITLE
feat: graphics reference element type #4142

### DIFF
--- a/companion/lib/Controls/ControlTypes/Button/LayerDefaults.ts
+++ b/companion/lib/Controls/ControlTypes/Button/LayerDefaults.ts
@@ -121,6 +121,21 @@ export function CreateElementOfType(type: SomeButtonGraphicsElement['type']): So
 			// Composite elements should not be created directly through this function
 			// They are created with custom logic in layeredStyleAddElement
 			throw new Error('Composite elements should be created through layeredStyleAddElement')
+		case 'reference':
+			return {
+				id: nanoid(),
+				name: 'Reference',
+				usage: ButtonGraphicsElementUsage.Automatic,
+				type: 'reference',
+				enabled: { value: true, isExpression: false },
+				opacity: { value: 100, isExpression: false },
+				x: { value: 0, isExpression: false },
+				y: { value: 0, isExpression: false },
+				width: { value: 100, isExpression: false },
+				height: { value: 100, isExpression: false },
+				rotation: { value: 0, isExpression: false },
+				location: { value: '', isExpression: false },
+			}
 		default:
 			assertNever(type)
 			throw new Error(`Unknown element type: ${type}`)

--- a/companion/lib/Controls/ControlTypes/Button/Layered.ts
+++ b/companion/lib/Controls/ControlTypes/Button/Layered.ts
@@ -1,10 +1,12 @@
 import { nanoid } from 'nanoid'
 import type { JsonValue } from 'type-fest'
+import { formatLocation } from '@companion-app/shared/ControlId.js'
 import type {
 	LayeredButtonModel,
 	LayeredButtonOptions,
 	NormalButtonRuntimeProps,
 } from '@companion-app/shared/Model/ButtonModel.js'
+import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
 import type { ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
 import type {
 	ButtonGraphicsBoxElement,
@@ -127,6 +129,12 @@ export class ControlButtonLayered
 	#lastDrawCompositeElements: ReadonlySet<CompositeElementIdString> | null = null
 
 	/**
+	 * Location strings (e.g. '1/0/0') of buttons this control references via reference elements.
+	 * When any of these locations are re-rendered, this control must be re-rendered too.
+	 */
+	#lastDrawReferencedLocations: ReadonlySet<string> | null = null
+
+	/**
 	 * The base style without feedbacks applied
 	 */
 	#drawElements: SomeButtonGraphicsElement[] = structuredClone(ControlButtonLayered.DefaultElements)
@@ -197,12 +205,16 @@ export class ControlButtonLayered
 			// Ensure control is stored before setup
 			if (isImport) setImmediate(() => this.postProcessImport())
 		}
+
+		// Listen for other controls finishing rendering (needed for reference element invalidation)
+		this.deps.graphics.on('button_drawn', this.onReferencedButtonDrawn)
 	}
 
 	/**
 	 * Prepare this control for deletion
 	 */
 	destroy(): void {
+		this.deps.graphics.off('button_drawn', this.onReferencedButtonDrawn)
 		this.#elementConversionCache.clear()
 		super.destroy()
 	}
@@ -249,25 +261,32 @@ export class ControlButtonLayered
 			injectedVariableValues
 		)
 
+		const locationStr = location ? formatLocation(location) : null
+
 		const feedbackOverrides = this.entities.getFeedbackStyleOverrides()
 
 		// Compute the new drawing, using the element conversion cache for per-element caching
-		const { elements, usedVariables, usedCompositeElements } = await ConvertSomeButtonGraphicsElementForDrawing(
-			this.deps.instance.definitions,
-			parser,
-			this.deps.graphics.renderPixelBuffers.bind(this.deps.graphics),
-			this.#drawElements,
-			feedbackOverrides,
-			true,
-			this.#elementConversionCache
-		)
+		const { elements, usedVariables, usedCompositeElements, referencedLocations } =
+			await ConvertSomeButtonGraphicsElementForDrawing(
+				this.deps.instance.definitions,
+				parser,
+				this.deps.graphics.renderPixelBuffers.bind(this.deps.graphics),
+				this.#drawElements,
+				feedbackOverrides,
+				true,
+				this.#elementConversionCache,
+				locationStr,
+				(location) => this.deps.graphics.getCachedRender(location) ?? null
+			)
 		this.#lastDrawVariables = usedVariables.size > 0 ? usedVariables : null
 		this.#lastDrawCompositeElements = usedCompositeElements.size > 0 ? usedCompositeElements : null
+		this.#lastDrawReferencedLocations = referencedLocations.size > 0 ? referencedLocations : null
 
 		const result: DrawStyleLayeredButtonModel = {
 			...this.getDrawStyleButtonStateProps(),
 
 			elements,
+			referencedLocations,
 
 			style: 'button-layered',
 			drawType: 'button',
@@ -684,6 +703,19 @@ export class ControlButtonLayered
 		this.#elementConversionCache.queueInvalidateCompositeType(allChangedElementIds)
 
 		this.logger.silly('composite element changed in button ' + this.controlId)
+		this.triggerRedraw()
+	}
+
+	/**
+	 * Called after any located control has finished rendering. If this control references the changed
+	 * location, invalidate the relevant cache entries and trigger a redraw.
+	 */
+	onReferencedButtonDrawn = (location: ControlLocation): void => {
+		const locStr = formatLocation(location)
+		if (!this.#lastDrawReferencedLocations?.has(locStr)) return
+
+		this.#elementConversionCache.queueInvalidateReferencedLocation(locStr)
+		this.logger.silly('referenced control rendered in button ' + this.controlId)
 		this.triggerRedraw()
 	}
 

--- a/companion/lib/Controls/ControlTypes/Button/Layered.ts
+++ b/companion/lib/Controls/ControlTypes/Button/Layered.ts
@@ -26,6 +26,7 @@ import {
 import type { VariableValues } from '@companion-app/shared/Model/Variables.js'
 import { ConvertSomeButtonGraphicsElementForDrawing } from '../../../Graphics/ConvertGraphicsElements.js'
 import { ElementConversionCache } from '../../../Graphics/ElementConversionCache.js'
+import type { ImageResult } from '../../../Graphics/ImageResult.js'
 import type { CompositeElementIdString } from '../../../Instance/Definitions.js'
 import { ParseLegacyStyle } from '../../../Resources/ConvertLegacyStyleToElements.js'
 import { lazy } from '../../../Resources/Util.js'
@@ -133,6 +134,12 @@ export class ControlButtonLayered
 	 * When any of these locations are re-rendered, this control must be re-rendered too.
 	 */
 	#lastDrawReferencedLocations: ReadonlySet<string> | null = null
+
+	/**
+	 * Locations where a reference cycle was detected in the last draw.
+	 * Used to suppress redundant redraws when we're already showing ∞ for a location.
+	 */
+	#lastCyclicReferences: ReadonlySet<string> | null = null
 
 	/**
 	 * The base style without feedbacks applied
@@ -266,7 +273,7 @@ export class ControlButtonLayered
 		const feedbackOverrides = this.entities.getFeedbackStyleOverrides()
 
 		// Compute the new drawing, using the element conversion cache for per-element caching
-		const { elements, usedVariables, usedCompositeElements, referencedLocations } =
+		const { elements, usedVariables, usedCompositeElements, referencedLocations, cyclicLocations } =
 			await ConvertSomeButtonGraphicsElementForDrawing(
 				this.deps.instance.definitions,
 				parser,
@@ -281,6 +288,7 @@ export class ControlButtonLayered
 		this.#lastDrawVariables = usedVariables.size > 0 ? usedVariables : null
 		this.#lastDrawCompositeElements = usedCompositeElements.size > 0 ? usedCompositeElements : null
 		this.#lastDrawReferencedLocations = referencedLocations.size > 0 ? referencedLocations : null
+		this.#lastCyclicReferences = cyclicLocations.size > 0 ? cyclicLocations : null
 
 		const result: DrawStyleLayeredButtonModel = {
 			...this.getDrawStyleButtonStateProps(),
@@ -710,9 +718,16 @@ export class ControlButtonLayered
 	 * Called after any located control has finished rendering. If this control references the changed
 	 * location, invalidate the relevant cache entries and trigger a redraw.
 	 */
-	onReferencedButtonDrawn = (location: ControlLocation): void => {
+	onReferencedButtonDrawn = (location: ControlLocation, render: ImageResult): void => {
 		const locStr = formatLocation(location)
 		if (!this.#lastDrawReferencedLocations?.has(locStr)) return
+
+		// Suppress ping-pong when we're already rendering a cycle: if we're already showing ∞ for this
+		// location AND the target still references us back, no visible output would change.
+		if (this.#lastCyclicReferences?.has(locStr)) {
+			const myLocation = this.deps.pageStore.getLocationOfControlId(this.controlId)
+			if (myLocation && render.referencedLocations.has(formatLocation(myLocation))) return
+		}
 
 		this.#elementConversionCache.queueInvalidateReferencedLocation(locStr)
 		this.logger.silly('referenced control rendered in button ' + this.controlId)

--- a/companion/lib/Controls/ControlTypes/Button/Preset.ts
+++ b/companion/lib/Controls/ControlTypes/Button/Preset.ts
@@ -250,7 +250,9 @@ export class ControlButtonPreset
 			this.#drawElements,
 			feedbackOverrides,
 			true,
-			this.#elementConversionCache
+			this.#elementConversionCache,
+			null,
+			null
 		)
 		this.#lastDrawVariables = usedVariables.size > 0 ? usedVariables : null
 		this.#lastDrawCompositeElements = usedCompositeElements.size > 0 ? usedCompositeElements : null

--- a/companion/lib/Controls/ControlTypes/PageButton.ts
+++ b/companion/lib/Controls/ControlTypes/PageButton.ts
@@ -97,7 +97,9 @@ export abstract class ControlButtonPage<TJson>
 			rawElements,
 			emptyMap,
 			true,
-			this.#elementConversionCache
+			this.#elementConversionCache,
+			null,
+			null
 		)
 		this.#lastDrawVariables = usedVariables.size > 0 ? usedVariables : null
 

--- a/companion/lib/Graphics/Controller.ts
+++ b/companion/lib/Graphics/Controller.ts
@@ -296,6 +296,7 @@ export class GraphicsController extends EventEmitter<GraphicsControllerEvents> {
 						const cacheKeyObj: Record<string, any> = {
 							...renderStyle,
 							elements: collectContentHashes(buttonStyle.elements), // use hashes of elements for the key
+							referencedLocations: [...(buttonStyle.referencedLocations ?? [])].sort(), // Sets serialize as {} in JSON.stringify
 						}
 						const cacheKey = JSON.stringify(cacheKeyObj)
 

--- a/companion/lib/Graphics/Controller.ts
+++ b/companion/lib/Graphics/Controller.ts
@@ -303,7 +303,7 @@ export class GraphicsController extends EventEmitter<GraphicsControllerEvents> {
 						render = this.#renderLRUCache.get(cacheKey)
 
 						if (!render) {
-							render = await this.#drawImageResult(renderStyle)
+							render = await this.#drawImageResult(renderStyle, buttonStyle.elements, buttonStyle.referencedLocations)
 							this.#renderLRUCache.set(cacheKey, render)
 						}
 					} else {
@@ -609,7 +609,11 @@ export class GraphicsController extends EventEmitter<GraphicsControllerEvents> {
 		this.#debounceResizeRenderCache()
 	}
 
-	async #drawImageResult(drawStyle: RendererButtonStyle): Promise<ImageResult> {
+	async #drawImageResult(
+		drawStyle: RendererButtonStyle,
+		drawElements: readonly SomeButtonGraphicsDrawElement[] | null = null,
+		referencedLocations: ReadonlySet<string> | undefined = undefined
+	): Promise<ImageResult> {
 		const processedStyle = GraphicsLayeredProcessedStyleGenerator.Generate(drawStyle)
 
 		const dataUrlResolution = { width: 72, height: 72, oversampling: 4 } // Default values
@@ -620,14 +624,19 @@ export class GraphicsController extends EventEmitter<GraphicsControllerEvents> {
 			CRASHED_WORKER_RETRY_COUNT
 		)
 
-		return new ImageResult(dataUrl, processedStyle, async (width, height, rotation, format) =>
-			this.#executePoolDrawButtonImageBuffer(
-				drawStyle,
-				{ width, height, oversampling: 4 }, // TODO - dynamic oversampling?
-				rotation,
-				format,
-				CRASHED_WORKER_RETRY_COUNT
-			)
+		return new ImageResult(
+			dataUrl,
+			processedStyle,
+			async (width, height, rotation, format) =>
+				this.#executePoolDrawButtonImageBuffer(
+					drawStyle,
+					{ width, height, oversampling: 4 }, // TODO - dynamic oversampling?
+					rotation,
+					format,
+					CRASHED_WORKER_RETRY_COUNT
+				),
+			drawElements,
+			referencedLocations ?? new Set()
 		)
 	}
 

--- a/companion/lib/Graphics/ConvertGraphicsElements.ts
+++ b/companion/lib/Graphics/ConvertGraphicsElements.ts
@@ -1,5 +1,7 @@
 import { createHash } from 'node:crypto'
 import type { JsonValue } from 'type-fest'
+import { formatLocation } from '@companion-app/shared/ControlId.js'
+import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
 import type { ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
 import type {
 	ButtonGraphicsBorder,
@@ -20,6 +22,8 @@ import type {
 	ButtonGraphicsImageElement,
 	ButtonGraphicsLineDrawElement,
 	ButtonGraphicsLineElement,
+	ButtonGraphicsReferenceDrawElement,
+	ButtonGraphicsReferenceElement,
 	ButtonGraphicsTextDrawElement,
 	ButtonGraphicsTextElement,
 	SomeButtonGraphicsDrawElement,
@@ -27,6 +31,7 @@ import type {
 } from '@companion-app/shared/Model/StyleLayersModel.js'
 import {
 	ButtonGraphicsDecorationType,
+	ButtonGraphicsElementUsage,
 	ButtonGraphicsShowStatusIcons,
 	type CompositeElementOptionKey,
 	type DrawImageBuffer,
@@ -38,6 +43,7 @@ import type {
 	CompositeElementIdString,
 	InstanceDefinitions,
 } from '../Instance/Definitions.js'
+import { ParseLocationString } from '../Internal/Util.js'
 import type { VariablesAndExpressionParser } from '../Variables/VariablesAndExpressionParser.js'
 import {
 	createParseElementsContext,
@@ -46,8 +52,9 @@ import {
 	type ExpressionReferences,
 	type ParseElementsContext,
 } from './ConvertGraphicsElements/Helper.js'
-import { computeElementContentHash } from './ConvertGraphicsElements/Util.js'
+import { collectContentHashes, computeElementContentHash } from './ConvertGraphicsElements/Util.js'
 import type { ElementConversionCache, ElementConversionCacheEntry } from './ElementConversionCache.js'
+import type { ImageResult } from './ImageResult.js'
 
 export async function ConvertSomeButtonGraphicsElementForDrawing(
 	compositeElementStore: InstanceDefinitions,
@@ -56,11 +63,14 @@ export async function ConvertSomeButtonGraphicsElementForDrawing(
 	elements: SomeButtonGraphicsElement[],
 	feedbackOverrides: ReadonlyMap<string, ReadonlyMap<string, ExpressionOrValue<JsonValue | undefined>>>,
 	onlyEnabled: boolean,
-	cache: ElementConversionCache | null
+	cache: ElementConversionCache | null,
+	currentLocationStr: string | null = null,
+	getRenderAtLocation: ((location: ControlLocation) => ImageResult | null) | null = null
 ): Promise<{
 	elements: SomeButtonGraphicsDrawElement[]
 	usedVariables: Set<string>
 	usedCompositeElements: Set<CompositeElementIdString>
+	referencedLocations: Set<string>
 }> {
 	// Apply any queued invalidations before processing
 	cache?.applyQueuedInvalidations()
@@ -68,6 +78,7 @@ export async function ConvertSomeButtonGraphicsElementForDrawing(
 	const globalReferences: ExpressionReferences = {
 		variables: new Set(),
 		compositeElements: new Set(),
+		referencedLocations: new Set(),
 	}
 
 	// Track all processed element IDs (with prefixes) for cache purging
@@ -81,7 +92,9 @@ export async function ConvertSomeButtonGraphicsElementForDrawing(
 		onlyEnabled,
 		cache,
 		globalReferences,
-		processedElementIds
+		processedElementIds,
+		currentLocationStr,
+		getRenderAtLocation
 	)
 
 	const newElements = await convertElements(context, elements, '')
@@ -94,6 +107,7 @@ export async function ConvertSomeButtonGraphicsElementForDrawing(
 		elements: newElements,
 		usedVariables: globalReferences.variables,
 		usedCompositeElements: globalReferences.compositeElements,
+		referencedLocations: globalReferences.referencedLocations,
 	}
 }
 
@@ -144,6 +158,10 @@ async function convertElements(
 					}
 					case 'composite': {
 						cacheEntry = await convertCompositeElementForDrawing(context, element, idPrefix)
+						break
+					}
+					case 'reference': {
+						cacheEntry = await convertReferenceElementForDrawing(context, element, idPrefix)
 						break
 					}
 					default:
@@ -259,6 +277,121 @@ function convertGroupElementForDrawing(
 
 	drawElement.contentHash = computeElementContentHash(drawElement)
 	return { drawElement, usedVariables, compositeElement: null }
+}
+
+/**
+ * Convert reference element for drawing.
+ * Evaluates the location expression and, if a render cache callback is provided,
+ * resolves the referenced button's draw elements inline.
+ */
+async function convertReferenceElementForDrawing(
+	context: ParseElementsContext,
+	element: ButtonGraphicsReferenceElement,
+	idPrefix: string
+): Promise<ElementConversionCacheEntry> {
+	const { helper, usedVariables } = context.createHelper(element)
+
+	// Perform enabled check first, to avoid executing expressions when not needed
+	const enabled = helper.getBoolean('enabled', true)
+	if (!enabled && context.onlyEnabled) {
+		return { drawElement: null, usedVariables, compositeElement: null }
+	}
+
+	const opacity = helper.getNumber('opacity', 1, 0.01)
+	const drawBounds = convertDrawBounds(helper)
+	const rotation = helper.getNumber('rotation', 0)
+
+	const locationStr = helper.getString('location', '')
+
+	const drawElement: ButtonGraphicsReferenceDrawElement = {
+		id: idPrefix + element.id,
+		type: 'reference',
+		usage: element.usage,
+		enabled,
+		opacity,
+		...drawBounds,
+		rotation,
+		children: [],
+		contentHash: '',
+	}
+
+	drawElement.contentHash = computeElementContentHash(drawElement)
+
+	// Inline reference resolution using the provided render cache callback
+	let referencedLocationStr: string | null = null
+	if (locationStr) {
+		if (!context.getRenderAtLocation) {
+			// References are disabled (no render callback) — show a placeholder
+			drawElement.children = [makeReferencePlaceholder(drawElement.id, '?')]
+		} else {
+			const currentLocation = ParseLocationString(context.currentLocationStr, undefined)
+			const targetLocation = ParseLocationString(locationStr, currentLocation ?? undefined)
+
+			if (targetLocation) {
+				const targetLocationStr = formatLocation(targetLocation)
+				referencedLocationStr = targetLocationStr
+
+				const targetRender = context.getRenderAtLocation(targetLocation)
+
+				// Always track the direct dependency so we re-render when the target eventually renders
+				context.globalReferences.referencedLocations.add(targetLocationStr)
+
+				// Loop detection: check if the target's render transitively references this button
+				const isLoop =
+					targetLocationStr === context.currentLocationStr ||
+					(context.currentLocationStr !== null &&
+						targetRender?.referencedLocations.has(context.currentLocationStr) === true)
+
+				if (isLoop) {
+					// Circular reference detected — show a placeholder instead of recursing infinitely
+					drawElement.children = [makeReferencePlaceholder(drawElement.id, '\u221e')]
+				} else if (targetRender?.drawElements) {
+					// Embed the referenced button's draw elements (exclude canvas elements which are render-specific)
+					drawElement.children = targetRender.drawElements.filter((el) => el.type !== 'canvas')
+
+					// Track transitive referenced locations for loop detection in parent renders
+					for (const loc of targetRender.referencedLocations) {
+						context.globalReferences.referencedLocations.add(loc)
+					}
+				}
+			}
+		}
+
+		// Recompute contentHash to include children hashes so the LRU cache invalidates when referenced content changes
+		const childHashes = collectContentHashes(drawElement.children).join(',')
+		drawElement.contentHash = createHash('sha256')
+			.update(drawElement.contentHash)
+			.update(':')
+			.update(childHashes)
+			.digest('hex')
+	}
+
+	return { drawElement, usedVariables, compositeElement: null, referencedLocation: referencedLocationStr }
+}
+
+function makeReferencePlaceholder(parentId: string, text: string): ButtonGraphicsTextDrawElement {
+	const el: ButtonGraphicsTextDrawElement = {
+		id: `${parentId}:placeholder`,
+		type: 'text',
+		usage: ButtonGraphicsElementUsage.Automatic,
+		enabled: true,
+		opacity: 1,
+		x: 0,
+		y: 0,
+		width: 1,
+		height: 1,
+		rotation: 0,
+		text,
+		fontsize: 'auto',
+		font: 'companion-sans',
+		color: 0xffffff,
+		outlineColor: 0,
+		halign: 'center',
+		valign: 'center',
+		contentHash: '',
+	}
+	el.contentHash = computeElementContentHash(el)
+	return el
 }
 
 function parseCompositeElementChildOptions(

--- a/companion/lib/Graphics/ConvertGraphicsElements.ts
+++ b/companion/lib/Graphics/ConvertGraphicsElements.ts
@@ -71,6 +71,7 @@ export async function ConvertSomeButtonGraphicsElementForDrawing(
 	usedVariables: Set<string>
 	usedCompositeElements: Set<CompositeElementIdString>
 	referencedLocations: Set<string>
+	cyclicLocations: Set<string>
 }> {
 	// Apply any queued invalidations before processing
 	cache?.applyQueuedInvalidations()
@@ -79,6 +80,7 @@ export async function ConvertSomeButtonGraphicsElementForDrawing(
 		variables: new Set(),
 		compositeElements: new Set(),
 		referencedLocations: new Set(),
+		cyclicLocations: new Set(),
 	}
 
 	// Track all processed element IDs (with prefixes) for cache purging
@@ -108,6 +110,7 @@ export async function ConvertSomeButtonGraphicsElementForDrawing(
 		usedVariables: globalReferences.variables,
 		usedCompositeElements: globalReferences.compositeElements,
 		referencedLocations: globalReferences.referencedLocations,
+		cyclicLocations: globalReferences.cyclicLocations,
 	}
 }
 
@@ -181,6 +184,7 @@ async function convertElements(
 			}
 			if (cacheEntry.compositeElement?.elementId)
 				context.globalReferences.compositeElements.add(cacheEntry.compositeElement.elementId)
+			if (cacheEntry.referencedLocation) context.globalReferences.referencedLocations.add(cacheEntry.referencedLocation)
 
 			// If this is a group, populate the children
 			if (element.type === 'group' || element.type === 'composite') {
@@ -344,6 +348,7 @@ async function convertReferenceElementForDrawing(
 
 				if (isLoop) {
 					// Circular reference detected — show a placeholder instead of recursing infinitely
+					context.globalReferences.cyclicLocations.add(targetLocationStr)
 					drawElement.children = [makeReferencePlaceholder(drawElement.id, '\u221e')]
 				} else if (targetRender?.drawElements) {
 					// Embed the referenced button's draw elements (exclude canvas elements which are render-specific)

--- a/companion/lib/Graphics/ConvertGraphicsElements.ts
+++ b/companion/lib/Graphics/ConvertGraphicsElements.ts
@@ -326,7 +326,7 @@ async function convertReferenceElementForDrawing(
 	if (locationStr) {
 		if (!context.getRenderAtLocation) {
 			// References are disabled (no render callback) — show a placeholder
-			drawElement.children = [makeReferencePlaceholder(drawElement.id, '?')]
+			drawElement.children = makeReferencePlaceholder(drawElement.id, 'Unresolved\nReference')
 		} else {
 			const currentLocation = ParseLocationString(context.currentLocationStr, undefined)
 			const targetLocation = ParseLocationString(locationStr, currentLocation ?? undefined)
@@ -349,7 +349,7 @@ async function convertReferenceElementForDrawing(
 				if (isLoop) {
 					// Circular reference detected — show a placeholder instead of recursing infinitely
 					context.globalReferences.cyclicLocations.add(targetLocationStr)
-					drawElement.children = [makeReferencePlaceholder(drawElement.id, '\u221e')]
+					drawElement.children = makeReferencePlaceholder(drawElement.id, '\u221e')
 				} else if (targetRender?.drawElements) {
 					// Embed the referenced button's draw elements (exclude canvas elements which are render-specific)
 					drawElement.children = targetRender.drawElements.filter((el) => el.type !== 'canvas')
@@ -374,9 +374,31 @@ async function convertReferenceElementForDrawing(
 	return { drawElement, usedVariables, compositeElement: null, referencedLocation: referencedLocationStr }
 }
 
-function makeReferencePlaceholder(parentId: string, text: string): ButtonGraphicsTextDrawElement {
-	const el: ButtonGraphicsTextDrawElement = {
-		id: `${parentId}:placeholder`,
+function makeReferencePlaceholder(
+	parentId: string,
+	text: string
+): [ButtonGraphicsBoxDrawElement, ButtonGraphicsTextDrawElement] {
+	const boxEl: ButtonGraphicsBoxDrawElement = {
+		id: `${parentId}:placeholder-bg`,
+		type: 'box',
+		usage: ButtonGraphicsElementUsage.Automatic,
+		enabled: true,
+		opacity: 1,
+		x: 0,
+		y: 0,
+		width: 1,
+		height: 1,
+		rotation: 0,
+		color: 0xff8c00,
+		borderWidth: 0,
+		borderColor: 0,
+		borderPosition: 'inside',
+		contentHash: '',
+	}
+	boxEl.contentHash = computeElementContentHash(boxEl)
+
+	const textEl: ButtonGraphicsTextDrawElement = {
+		id: `${parentId}:placeholder-text`,
 		type: 'text',
 		usage: ButtonGraphicsElementUsage.Automatic,
 		enabled: true,
@@ -395,8 +417,9 @@ function makeReferencePlaceholder(parentId: string, text: string): ButtonGraphic
 		valign: 'center',
 		contentHash: '',
 	}
-	el.contentHash = computeElementContentHash(el)
-	return el
+	textEl.contentHash = computeElementContentHash(textEl)
+
+	return [boxEl, textEl]
 }
 
 function parseCompositeElementChildOptions(

--- a/companion/lib/Graphics/ConvertGraphicsElements/Helper.ts
+++ b/companion/lib/Graphics/ConvertGraphicsElements/Helper.ts
@@ -22,6 +22,8 @@ export interface ExpressionReferences {
 	readonly variables: Set<string>
 	readonly compositeElements: Set<CompositeElementIdString>
 	readonly referencedLocations: Set<string>
+	/** Locations where a cycle was detected during this conversion (subset of referencedLocations) */
+	readonly cyclicLocations: Set<string>
 }
 
 export class ElementExpressionHelper<T> {

--- a/companion/lib/Graphics/ConvertGraphicsElements/Helper.ts
+++ b/companion/lib/Graphics/ConvertGraphicsElements/Helper.ts
@@ -1,6 +1,7 @@
 import type { JsonValue } from 'type-fest'
 import type { ExecuteExpressionResult } from '@companion-app/shared/Expression/ExpressionResult.js'
 import type { HorizontalAlignment, VerticalAlignment } from '@companion-app/shared/Graphics/Util.js'
+import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
 import type { ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
 import type { DrawImageBuffer } from '@companion-app/shared/Model/StyleModel.js'
 import {
@@ -15,10 +16,12 @@ import type {
 } from '../../Instance/Definitions.js'
 import type { VariablesAndExpressionParser } from '../../Variables/VariablesAndExpressionParser.js'
 import type { ElementConversionCache } from '../ElementConversionCache.js'
+import type { ImageResult } from '../ImageResult.js'
 
 export interface ExpressionReferences {
 	readonly variables: Set<string>
 	readonly compositeElements: Set<CompositeElementIdString>
+	readonly referencedLocations: Set<string>
 }
 
 export class ElementExpressionHelper<T> {
@@ -243,6 +246,12 @@ export interface ParseElementsContext {
 	/**  Function to prepare pixel buffers for image elements */
 	readonly drawPixelBuffers: DrawPixelBuffers
 
+	/** Location string of the button being drawn (e.g. '1/0/0'), used for loop detection */
+	readonly currentLocationStr: string | null
+
+	/** Callback to fetch the last-rendered ImageResult for a given location */
+	readonly getRenderAtLocation: ((location: ControlLocation) => ImageResult | null) | null
+
 	/**
 	 * Create a child factory for recursive conversion (e.g., inside composite elements)
 	 * with prop overrides injected into the parser
@@ -269,7 +278,9 @@ export function createParseElementsContext(
 	onlyEnabled: boolean,
 	cache: ElementConversionCache | null,
 	globalReferences: ExpressionReferences,
-	processedElementIds: Set<string>
+	processedElementIds: Set<string>,
+	currentLocationStr: string | null,
+	getRenderAtLocation: ((location: ControlLocation) => ImageResult | null) | null
 ): ParseElementsContext {
 	return {
 		cache,
@@ -277,6 +288,8 @@ export function createParseElementsContext(
 		processedElementIds,
 		onlyEnabled,
 		drawPixelBuffers,
+		currentLocationStr,
+		getRenderAtLocation,
 
 		createHelper<T extends { readonly id: string }>(
 			element: T
@@ -298,7 +311,9 @@ export function createParseElementsContext(
 				onlyEnabled,
 				cache,
 				globalReferences,
-				processedElementIds
+				processedElementIds,
+				currentLocationStr,
+				getRenderAtLocation
 			)
 		},
 

--- a/companion/lib/Graphics/ElementConversionCache.ts
+++ b/companion/lib/Graphics/ElementConversionCache.ts
@@ -21,6 +21,9 @@ export interface ElementConversionCacheEntry {
 		/** Prefix applied to child element IDs */
 		readonly childIdPrefix: string
 	} | null
+
+	/** The location string (e.g. '1/0/0') referenced by this element (if it is a reference element) */
+	readonly referencedLocation?: string | null
 }
 
 /**
@@ -84,6 +87,18 @@ export class ElementConversionCache {
 	queueInvalidateCompositeType(compositeTypeIds: Iterable<CompositeElementIdString>): void {
 		for (const id of compositeTypeIds) {
 			this.#compositeTypesToInvalidate.add(id)
+		}
+	}
+
+	/**
+	 * Queue all reference elements pointing to a given location for invalidation.
+	 * @param locationStr The location string (e.g. '1/0/0') whose referencing elements should be invalidated
+	 */
+	queueInvalidateReferencedLocation(locationStr: string): void {
+		for (const [elementId, entry] of this.#cache) {
+			if ((entry.referencedLocation ?? null) === locationStr) {
+				this.#invalidationQueue.add(elementId)
+			}
 		}
 	}
 

--- a/companion/lib/Graphics/ElementConversionCache.ts
+++ b/companion/lib/Graphics/ElementConversionCache.ts
@@ -22,7 +22,16 @@ export interface ElementConversionCacheEntry {
 		readonly childIdPrefix: string
 	} | null
 
-	/** The location string (e.g. '1/0/0') referenced by this element (if it is a reference element) */
+	/**
+	 * The location string (e.g. '1/0/0') directly referenced by this element (if it is a reference element).
+	 *
+	 * This intentionally stores only the **direct** reference target, not the full transitive closure.
+	 * Transitive invalidation is handled by the event-driven chain: when C changes, B redraws and emits
+	 * `button_drawn`, which A observes and uses to re-fetch B's now-updated render via `getRenderAtLocation`.
+	 * Storing transitive locations here would cause A to evict its cache and call `getRenderAtLocation(B)`
+	 * before B has had a chance to re-render, embedding stale B content and triggering a redundant
+	 * extra redraw.
+	 */
 	readonly referencedLocation?: string | null
 }
 

--- a/companion/lib/Graphics/ImageResult.ts
+++ b/companion/lib/Graphics/ImageResult.ts
@@ -1,5 +1,6 @@
 import type * as imageRs from '@julusian/image-rs'
 import type { HorizontalAlignment, VerticalAlignment } from '@companion-app/shared/Graphics/Util.js'
+import type { SomeButtonGraphicsDrawElement } from '@companion-app/shared/Model/StyleLayersModel.js'
 import type { SurfaceRotation } from '@companion-app/shared/Model/Surfaces.js'
 
 export interface ImageResultProcessedStyle {
@@ -49,10 +50,30 @@ export class ImageResult {
 	 */
 	readonly updated: number
 
-	constructor(dataUrl: string, style: ImageResultProcessedStyle | null, drawNative: ImageResultNativeDrawFn) {
+	/**
+	 * The draw elements that produced this render. Only set for layered button controls.
+	 * Used by the reference element post-processor to embed another control's elements.
+	 */
+	readonly drawElements: readonly SomeButtonGraphicsDrawElement[] | null
+
+	/**
+	 * The set of location strings (e.g. '1/0/0') transitively referenced by this render.
+	 * Used for loop detection when embedding reference elements.
+	 */
+	readonly referencedLocations: ReadonlySet<string>
+
+	constructor(
+		dataUrl: string,
+		style: ImageResultProcessedStyle | null,
+		drawNative: ImageResultNativeDrawFn,
+		drawElements: readonly SomeButtonGraphicsDrawElement[] | null = null,
+		referencedLocations: ReadonlySet<string> = new Set()
+	) {
 		this.#dataUrl = dataUrl
 		this.style = style
 		this.#drawNative = drawNative
+		this.drawElements = drawElements
+		this.referencedLocations = referencedLocations
 
 		this.updated = Date.now()
 	}

--- a/companion/lib/ImportExport/Controller.ts
+++ b/companion/lib/ImportExport/Controller.ts
@@ -396,6 +396,8 @@ export class ImportExportController {
 						rawElements,
 						new Map(),
 						true,
+						null, // Future: we should be able to resolve references within this import ui, but it needs some thought on how to cache and resolve cross-page references
+						null,
 						null
 					)
 

--- a/companion/lib/Preview/Controller.ts
+++ b/companion/lib/Preview/Controller.ts
@@ -26,6 +26,7 @@ export class PreviewController {
 		this.#elementStream = new PreviewElementStream(
 			instanceDefinitions,
 			graphicsController,
+			pageStore,
 			controlsController,
 			controlEvents
 		)

--- a/companion/lib/Preview/ElementStream.ts
+++ b/companion/lib/Preview/ElementStream.ts
@@ -1,5 +1,7 @@
 import EventEmitter from 'node:events'
 import z from 'zod'
+import { formatLocation } from '@companion-app/shared/ControlId.js'
+import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
 import type { SomeButtonGraphicsDrawElement } from '@companion-app/shared/Model/StyleLayersModel.js'
 import type { ControlCommonEvents } from '../Controls/ControlDependencies.js'
 import type { ControlsController } from '../Controls/Controller.js'
@@ -7,6 +9,7 @@ import type { GraphicsController } from '../Graphics/Controller.js'
 import { ConvertSomeButtonGraphicsElementForDrawing } from '../Graphics/ConvertGraphicsElements.js'
 import type { CompositeElementIdString, InstanceDefinitions } from '../Instance/Definitions.js'
 import LogController from '../Log/Controller.js'
+import type { IPageStore } from '../Page/Store.js'
 import { publicProcedure, router, toIterable } from '../UI/TRPC.js'
 
 export interface ElementStreamResult {
@@ -24,6 +27,7 @@ export class PreviewElementStream {
 
 	readonly #instanceDefinitions: InstanceDefinitions
 	readonly #graphicsController: GraphicsController
+	readonly #pageStore: IPageStore
 	readonly #controlsController: ControlsController
 	readonly #controlEvents: EventEmitter<ControlCommonEvents>
 
@@ -32,17 +36,19 @@ export class PreviewElementStream {
 	constructor(
 		instanceDefinitions: InstanceDefinitions,
 		graphicsController: GraphicsController,
+		pageStore: IPageStore,
 		controlsController: ControlsController,
 		controlEvents: EventEmitter<ControlCommonEvents>
 	) {
 		this.#instanceDefinitions = instanceDefinitions
 		this.#graphicsController = graphicsController
+		this.#pageStore = pageStore
 		this.#controlsController = controlsController
 		this.#controlEvents = controlEvents
 
 		// Listen for element changes to trigger re-evaluation
 		this.#controlEvents.on('layeredStyleElementChanged', this.#onElementChanged)
-		this.#controlEvents.on('invalidateControlRender', this.#onControlRender)
+		this.#graphicsController.on('button_drawn', this.#onButtonDrawn)
 	}
 
 	createTrpcRouter() {
@@ -78,7 +84,7 @@ export class PreviewElementStream {
 								elementId: input.elementId,
 								trackedExpressions: new Set<string>(),
 								trackedCompositeElements: new Set(),
-
+								trackedReferencedLocations: new Set(),
 								latestResult: { ok: true, element: null },
 								changes: new EventEmitter(),
 								isEvaluating: false,
@@ -123,13 +129,12 @@ export class PreviewElementStream {
 		}
 	}
 
-	#onControlRender = (controlId: string): void => {
-		// TODO - This is rather heavy-handled, we should ideally track which elements triggered the change
-
-		// Find all sessions for this control
+	#onButtonDrawn = (location: ControlLocation): void => {
+		const locationStr = formatLocation(location)
+		// Re-evaluate sessions that reference this location
 		for (const [elementStreamId, session] of this.#sessions) {
-			if (session.controlId === controlId) {
-				this.#logger.silly(`Re-evaluating element: ${elementStreamId} due to control render invalidation`)
+			if (session.trackedReferencedLocations.has(locationStr)) {
+				this.#logger.silly(`Re-evaluating element: ${elementStreamId} due to button drawn`)
 				this.#triggerElementReEvaluation(session)
 			}
 		}
@@ -159,6 +164,7 @@ export class PreviewElementStream {
 			session.latestResult = { ok: true, element: newValue.element }
 			session.trackedExpressions = newValue.referencedVariableIds
 			session.trackedCompositeElements = newValue.referencedCompositeElements
+			session.trackedReferencedLocations = newValue.referencedLocations
 
 			session.changes.emit('change', { ok: true, element: newValue.element })
 		} catch (err) {
@@ -212,27 +218,47 @@ export class PreviewElementStream {
 		element: SomeButtonGraphicsDrawElement | null
 		referencedVariableIds: Set<string>
 		referencedCompositeElements: Set<CompositeElementIdString>
+		referencedLocations: Set<string>
 	}> {
 		const control = this.#controlsController.getControl(controlId)
 		if (!control || !control.supportsLayeredStyle || !control.supportsEntities) {
-			return { element: null, referencedVariableIds: new Set(), referencedCompositeElements: new Set() }
+			return {
+				element: null,
+				referencedVariableIds: new Set(),
+				referencedCompositeElements: new Set(),
+				referencedLocations: new Set(),
+			}
 		}
 
 		const elementDef = control.layeredStyleGetElementById(elementId)
 		if (!elementDef) {
-			return { element: null, referencedVariableIds: new Set(), referencedCompositeElements: new Set() }
+			return {
+				element: null,
+				referencedVariableIds: new Set(),
+				referencedCompositeElements: new Set(),
+				referencedLocations: new Set(),
+			}
 		}
 
 		const feedbackOverrides = control.entities.getFeedbackStyleOverrides()
 
 		if (!elementDef) {
-			return { element: null, referencedVariableIds: new Set(), referencedCompositeElements: new Set() }
+			return {
+				element: null,
+				referencedVariableIds: new Set(),
+				referencedCompositeElements: new Set(),
+				referencedLocations: new Set(),
+			}
 		}
 
 		const parser = this.#controlsController.createVariablesAndExpressionParser(controlId, null)
 
+		const controlLocation = this.#pageStore.getLocationOfControlId(controlId)
+		const currentLocationStr = controlLocation ? formatLocation(controlLocation) : null
+
 		try {
 			// For group elements, clear children since they should be watched independently
+			// Reference elements keep their children (embedded from referenced control)
 			let elementDefToProcess = elementDef
 			if (elementDef.type === 'group') {
 				elementDefToProcess = { ...elementDef, children: [] }
@@ -244,6 +270,7 @@ export class PreviewElementStream {
 				elements,
 				usedVariables,
 				usedCompositeElements: connectionCompositeElements,
+				referencedLocations,
 			} = await ConvertSomeButtonGraphicsElementForDrawing(
 				this.#instanceDefinitions,
 				parser,
@@ -251,7 +278,9 @@ export class PreviewElementStream {
 				[elementDefToProcess],
 				feedbackOverrides,
 				false, // onlyEnabled
-				null
+				null,
+				currentLocationStr,
+				(location) => this.#graphicsController.getCachedRender(location) ?? null
 			)
 
 			if (elements.length === 0) {
@@ -264,6 +293,7 @@ export class PreviewElementStream {
 				element: elements[0],
 				referencedVariableIds: usedVariables,
 				referencedCompositeElements: connectionCompositeElements,
+				referencedLocations,
 			}
 		} catch (error) {
 			this.#logger.error('Error evaluating element:', error)
@@ -278,6 +308,7 @@ interface ElementStreamSession {
 	readonly elementId: string
 	trackedExpressions: Set<string>
 	trackedCompositeElements: Set<CompositeElementIdString>
+	trackedReferencedLocations: Set<string>
 
 	latestResult: ElementStreamResult
 

--- a/companion/test/Graphics/ConvertGraphicsElements.test.ts
+++ b/companion/test/Graphics/ConvertGraphicsElements.test.ts
@@ -5,9 +5,12 @@ import { CompanionFieldVariablesSupport, type ExpressionOrValue } from '@compani
 import type {
 	ButtonGraphicsBoxDrawElement,
 	ButtonGraphicsBoxElement,
+	ButtonGraphicsCanvasDrawElement,
 	ButtonGraphicsGroupDrawElement,
 	ButtonGraphicsGroupElement,
 	ButtonGraphicsImageElement,
+	ButtonGraphicsReferenceDrawElement,
+	ButtonGraphicsReferenceElement,
 	ButtonGraphicsTextDrawElement,
 	ButtonGraphicsTextElement,
 	SomeButtonGraphicsDrawElement,
@@ -23,6 +26,7 @@ import { VARIABLE_UNKNOWN_VALUE } from '@companion-app/shared/Variables.js'
 import { ConvertSomeButtonGraphicsElementForDrawing } from '../../lib/Graphics/ConvertGraphicsElements.js'
 import { collectContentHashes } from '../../lib/Graphics/ConvertGraphicsElements/Util.js'
 import { ElementConversionCache } from '../../lib/Graphics/ElementConversionCache.js'
+import { ImageResult } from '../../lib/Graphics/ImageResult.js'
 import type { CompositeElementDefinition, InstanceDefinitions } from '../../lib/Instance/Definitions.js'
 import {
 	executeExpression,
@@ -177,6 +181,34 @@ function makeGroupEl(
 		...overrides,
 		children,
 	}
+}
+
+function makeReferenceEl(overrides: Partial<ButtonGraphicsReferenceElement> = {}): ButtonGraphicsReferenceElement {
+	return {
+		id: 'ref1',
+		name: '',
+		type: 'reference',
+		usage: USAGE,
+		enabled: val(true),
+		opacity: val(100),
+		x: val(0),
+		y: val(0),
+		width: val(100),
+		height: val(100),
+		rotation: val(0),
+		location: val(''),
+		...overrides,
+	}
+}
+
+/**
+ * Creates a minimal mock ImageResult for use in reference element tests.
+ */
+function createMockImageResult(
+	drawElements: SomeButtonGraphicsDrawElement[] = [],
+	referencedLocations: ReadonlySet<string> = new Set()
+): ImageResult {
+	return new ImageResult('', null, async () => Buffer.alloc(0), drawElements, referencedLocations)
 }
 
 /**
@@ -370,6 +402,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -394,6 +428,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -418,6 +454,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -434,6 +472,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				false,
+				null,
+				null,
 				null
 			)
 
@@ -453,6 +493,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -475,6 +517,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -505,6 +549,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -534,6 +580,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -574,6 +622,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -622,6 +672,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -651,6 +703,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -680,6 +734,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -700,6 +756,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -721,6 +779,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -740,6 +800,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -761,7 +823,9 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
-				cache
+				cache,
+				null,
+				null
 			)
 
 			// Cache should now contain the element
@@ -778,7 +842,9 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
-				cache
+				cache,
+				null,
+				null
 			)
 
 			// Verify cache was queried
@@ -800,7 +866,9 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
-				cache
+				cache,
+				null,
+				null
 			)
 
 			// Queue invalidation for the variable and apply it
@@ -815,7 +883,9 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
-				cache
+				cache,
+				null,
+				null
 			)
 
 			// Content should be different
@@ -839,7 +909,9 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
-				cache
+				cache,
+				null,
+				null
 			)
 
 			expect(cache.get('text1')).toBeDefined()
@@ -853,7 +925,9 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				[elements[0]],
 				new Map(),
 				true,
-				cache
+				cache,
+				null,
+				null
 			)
 
 			// Cache should now only have text1
@@ -876,7 +950,9 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
-				cache
+				cache,
+				null,
+				null
 			)
 
 			// Verify both are cached
@@ -905,7 +981,9 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				disabledElements,
 				new Map(),
 				true,
-				cache
+				cache,
+				null,
+				null
 			)
 			expect(result.elements).toHaveLength(0)
 
@@ -924,7 +1002,9 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
-				cache
+				cache,
+				null,
+				null
 			)
 
 			// Should have the group with its child
@@ -985,7 +1065,9 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
-				cache
+				cache,
+				null,
+				null
 			)
 
 			// Find the child cache key from the spy calls (includes the propOverridesHash prefix)
@@ -1015,7 +1097,9 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				disabledElements,
 				new Map(),
 				true,
-				cache
+				cache,
+				null,
+				null
 			)
 
 			// Child should still be in cache (verify by checking cache.get returns a value)
@@ -1032,7 +1116,9 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
-				cache
+				cache,
+				null,
+				null
 			)
 
 			// Child should NOT have been re-cached (cache hit)
@@ -1058,6 +1144,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				globalReferences,
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -1076,6 +1164,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -1086,6 +1176,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -1104,6 +1196,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements1,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -1114,6 +1208,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements2,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -1161,6 +1257,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -1213,6 +1311,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -1233,6 +1333,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -1281,6 +1383,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -1304,6 +1408,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -1322,6 +1428,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -1380,6 +1488,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -1434,6 +1544,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -1482,6 +1594,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -1505,6 +1619,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -1529,6 +1645,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -1553,6 +1671,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -1574,6 +1694,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -1596,6 +1718,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 					elements,
 					new Map(),
 					true,
+					null,
+					null,
 					null
 				)
 
@@ -1652,6 +1776,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -1708,6 +1834,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -1766,6 +1894,8 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
@@ -1794,11 +1924,278 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 				elements,
 				new Map(),
 				true,
+				null,
+				null,
 				null
 			)
 
 			// Should fall back to 'inside' as default
 			expect((result.elements[0] as { borderPosition: string }).borderPosition).toBe('inside')
+		})
+	})
+
+	describe('reference element conversion', () => {
+		test('shows placeholder when no getRenderAtLocation is provided (references disabled)', async () => {
+			const elements: SomeButtonGraphicsElement[] = [makeReferenceEl({ location: val('1/0/0') })]
+
+			const result = await ConvertSomeButtonGraphicsElementForDrawing(
+				createMockInstanceDefinitions(),
+				createMockParser(),
+				mockDrawPixelBuffers,
+				elements,
+				new Map(),
+				true,
+				null,
+				null,
+				null
+			)
+
+			expect(result.elements).toHaveLength(1)
+			expect(result.elements[0].type).toBe('reference')
+			const refEl = result.elements[0] as ButtonGraphicsReferenceDrawElement
+			expect(refEl.children).toHaveLength(1)
+			expect(refEl.children[0].type).toBe('text')
+		})
+
+		test('produces an empty reference element when location is empty', async () => {
+			const getRenderAtLocation = vi.fn(() => null)
+			const elements: SomeButtonGraphicsElement[] = [makeReferenceEl({ location: val('') })]
+
+			const result = await ConvertSomeButtonGraphicsElementForDrawing(
+				createMockInstanceDefinitions(),
+				createMockParser(),
+				mockDrawPixelBuffers,
+				elements,
+				new Map(),
+				true,
+				null,
+				'1/0/0',
+				getRenderAtLocation
+			)
+
+			expect(result.elements).toHaveLength(1)
+			const refEl = result.elements[0] as ButtonGraphicsReferenceDrawElement
+			expect(refEl.children).toHaveLength(0)
+			expect(getRenderAtLocation).not.toHaveBeenCalled()
+		})
+
+		test('produces an empty reference element when location is invalid', async () => {
+			const getRenderAtLocation = vi.fn(() => null)
+			const elements: SomeButtonGraphicsElement[] = [makeReferenceEl({ location: val('not-valid') })]
+
+			const result = await ConvertSomeButtonGraphicsElementForDrawing(
+				createMockInstanceDefinitions(),
+				createMockParser(),
+				mockDrawPixelBuffers,
+				elements,
+				new Map(),
+				true,
+				null,
+				'1/0/0',
+				getRenderAtLocation
+			)
+
+			const refEl = result.elements[0] as ButtonGraphicsReferenceDrawElement
+			expect(refEl.children).toHaveLength(0)
+		})
+
+		test('produces an empty reference element when no render exists at the location', async () => {
+			const getRenderAtLocation = vi.fn(() => null)
+			const elements: SomeButtonGraphicsElement[] = [makeReferenceEl({ location: val('1/0/1') })]
+
+			const result = await ConvertSomeButtonGraphicsElementForDrawing(
+				createMockInstanceDefinitions(),
+				createMockParser(),
+				mockDrawPixelBuffers,
+				elements,
+				new Map(),
+				true,
+				null,
+				'1/0/0',
+				getRenderAtLocation
+			)
+
+			const refEl = result.elements[0] as ButtonGraphicsReferenceDrawElement
+			expect(refEl.children).toHaveLength(0)
+		})
+
+		test('embeds draw elements from the referenced location', async () => {
+			const referencedDrawElements: SomeButtonGraphicsDrawElement[] = [
+				makeTextDrawEl({ id: 'ref-text', text: 'Hello from ref' }),
+			]
+			const mockRender = createMockImageResult(referencedDrawElements)
+			const getRenderAtLocation = vi.fn(() => mockRender)
+
+			const elements: SomeButtonGraphicsElement[] = [makeReferenceEl({ location: val('1/0/1') })]
+
+			const result = await ConvertSomeButtonGraphicsElementForDrawing(
+				createMockInstanceDefinitions(),
+				createMockParser(),
+				mockDrawPixelBuffers,
+				elements,
+				new Map(),
+				true,
+				null,
+				'1/0/0',
+				getRenderAtLocation
+			)
+
+			expect(result.elements).toHaveLength(1)
+			const refEl = result.elements[0] as ButtonGraphicsReferenceDrawElement
+			expect(refEl.type).toBe('reference')
+			expect(refEl.children).toHaveLength(1)
+			expect(refEl.children[0]).toMatchObject({ type: 'text', text: 'Hello from ref' })
+		})
+
+		test('excludes canvas elements from the referenced location', async () => {
+			const canvasDrawEl: ButtonGraphicsCanvasDrawElement = {
+				id: 'canvas1',
+				type: 'canvas',
+				usage: ButtonGraphicsElementUsage.Automatic,
+				contentHash: 'hash-canvas',
+				decoration: ButtonGraphicsDecorationType.FollowDefault,
+				showStatusIcons: ButtonGraphicsShowStatusIcons.FollowDefault,
+			}
+			const referencedDrawElements: SomeButtonGraphicsDrawElement[] = [
+				canvasDrawEl,
+				makeTextDrawEl({ id: 'ref-text', text: 'Visible' }),
+			]
+			const mockRender = createMockImageResult(referencedDrawElements)
+			const getRenderAtLocation = vi.fn(() => mockRender)
+
+			const elements: SomeButtonGraphicsElement[] = [makeReferenceEl({ location: val('1/0/1') })]
+
+			const result = await ConvertSomeButtonGraphicsElementForDrawing(
+				createMockInstanceDefinitions(),
+				createMockParser(),
+				mockDrawPixelBuffers,
+				elements,
+				new Map(),
+				true,
+				null,
+				'1/0/0',
+				getRenderAtLocation
+			)
+
+			const refEl = result.elements[0] as ButtonGraphicsReferenceDrawElement
+			// Canvas should be excluded; only the text should appear
+			expect(refEl.children).toHaveLength(1)
+			expect(refEl.children[0].type).toBe('text')
+		})
+
+		test('records the referenced location in referencedLocations', async () => {
+			const referencedDrawElements: SomeButtonGraphicsDrawElement[] = [makeTextDrawEl({ id: 'ref-text', text: 'Hi' })]
+			const mockRender = createMockImageResult(referencedDrawElements)
+			const getRenderAtLocation = vi.fn(() => mockRender)
+
+			const elements: SomeButtonGraphicsElement[] = [makeReferenceEl({ location: val('1/0/1') })]
+
+			const result = await ConvertSomeButtonGraphicsElementForDrawing(
+				createMockInstanceDefinitions(),
+				createMockParser(),
+				mockDrawPixelBuffers,
+				elements,
+				new Map(),
+				true,
+				null,
+				'1/0/0',
+				getRenderAtLocation
+			)
+
+			expect(result.referencedLocations.has('1/0/1')).toBe(true)
+		})
+
+		test('shows placeholder when reference target is the current location (self-loop)', async () => {
+			const getRenderAtLocation = vi.fn(() => null)
+
+			const elements: SomeButtonGraphicsElement[] = [makeReferenceEl({ location: val('1/0/0') })]
+
+			const result = await ConvertSomeButtonGraphicsElementForDrawing(
+				createMockInstanceDefinitions(),
+				createMockParser(),
+				mockDrawPixelBuffers,
+				elements,
+				new Map(),
+				true,
+				null,
+				'1/0/0', // same location as target → self-reference loop
+				getRenderAtLocation
+			)
+
+			const refEl = result.elements[0] as ButtonGraphicsReferenceDrawElement
+			expect(refEl.children).toHaveLength(1)
+			expect(refEl.children[0].type).toBe('text')
+		})
+
+		test('shows placeholder when reference target transitively references the current location (indirect loop)', async () => {
+			// Target '1/0/1' has already been rendered, and its render references back to '1/0/0'
+			const targetRender = createMockImageResult(
+				[makeTextDrawEl({ id: 'ref-text', text: 'Unreachable' })],
+				new Set(['1/0/0']) // back-reference to current button
+			)
+			const getRenderAtLocation = vi.fn(() => targetRender)
+
+			const elements: SomeButtonGraphicsElement[] = [makeReferenceEl({ location: val('1/0/1') })]
+
+			const result = await ConvertSomeButtonGraphicsElementForDrawing(
+				createMockInstanceDefinitions(),
+				createMockParser(),
+				mockDrawPixelBuffers,
+				elements,
+				new Map(),
+				true,
+				null,
+				'1/0/0',
+				getRenderAtLocation
+			)
+
+			const refEl = result.elements[0] as ButtonGraphicsReferenceDrawElement
+			expect(refEl.children).toHaveLength(1)
+			expect(refEl.children[0].type).toBe('text')
+		})
+
+		test('propagates transitive referencedLocations from the target render', async () => {
+			const targetRender = createMockImageResult(
+				[makeTextDrawEl({ id: 'ref-text', text: 'Hi' })],
+				new Set(['1/0/2', '1/0/3'])
+			)
+			const getRenderAtLocation = vi.fn(() => targetRender)
+
+			const elements: SomeButtonGraphicsElement[] = [makeReferenceEl({ location: val('1/0/1') })]
+
+			const result = await ConvertSomeButtonGraphicsElementForDrawing(
+				createMockInstanceDefinitions(),
+				createMockParser(),
+				mockDrawPixelBuffers,
+				elements,
+				new Map(),
+				true,
+				null,
+				'1/0/0',
+				getRenderAtLocation
+			)
+
+			expect(result.referencedLocations.has('1/0/1')).toBe(true)
+			expect(result.referencedLocations.has('1/0/2')).toBe(true)
+			expect(result.referencedLocations.has('1/0/3')).toBe(true)
+		})
+
+		test('reference element is omitted when disabled and onlyEnabled=true', async () => {
+			const elements: SomeButtonGraphicsElement[] = [makeReferenceEl({ enabled: val(false), location: val('1/0/1') })]
+
+			const result = await ConvertSomeButtonGraphicsElementForDrawing(
+				createMockInstanceDefinitions(),
+				createMockParser(),
+				mockDrawPixelBuffers,
+				elements,
+				new Map(),
+				true,
+				null,
+				'1/0/0',
+				vi.fn(() => null)
+			)
+
+			expect(result.elements).toHaveLength(0)
 		})
 	})
 })

--- a/companion/test/Graphics/ConvertGraphicsElements.test.ts
+++ b/companion/test/Graphics/ConvertGraphicsElements.test.ts
@@ -1991,8 +1991,9 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 			expect(result.elements).toHaveLength(1)
 			expect(result.elements[0].type).toBe('reference')
 			const refEl = result.elements[0] as ButtonGraphicsReferenceDrawElement
-			expect(refEl.children).toHaveLength(1)
-			expect(refEl.children[0].type).toBe('text')
+			expect(refEl.children).toHaveLength(2)
+			expect(refEl.children[0].type).toBe('box')
+			expect(refEl.children[1].type).toBe('text')
 		})
 
 		test('produces an empty reference element when location is empty', async () => {
@@ -2161,8 +2162,9 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 			)
 
 			const refEl = result.elements[0] as ButtonGraphicsReferenceDrawElement
-			expect(refEl.children).toHaveLength(1)
-			expect(refEl.children[0].type).toBe('text')
+			expect(refEl.children).toHaveLength(2)
+			expect(refEl.children[0].type).toBe('box')
+			expect(refEl.children[1].type).toBe('text')
 		})
 
 		test('shows placeholder when reference target transitively references the current location (indirect loop)', async () => {
@@ -2188,8 +2190,9 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 			)
 
 			const refEl = result.elements[0] as ButtonGraphicsReferenceDrawElement
-			expect(refEl.children).toHaveLength(1)
-			expect(refEl.children[0].type).toBe('text')
+			expect(refEl.children).toHaveLength(2)
+			expect(refEl.children[0].type).toBe('box')
+			expect(refEl.children[1].type).toBe('text')
 		})
 
 		test('propagates transitive referencedLocations from the target render', async () => {

--- a/companion/test/Graphics/ConvertGraphicsElements.test.ts
+++ b/companion/test/Graphics/ConvertGraphicsElements.test.ts
@@ -1125,6 +1125,44 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 			const childSetCalls = setSpy.mock.calls.filter((call) => call[0] === childKey)
 			expect(childSetCalls).toHaveLength(0)
 		})
+
+		test('cache hit still propagates referencedLocation into global referencedLocations', async () => {
+			const cache = new ElementConversionCache()
+			const referencedDrawElements: SomeButtonGraphicsDrawElement[] = [makeTextDrawEl({ id: 'ref-text', text: 'Hi' })]
+			const mockRender = createMockImageResult(referencedDrawElements)
+			const getRenderAtLocation = vi.fn(() => mockRender)
+
+			const elements: SomeButtonGraphicsElement[] = [makeReferenceEl({ location: val('2/0/0') })]
+
+			// First call — populates cache
+			const result1 = await ConvertSomeButtonGraphicsElementForDrawing(
+				createMockInstanceDefinitions(),
+				createMockParser(),
+				mockDrawPixelBuffers,
+				elements,
+				new Map(),
+				true,
+				cache,
+				'1/0/0',
+				getRenderAtLocation
+			)
+			expect(result1.referencedLocations.has('2/0/0')).toBe(true)
+
+			// Second call — cache hit path
+			const result2 = await ConvertSomeButtonGraphicsElementForDrawing(
+				createMockInstanceDefinitions(),
+				createMockParser(),
+				mockDrawPixelBuffers,
+				elements,
+				new Map(),
+				true,
+				cache,
+				'1/0/0',
+				getRenderAtLocation
+			)
+			// Must still report '2/0/0' even though element was served from cache
+			expect(result2.referencedLocations.has('2/0/0')).toBe(true)
+		})
 	})
 
 	describe('feedback overrides', () => {
@@ -2196,6 +2234,75 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 			)
 
 			expect(result.elements).toHaveLength(0)
+		})
+
+		test('cyclicLocations is empty when no cycle exists', async () => {
+			const mockRender = createMockImageResult([makeTextDrawEl({ id: 'ref-text', text: 'Hi' })])
+			const getRenderAtLocation = vi.fn(() => mockRender)
+
+			const elements: SomeButtonGraphicsElement[] = [makeReferenceEl({ location: val('1/0/1') })]
+
+			const result = await ConvertSomeButtonGraphicsElementForDrawing(
+				createMockInstanceDefinitions(),
+				createMockParser(),
+				mockDrawPixelBuffers,
+				elements,
+				new Map(),
+				true,
+				null,
+				'1/0/0',
+				getRenderAtLocation
+			)
+
+			expect(result.cyclicLocations.size).toBe(0)
+		})
+
+		test('cyclicLocations contains the location on a self-reference loop', async () => {
+			const getRenderAtLocation = vi.fn(() => null)
+
+			const elements: SomeButtonGraphicsElement[] = [makeReferenceEl({ location: val('1/0/0') })]
+
+			const result = await ConvertSomeButtonGraphicsElementForDrawing(
+				createMockInstanceDefinitions(),
+				createMockParser(),
+				mockDrawPixelBuffers,
+				elements,
+				new Map(),
+				true,
+				null,
+				'1/0/0', // self-reference
+				getRenderAtLocation
+			)
+
+			expect(result.cyclicLocations.has('1/0/0')).toBe(true)
+			// Also tracked in referencedLocations
+			expect(result.referencedLocations.has('1/0/0')).toBe(true)
+		})
+
+		test('cyclicLocations contains the location on an indirect loop', async () => {
+			// Target '1/0/1' has a render that references back to '1/0/0'
+			const targetRender = createMockImageResult([makeTextDrawEl({ id: 'ref-text', text: 'Loop' })], new Set(['1/0/0']))
+			const getRenderAtLocation = vi.fn(() => targetRender)
+
+			const elements: SomeButtonGraphicsElement[] = [makeReferenceEl({ location: val('1/0/1') })]
+
+			const result = await ConvertSomeButtonGraphicsElementForDrawing(
+				createMockInstanceDefinitions(),
+				createMockParser(),
+				mockDrawPixelBuffers,
+				elements,
+				new Map(),
+				true,
+				null,
+				'1/0/0',
+				getRenderAtLocation
+			)
+
+			expect(result.cyclicLocations.has('1/0/1')).toBe(true)
+			// The direct location is still in referencedLocations
+			expect(result.referencedLocations.has('1/0/1')).toBe(true)
+			// Only the cyclic entry, not an unrelated location
+			expect(result.cyclicLocations.size).toBe(1)
 		})
 	})
 })

--- a/shared-lib/lib/Graphics/ElementPropertiesSchemas.ts
+++ b/shared-lib/lib/Graphics/ElementPropertiesSchemas.ts
@@ -455,6 +455,25 @@ export const compositeElementSchema: ElementSchemaSection[] = [
 	{ id: 'position', label: 'Position & Size', fields: [...boundsFields] },
 ]
 
+export const referenceElementSchema: ElementSchemaSection[] = [
+	{ id: 'layer', label: 'Layer', fields: [...commonElementFields] },
+	{ id: 'position', label: 'Position & Size', fields: [...boundsFields, ...rotationFields] },
+	{
+		id: 'source',
+		label: 'Source',
+		fields: [
+			{
+				type: 'textinput',
+				id: 'location',
+				label: 'Location',
+				tooltip: 'The location of the button to reference, in the format "page/row/column"',
+				default: '',
+				useVariables: CompanionFieldVariablesSupport.InternalParser,
+			},
+		],
+	},
+]
+
 /**
  * Section-structured schemas per element type.
  */
@@ -467,6 +486,7 @@ export const elementSchemas = {
 	circle: circleElementSchema,
 	composite: compositeElementSchema,
 	canvas: canvasElementSchema,
+	reference: referenceElementSchema,
 } as const satisfies Record<string, ElementSchemaSection[]>
 
 export function getElementSchemaProperty(

--- a/shared-lib/lib/Graphics/ElementPropertiesSchemas.ts
+++ b/shared-lib/lib/Graphics/ElementPropertiesSchemas.ts
@@ -466,7 +466,8 @@ export const referenceElementSchema: ElementSchemaSection[] = [
 				type: 'textinput',
 				id: 'location',
 				label: 'Location',
-				tooltip: 'The location of the button to reference, in the format "page/row/column"',
+				tooltip:
+					'The location of the button to reference, in the format "page/row/column" (e.g. "1/0/0" for page 1, row 0, column 0)',
 				default: '',
 				useVariables: CompanionFieldVariablesSupport.InternalParser,
 			},

--- a/shared-lib/lib/Graphics/LayeredRenderer.ts
+++ b/shared-lib/lib/Graphics/LayeredRenderer.ts
@@ -6,6 +6,7 @@ import type {
 	ButtonGraphicsGroupDrawElement,
 	ButtonGraphicsImageDrawElement,
 	ButtonGraphicsLineDrawElement,
+	ButtonGraphicsReferenceDrawElement,
 	ButtonGraphicsTextDrawElement,
 	SomeButtonGraphicsDrawElement,
 } from '../Model/StyleLayersModel.js'
@@ -122,6 +123,24 @@ export class GraphicsLayeredButtonRenderer {
 						})
 						break
 					}
+					case 'reference': {
+						await img.usingTemporaryLayer(element.opacity, async (img) => {
+							await img.usingRotation(drawBounds, element.rotation, async () => {
+								elementBounds = await this.#drawReferenceElement(img, drawBounds, element, skipDraw)
+
+								await this.#drawElements(
+									img,
+									element.children,
+									elementsToHide,
+									selectedElementId,
+									rootBounds,
+									elementBounds,
+									skipDraw
+								)
+							})
+						})
+						break
+					}
 					case 'image':
 						elementBounds = await this.#drawImageElement(img, drawBounds, element, skipDraw)
 
@@ -182,6 +201,15 @@ export class GraphicsLayeredButtonRenderer {
 		}
 
 		return drawBounds
+	}
+
+	static async #drawReferenceElement(
+		_img: ImageBase<any>,
+		parentBounds: DrawBounds,
+		element: ButtonGraphicsReferenceDrawElement,
+		_skipDraw: boolean
+	): Promise<DrawBounds> {
+		return parentBounds.compose(element.x, element.y, element.width, element.height)
 	}
 
 	static async #drawImageElement(

--- a/shared-lib/lib/Graphics/LayeredRenderer.ts
+++ b/shared-lib/lib/Graphics/LayeredRenderer.ts
@@ -128,6 +128,8 @@ export class GraphicsLayeredButtonRenderer {
 							await img.usingRotation(drawBounds, element.rotation, async () => {
 								elementBounds = await this.#drawReferenceElement(img, drawBounds, element, skipDraw)
 
+								// Note: children of a reference element cannot be individually selected,
+								// so the return value (selected child bounds) is intentionally discarded.
 								await this.#drawElements(
 									img,
 									element.children,

--- a/shared-lib/lib/Model/StyleLayersModel.ts
+++ b/shared-lib/lib/Model/StyleLayersModel.ts
@@ -198,6 +198,18 @@ export interface ButtonGraphicsCompositeElement extends ButtonGraphicsElementBas
 	[customKey: CompositeElementOptionKey]: ExpressionOrValue<JsonValue | undefined> | undefined
 }
 
+export interface ButtonGraphicsReferenceDrawElement
+	extends ButtonGraphicsDrawBase, ButtonGraphicsDrawBounds, ButtonGraphicsDrawRotation {
+	type: 'reference'
+	children: SomeButtonGraphicsDrawElement[]
+}
+
+export interface ButtonGraphicsReferenceElement
+	extends ButtonGraphicsElementBase, ButtonGraphicsBounds, ButtonGraphicsRotation {
+	type: 'reference'
+	location: ExpressionOrValue<string>
+}
+
 export type SomeButtonGraphicsDrawElement =
 	| ButtonGraphicsCanvasDrawElement
 	| ButtonGraphicsTextDrawElement
@@ -206,6 +218,7 @@ export type SomeButtonGraphicsDrawElement =
 	| ButtonGraphicsLineDrawElement
 	| ButtonGraphicsGroupDrawElement
 	| ButtonGraphicsCircleDrawElement
+	| ButtonGraphicsReferenceDrawElement
 
 export type SomeButtonGraphicsElement =
 	| ButtonGraphicsCanvasElement
@@ -216,3 +229,4 @@ export type SomeButtonGraphicsElement =
 	| ButtonGraphicsGroupElement
 	| ButtonGraphicsCircleElement
 	| ButtonGraphicsCompositeElement
+	| ButtonGraphicsReferenceElement

--- a/shared-lib/lib/Model/StyleModel.ts
+++ b/shared-lib/lib/Model/StyleModel.ts
@@ -18,6 +18,12 @@ export interface DrawStyleLayeredButtonModel extends DrawStyleButtonStateProps {
 	drawType: 'button' | 'pagenum' | 'pageup' | 'pagedown'
 
 	elements: SomeButtonGraphicsDrawElement[]
+
+	/**
+	 * Location strings (e.g. '1/0/0') transitively referenced by this button's elements.
+	 * Only populated for layered buttons that went through reference element resolution.
+	 */
+	referencedLocations?: ReadonlySet<string>
 }
 
 export interface DrawImageBuffer {

--- a/tools/generate_graphics_types.mts
+++ b/tools/generate_graphics_types.mts
@@ -175,7 +175,29 @@ for (const [id, sections] of Object.entries(elementSchemas)) {
 
 	const filteredFields = fields.filter((field) => !ignoreFields.has(field.id))
 
-	if (id !== 'composite') {
+	if (id === 'reference') {
+		// Reference element has a manually defined draw form with embedded children
+		// Only generate the element (config) interface; the draw interface is handled manually below
+		const drawElementName = `ButtonGraphicsReferenceDrawElement`
+		allDrawElementTypes.push(drawElementName)
+
+		generatedFile += `export interface ${drawElementName} extends ${drawInterfaces.filter((i) => i !== 'ButtonGraphicsDrawBase' || true).join(', ')} {\n`
+		generatedFile += `\ttype: 'reference'\n`
+		generatedFile += `\tchildren: SomeButtonGraphicsDrawElement[]\n`
+		generatedFile += '}\n\n'
+
+		// Generate the config element interface (location field comes from schema)
+		const elementName = `ButtonGraphics${typeName}Element`
+		allElementTypes.push(elementName)
+
+		generatedFile += `export interface ${elementName} extends ${elementInterfaces.join(', ')} {\n`
+		generatedFile += `\ttype: 'reference'\n`
+		for (const field of filteredFields) {
+			const tsType = convertFieldType(field, true)
+			generatedFile += `\t${field.id}: ${tsType}\n`
+		}
+		generatedFile += '}\n\n'
+	} else if (id !== 'composite') {
 		// Generate draw element interface
 		const drawElementName = `ButtonGraphics${typeName}DrawElement`
 		allDrawElementTypes.push(drawElementName)
@@ -188,26 +210,38 @@ for (const [id, sections] of Object.entries(elementSchemas)) {
 		}
 		if (id === 'group') generatedFile += `\tchildren: SomeButtonGraphicsDrawElement[]\n`
 		generatedFile += '}\n\n'
-	}
 
-	// Generate raw element interface
-	const elementName = `ButtonGraphics${typeName}Element`
-	allElementTypes.push(elementName)
+		// Generate raw element interface
+		const elementName = `ButtonGraphics${typeName}Element`
+		allElementTypes.push(elementName)
 
-	generatedFile += `export interface ${elementName} extends ${elementInterfaces.join(', ')} {\n`
-	generatedFile += `\ttype: '${id}'\n`
-	for (const field of filteredFields) {
-		const tsType = convertFieldType(field, true)
-		generatedFile += `\t${field.id}: ${tsType}\n`
+		generatedFile += `export interface ${elementName} extends ${elementInterfaces.join(', ')} {\n`
+		generatedFile += `\ttype: '${id}'\n`
+		for (const field of filteredFields) {
+			const tsType = convertFieldType(field, true)
+			generatedFile += `\t${field.id}: ${tsType}\n`
+		}
+		if (id === 'group') generatedFile += `\tchildren: SomeButtonGraphicsElement[]\n`
+		generatedFile += '}\n\n'
+	} else {
+		// composite - no draw element, just config element
+		const elementName = `ButtonGraphics${typeName}Element`
+		allElementTypes.push(elementName)
+
+		generatedFile += `export interface ${elementName} extends ${elementInterfaces.join(', ')} {\n`
+		generatedFile += `\ttype: '${id}'\n`
+		for (const field of filteredFields) {
+			const tsType = convertFieldType(field, true)
+			generatedFile += `\t${field.id}: ${tsType}\n`
+		}
+		if (id === 'composite') {
+			generatedFile += `\tconnectionId: string\n`
+			generatedFile += `\telementId: string\n`
+			generatedFile += `\n\t/**\n\t* Custom elements have options defined by their composite definition\n\t */\n`
+			generatedFile += `\t[customKey: CompositeElementOptionKey]: ExpressionOrValue<JsonValue | undefined> | undefined\n`
+		}
+		generatedFile += '}\n\n'
 	}
-	if (id === 'group') generatedFile += `\tchildren: SomeButtonGraphicsElement[]\n`
-	if (id === 'composite') {
-		generatedFile += `\tconnectionId: string\n`
-		generatedFile += `\telementId: string\n`
-		generatedFile += `\n\t/**\n\t* Custom elements have options defined by their composite definition\n\t */\n`
-		generatedFile += `\t[customKey: CompositeElementOptionKey]: ExpressionOrValue<JsonValue | undefined> | undefined\n`
-	}
-	generatedFile += '}\n\n'
 }
 
 generatedFile += `export type SomeButtonGraphicsDrawElement =\n`

--- a/webui/src/Buttons/EditButton/LayeredButtonEditor/Buttons.tsx
+++ b/webui/src/Buttons/EditButton/LayeredButtonEditor/Buttons.tsx
@@ -5,6 +5,7 @@ import {
 	faEye,
 	faImage,
 	faLayerGroup,
+	faLink,
 	faMinus,
 	faPlus,
 	faSquare,
@@ -249,6 +250,13 @@ const AddElementDropdownPopoverContent = observer(function AddElementDropdownPop
 				elementType="circle"
 				label="Circle"
 				icon={faCircle}
+			/>
+			<AddElementDropdownPopoverButton
+				styleStore={styleStore}
+				controlId={controlId}
+				elementType="reference"
+				label="Reference"
+				icon={faLink}
 			/>
 
 			{/* Composite Elements grouped by connection */}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reference elements for layered buttons to embed another control’s visuals.
  * New "Reference" option (link icon) in the layered button editor.
  * References trigger targeted redraws when their source control renders, improving update efficiency.
  * Circular references are detected and suppressed to avoid infinite redraw loops; unresolved references show a placeholder.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->