### PR TITLE
feat: add action and feedback to enable/monitor active remote surfaces #4194

### DIFF
--- a/companion/lib/Controls/ControlTypes/Button/Layered.ts
+++ b/companion/lib/Controls/ControlTypes/Button/Layered.ts
@@ -315,7 +315,13 @@ export class ControlButtonLayered
 		foundConnectionLabels: Set<string>,
 		foundVariables: Set<string>
 	): void {
-		new VisitorReferencesCollector(this.deps.internalModule, foundConnectionIds, foundConnectionLabels, foundVariables)
+		new VisitorReferencesCollector(
+			this.deps.internalModule,
+			foundConnectionIds,
+			foundConnectionLabels,
+			foundVariables,
+			undefined
+		)
 			.visitEntities(this.entities.getAllEntities(), [])
 			.visitDrawElements(this.#drawElements)
 	}
@@ -656,7 +662,12 @@ export class ControlButtonLayered
 		const allEntities = this.entities.getAllEntities()
 
 		// Fix up references
-		const changed = new VisitorReferencesUpdater(this.deps.internalModule, { [labelFrom]: labelTo }, undefined)
+		const changed = new VisitorReferencesUpdater(
+			this.deps.internalModule,
+			{ [labelFrom]: labelTo },
+			undefined,
+			undefined
+		)
 			.visitEntities(allEntities, [])
 			.visitDrawElements(this.#drawElements)
 			.recheckChangedFeedbacks()

--- a/companion/lib/Controls/ControlTypes/Button/Preset.ts
+++ b/companion/lib/Controls/ControlTypes/Button/Preset.ts
@@ -286,7 +286,13 @@ export class ControlButtonPreset
 		foundConnectionLabels: Set<string>,
 		foundVariables: Set<string>
 	): void {
-		new VisitorReferencesCollector(this.deps.internalModule, foundConnectionIds, foundConnectionLabels, foundVariables)
+		new VisitorReferencesCollector(
+			this.deps.internalModule,
+			foundConnectionIds,
+			foundConnectionLabels,
+			foundVariables,
+			undefined
+		)
 			.visitDrawElements(this.#drawElements)
 			.visitEntities(this.entities.getAllEntities(), [])
 	}
@@ -300,7 +306,12 @@ export class ControlButtonPreset
 		const allEntities = this.entities.getAllEntities()
 
 		// Fix up references
-		const changed = new VisitorReferencesUpdater(this.deps.internalModule, { [labelFrom]: labelTo }, undefined)
+		const changed = new VisitorReferencesUpdater(
+			this.deps.internalModule,
+			{ [labelFrom]: labelTo },
+			undefined,
+			undefined
+		)
 			.visitDrawElements(this.#drawElements)
 			.visitEntities(allEntities, [])
 			.recheckChangedFeedbacks()

--- a/companion/lib/Controls/ControlTypes/ExpressionVariable.ts
+++ b/companion/lib/Controls/ControlTypes/ExpressionVariable.ts
@@ -173,7 +173,8 @@ export class ControlExpressionVariable
 			this.deps.internalModule,
 			foundConnectionIds,
 			foundConnectionLabels,
-			foundVariables
+			foundVariables,
+			undefined
 		).visitEntities(this.entities.getAllEntities(), [])
 	}
 
@@ -217,7 +218,12 @@ export class ControlExpressionVariable
 		const allEntities = this.entities.getAllEntities()
 
 		// Fix up references
-		const changed = new VisitorReferencesUpdater(this.deps.internalModule, { [labelFrom]: labelTo }, undefined)
+		const changed = new VisitorReferencesUpdater(
+			this.deps.internalModule,
+			{ [labelFrom]: labelTo },
+			undefined,
+			undefined
+		)
 			.visitEntities(allEntities, [])
 			.recheckChangedFeedbacks()
 			.hasChanges()

--- a/companion/lib/Controls/ControlTypes/Triggers/Trigger.ts
+++ b/companion/lib/Controls/ControlTypes/Triggers/Trigger.ts
@@ -281,7 +281,13 @@ export class ControlTrigger
 		foundConnectionLabels: Set<string>,
 		foundVariables: Set<string>
 	): void {
-		new VisitorReferencesCollector(this.deps.internalModule, foundConnectionIds, foundConnectionLabels, foundVariables)
+		new VisitorReferencesCollector(
+			this.deps.internalModule,
+			foundConnectionIds,
+			foundConnectionLabels,
+			foundVariables,
+			undefined
+		)
 			.visitEntities(this.entities.getAllEntities(), [])
 			.visitEvents(this.events)
 	}
@@ -398,7 +404,12 @@ export class ControlTrigger
 	 */
 	renameVariables(labelFrom: string, labelTo: string): void {
 		// Fix up references
-		const changed = new VisitorReferencesUpdater(this.deps.internalModule, { [labelFrom]: labelTo }, undefined)
+		const changed = new VisitorReferencesUpdater(
+			this.deps.internalModule,
+			{ [labelFrom]: labelTo },
+			undefined,
+			undefined
+		)
 			.visitEntities(this.entities.getAllEntities(), [])
 			.visitEvents(this.events)
 			.recheckChangedFeedbacks()

--- a/companion/lib/Graphics/ConvertGraphicsElements.ts
+++ b/companion/lib/Graphics/ConvertGraphicsElements.ts
@@ -498,6 +498,7 @@ function parseCompositeElementChildOptions(
 			case 'internal:page':
 			case 'internal:image-file':
 			case 'internal:surface_serial':
+			case 'internal:outbound_surface_id':
 			case 'internal:vertical-alignment':
 			case 'internal:trigger':
 			case 'internal:trigger_collection':

--- a/companion/lib/ImportExport/Import.ts
+++ b/companion/lib/ImportExport/Import.ts
@@ -82,7 +82,7 @@ export class ImportController {
 		}
 		this.#graphicsController.clearAllForPage(topage)
 
-		this.#performPageImport(pageInfo, topage, instanceIdMap)
+		this.#performPageImport(pageInfo, topage, instanceIdMap, undefined)
 
 		// Report the used remap to the ui, for future imports
 		const instanceRemap2: ConnectionRemappings = {}
@@ -121,7 +121,7 @@ export class ImportController {
 			// If trigger already exists, generate a new id
 			if (this.#controlsController.getControl(controlId)) controlId = CreateTriggerControlId(nanoid())
 
-			const fixedControlObj = fixupTriggerControl(this.#internalModule, trigger, instanceIdMap)
+			const fixedControlObj = fixupTriggerControl(this.#internalModule, trigger, instanceIdMap, undefined)
 			this.#controlsController.importTrigger(controlId, fixedControlObj)
 		}
 
@@ -151,6 +151,16 @@ export class ImportController {
 			: {}
 		const instanceIdMap = this.#importInstances(data.instances, preserveRemap)
 
+		// Pre-compute outbound surface ID remap so pages and triggers can reference new IDs
+		const outboundSurfaceIdRemap: Record<string, string> = {}
+		if (isImporting(config.surfaces.remote)) {
+			for (const remoteInfo of Object.values(data.surfacesRemote || {})) {
+				if (remoteInfo && remoteInfo.id) {
+					outboundSurfaceIdRemap[remoteInfo.id] = nanoid()
+				}
+			}
+		}
+
 		// import custom variables
 		if (isImporting(config.customVariables)) {
 			this.#variablesController.custom.replaceCollections(data.customVariablesCollections || [])
@@ -163,7 +173,12 @@ export class ImportController {
 
 			for (const [id, variableDefinition] of Object.entries(data.expressionVariables || {})) {
 				const controlId = CreateExpressionVariableControlId(id)
-				const fixedControlObj = fixupExpressionVariableControl(this.#internalModule, variableDefinition, instanceIdMap)
+				const fixedControlObj = fixupExpressionVariableControl(
+					this.#internalModule,
+					variableDefinition,
+					instanceIdMap,
+					outboundSurfaceIdRemap
+				)
 
 				this.#controlsController.importExpressionVariable(controlId, fixedControlObj)
 			}
@@ -190,7 +205,7 @@ export class ImportController {
 					)
 				}
 
-				this.#performPageImport(pageInfo, pageNumber, instanceIdMap)
+				this.#performPageImport(pageInfo, pageNumber, instanceIdMap, outboundSurfaceIdRemap)
 			}
 		}
 
@@ -278,11 +293,15 @@ export class ImportController {
 						surfaceInstancesMap.get(instanceId) || fallbackSurfaceInstances.get(remoteInfo.moduleId) || instanceId
 				}
 
+				// Use the pre-computed new ID to avoid conflicts
+				const newId = outboundSurfaceIdRemap[remoteInfo.id] ?? remoteInfo.id
+
 				// Future: validation
 				this.#surfacesController.outbound.addOutboundConnection({
 					...remoteInfo,
 					// Translate the instanceId
 					instanceId: instanceId,
+					id: newId,
 				})
 			}
 		}
@@ -295,7 +314,12 @@ export class ImportController {
 
 			for (const [id, trigger] of Object.entries(data.triggers || {})) {
 				const controlId = CreateTriggerControlId(id)
-				const fixedControlObj = fixupTriggerControl(this.#internalModule, trigger, instanceIdMap)
+				const fixedControlObj = fixupTriggerControl(
+					this.#internalModule,
+					trigger,
+					instanceIdMap,
+					outboundSurfaceIdRemap
+				)
 				this.#controlsController.importTrigger(controlId, fixedControlObj)
 			}
 		}
@@ -312,7 +336,8 @@ export class ImportController {
 	#performPageImport = (
 		pageInfo: ExportPageContentv6,
 		topage: number,
-		instanceIdMap: InstanceAppliedRemappings
+		instanceIdMap: InstanceAppliedRemappings,
+		outboundSurfaceIdRemap: Record<string, string> | undefined
 	): void => {
 		{
 			// Ensure the configured grid size is large enough for the import
@@ -348,7 +373,8 @@ export class ImportController {
 		const referencesUpdater = new VisitorReferencesUpdater(
 			this.#internalModule,
 			connectionLabelRemap,
-			connectionIdRemap
+			connectionIdRemap,
+			outboundSurfaceIdRemap
 		)
 
 		// Import the controls

--- a/companion/lib/ImportExport/ImportFixup.ts
+++ b/companion/lib/ImportExport/ImportFixup.ts
@@ -55,7 +55,7 @@ export function fixupTriggerControl(
 	}
 
 	new VisitorReferencesUpdater(internalModule, connectionLabelRemap, connectionIdRemap, outboundSurfaceIdRemap)
-		.visitEntities([], result.condition.concat(result.actions))
+		.visitEntities([], [...result.localVariables, ...result.condition, ...result.actions])
 		.visitEvents(result.events || [])
 
 	return result

--- a/companion/lib/ImportExport/ImportFixup.ts
+++ b/companion/lib/ImportExport/ImportFixup.ts
@@ -17,7 +17,8 @@ export type InstanceAppliedRemappings = Record<
 export function fixupTriggerControl(
 	internalModule: InternalController,
 	control: ExportTriggerContentv6,
-	instanceIdMap: InstanceAppliedRemappings
+	instanceIdMap: InstanceAppliedRemappings,
+	outboundSurfaceIdRemap: Record<string, string> | undefined
 ): TriggerModel {
 	// Future: this does not feel durable
 
@@ -53,7 +54,7 @@ export function fixupTriggerControl(
 		result.localVariables = fixupEntitiesRecursive(instanceIdMap, structuredClone(control.localVariables))
 	}
 
-	new VisitorReferencesUpdater(internalModule, connectionLabelRemap, connectionIdRemap)
+	new VisitorReferencesUpdater(internalModule, connectionLabelRemap, connectionIdRemap, outboundSurfaceIdRemap)
 		.visitEntities([], result.condition.concat(result.actions))
 		.visitEvents(result.events || [])
 
@@ -63,7 +64,8 @@ export function fixupTriggerControl(
 export function fixupExpressionVariableControl(
 	internalModule: InternalController,
 	control: ExpressionVariableModel,
-	instanceIdMap: InstanceAppliedRemappings
+	instanceIdMap: InstanceAppliedRemappings,
+	outboundSurfaceIdRemap: Record<string, string>
 ): ExpressionVariableModel {
 	// Future: this does not feel durable
 
@@ -93,10 +95,12 @@ export function fixupExpressionVariableControl(
 		result.localVariables = fixupEntitiesRecursive(instanceIdMap, structuredClone(control.localVariables))
 	}
 
-	const visitor = new VisitorReferencesUpdater(internalModule, connectionLabelRemap, connectionIdRemap).visitEntities(
-		[],
-		result.localVariables
-	)
+	const visitor = new VisitorReferencesUpdater(
+		internalModule,
+		connectionLabelRemap,
+		connectionIdRemap,
+		outboundSurfaceIdRemap
+	).visitEntities([], result.localVariables)
 	if (result.entity) visitor.visitEntities([], [result.entity])
 
 	return result

--- a/companion/lib/Internal/Surface.ts
+++ b/companion/lib/Internal/Surface.ts
@@ -54,6 +54,13 @@ const CHOICES_SURFACE_GROUP: SomeCompanionInputField = {
 	includeSelf: true,
 }
 
+const CHOICES_OUTBOUND_SURFACE_ID: SomeCompanionInputField = {
+	type: 'internal:outbound_surface_id',
+	label: 'Remote surface',
+	id: 'surfaceId',
+	disableAutoExpression: true,
+}
+
 const CHOICES_PAGE: SomeCompanionInputField = {
 	type: 'internal:page',
 	label: 'Page',
@@ -122,6 +129,10 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 		this.#surfaceController.on('surface-in-group', () => debounceUpdateVariables())
 		this.#surfaceController.on('surface_name', () => debounceUpdateVariables())
 		this.#surfaceController.on('group_name', () => debounceUpdateVariables())
+
+		this.#surfaceController.outbound.events.on('clientInfo', () => {
+			this.emit('checkFeedbacks', 'outbound_surface_enabled')
+		})
 	}
 
 	#fetchSurfaceId(
@@ -424,6 +435,28 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 
 				optionsSupportExpressions: true,
 			},
+
+			outbound_surface_set_enabled: {
+				label: 'Remote surface: Enable/Disable',
+				description: undefined,
+				options: [
+					CHOICES_OUTBOUND_SURFACE_ID,
+					{
+						type: 'dropdown',
+						label: 'Enable',
+						id: 'setType',
+						default: 'toggle',
+						choices: [
+							{ id: 'enable', label: 'Enable' },
+							{ id: 'disable', label: 'Disable' },
+							{ id: 'toggle', label: 'Toggle' },
+						],
+						disableAutoExpression: true,
+					},
+				],
+
+				optionsSupportExpressions: true,
+			},
 		}
 	}
 
@@ -581,6 +614,21 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 				this.#surfaceController.adjustDevicePosition(surfaceId, xAdjustment, yAdjustment, true)
 				break
 			}
+			case 'outbound_surface_set_enabled': {
+				const surfaceId = stringifyVariableValue(action.options.surfaceId)?.trim()
+				if (!surfaceId) break
+
+				const setType = stringifyVariableValue(action.options.setType)
+				let newEnabled: boolean
+				if (setType === 'toggle') {
+					newEnabled = !(this.#surfaceController.outbound.getById(surfaceId)?.enabled ?? false)
+				} else {
+					newEnabled = setType !== 'disable'
+				}
+
+				this.#surfaceController.outbound.setOutboundEnabled(surfaceId, newEnabled)
+				break
+			}
 			default:
 				return null
 		}
@@ -631,6 +679,19 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 				],
 				optionsSupportExpressions: true,
 			},
+
+			outbound_surface_enabled: {
+				feedbackType: FeedbackEntitySubType.Boolean,
+				label: 'Remote surface: When enabled',
+				description: 'Change style when a remote surface is enabled',
+				feedbackStyle: {
+					color: 0xffffff,
+					bgcolor: 0x00aa00,
+				},
+				showInvert: true,
+				options: [CHOICES_OUTBOUND_SURFACE_ID],
+				optionsSupportExpressions: true,
+			},
 		}
 	}
 
@@ -645,9 +706,24 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 
 			return currentPage == thePage
 		}
+		if (feedback.definitionId == 'outbound_surface_enabled') {
+			const surfaceId = stringifyVariableValue(feedback.options.surfaceId)?.trim()
+			if (!surfaceId) return false
+
+			return this.#surfaceController.outbound.getById(surfaceId)?.enabled ?? false
+		}
 	}
 
-	visitReferences(_visitor: InternalVisitor, _actions: ActionForVisitor[], _feedbacks: FeedbackForVisitor[]): void {
-		// Nothing to do
+	visitReferences(visitor: InternalVisitor, actions: ActionForVisitor[], feedbacks: FeedbackForVisitor[]): void {
+		for (const action of actions) {
+			if (action.action === 'outbound_surface_set_enabled') {
+				visitor.visitOutboundSurfaceId(action.options, 'surfaceId')
+			}
+		}
+		for (const feedback of feedbacks) {
+			if (feedback.type === 'outbound_surface_enabled') {
+				visitor.visitOutboundSurfaceId(feedback.options, 'surfaceId', feedback.id)
+			}
+		}
 	}
 }

--- a/companion/lib/Resources/Visitors/ReferencesCollector.ts
+++ b/companion/lib/Resources/Visitors/ReferencesCollector.ts
@@ -8,11 +8,17 @@ export class VisitorReferencesCollector extends VisitorReferencesBase<VisitorRef
 		internalModule: InternalController,
 		foundConnectionIds: Set<string> | undefined,
 		foundConnectionLabels: Set<string> | undefined,
-		foundVariables: Set<string> | undefined
+		foundVariables: Set<string> | undefined,
+		foundOutboundSurfaceIds: Set<string> | undefined
 	) {
 		super(
 			internalModule,
-			new VisitorReferencesCollectorVisitor(foundConnectionIds, foundConnectionLabels, foundVariables)
+			new VisitorReferencesCollectorVisitor(
+				foundConnectionIds,
+				foundConnectionLabels,
+				foundVariables,
+				foundOutboundSurfaceIds
+			)
 		)
 	}
 }
@@ -36,14 +42,31 @@ export class VisitorReferencesCollectorVisitor {
 	 */
 	readonly variables: Set<string>
 
+	/**
+	 * Referenced outbound surface ids
+	 */
+	readonly outboundSurfaceIds: Set<string>
+
 	constructor(
 		foundConnectionIds: Set<string> | undefined,
 		foundConnectionLabels: Set<string> | undefined,
-		foundVariables: Set<string> | undefined
+		foundVariables: Set<string> | undefined,
+		foundOutboundSurfaceIds: Set<string> | undefined
 	) {
 		this.connectionLabels = foundConnectionLabels || new Set()
 		this.connectionIds = foundConnectionIds || new Set()
 		this.variables = foundVariables || new Set()
+		this.outboundSurfaceIds = foundOutboundSurfaceIds || new Set()
+	}
+
+	/**
+	 * Visit an outbound surface id property
+	 */
+	visitOutboundSurfaceId(obj: Record<string, any>, propName: string, _feedbackId?: string): void {
+		const surfaceId = this.#getAndUnwrapPropertyValue(obj, propName)
+		if (surfaceId.isExpression || typeof surfaceId.value !== 'string') return
+
+		this.outboundSurfaceIds.add(surfaceId.value)
 	}
 
 	/**

--- a/companion/lib/Resources/Visitors/ReferencesUpdater.ts
+++ b/companion/lib/Resources/Visitors/ReferencesUpdater.ts
@@ -7,9 +7,13 @@ export class VisitorReferencesUpdater extends VisitorReferencesBase<VisitorRefer
 	constructor(
 		internalModule: InternalController,
 		connectionLabelsRemap: Record<string, string> | undefined,
-		connectionIdRemap: Record<string, string> | undefined
+		connectionIdRemap: Record<string, string> | undefined,
+		outboundSurfaceIdRemap: Record<string, string> | undefined
 	) {
-		super(internalModule, new VisitorReferencesUpdaterVisitor(connectionLabelsRemap, connectionIdRemap))
+		super(
+			internalModule,
+			new VisitorReferencesUpdaterVisitor(connectionLabelsRemap, connectionIdRemap, outboundSurfaceIdRemap)
+		)
 	}
 
 	recheckChangedFeedbacks(): this {
@@ -41,6 +45,11 @@ export class VisitorReferencesUpdaterVisitor {
 	readonly connectionIdRemap: Record<string, string> | undefined
 
 	/**
+	 * outbound surface id remapping
+	 */
+	readonly outboundSurfaceIdRemap: Record<string, string> | undefined
+
+	/**
 	 * Feedback ids that have been changed
 	 */
 	readonly changedFeedbackIds = new Set<string>()
@@ -52,10 +61,12 @@ export class VisitorReferencesUpdaterVisitor {
 
 	constructor(
 		connectionLabelsRemap: Record<string, string> | undefined,
-		connectionIdRemap: Record<string, string> | undefined
+		connectionIdRemap: Record<string, string> | undefined,
+		outboundSurfaceIdRemap: Record<string, string> | undefined
 	) {
 		this.connectionLabelsRemap = connectionLabelsRemap
 		this.connectionIdRemap = connectionIdRemap
+		this.outboundSurfaceIdRemap = outboundSurfaceIdRemap
 	}
 
 	/**
@@ -64,6 +75,24 @@ export class VisitorReferencesUpdaterVisitor {
 	#trackChange(feedbackId: string | undefined): void {
 		this.changed = true
 		if (feedbackId) this.changedFeedbackIds.add(feedbackId)
+	}
+
+	/**
+	 * Visit an outbound surface id property
+	 */
+	visitOutboundSurfaceId(obj: Record<string, any>, propName: string | number, feedbackId?: string): void {
+		if (!this.outboundSurfaceIdRemap) return
+
+		this.#updateValue(obj, propName, (oldValue, isExpression) => {
+			if (!this.outboundSurfaceIdRemap || isExpression) return oldValue // An expression can't be a plain surface id
+
+			const newId = this.outboundSurfaceIdRemap[oldValue]
+			if (newId && newId !== oldValue) {
+				this.#trackChange(feedbackId)
+				return newId
+			}
+			return oldValue
+		})
 	}
 
 	/**

--- a/companion/lib/Surface/Outbound.ts
+++ b/companion/lib/Surface/Outbound.ts
@@ -405,6 +405,26 @@ export class SurfaceOutboundController {
 		})
 	}
 
+	getById(id: string): OutboundSurfaceInfo | undefined {
+		return this.#storage.get(id)
+	}
+
+	setOutboundEnabled(id: string, enabled: boolean): void {
+		const surfaceInfo = this.#storage.get(id)
+		if (!surfaceInfo) return
+
+		surfaceInfo.enabled = !!enabled
+		this.#dbTable.set(id, surfaceInfo)
+
+		this.#startStopConnection(surfaceInfo)
+
+		this.events.emit('clientInfo', {
+			type: 'add',
+			itemId: id,
+			info: surfaceInfo,
+		})
+	}
+
 	addOutboundConnection(newInfo: OutboundSurfaceInfo): void {
 		if (this.#storage.has(newInfo.id)) throw new Error(`Outbound surface with ID ${newInfo.id} already exists`)
 

--- a/companion/lib/Surface/Outbound.ts
+++ b/companion/lib/Surface/Outbound.ts
@@ -286,21 +286,8 @@ export class SurfaceOutboundController {
 				.mutation(async ({ input }) => {
 					const { id, enabled } = input
 
-					const surfaceInfo = this.#storage.get(id)
-					if (!surfaceInfo) throw new Error('Surface not found')
-
-					surfaceInfo.enabled = !!enabled
-					this.#dbTable.set(id, surfaceInfo)
-
-					// Start/stop the connection
-					this.#startStopConnection(surfaceInfo)
-
-					this.events.emit('clientInfo', {
-						type: 'add',
-						itemId: id,
-
-						info: surfaceInfo,
-					})
+					const success = this.setOutboundEnabled(id, enabled)
+					if (!success) throw new Error('Surface not found')
 				}),
 
 			saveConfig: publicProcedure
@@ -409,9 +396,9 @@ export class SurfaceOutboundController {
 		return this.#storage.get(id)
 	}
 
-	setOutboundEnabled(id: string, enabled: boolean): void {
+	setOutboundEnabled(id: string, enabled: boolean): boolean {
 		const surfaceInfo = this.#storage.get(id)
-		if (!surfaceInfo) return
+		if (!surfaceInfo) return false
 
 		surfaceInfo.enabled = !!enabled
 		this.#dbTable.set(id, surfaceInfo)
@@ -423,6 +410,8 @@ export class SurfaceOutboundController {
 			itemId: id,
 			info: surfaceInfo,
 		})
+
+		return true
 	}
 
 	addOutboundConnection(newInfo: OutboundSurfaceInfo): void {

--- a/companion/test/Resources/Visitors/ReferencesCollector.test.ts
+++ b/companion/test/Resources/Visitors/ReferencesCollector.test.ts
@@ -18,8 +18,9 @@ function makeVisitor(opts?: {
 	ids?: Set<string>
 	labels?: Set<string>
 	variables?: Set<string>
+	outboundSurfaceIds?: Set<string>
 }): VisitorReferencesCollectorVisitor {
-	return new VisitorReferencesCollectorVisitor(opts?.ids, opts?.labels, opts?.variables)
+	return new VisitorReferencesCollectorVisitor(opts?.ids, opts?.labels, opts?.variables, opts?.outboundSurfaceIds)
 }
 
 // ─── Constructor ─────────────────────────────────────────────────────────────
@@ -29,32 +30,37 @@ describe('VisitorReferencesCollectorVisitor – constructor', () => {
 		const ids = new Set<string>(['existing-id'])
 		const labels = new Set<string>(['existing-label'])
 		const variables = new Set<string>(['existing-label:var'])
+		const outboundSurfaceIds = new Set<string>(['existing-surface-id'])
 
-		const visitor = new VisitorReferencesCollectorVisitor(ids, labels, variables)
+		const visitor = new VisitorReferencesCollectorVisitor(ids, labels, variables, outboundSurfaceIds)
 
 		expect(visitor.connectionIds).toBe(ids)
 		expect(visitor.connectionLabels).toBe(labels)
 		expect(visitor.variables).toBe(variables)
+		expect(visitor.outboundSurfaceIds).toBe(outboundSurfaceIds)
 	})
 
 	it('creates fresh sets when all arguments are undefined', () => {
-		const visitor = new VisitorReferencesCollectorVisitor(undefined, undefined, undefined)
+		const visitor = new VisitorReferencesCollectorVisitor(undefined, undefined, undefined, undefined)
 
 		expect(visitor.connectionIds).toBeInstanceOf(Set)
 		expect(visitor.connectionLabels).toBeInstanceOf(Set)
 		expect(visitor.variables).toBeInstanceOf(Set)
+		expect(visitor.outboundSurfaceIds).toBeInstanceOf(Set)
 		expect(visitor.connectionIds.size).toBe(0)
 		expect(visitor.connectionLabels.size).toBe(0)
 		expect(visitor.variables.size).toBe(0)
+		expect(visitor.outboundSurfaceIds.size).toBe(0)
 	})
 
 	it('creates fresh sets independently for each undefined argument', () => {
 		const ids = new Set<string>()
-		const visitor = new VisitorReferencesCollectorVisitor(ids, undefined, undefined)
+		const visitor = new VisitorReferencesCollectorVisitor(ids, undefined, undefined, undefined)
 
 		expect(visitor.connectionIds).toBe(ids)
 		expect(visitor.connectionLabels).toBeInstanceOf(Set)
 		expect(visitor.variables).toBeInstanceOf(Set)
+		expect(visitor.outboundSurfaceIds).toBeInstanceOf(Set)
 	})
 })
 
@@ -366,15 +372,18 @@ describe('VisitorReferencesCollectorVisitor – shared external sets', () => {
 		const ids = new Set<string>()
 		const labels = new Set<string>()
 		const vars = new Set<string>()
+		const outboundSurfaceIds = new Set<string>()
 
-		const visitor = new VisitorReferencesCollectorVisitor(ids, labels, vars)
+		const visitor = new VisitorReferencesCollectorVisitor(ids, labels, vars, outboundSurfaceIds)
 		visitor.visitConnectionId({ id: 'ext-id' }, 'id')
 		visitor.visitString({ text: '$(ext-conn:ext-var)' }, 'text')
 		visitor.visitVariableName({ v: 'ext-conn2:ext-var2' }, 'v')
+		visitor.visitOutboundSurfaceId({ surfaceId: exprVal('ext-surface') }, 'surfaceId')
 
 		expect(ids).toEqual(new Set(['ext-id']))
 		expect(labels).toEqual(new Set(['ext-conn', 'ext-conn2']))
 		expect(vars).toEqual(new Set(['ext-conn:ext-var', 'ext-conn2:ext-var2']))
+		expect(outboundSurfaceIds).toEqual(new Set(['ext-surface']))
 	})
 
 	it('accumulates across multiple visit calls', () => {
@@ -384,5 +393,55 @@ describe('VisitorReferencesCollectorVisitor – shared external sets', () => {
 		visitor.visitConnectionIdArray({ c: ['id-3', 'id-4'] }, 'c')
 
 		expect(visitor.connectionIds).toEqual(new Set(['id-1', 'id-2', 'id-3', 'id-4']))
+	})
+})
+
+// ─── visitOutboundSurfaceId ──────────────────────────────────────────────────
+
+describe('VisitorReferencesCollectorVisitor – visitOutboundSurfaceId', () => {
+	it('adds an ExpressionOrValue (isExpression: false) string value to outboundSurfaceIds', () => {
+		const visitor = makeVisitor()
+		visitor.visitOutboundSurfaceId({ surfaceId: exprVal('surface-abc') }, 'surfaceId')
+		expect(visitor.outboundSurfaceIds).toEqual(new Set(['surface-abc']))
+	})
+
+	it('ignores an expression (isExpression: true)', () => {
+		const visitor = makeVisitor()
+		visitor.visitOutboundSurfaceId({ surfaceId: exprExpr('$(some:var)') }, 'surfaceId')
+		expect(visitor.outboundSurfaceIds.size).toBe(0)
+	})
+
+	it('ignores a non-string value', () => {
+		const visitor = makeVisitor()
+		visitor.visitOutboundSurfaceId({ surfaceId: exprVal(42) }, 'surfaceId')
+		expect(visitor.outboundSurfaceIds.size).toBe(0)
+	})
+
+	it('ignores null', () => {
+		const visitor = makeVisitor()
+		visitor.visitOutboundSurfaceId({ surfaceId: null }, 'surfaceId')
+		expect(visitor.outboundSurfaceIds.size).toBe(0)
+	})
+
+	it('does not mutate connectionIds or connectionLabels', () => {
+		const visitor = makeVisitor()
+		visitor.visitOutboundSurfaceId({ surfaceId: exprVal('surface-abc') }, 'surfaceId')
+		expect(visitor.connectionIds.size).toBe(0)
+		expect(visitor.connectionLabels.size).toBe(0)
+	})
+
+	it('uses an externally-supplied outboundSurfaceIds set', () => {
+		const outboundSurfaceIds = new Set<string>()
+		const visitor = new VisitorReferencesCollectorVisitor(undefined, undefined, undefined, outboundSurfaceIds)
+		visitor.visitOutboundSurfaceId({ surfaceId: exprVal('surface-xyz') }, 'surfaceId')
+		expect(outboundSurfaceIds).toEqual(new Set(['surface-xyz']))
+	})
+
+	it('accumulates multiple outbound surface ids', () => {
+		const visitor = makeVisitor()
+		visitor.visitOutboundSurfaceId({ surfaceId: exprVal('s1') }, 'surfaceId')
+		visitor.visitOutboundSurfaceId({ surfaceId: exprVal('s2') }, 'surfaceId')
+		visitor.visitOutboundSurfaceId({ surfaceId: exprVal('s1') }, 'surfaceId') // duplicate
+		expect(visitor.outboundSurfaceIds).toEqual(new Set(['s1', 's2']))
 	})
 })

--- a/companion/test/Resources/Visitors/ReferencesUpdater.test.ts
+++ b/companion/test/Resources/Visitors/ReferencesUpdater.test.ts
@@ -14,8 +14,9 @@ function exprExpr(value: string): { value: string; isExpression: true } {
 function makeUpdater(opts?: {
 	labelRemap?: Record<string, string>
 	idRemap?: Record<string, string>
+	outboundSurfaceIdRemap?: Record<string, string>
 }): VisitorReferencesUpdaterVisitor {
-	return new VisitorReferencesUpdaterVisitor(opts?.labelRemap, opts?.idRemap)
+	return new VisitorReferencesUpdaterVisitor(opts?.labelRemap, opts?.idRemap, opts?.outboundSurfaceIdRemap)
 }
 
 // ─── Constructor ─────────────────────────────────────────────────────────────
@@ -24,17 +25,20 @@ describe('VisitorReferencesUpdaterVisitor – constructor', () => {
 	it('stores the provided remaps', () => {
 		const labelRemap = { old: 'new' }
 		const idRemap = { 'old-id': 'new-id' }
-		const visitor = new VisitorReferencesUpdaterVisitor(labelRemap, idRemap)
+		const outboundSurfaceIdRemap = { 'old-surface-id': 'new-surface-id' }
+		const visitor = new VisitorReferencesUpdaterVisitor(labelRemap, idRemap, outboundSurfaceIdRemap)
 
 		expect(visitor.connectionLabelsRemap).toBe(labelRemap)
 		expect(visitor.connectionIdRemap).toBe(idRemap)
+		expect(visitor.outboundSurfaceIdRemap).toBe(outboundSurfaceIdRemap)
 	})
 
 	it('stores undefined remaps', () => {
-		const visitor = new VisitorReferencesUpdaterVisitor(undefined, undefined)
+		const visitor = new VisitorReferencesUpdaterVisitor(undefined, undefined, undefined)
 
 		expect(visitor.connectionLabelsRemap).toBeUndefined()
 		expect(visitor.connectionIdRemap).toBeUndefined()
+		expect(visitor.outboundSurfaceIdRemap).toBeUndefined()
 	})
 
 	it('starts with changed = false and empty changedFeedbackIds', () => {
@@ -541,6 +545,78 @@ describe('VisitorReferencesUpdaterVisitor – change tracking', () => {
 		visitor.visitConnectionId({ conn: 'old-id' }, 'conn', undefined)
 
 		expect(visitor.changed).toBe(true)
+		expect(visitor.changedFeedbackIds.size).toBe(0)
+	})
+})
+
+// ─── visitOutboundSurfaceId ──────────────────────────────────────────────────
+
+describe('VisitorReferencesUpdaterVisitor – visitOutboundSurfaceId', () => {
+	it('remaps a plain string surface id', () => {
+		const visitor = makeUpdater({ outboundSurfaceIdRemap: { 'old-surface': 'new-surface' } })
+		const obj = structuredClone({ surfaceId: 'old-surface' })
+
+		visitor.visitOutboundSurfaceId(obj, 'surfaceId')
+
+		expect(obj.surfaceId).toBe('new-surface')
+		expect(visitor.changed).toBe(true)
+	})
+
+	it('leaves a surface id unchanged when not in remap', () => {
+		const visitor = makeUpdater({ outboundSurfaceIdRemap: { 'other-surface': 'new-surface' } })
+		const obj = structuredClone({ surfaceId: 'my-surface' })
+
+		visitor.visitOutboundSurfaceId(obj, 'surfaceId')
+
+		expect(obj.surfaceId).toBe('my-surface')
+		expect(visitor.changed).toBe(false)
+	})
+
+	it('does nothing when no outboundSurfaceIdRemap is provided', () => {
+		const visitor = makeUpdater()
+		const obj = structuredClone({ surfaceId: 'old-surface' })
+
+		visitor.visitOutboundSurfaceId(obj, 'surfaceId')
+
+		expect(obj.surfaceId).toBe('old-surface')
+		expect(visitor.changed).toBe(false)
+	})
+
+	it('skips expression strings (isExpression: true)', () => {
+		const visitor = makeUpdater({ outboundSurfaceIdRemap: { 'old-surface': 'new-surface' } })
+		const obj = structuredClone({ surfaceId: exprExpr('some-expression') })
+
+		visitor.visitOutboundSurfaceId(obj, 'surfaceId')
+
+		expect(obj.surfaceId).toEqual(exprExpr('some-expression'))
+		expect(visitor.changed).toBe(false)
+	})
+
+	it('remaps a literal id wrapped in ExpressionOrValue (isExpression: false)', () => {
+		const visitor = makeUpdater({ outboundSurfaceIdRemap: { 'old-surface': 'new-surface' } })
+		const obj = structuredClone({ surfaceId: exprVal('old-surface') })
+
+		visitor.visitOutboundSurfaceId(obj, 'surfaceId')
+
+		expect(obj.surfaceId).toEqual(exprVal('new-surface'))
+		expect(visitor.changed).toBe(true)
+	})
+
+	it('tracks the feedbackId when a change is made', () => {
+		const visitor = makeUpdater({ outboundSurfaceIdRemap: { 'old-surface': 'new-surface' } })
+		const obj = structuredClone({ surfaceId: 'old-surface' })
+
+		visitor.visitOutboundSurfaceId(obj, 'surfaceId', 'fb-1')
+
+		expect(visitor.changedFeedbackIds).toEqual(new Set(['fb-1']))
+	})
+
+	it('does not add feedbackId when no change is made', () => {
+		const visitor = makeUpdater({ outboundSurfaceIdRemap: { 'other-surface': 'new-surface' } })
+		const obj = structuredClone({ surfaceId: 'my-surface' })
+
+		visitor.visitOutboundSurfaceId(obj, 'surfaceId', 'fb-1')
+
 		expect(visitor.changedFeedbackIds.size).toBe(0)
 	})
 })

--- a/shared-lib/lib/Model/Options.ts
+++ b/shared-lib/lib/Model/Options.ts
@@ -69,6 +69,7 @@ export interface CompanionInputFieldBaseExtended {
 		| 'internal:connection_id'
 		| 'internal:connection_collection'
 		| 'internal:surface_serial'
+		| 'internal:outbound_surface_id'
 		| 'internal:page'
 		| 'internal:horizontal-alignment'
 		| 'internal:vertical-alignment'
@@ -140,6 +141,9 @@ export interface InternalInputFieldSurfaceSerial extends CompanionInputFieldBase
 	default: string
 	useRawSurfaces?: boolean
 }
+export interface InternalInputFieldOutboundSurfaceId extends CompanionInputFieldBaseExtended {
+	type: 'internal:outbound_surface_id'
+}
 export interface InternalInputFieldPage extends CompanionInputFieldBaseExtended {
 	type: 'internal:page'
 	includeStartup: boolean
@@ -176,6 +180,7 @@ export type InternalInputField =
 	| InternalInputFieldConnectionId
 	| InternalInputFieldConnectionCollection
 	| InternalInputFieldSurfaceSerial
+	| InternalInputFieldOutboundSurfaceId
 	| InternalInputFieldPage
 	| InternalInputFieldHorizontalAlignment
 	| InternalInputFieldVerticalAlignment

--- a/shared-lib/lib/ValidateInputValue.ts
+++ b/shared-lib/lib/ValidateInputValue.ts
@@ -306,6 +306,7 @@ export function validateInputValue(
 		case 'internal:date':
 		case 'internal:page':
 		case 'internal:surface_serial':
+		case 'internal:outbound_surface_id':
 		case 'internal:time':
 		case 'internal:variable':
 		case 'internal:trigger':

--- a/webui/src/Controls/InternalModuleField.tsx
+++ b/webui/src/Controls/InternalModuleField.tsx
@@ -86,6 +86,8 @@ export function InternalModuleField(
 					useRawSurfaces={option.useRawSurfaces}
 				/>
 			)
+		case 'internal:outbound_surface_id':
+			return <OutboundSurfaceDropdown id={id} disabled={readonly} value={value} setValue={setValue} />
 		case 'internal:trigger':
 			return (
 				<InternalTriggerDropdown
@@ -469,6 +471,34 @@ const InternalSurfaceBySerialDropdown = observer(function InternalSurfaceBySeria
 
 		return choices
 	}, [surfaces, isLocatedInGrid, includeSelf, useRawSurfaces])
+
+	return <DropdownInputField htmlName={id} disabled={disabled} value={value} choices={choices} setValue={setValue} />
+})
+
+interface OutboundSurfaceDropdownProps {
+	id: string | undefined
+	value: any
+	setValue: (value: any) => void
+	disabled: boolean
+}
+
+const OutboundSurfaceDropdown = observer(function OutboundSurfaceDropdown({
+	id,
+	value,
+	setValue,
+	disabled,
+}: Readonly<OutboundSurfaceDropdownProps>) {
+	const { surfaces } = useContext(RootAppStoreContext)
+
+	const choices = useComputed((): DropdownChoice[] => {
+		return surfaces.outboundSurfaces
+			.values()
+			.map((surface) => ({
+				id: surface.id,
+				label: surface.displayName || surface.id,
+			}))
+			.toArray()
+	}, [surfaces])
 
 	return <DropdownInputField htmlName={id} disabled={disabled} value={value} choices={choices} setValue={setValue} />
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Control and monitor remote (outbound) surfaces with enable/disable action and status feedback
  * Remote surface selector added to configuration UI

* **Improvements**
  * Robust import/export: outbound surface IDs are remapped during imports to avoid conflicts and fix references
  * Reference tracking and updates now include outbound surface references

* **Bug Fixes**
  * Prevented an error for a previously unhandled internal option type during parsing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->