### PR TITLE
feat: one click convert page buttons to be editable

### DIFF
--- a/companion/lib/Controls/ControlTypes/Button/Base.ts
+++ b/companion/lib/Controls/ControlTypes/Button/Base.ts
@@ -31,6 +31,7 @@ export abstract class ButtonControlBase<TJson, TOptions extends ButtonOptionsBas
 	implements ControlWithEntities, ControlWithOptions, ControlWithPushed
 {
 	readonly supportsEntities = true
+	readonly supportsConvert = false
 	readonly supportsOptions = true
 	readonly supportsPushed = true
 

--- a/companion/lib/Controls/ControlTypes/Button/Preset.ts
+++ b/companion/lib/Controls/ControlTypes/Button/Preset.ts
@@ -28,6 +28,7 @@ import type {
 	ControlWithLayeredStyle,
 	ControlWithoutActions,
 	ControlWithoutActionSets,
+	ControlWithoutConvert,
 	ControlWithoutEvents,
 	ControlWithoutOptions,
 	ControlWithoutPushed,
@@ -55,7 +56,8 @@ export class ControlButtonPreset
 		ControlWithoutActionSets,
 		ControlWithEntities,
 		ControlWithoutOptions,
-		ControlWithoutPushed
+		ControlWithoutPushed,
+		ControlWithoutConvert
 {
 	readonly type = 'preset:button'
 
@@ -66,6 +68,7 @@ export class ControlButtonPreset
 	readonly supportsEntities = true
 	readonly supportsOptions = false
 	readonly supportsPushed = false
+	readonly supportsConvert = false
 
 	readonly entities: ControlEntityListPoolButton
 

--- a/companion/lib/Controls/ControlTypes/ExpressionVariable.ts
+++ b/companion/lib/Controls/ControlTypes/ExpressionVariable.ts
@@ -53,6 +53,7 @@ export class ControlExpressionVariable
 	readonly type = 'expression-variable'
 
 	readonly supportsActions = false
+	readonly supportsConvert = false
 	readonly supportsEvents = false
 	readonly supportsEntities = true
 	readonly supportsLayeredStyle = false

--- a/companion/lib/Controls/ControlTypes/PageButton.ts
+++ b/companion/lib/Controls/ControlTypes/PageButton.ts
@@ -1,4 +1,7 @@
-import type { SomeButtonModel } from '@companion-app/shared/Model/ButtonModel.js'
+import { nanoid } from 'nanoid'
+import type { LayeredButtonModel, SomeButtonModel } from '@companion-app/shared/Model/ButtonModel.js'
+import { EntityModelType } from '@companion-app/shared/Model/EntityModel.js'
+import type { ExpressionableOptionsObject } from '@companion-app/shared/Model/Options.js'
 import type { SomeButtonGraphicsElement } from '@companion-app/shared/Model/StyleLayersModel.js'
 import { type DrawStyleLayeredButtonModel } from '@companion-app/shared/Model/StyleModel.js'
 import { ConvertSomeButtonGraphicsElementForDrawing } from '../../Graphics/ConvertGraphicsElements.js'
@@ -167,4 +170,38 @@ export abstract class ControlButtonPage<TJson>
 	}
 
 	abstract convertControl(): SomeButtonModel
+
+	// in ControlButtonPage
+	protected buildConvertedControl(
+		elements: SomeButtonGraphicsElement[],
+		action: { definitionId: string; options: ExpressionableOptionsObject }
+	): LayeredButtonModel {
+		return {
+			type: 'button-layered',
+			options: { stepProgression: 'auto', rotaryActions: false, canModifyStyleInApis: false },
+			style: { layers: structuredClone(elements) },
+			feedbacks: [],
+			steps: {
+				'0': {
+					action_sets: {
+						down: [
+							{
+								type: EntityModelType.Action,
+								id: nanoid(),
+								definitionId: action.definitionId,
+								connectionId: 'internal',
+								options: action.options,
+								upgradeIndex: undefined,
+							},
+						],
+						up: undefined,
+						rotate_left: undefined,
+						rotate_right: undefined,
+					},
+					options: { runWhileHeld: [] },
+				},
+			},
+			localVariables: [],
+		}
+	}
 }

--- a/companion/lib/Controls/ControlTypes/PageButton.ts
+++ b/companion/lib/Controls/ControlTypes/PageButton.ts
@@ -1,9 +1,11 @@
+import type { SomeButtonModel } from '@companion-app/shared/Model/ButtonModel.js'
 import type { SomeButtonGraphicsElement } from '@companion-app/shared/Model/StyleLayersModel.js'
 import { type DrawStyleLayeredButtonModel } from '@companion-app/shared/Model/StyleModel.js'
 import { ConvertSomeButtonGraphicsElementForDrawing } from '../../Graphics/ConvertGraphicsElements.js'
 import { ElementConversionCache } from '../../Graphics/ElementConversionCache.js'
 import { ControlBase } from '../ControlBase.js'
 import type {
+	ControlWithConvert,
 	ControlWithoutActions,
 	ControlWithoutActionSets,
 	ControlWithoutEvents,
@@ -32,6 +34,7 @@ const emptyMap: ReadonlyMap<string, never> = new Map<string, never>()
 export abstract class ControlButtonPage<TJson>
 	extends ControlBase<TJson>
 	implements
+		ControlWithConvert,
 		ControlWithoutActions,
 		ControlWithoutLayeredStyle,
 		ControlWithoutEvents,
@@ -40,6 +43,7 @@ export abstract class ControlButtonPage<TJson>
 		ControlWithoutPushed
 {
 	readonly supportsActions = false
+	readonly supportsConvert = true
 	readonly supportsEntities = false
 	readonly supportsLayeredStyle = false
 	readonly supportsEvents = false
@@ -161,4 +165,6 @@ export abstract class ControlButtonPage<TJson>
 		this.logger.silly('variable changed in button ' + this.controlId)
 		this.triggerRedraw()
 	}
+
+	abstract convertControl(): SomeButtonModel
 }

--- a/companion/lib/Controls/ControlTypes/PageDown.ts
+++ b/companion/lib/Controls/ControlTypes/PageDown.ts
@@ -1,6 +1,4 @@
-import { nanoid } from 'nanoid'
 import type { LayeredButtonModel, PageDownButtonModel } from '@companion-app/shared/Model/ButtonModel.js'
-import { EntityModelType } from '@companion-app/shared/Model/EntityModel.js'
 import { exprExpr, exprVal } from '@companion-app/shared/Model/Options.js'
 import type {
 	ButtonGraphicsBoxElement,
@@ -152,40 +150,11 @@ export class ControlButtonPageDown extends ControlButtonPage<PageDownButtonModel
 	}
 
 	convertControl(): LayeredButtonModel {
-		return {
-			type: 'button-layered',
+		return this.buildConvertedControl(pageDownElements, {
+			definitionId: 'dec_page',
 			options: {
-				stepProgression: 'auto',
-				rotaryActions: false,
-				canModifyStyleInApis: false,
+				surfaceId: exprVal('self'),
 			},
-			style: {
-				layers: structuredClone(pageDownElements),
-			},
-			feedbacks: [],
-			steps: {
-				'0': {
-					action_sets: {
-						down: [
-							{
-								type: EntityModelType.Action,
-								id: nanoid(),
-								definitionId: 'dec_page',
-								connectionId: 'internal',
-								options: {
-									surfaceId: exprVal('self'),
-								},
-								upgradeIndex: undefined,
-							},
-						],
-						up: undefined,
-						rotate_left: undefined,
-						rotate_right: undefined,
-					},
-					options: { runWhileHeld: [] },
-				},
-			},
-			localVariables: [],
-		}
+		})
 	}
 }

--- a/companion/lib/Controls/ControlTypes/PageDown.ts
+++ b/companion/lib/Controls/ControlTypes/PageDown.ts
@@ -1,4 +1,6 @@
-import type { PageDownButtonModel } from '@companion-app/shared/Model/ButtonModel.js'
+import { nanoid } from 'nanoid'
+import type { LayeredButtonModel, PageDownButtonModel } from '@companion-app/shared/Model/ButtonModel.js'
+import { EntityModelType } from '@companion-app/shared/Model/EntityModel.js'
 import { exprExpr, exprVal } from '@companion-app/shared/Model/Options.js'
 import type {
 	ButtonGraphicsBoxElement,
@@ -146,6 +148,44 @@ export class ControlButtonPageDown extends ControlButtonPage<PageDownButtonModel
 	toJSON(_clone = true): PageDownButtonModel {
 		return {
 			type: this.type,
+		}
+	}
+
+	convertControl(): LayeredButtonModel {
+		return {
+			type: 'button-layered',
+			options: {
+				stepProgression: 'auto',
+				rotaryActions: false,
+				canModifyStyleInApis: false,
+			},
+			style: {
+				layers: structuredClone(pageDownElements),
+			},
+			feedbacks: [],
+			steps: {
+				'0': {
+					action_sets: {
+						down: [
+							{
+								type: EntityModelType.Action,
+								id: nanoid(),
+								definitionId: 'dec_page',
+								connectionId: 'internal',
+								options: {
+									surfaceId: exprVal('self'),
+								},
+								upgradeIndex: undefined,
+							},
+						],
+						up: undefined,
+						rotate_left: undefined,
+						rotate_right: undefined,
+					},
+					options: { runWhileHeld: [] },
+				},
+			},
+			localVariables: [],
 		}
 	}
 }

--- a/companion/lib/Controls/ControlTypes/PageNumber.ts
+++ b/companion/lib/Controls/ControlTypes/PageNumber.ts
@@ -1,6 +1,4 @@
-import { nanoid } from 'nanoid'
 import type { LayeredButtonModel, PageNumberButtonModel } from '@companion-app/shared/Model/ButtonModel.js'
-import { EntityModelType } from '@companion-app/shared/Model/EntityModel.js'
 import { exprExpr, exprVal } from '@companion-app/shared/Model/Options.js'
 import type {
 	ButtonGraphicsBoxElement,
@@ -143,41 +141,12 @@ export class ControlButtonPageNumber extends ControlButtonPage<PageNumberButtonM
 	}
 
 	convertControl(): LayeredButtonModel {
-		return {
-			type: 'button-layered',
+		return this.buildConvertedControl(pageNumberElements, {
+			definitionId: 'set_page',
 			options: {
-				stepProgression: 'auto',
-				rotaryActions: false,
-				canModifyStyleInApis: false,
+				surfaceId: exprVal('self'),
+				page: exprVal(1),
 			},
-			style: {
-				layers: structuredClone(pageNumberElements),
-			},
-			feedbacks: [],
-			steps: {
-				'0': {
-					action_sets: {
-						down: [
-							{
-								type: EntityModelType.Action,
-								id: nanoid(),
-								definitionId: 'set_page',
-								connectionId: 'internal',
-								options: {
-									surfaceId: exprVal('self'),
-									page: exprVal('startup'),
-								},
-								upgradeIndex: undefined,
-							},
-						],
-						up: undefined,
-						rotate_left: undefined,
-						rotate_right: undefined,
-					},
-					options: { runWhileHeld: [] },
-				},
-			},
-			localVariables: [],
-		}
+		})
 	}
 }

--- a/companion/lib/Controls/ControlTypes/PageNumber.ts
+++ b/companion/lib/Controls/ControlTypes/PageNumber.ts
@@ -1,4 +1,6 @@
-import type { PageNumberButtonModel } from '@companion-app/shared/Model/ButtonModel.js'
+import { nanoid } from 'nanoid'
+import type { LayeredButtonModel, PageNumberButtonModel } from '@companion-app/shared/Model/ButtonModel.js'
+import { EntityModelType } from '@companion-app/shared/Model/EntityModel.js'
 import { exprExpr, exprVal } from '@companion-app/shared/Model/Options.js'
 import type {
 	ButtonGraphicsBoxElement,
@@ -137,6 +139,45 @@ export class ControlButtonPageNumber extends ControlButtonPage<PageNumberButtonM
 	toJSON(_clone = true): PageNumberButtonModel {
 		return {
 			type: this.type,
+		}
+	}
+
+	convertControl(): LayeredButtonModel {
+		return {
+			type: 'button-layered',
+			options: {
+				stepProgression: 'auto',
+				rotaryActions: false,
+				canModifyStyleInApis: false,
+			},
+			style: {
+				layers: structuredClone(pageNumberElements),
+			},
+			feedbacks: [],
+			steps: {
+				'0': {
+					action_sets: {
+						down: [
+							{
+								type: EntityModelType.Action,
+								id: nanoid(),
+								definitionId: 'set_page',
+								connectionId: 'internal',
+								options: {
+									surfaceId: exprVal('self'),
+									page: exprVal('startup'),
+								},
+								upgradeIndex: undefined,
+							},
+						],
+						up: undefined,
+						rotate_left: undefined,
+						rotate_right: undefined,
+					},
+					options: { runWhileHeld: [] },
+				},
+			},
+			localVariables: [],
 		}
 	}
 }

--- a/companion/lib/Controls/ControlTypes/PageUp.ts
+++ b/companion/lib/Controls/ControlTypes/PageUp.ts
@@ -1,4 +1,6 @@
-import type { PageUpButtonModel } from '@companion-app/shared/Model/ButtonModel.js'
+import { nanoid } from 'nanoid'
+import type { LayeredButtonModel, PageUpButtonModel } from '@companion-app/shared/Model/ButtonModel.js'
+import { EntityModelType } from '@companion-app/shared/Model/EntityModel.js'
 import { exprExpr, exprVal } from '@companion-app/shared/Model/Options.js'
 import type {
 	ButtonGraphicsBoxElement,
@@ -146,6 +148,44 @@ export class ControlButtonPageUp extends ControlButtonPage<PageUpButtonModel> {
 	toJSON(_clone = true): PageUpButtonModel {
 		return {
 			type: this.type,
+		}
+	}
+
+	convertControl(): LayeredButtonModel {
+		return {
+			type: 'button-layered',
+			options: {
+				stepProgression: 'auto',
+				rotaryActions: false,
+				canModifyStyleInApis: false,
+			},
+			style: {
+				layers: structuredClone(pageUpElements),
+			},
+			feedbacks: [],
+			steps: {
+				'0': {
+					action_sets: {
+						down: [
+							{
+								type: EntityModelType.Action,
+								id: nanoid(),
+								definitionId: 'inc_page',
+								connectionId: 'internal',
+								options: {
+									surfaceId: exprVal('self'),
+								},
+								upgradeIndex: undefined,
+							},
+						],
+						up: undefined,
+						rotate_left: undefined,
+						rotate_right: undefined,
+					},
+					options: { runWhileHeld: [] },
+				},
+			},
+			localVariables: [],
 		}
 	}
 }

--- a/companion/lib/Controls/ControlTypes/PageUp.ts
+++ b/companion/lib/Controls/ControlTypes/PageUp.ts
@@ -1,6 +1,4 @@
-import { nanoid } from 'nanoid'
 import type { LayeredButtonModel, PageUpButtonModel } from '@companion-app/shared/Model/ButtonModel.js'
-import { EntityModelType } from '@companion-app/shared/Model/EntityModel.js'
 import { exprExpr, exprVal } from '@companion-app/shared/Model/Options.js'
 import type {
 	ButtonGraphicsBoxElement,
@@ -152,40 +150,11 @@ export class ControlButtonPageUp extends ControlButtonPage<PageUpButtonModel> {
 	}
 
 	convertControl(): LayeredButtonModel {
-		return {
-			type: 'button-layered',
+		return this.buildConvertedControl(pageUpElements, {
+			definitionId: 'inc_page',
 			options: {
-				stepProgression: 'auto',
-				rotaryActions: false,
-				canModifyStyleInApis: false,
+				surfaceId: exprVal('self'),
 			},
-			style: {
-				layers: structuredClone(pageUpElements),
-			},
-			feedbacks: [],
-			steps: {
-				'0': {
-					action_sets: {
-						down: [
-							{
-								type: EntityModelType.Action,
-								id: nanoid(),
-								definitionId: 'inc_page',
-								connectionId: 'internal',
-								options: {
-									surfaceId: exprVal('self'),
-								},
-								upgradeIndex: undefined,
-							},
-						],
-						up: undefined,
-						rotate_left: undefined,
-						rotate_right: undefined,
-					},
-					options: { runWhileHeld: [] },
-				},
-			},
-			localVariables: [],
-		}
+		})
 	}
 }

--- a/companion/lib/Controls/ControlTypes/Triggers/Trigger.ts
+++ b/companion/lib/Controls/ControlTypes/Triggers/Trigger.ts
@@ -60,6 +60,7 @@ export class ControlTrigger
 	readonly type = 'trigger'
 
 	readonly supportsActions = true
+	readonly supportsConvert = false
 	readonly supportsEvents = true
 	readonly supportsEntities = true
 	readonly supportsStyle = false

--- a/companion/lib/Controls/ControlsTrpcRouter.ts
+++ b/companion/lib/Controls/ControlsTrpcRouter.ts
@@ -42,6 +42,23 @@ export function createControlsTrpcRouter(
 				return controlsController.importControl(input.location, model)
 			}),
 
+		convertControl: publicProcedure
+			.input(
+				z.object({
+					location: zodLocation,
+				})
+			)
+			.mutation(async ({ input }) => {
+				const controlId = pageStore.getControlIdAt(input.location)
+				if (!controlId) return null
+
+				const control = controlsMap.get(controlId)
+				if (!control || !control.supportsConvert) return null
+
+				const newModel = control.convertControl()
+				return controlsController.importControl(input.location, newModel)
+			}),
+
 		resetControl: publicProcedure
 			.input(
 				z.object({

--- a/companion/lib/Controls/IControlFragments.ts
+++ b/companion/lib/Controls/IControlFragments.ts
@@ -1,4 +1,5 @@
 import type { JsonObject, JsonValue } from 'type-fest'
+import type { SomeButtonModel } from '@companion-app/shared/Model/ButtonModel.js'
 import type { EventInstance } from '@companion-app/shared/Model/EventModel.js'
 import type { ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
 import type { SomeButtonGraphicsElement } from '@companion-app/shared/Model/StyleLayersModel.js'
@@ -15,7 +16,8 @@ export type SomeControl<TJson> = ControlBase<TJson> &
 	(ControlWithEvents | ControlWithoutEvents) &
 	(ControlWithActionSets | ControlWithoutActionSets) &
 	(ControlWithOptions | ControlWithoutOptions) &
-	(ControlWithPushed | ControlWithoutPushed)
+	(ControlWithPushed | ControlWithoutPushed) &
+	(ControlWithConvert | ControlWithoutConvert)
 
 export interface ControlWithoutLayeredStyle extends ControlBase<any> {
 	readonly supportsLayeredStyle: false
@@ -227,4 +229,19 @@ export interface ControlWithPushed extends ControlBase<any> {
 
 export interface ControlWithoutPushed extends ControlBase<any> {
 	readonly supportsPushed: false
+}
+
+export interface ControlWithConvert extends ControlBase<any> {
+	readonly supportsConvert: true
+
+	/**
+	 * Convert this control to another type of control.
+	 * This is intended to convert some 'automatic' controls, to a 'manual' editable form
+	 * @returns The new model for the converted control
+	 */
+	convertControl(): SomeButtonModel
+}
+
+export interface ControlWithoutConvert extends ControlBase<any> {
+	readonly supportsConvert: false
 }

--- a/webui/src/Buttons/EditButton/ConvertToNormalButton.tsx
+++ b/webui/src/Buttons/EditButton/ConvertToNormalButton.tsx
@@ -1,0 +1,39 @@
+import { faPencil } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { useCallback, useRef } from 'react'
+import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
+import { Button } from '~/Components/Button'
+import { GenericConfirmModal, type GenericConfirmModalRef } from '~/Components/GenericConfirmModal.js'
+import { trpc, useMutationExt } from '~/Resources/TRPC'
+
+interface ConvertToNormalButtonProps {
+	location: ControlLocation
+}
+
+export function ConvertToNormalButton({ location }: ConvertToNormalButtonProps): JSX.Element {
+	const convertModalRef = useRef<GenericConfirmModalRef>(null)
+	const convertControlMutation = useMutationExt(trpc.controls.convertControl.mutationOptions())
+
+	const doConvertControl = useCallback(() => {
+		convertModalRef.current?.show(
+			'Convert to Normal Button',
+			'This will convert this special button into a normal button with equivalent actions. This cannot be undone.',
+			'Convert',
+			() => {
+				convertControlMutation.mutateAsync({ location }).catch((e) => {
+					console.error(`Convert failed: ${e}`)
+				})
+			}
+		)
+	}, [convertControlMutation, location])
+
+	return (
+		<>
+			<GenericConfirmModal ref={convertModalRef} />
+			<Button color="secondary" onClick={doConvertControl} title="Convert to Normal Button">
+				<FontAwesomeIcon icon={faPencil} className="me-1" />
+				Edit
+			</Button>
+		</>
+	)
+}

--- a/webui/src/Buttons/EditButton/EditButton.tsx
+++ b/webui/src/Buttons/EditButton/EditButton.tsx
@@ -17,6 +17,7 @@ import { KeyReceiver } from '~/Resources/util.js'
 import { RootAppStoreContext } from '~/Stores/RootAppStore.js'
 import { ControlClearButton } from './ControlClearButton.js'
 import { ControlHotPressButtons } from './ControlHotPressButtons.js'
+import { ConvertToNormalButton } from './ConvertToNormalButton.js'
 import { LayeredButtonEditor } from './LayeredButtonEditor/LayeredButtonEditor.js'
 import { SelectButtonTypeDropdown } from './SelectButtonTypeDropdown.js'
 
@@ -106,6 +107,9 @@ const EditButtonContent = observer(function EditButton({
 					<div className="d-flex flex-wrap align-items-center gap-1">
 						<ControlClearButton location={location} resetModalRef={resetModalRef} />
 						<MyErrorBoundary>
+							{(config.type === 'pageup' || config.type === 'pagenum' || config.type === 'pagedown') && (
+								<ConvertToNormalButton location={location} />
+							)}
 							{config.type === 'button-layered' && (
 								<ControlHotPressButtons location={location} showRotaries={config.options.rotaryActions} />
 							)}


### PR DESCRIPTION
Related #2748 #3649

Adds a 'one click' to convert a page button to the equivalent as a user editable button.  
The drawing was recently reworked to use the layers system in preparation for this, and we have had suitable actions for ages.

https://github.com/user-attachments/assets/29749a1f-80d7-46b1-8967-d8d2824a31de



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Convert to Normal Button" action in the button editor for Page Up, Page Down, and Page Number controls.
  * Conversion runs from the editor and replaces the page-style button with a standard button; a confirmation dialog warns this action is irreversible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->