### PR TITLE
Add Timeline editor page integrated into the web UI

### DIFF
--- a/webui/src/Buttons/EditButton/EditButton.tsx
+++ b/webui/src/Buttons/EditButton/EditButton.tsx
@@ -19,6 +19,7 @@ import { ControlClearButton } from './ControlClearButton.js'
 import { ControlHotPressButtons } from './ControlHotPressButtons.js'
 import { ConvertToNormalButton } from './ConvertToNormalButton.js'
 import { LayeredButtonEditor } from './LayeredButtonEditor/LayeredButtonEditor.js'
+import { OpenInTimelineButton } from './OpenInTimelineButton.js'
 import { SelectButtonTypeDropdown } from './SelectButtonTypeDropdown.js'
 
 interface EditButtonProps {
@@ -111,7 +112,10 @@ const EditButtonContent = observer(function EditButton({
 								<ConvertToNormalButton location={location} />
 							)}
 							{config.type === 'button-layered' && (
-								<ControlHotPressButtons location={location} showRotaries={config.options.rotaryActions} />
+								<>
+									<ControlHotPressButtons location={location} showRotaries={config.options.rotaryActions} />
+									<OpenInTimelineButton location={location} />
+								</>
 							)}
 						</MyErrorBoundary>
 					</div>

--- a/webui/src/Buttons/EditButton/OpenInTimelineButton.tsx
+++ b/webui/src/Buttons/EditButton/OpenInTimelineButton.tsx
@@ -1,0 +1,23 @@
+import { faChartGantt } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { useNavigate } from '@tanstack/react-router'
+import { useCallback } from 'react'
+import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
+import { Button } from '~/Components/Button'
+
+export function OpenInTimelineButton({ location }: { location: ControlLocation }): React.JSX.Element {
+	const navigate = useNavigate()
+
+	const openTimeline = useCallback(() => {
+		void navigate({
+			to: '/timeline',
+			search: { page: location.pageNumber, row: location.row, column: location.column },
+		})
+	}, [navigate, location.pageNumber, location.row, location.column])
+
+	return (
+		<Button color="info" onClick={openTimeline} title="Open this button in the Timeline editor">
+			<FontAwesomeIcon icon={faChartGantt} /> Timeline
+		</Button>
+	)
+}

--- a/webui/src/Layout/Sidebar.tsx
+++ b/webui/src/Layout/Sidebar.tsx
@@ -2,6 +2,7 @@ import { faFacebook, faGithub, faSlack } from '@fortawesome/free-brands-svg-icon
 import {
 	faArrowsDownToLine,
 	faArrowsUpToLine,
+	faChartGantt,
 	faCheck,
 	faClipboardList,
 	faClock,
@@ -409,6 +410,7 @@ export const MySidebar = memo(function MySidebar() {
 						path="/connections"
 					/>
 					<SidebarMenuItem name="Buttons" icon={faTableCells} path="/buttons" />
+					<SidebarMenuItem name="Timeline" icon={faChartGantt} path="/timeline" />
 					<SidebarMenuItem name="Image Library" icon={faImages} path="/image-library" />
 					<SidebarMenuItemGroup
 						name="Surfaces"

--- a/webui/src/Timeline/TimelinePage.tsx
+++ b/webui/src/Timeline/TimelinePage.tsx
@@ -1,0 +1,838 @@
+import { observer } from 'mobx-react-lite'
+import { nanoid } from 'nanoid'
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
+import type { SomeButtonModel } from '@companion-app/shared/Model/ButtonModel.js'
+import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
+import { useControlConfig } from '~/Hooks/useControlConfig.js'
+import { trpc, useMutationExt } from '~/Resources/TRPC.js'
+import { RootAppStoreContext } from '~/Stores/RootAppStore.js'
+import ActionInspector from './components/ActionInspector.js'
+import AddActionModal, { type ActionTemplate } from './components/AddActionModal.js'
+import { TimelineButtonGrid } from './components/ButtonGrid.js'
+import LibraryPanel from './components/LibraryPanel.js'
+import Timeline, { type TimelineButton } from './components/Timeline.js'
+import { buildActionLibrary } from './library.js'
+import {
+	intToColor,
+	type ButtonControl,
+	type CompanionAction,
+	type CompanionInstance,
+	type ExecutionMode,
+	type TriggerKey,
+} from './types.js'
+import { useTimelineData } from './useTimelineData.js'
+import './timeline.scss'
+
+function genId(): string {
+	return nanoid(10)
+}
+
+interface TimelinePageProps {
+	initialLocation?: ControlLocation
+}
+
+export const TimelinePage = observer(function TimelinePage({ initialLocation }: TimelinePageProps): React.JSX.Element {
+	const { pages, userConfig, connections, entityDefinitions } = useContext(RootAppStoreContext)
+
+	const gridSize = userConfig.properties?.gridSize ?? { minColumn: 0, maxColumn: 7, minRow: 0, maxRow: 3 }
+
+	const [pageNumber, setPageNumber] = useState(initialLocation?.pageNumber ?? 1)
+	const [selectedLocation, setSelectedLocation] = useState<ControlLocation | null>(initialLocation ?? null)
+
+	// Re-focus when navigated here for a specific button (e.g. from the button editor)
+	const initialKey = initialLocation
+		? `${initialLocation.pageNumber}:${initialLocation.row}:${initialLocation.column}`
+		: null
+	useEffect(() => {
+		if (!initialLocation) return
+		setSelectedLocation(initialLocation)
+		setPageNumber(initialLocation.pageNumber)
+		setSelectedAction(null)
+		setPlayheadMs(0)
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [initialKey])
+	const [selectedAction, setSelectedAction] = useState<{ id: string; triggerKey: TriggerKey; stepKey: string } | null>(
+		null
+	)
+	const [showLibrary, setShowLibrary] = useState(true)
+	const [addingAction, setAddingAction] = useState<{
+		stepKey: string
+		triggerKey: TriggerKey
+		delay: number
+		groupPath?: string[]
+	} | null>(null)
+
+	const [playheadMs, setPlayheadMs] = useState(0)
+	const [isPlaying, setIsPlaying] = useState(false)
+	const [isPaused, setIsPaused] = useState(false)
+	const timelineVisibleMsRef = useRef(5000)
+	const animFrameRef = useRef<number | null>(null)
+	const playStartRef = useRef<{ wallTime: number; startMs: number } | null>(null)
+
+	const controlId = selectedLocation ? (pages.getControlIdAtLocation(selectedLocation) ?? null) : null
+	const { controlConfig } = useControlConfig(controlId)
+	const buttonModel: SomeButtonModel | null =
+		controlConfig && controlConfig.config.type === 'button-layered' ? controlConfig.config : null
+
+	const { control, dirty, saveStatus, updateButton, undo } = useTimelineData(controlId, buttonModel)
+
+	// ── Live-derived data (read directly so mobx tracks changes) ───────────────
+	const instances: Record<string, CompanionInstance> = {}
+	instances['internal'] = { instance_type: 'internal', label: 'Internal' }
+	for (const [id, conn] of connections.connections.entries()) {
+		instances[id] = { instance_type: conn.moduleId, label: conn.label, enabled: conn.enabled }
+	}
+
+	const usedKeys = useMemo(() => {
+		const set = new Set<string>()
+		if (control) {
+			const walk = (actions: CompanionAction[]) => {
+				for (const a of actions) {
+					set.add(`${a.instance}:${a.action}`)
+					for (const kids of Object.values(a.children ?? {})) walk(kids)
+				}
+			}
+			for (const step of Object.values(control.steps)) {
+				for (const acts of Object.values(step.action_sets)) walk(acts ?? [])
+			}
+		}
+		return set
+	}, [control])
+
+	const library = buildActionLibrary(connections, entityDefinitions, usedKeys)
+
+	const hotPressMutation = useMutationExt(trpc.controls.hotPressControl.mutationOptions())
+	const pressButton = useCallback(
+		(down: boolean) => {
+			if (!selectedLocation) return
+			hotPressMutation
+				.mutateAsync({ location: selectedLocation, direction: down, surfaceId: 'timeline' })
+				.catch(() => undefined)
+		},
+		[hotPressMutation, selectedLocation]
+	)
+
+	// ── Selection helpers ──────────────────────────────────────────────────────
+	const selectButton = useCallback((location: ControlLocation) => {
+		setSelectedLocation(location)
+		setSelectedAction(null)
+		setPlayheadMs(0)
+	}, [])
+
+	const handleActionSelect = useCallback((actionId: string | null, triggerKey: TriggerKey, stepKey: string) => {
+		setSelectedAction(actionId ? { id: actionId, triggerKey, stepKey } : null)
+	}, [])
+
+	// ── Action-set mutation helpers (ported from the standalone App) ───────────
+	const handleActionMove = useCallback(
+		(stepKey: string, triggerKey: TriggerKey, actionId: string, newDelay: number) => {
+			updateButton((ctrl) => {
+				const step = ctrl.steps[stepKey]
+				const actions = step.action_sets[triggerKey] ?? []
+				return {
+					...ctrl,
+					steps: {
+						...ctrl.steps,
+						[stepKey]: {
+							...step,
+							action_sets: {
+								...step.action_sets,
+								[triggerKey]: actions.map((a) => (a.id === actionId ? { ...a, delay: newDelay } : a)),
+							},
+						},
+					},
+				}
+			})
+		},
+		[updateButton]
+	)
+
+	const handleActionDelayChange = handleActionMove
+
+	const handleActionAdd = useCallback((stepKey: string, triggerKey: TriggerKey, delay: number) => {
+		setAddingAction({ stepKey, triggerKey, delay })
+	}, [])
+
+	const handleActionDelete = useCallback(
+		(stepKey: string, triggerKey: TriggerKey, actionId: string) => {
+			updateButton((ctrl) => {
+				const step = ctrl.steps[stepKey]
+				const actions = step.action_sets[triggerKey] ?? []
+				return {
+					...ctrl,
+					steps: {
+						...ctrl.steps,
+						[stepKey]: {
+							...step,
+							action_sets: { ...step.action_sets, [triggerKey]: actions.filter((a) => a.id !== actionId) },
+						},
+					},
+				}
+			})
+			setSelectedAction((sa) => (sa?.id === actionId ? null : sa))
+		},
+		[updateButton]
+	)
+
+	const handleActionDrop = useCallback(
+		(
+			stepKey: string,
+			triggerKey: TriggerKey,
+			delay: number,
+			template: { connectionId: string; definitionId: string; options: Record<string, unknown> }
+		) => {
+			const newAction: CompanionAction = {
+				id: genId(),
+				instance: template.connectionId,
+				action: template.definitionId,
+				delay,
+				options: template.options ?? {},
+			}
+			updateButton((ctrl) => {
+				const s = ctrl.steps[stepKey] ?? { action_sets: {} }
+				return {
+					...ctrl,
+					steps: {
+						...ctrl.steps,
+						[stepKey]: {
+							...s,
+							action_sets: { ...s.action_sets, [triggerKey]: [...(s.action_sets[triggerKey] ?? []), newAction] },
+						},
+					},
+				}
+			})
+			setSelectedAction({ id: newAction.id, triggerKey, stepKey })
+		},
+		[updateButton]
+	)
+
+	const handleActionChange = useCallback(
+		(updated: CompanionAction) => {
+			if (!selectedAction) return
+			updateButton((ctrl) => {
+				const step = ctrl.steps[selectedAction.stepKey]
+				const actions = step.action_sets[selectedAction.triggerKey] ?? []
+				return {
+					...ctrl,
+					steps: {
+						...ctrl.steps,
+						[selectedAction.stepKey]: {
+							...step,
+							action_sets: {
+								...step.action_sets,
+								[selectedAction.triggerKey]: actions.map((a) => (a.id === updated.id ? updated : a)),
+							},
+						},
+					},
+				}
+			})
+		},
+		[selectedAction, updateButton]
+	)
+
+	// ── Group helpers ──────────────────────────────────────────────────────────
+	const updateGroupAtPath = useCallback(
+		(stepKey: string, triggerKey: TriggerKey, path: string[], updater: (c: CompanionAction[]) => CompanionAction[]) => {
+			if (path.length === 0) return
+			const traverse = (actions: CompanionAction[], remaining: string[]): CompanionAction[] => {
+				const [id, ...rest] = remaining
+				return actions.map((a) => {
+					if (a.id !== id) return a
+					const kids = a.children?.default ?? []
+					return {
+						...a,
+						children: { ...a.children, default: rest.length === 0 ? updater(kids) : traverse(kids, rest) },
+					}
+				})
+			}
+			updateButton((ctrl) => {
+				const step = ctrl.steps[stepKey]
+				return {
+					...ctrl,
+					steps: {
+						...ctrl.steps,
+						[stepKey]: {
+							...step,
+							action_sets: {
+								...step.action_sets,
+								[triggerKey]: traverse(step.action_sets[triggerKey] ?? [], path),
+							},
+						},
+					},
+				}
+			})
+		},
+		[updateButton]
+	)
+
+	const handleChildActionMove = useCallback(
+		(stepKey: string, triggerKey: TriggerKey, path: string[], childId: string, newDelay: number) =>
+			updateGroupAtPath(stepKey, triggerKey, path, (cs) =>
+				cs.map((c) => (c.id === childId ? { ...c, delay: newDelay } : c))
+			),
+		[updateGroupAtPath]
+	)
+
+	const handleChildActionReorder = useCallback(
+		(stepKey: string, triggerKey: TriggerKey, path: string[], fromIdx: number, toIdx: number) =>
+			updateGroupAtPath(stepKey, triggerKey, path, (cs) => {
+				const next = [...cs]
+				const [moved] = next.splice(fromIdx, 1)
+				next.splice(toIdx, 0, moved)
+				return next
+			}),
+		[updateGroupAtPath]
+	)
+
+	const handleChildActionAdd = useCallback(
+		(stepKey: string, triggerKey: TriggerKey, path: string[], delay: number) =>
+			setAddingAction({ stepKey, triggerKey, delay, groupPath: path }),
+		[]
+	)
+
+	const handleChildActionDrop = useCallback(
+		(
+			stepKey: string,
+			triggerKey: TriggerKey,
+			path: string[],
+			template: { connectionId: string; definitionId: string; options: Record<string, unknown> },
+			delay: number
+		) => {
+			const isGroup = template.connectionId === 'internal' && template.definitionId === 'action_group'
+			const newAction: CompanionAction = {
+				id: genId(),
+				action: template.definitionId,
+				instance: template.connectionId,
+				options: { ...template.options, ...(isGroup ? { execution_mode: 'concurrent' } : {}) },
+				delay,
+				...(isGroup ? { children: { default: [] } } : {}),
+			}
+			updateGroupAtPath(stepKey, triggerKey, path, (cs) => [...cs, newAction])
+		},
+		[updateGroupAtPath]
+	)
+
+	const handleChildExecutionModeChange = useCallback(
+		(stepKey: string, triggerKey: TriggerKey, path: string[], childId: string, mode: ExecutionMode) =>
+			updateGroupAtPath(stepKey, triggerKey, path, (cs) =>
+				cs.map((c) => (c.id === childId ? { ...c, options: { ...c.options, execution_mode: mode } } : c))
+			),
+		[updateGroupAtPath]
+	)
+
+	const handleModalAdd = useCallback(
+		(template: ActionTemplate) => {
+			if (!addingAction) return
+			const { stepKey, triggerKey, delay, groupPath } = addingAction
+			if (groupPath && groupPath.length > 0) {
+				handleChildActionDrop(
+					stepKey,
+					triggerKey,
+					groupPath,
+					{ connectionId: template.connectionId, definitionId: template.definitionId, options: template.options },
+					delay
+				)
+				setAddingAction(null)
+				return
+			}
+			const newAction: CompanionAction = {
+				id: genId(),
+				action: template.definitionId,
+				instance: template.connectionId,
+				options: template.options,
+				delay,
+			}
+			updateButton((ctrl) => {
+				const step = ctrl.steps[stepKey]
+				return {
+					...ctrl,
+					steps: {
+						...ctrl.steps,
+						[stepKey]: {
+							...step,
+							action_sets: { ...step.action_sets, [triggerKey]: [...(step.action_sets[triggerKey] ?? []), newAction] },
+						},
+					},
+				}
+			})
+			setSelectedAction({ id: newAction.id, triggerKey, stepKey })
+			setAddingAction(null)
+		},
+		[addingAction, handleChildActionDrop, updateButton]
+	)
+
+	// ── Step / trigger management ──────────────────────────────────────────────
+	const handleStepAdd = useCallback(() => {
+		updateButton((ctrl) => {
+			const nextKey = String(Object.keys(ctrl.steps).length)
+			return {
+				...ctrl,
+				steps: { ...ctrl.steps, [nextKey]: { action_sets: { down: [], up: [] }, options: { runWhileHeld: [] } } },
+			}
+		})
+	}, [updateButton])
+
+	const handleStepRemove = useCallback(
+		(stepKey: string) => {
+			updateButton((ctrl) => {
+				const remaining = Object.entries(ctrl.steps).filter(([k]) => k !== stepKey)
+				const reindexed: ButtonControl['steps'] = {}
+				remaining.forEach(([, v], i) => {
+					reindexed[String(i)] = v
+				})
+				return { ...ctrl, steps: reindexed }
+			})
+		},
+		[updateButton]
+	)
+
+	const handleTriggerAdd = useCallback(
+		(stepKey: string, holdMs: number) => {
+			updateButton((ctrl) => {
+				const step = ctrl.steps[stepKey]
+				if (!step || String(holdMs) in step.action_sets) return ctrl
+				return {
+					...ctrl,
+					steps: {
+						...ctrl.steps,
+						[stepKey]: { ...step, action_sets: { ...step.action_sets, [String(holdMs)]: [] } },
+					},
+				}
+			})
+		},
+		[updateButton]
+	)
+
+	const handleTriggerRemove = useCallback(
+		(stepKey: string, triggerKey: TriggerKey) => {
+			updateButton((ctrl) => {
+				const step = ctrl.steps[stepKey]
+				if (!step) return ctrl
+				const { [triggerKey]: _removed, ...rest } = step.action_sets
+				return { ...ctrl, steps: { ...ctrl.steps, [stepKey]: { ...step, action_sets: rest } } }
+			})
+			setSelectedAction((sa) => (sa?.triggerKey === triggerKey && sa?.stepKey === stepKey ? null : sa))
+		},
+		[updateButton]
+	)
+
+	const handleExecutionModeChange = useCallback(
+		(stepKey: string, triggerKey: TriggerKey, mode: ExecutionMode) => {
+			updateButton((ctrl) => {
+				const step = ctrl.steps[stepKey]
+				const actions = step.action_sets[triggerKey] ?? []
+				return {
+					...ctrl,
+					steps: {
+						...ctrl.steps,
+						[stepKey]: {
+							...step,
+							action_sets: {
+								...step.action_sets,
+								[triggerKey]: actions.map((a) =>
+									a.instance === 'internal' && a.action === 'action_group'
+										? { ...a, options: { ...a.options, execution_mode: mode } }
+										: a
+								),
+							},
+						},
+					},
+				}
+			})
+		},
+		[updateButton]
+	)
+
+	// ── Derived inspector data ─────────────────────────────────────────────────
+	const selectedActionData = useMemo<CompanionAction | null>(() => {
+		if (!control || !selectedAction) return null
+		const step = control.steps[selectedAction.stepKey]
+		if (!step) return null
+		const actions = step.action_sets[selectedAction.triggerKey] ?? []
+		return actions.find((a) => a.id === selectedAction.id) ?? null
+	}, [control, selectedAction])
+
+	const waitAfterMs = useMemo<number | null>(() => {
+		if (!control || !selectedAction || !selectedActionData) return null
+		const step = control.steps[selectedAction.stepKey]
+		if (!step) return null
+		const sorted = [...(step.action_sets[selectedAction.triggerKey] ?? [])].sort((a, b) => a.delay - b.delay)
+		const idx = sorted.findIndex((a) => a.id === selectedAction.id)
+		if (idx === -1 || idx === sorted.length - 1) return null
+		return sorted[idx + 1].delay - selectedActionData.delay
+	}, [control, selectedAction, selectedActionData])
+
+	const handleSetWaitAfter = useCallback(
+		(ms: number) => {
+			if (!selectedAction) return
+			updateButton((ctrl) => {
+				const s = ctrl.steps[selectedAction.stepKey]
+				if (!s) return ctrl
+				const actions = s.action_sets[selectedAction.triggerKey] ?? []
+				const sorted = [...actions].sort((a, b) => a.delay - b.delay)
+				const idx = sorted.findIndex((a) => a.id === selectedAction.id)
+				if (idx === -1 || idx === sorted.length - 1) return ctrl
+				const selected = sorted[idx]
+				const nextAction = sorted[idx + 1]
+				const targetDelay = selected.delay + Math.max(0, ms)
+				const delta = targetDelay - nextAction.delay
+				if (delta === 0) return ctrl
+				const shiftIds = new Set(sorted.slice(idx + 1).map((a) => a.id))
+				return {
+					...ctrl,
+					steps: {
+						...ctrl.steps,
+						[selectedAction.stepKey]: {
+							...s,
+							action_sets: {
+								...s.action_sets,
+								[selectedAction.triggerKey]: actions.map((a) =>
+									shiftIds.has(a.id) ? { ...a, delay: Math.max(0, a.delay + delta) } : a
+								),
+							},
+						},
+					},
+				}
+			})
+		},
+		[selectedAction, updateButton]
+	)
+
+	const handleAddActionAfter = useCallback(
+		(ms: number) => {
+			if (!selectedAction || !selectedActionData) return
+			setAddingAction({
+				stepKey: selectedAction.stepKey,
+				triggerKey: selectedAction.triggerKey,
+				delay: selectedActionData.delay + Math.max(0, ms),
+			})
+		},
+		[selectedAction, selectedActionData]
+	)
+
+	const handleSyncOptionToAll = useCallback(
+		(key: string, value: unknown) => {
+			if (!selectedActionData) return
+			const { action: actionId, instance: instanceId, id: selfId } = selectedActionData
+			updateButton((ctrl) => {
+				const newSteps: ButtonControl['steps'] = {}
+				for (const [sk, step] of Object.entries(ctrl.steps)) {
+					const newSets: typeof step.action_sets = {}
+					for (const [tk, actions] of Object.entries(step.action_sets)) {
+						newSets[tk] = (actions ?? []).map((a) =>
+							a.id !== selfId && a.action === actionId && a.instance === instanceId
+								? { ...a, options: { ...a.options, [key]: value } }
+								: a
+						)
+					}
+					newSteps[sk] = { ...step, action_sets: newSets }
+				}
+				return { ...ctrl, steps: newSteps }
+			})
+		},
+		[selectedActionData, updateButton]
+	)
+
+	const knownActionIds = useMemo(() => {
+		const ids = new Set<string>()
+		for (const a of library) if (a.definitionId) ids.add(a.definitionId)
+		return [...ids].sort()
+	}, [library])
+
+	// ── Playback (local scrub; fires the real button via hot-press) ────────────
+	const stopAnimation = useCallback(() => {
+		if (animFrameRef.current) cancelAnimationFrame(animFrameRef.current)
+		playStartRef.current = null
+	}, [])
+
+	const handlePause = useCallback(() => {
+		stopAnimation()
+		setIsPlaying(false)
+		setIsPaused(true)
+	}, [stopAnimation])
+
+	const handleStop = useCallback(() => {
+		stopAnimation()
+		setIsPlaying(false)
+		setIsPaused(false)
+		setPlayheadMs(0)
+	}, [stopAnimation])
+
+	const startPlayFrom = useCallback(
+		(startMs: number) => {
+			if (!control) return
+			const actionEnd = (a: CompanionAction, parentDelay = 0): number => {
+				const absStart = parentDelay + a.delay
+				const dur = ['timeout', 'duration'].reduce((best, k) => {
+					const v = a.options?.[k]
+					const n = Number(v)
+					return v != null && v !== '' && !isNaN(n) && n > 0 ? Math.max(best, n) : best
+				}, 0)
+				let end = absStart + dur
+				for (const kids of Object.values(a.children ?? {}))
+					for (const c of kids ?? []) end = Math.max(end, actionEnd(c, absStart))
+				return end
+			}
+			let maxEndMs = 0
+			for (const step of Object.values(control.steps))
+				for (const acts of Object.values(step.action_sets))
+					for (const a of acts ?? []) maxEndMs = Math.max(maxEndMs, actionEnd(a))
+			const tail = Math.max(300, Math.round(timelineVisibleMsRef.current / 8))
+			const maxMs = maxEndMs + tail
+			if (startMs >= maxMs) {
+				setPlayheadMs(0)
+				return
+			}
+
+			setIsPlaying(true)
+			setIsPaused(false)
+			playStartRef.current = { wallTime: performance.now(), startMs }
+			pressButton(true)
+			setTimeout(() => pressButton(false), 50)
+
+			const tick = () => {
+				const ref = playStartRef.current
+				if (!ref) return
+				const currentMs = ref.startMs + (performance.now() - ref.wallTime)
+				setPlayheadMs(currentMs)
+				if (currentMs < maxMs) {
+					animFrameRef.current = requestAnimationFrame(tick)
+				} else {
+					setPlayheadMs(maxMs)
+					setIsPlaying(false)
+					setIsPaused(false)
+					playStartRef.current = null
+				}
+			}
+			animFrameRef.current = requestAnimationFrame(tick)
+		},
+		[control, pressButton]
+	)
+
+	const handlePlay = useCallback(() => {
+		if (!control) return
+		if (isPlaying) {
+			handlePause()
+			return
+		}
+		startPlayFrom(playheadMs)
+	}, [control, isPlaying, playheadMs, startPlayFrom, handlePause])
+
+	// Stop playback when the selected button changes
+	useEffect(() => {
+		stopAnimation()
+		setIsPlaying(false)
+		setIsPaused(false)
+	}, [controlId, stopAnimation])
+
+	// ── Keyboard shortcuts (scoped to this page) ───────────────────────────────
+	const handlePlayRef = useRef(handlePlay)
+	const handleStopRef = useRef(handleStop)
+	const selectedActionRef = useRef(selectedAction)
+	const undoRef = useRef(undo)
+	const deleteRef = useRef(handleActionDelete)
+	handlePlayRef.current = handlePlay
+	handleStopRef.current = handleStop
+	selectedActionRef.current = selectedAction
+	undoRef.current = undo
+	deleteRef.current = handleActionDelete
+
+	useEffect(() => {
+		const isTyping = (t: EventTarget | null) => {
+			const el = t as HTMLElement | null
+			return (
+				!!el && (el.tagName === 'INPUT' || el.tagName === 'SELECT' || el.tagName === 'TEXTAREA' || el.isContentEditable)
+			)
+		}
+		const handler = (e: KeyboardEvent) => {
+			if (isTyping(e.target)) return
+			if ((e.metaKey || e.ctrlKey) && e.key === 'z' && !e.shiftKey) {
+				e.preventDefault()
+				undoRef.current()
+				return
+			}
+			if (e.key === ' ') {
+				e.preventDefault()
+				handlePlayRef.current()
+			} else if (e.key === 'Escape') {
+				e.preventDefault()
+				handleStopRef.current()
+			} else if (e.key === 'Delete' || e.key === 'Backspace') {
+				const sa = selectedActionRef.current
+				if (sa) {
+					e.preventDefault()
+					deleteRef.current(sa.stepKey, sa.triggerKey, sa.id)
+				}
+			} else if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+				e.preventDefault()
+				const step = e.shiftKey ? 500 : e.ctrlKey || e.metaKey ? 100 : 50
+				setPlayheadMs((ms) => Math.max(0, ms + (e.key === 'ArrowRight' ? step : -step)))
+			}
+		}
+		window.addEventListener('keydown', handler)
+		return () => window.removeEventListener('keydown', handler)
+	}, [])
+
+	// ── Render data ────────────────────────────────────────────────────────────
+	const pageName = pages.get(pageNumber)?.name || `Page ${pageNumber}`
+	const buttonLabel = control?.style?.text?.trim() || (controlId ? 'Button' : '')
+	const timelineButtons: TimelineButton[] = useMemo(() => {
+		if (!control || !controlId) return []
+		return [{ key: controlId, label: buttonLabel, pageSlot: pageName, control }]
+	}, [control, controlId, buttonLabel, pageName])
+
+	const buttonStyle = control?.style
+	const bgColor = buttonStyle ? intToColor(buttonStyle.bgcolor ?? 0) : '#1a1a1a'
+	const fgColor = buttonStyle ? intToColor(buttonStyle.color ?? 0xffffff) : '#fff'
+
+	const pageCount = Math.max(1, pages.pageCount)
+
+	return (
+		<div className="ct-root">
+			<div className="app">
+				{addingAction && (
+					<AddActionModal library={library} onAdd={handleModalAdd} onClose={() => setAddingAction(null)} />
+				)}
+
+				<div className="titlebar">
+					<div className="titlebar-title">
+						<span className="live-badge">LIVE</span>
+						Timeline
+						{dirty && <span className="dirty-dot" />}
+						{saveStatus && <span className="save-status">{saveStatus}</span>}
+					</div>
+					<div className="titlebar-actions">
+						<button className="toolbar-btn" onClick={handleStop} disabled={!isPlaying && !isPaused} title="Stop [Esc]">
+							■
+						</button>
+						<button
+							className={`toolbar-btn ${isPlaying ? 'toolbar-btn--playing' : isPaused ? 'toolbar-btn--active' : ''}`}
+							onClick={handlePlay}
+							disabled={!controlId || !control}
+							title={isPlaying ? 'Pause [Space]' : 'Play from playhead [Space]'}
+						>
+							{isPlaying ? '⏸' : '▶'}
+						</button>
+						<button
+							className="toolbar-btn toolbar-btn--test"
+							onMouseDown={() => pressButton(true)}
+							onMouseUp={() => pressButton(false)}
+							onMouseLeave={() => pressButton(false)}
+							disabled={!controlId}
+							title="Hold to test this button live in Companion"
+						>
+							▶ Test
+						</button>
+						<button
+							className={`toolbar-btn ${showLibrary ? 'toolbar-btn--active' : ''}`}
+							onClick={() => setShowLibrary((v) => !v)}
+							title="Toggle action library"
+						>
+							⊞ Library
+						</button>
+					</div>
+				</div>
+
+				<div className="workspace">
+					<div className="sidebar-panel">
+						<div className="sidebar-header">Buttons</div>
+						<div className="ct-page-bar">
+							<button
+								className="step-tab"
+								disabled={pageNumber <= 1}
+								onClick={() => setPageNumber((p) => Math.max(1, p - 1))}
+							>
+								‹
+							</button>
+							<span className="ct-page-name">{pageName}</span>
+							<button
+								className="step-tab"
+								disabled={pageNumber >= pageCount}
+								onClick={() => setPageNumber((p) => Math.min(pageCount, p + 1))}
+							>
+								›
+							</button>
+						</div>
+						<TimelineButtonGrid
+							pageNumber={pageNumber}
+							gridSize={gridSize}
+							selectedLocation={selectedLocation}
+							onSelect={selectButton}
+						/>
+					</div>
+
+					{showLibrary && <LibraryPanel library={library} />}
+
+					<div className="main-panel">
+						{control && (
+							<div className="button-header" style={{ backgroundColor: bgColor, color: fgColor }}>
+								<span className="button-header-key">{pageName}</span>
+								<span className="button-header-text">{buttonStyle?.text || '(no label)'}</span>
+							</div>
+						)}
+						<div className="view-tabs">
+							<button className="view-tab view-tab--active">Timeline</button>
+						</div>
+						{control ? (
+							<Timeline
+								buttons={timelineButtons}
+								selectedKey={controlId}
+								instances={instances}
+								selectedActionId={selectedAction?.id ?? null}
+								playheadMs={playheadMs}
+								onPlayheadChange={setPlayheadMs}
+								onActionSelect={handleActionSelect}
+								onActionMove={handleActionMove}
+								onActionAdd={handleActionAdd}
+								onActionDrop={handleActionDrop}
+								onActionDelete={handleActionDelete}
+								onStepAdd={handleStepAdd}
+								onStepRemove={handleStepRemove}
+								onTriggerAdd={handleTriggerAdd}
+								onTriggerRemove={handleTriggerRemove}
+								onActionDelayChange={handleActionDelayChange}
+								onExecutionModeChange={handleExecutionModeChange}
+								onVisibleMsChange={(ms) => {
+									timelineVisibleMsRef.current = ms
+								}}
+								onChildActionMove={handleChildActionMove}
+								onChildActionReorder={handleChildActionReorder}
+								onChildActionAdd={handleChildActionAdd}
+								onChildActionDrop={handleChildActionDrop}
+								onChildExecutionModeChange={handleChildExecutionModeChange}
+							/>
+						) : (
+							<div className="timeline-empty">
+								<p>Select a button to start editing its action timeline</p>
+							</div>
+						)}
+					</div>
+
+					{selectedActionData && selectedAction ? (
+						<div className="inspector-panel">
+							<ActionInspector
+								action={selectedActionData}
+								triggerKey={selectedAction.triggerKey}
+								stepKey={selectedAction.stepKey}
+								instances={instances}
+								knownActionIds={knownActionIds}
+								waitAfterMs={waitAfterMs}
+								onChange={handleActionChange}
+								onSetWaitAfter={handleSetWaitAfter}
+								onAddActionAfter={handleAddActionAfter}
+								onDelete={() =>
+									handleActionDelete(selectedAction.stepKey, selectedAction.triggerKey, selectedAction.id)
+								}
+								onSyncOptionToAll={handleSyncOptionToAll}
+							/>
+						</div>
+					) : (
+						<div className="inspector-panel inspector-panel--empty">
+							<p>Select an action to inspect</p>
+						</div>
+					)}
+				</div>
+			</div>
+		</div>
+	)
+})

--- a/webui/src/Timeline/adapter.ts
+++ b/webui/src/Timeline/adapter.ts
@@ -1,0 +1,180 @@
+// Translation between Companion v5's entity model and the flat timeline model.
+//
+// Ported from the standalone Companion Timeline app's main.cjs
+// (`processActionsFromCompanion` / `processActionsToCompanion`). In v5 there is no
+// per-action `delay`: gaps are explicit `internal: wait` action entities. Reading, we
+// collapse `wait` entities into a `delay` offset on the following action; writing, we
+// re-insert `wait` entities for the gaps between consecutive action delays.
+
+import { nanoid } from 'nanoid'
+import type { SomeButtonModel } from '@companion-app/shared/Model/ButtonModel.js'
+import {
+	EntityModelType,
+	type ActionEntityModel,
+	type SomeEntityModel,
+} from '@companion-app/shared/Model/EntityModel.js'
+import type { ActionSets, ButtonControl, CompanionAction, Step } from './types.js'
+
+const WAIT_TIME_OPTION = 'time'
+
+function isWait(e: SomeEntityModel): boolean {
+	return e.type === EntityModelType.Action && e.connectionId === 'internal' && e.definitionId === 'wait'
+}
+function isActionGroup(e: SomeEntityModel | CompanionAction): boolean {
+	const conn = 'connectionId' in e ? e.connectionId : e.instance
+	const def = 'definitionId' in e ? e.definitionId : e.action
+	return conn === 'internal' && def === 'action_group'
+}
+
+// Companion stores option values as { isExpression, value } pairs. The flat model uses raw values.
+function flattenOptions(opts: Record<string, any> | undefined): Record<string, unknown> {
+	const out: Record<string, unknown> = {}
+	for (const [k, v] of Object.entries(opts ?? {})) {
+		out[k] = v !== null && typeof v === 'object' && 'value' in v ? v.value : v
+	}
+	return out
+}
+
+function optionTime(e: SomeEntityModel): number {
+	const raw = (e.options as Record<string, any>)?.[WAIT_TIME_OPTION]
+	const v = raw !== null && typeof raw === 'object' && 'value' in raw ? raw.value : raw
+	const n = Number(v)
+	return isNaN(n) ? 0 : n
+}
+
+// ── Read: v5 entities → flat actions ────────────────────────────────────────
+
+export function entitiesToFlatActions(entities: SomeEntityModel[] | undefined): CompanionAction[] {
+	let accMs = 0
+	const result: CompanionAction[] = []
+	for (const e of entities ?? []) {
+		if (e.type !== EntityModelType.Action) continue
+		if (isWait(e)) {
+			accMs += optionTime(e)
+			continue
+		}
+		if (isActionGroup(e)) {
+			const children: Record<string, CompanionAction[]> = {}
+			for (const [setKey, kids] of Object.entries(e.children ?? {})) {
+				children[setKey] = entitiesToFlatActions(kids)
+			}
+			result.push({
+				id: e.id,
+				action: e.definitionId,
+				instance: e.connectionId,
+				options: flattenOptions(e.options),
+				delay: accMs,
+				disabled: e.disabled,
+				children,
+			})
+			accMs = 0
+			continue
+		}
+		result.push({
+			id: e.id,
+			action: e.definitionId,
+			instance: e.connectionId,
+			options: flattenOptions(e.options),
+			delay: accMs,
+			disabled: e.disabled,
+		})
+		accMs = 0
+	}
+	return result
+}
+
+// ── Write: flat actions → v5 entities ───────────────────────────────────────
+
+function wrapOptions(
+	flat: Record<string, unknown> | undefined
+): Record<string, { value: unknown; isExpression: boolean }> {
+	const out: Record<string, { value: unknown; isExpression: boolean }> = {}
+	for (const [k, v] of Object.entries(flat ?? {})) {
+		out[k] = v !== null && typeof v === 'object' && 'value' in v ? (v as any) : { value: v, isExpression: false }
+	}
+	return out
+}
+
+function makeWaitEntity(ms: number): ActionEntityModel {
+	return {
+		type: EntityModelType.Action,
+		id: nanoid(),
+		connectionId: 'internal',
+		definitionId: 'wait',
+		options: { [WAIT_TIME_OPTION]: { value: String(ms), isExpression: false } },
+		upgradeIndex: undefined,
+	}
+}
+
+export function flatActionsToEntities(actions: CompanionAction[]): SomeEntityModel[] {
+	const sorted = [...actions]
+		.filter((a) => a.instance && a.action) // skip blank/incomplete actions
+		.sort((a, b) => (a.delay || 0) - (b.delay || 0))
+	const result: SomeEntityModel[] = []
+	let prevMs = 0
+	for (const a of sorted) {
+		const gap = (a.delay || 0) - prevMs
+		if (gap > 0) result.push(makeWaitEntity(gap))
+
+		if (isActionGroup(a)) {
+			const children: Record<string, SomeEntityModel[]> = {}
+			for (const [setKey, kids] of Object.entries(a.children ?? {})) {
+				children[setKey] = flatActionsToEntities(kids ?? [])
+			}
+			result.push({
+				type: EntityModelType.Action,
+				id: a.id,
+				connectionId: 'internal',
+				definitionId: 'action_group',
+				options: wrapOptions(a.options) as any,
+				upgradeIndex: undefined,
+				children,
+				...(a.disabled != null ? { disabled: a.disabled } : {}),
+			})
+		} else {
+			result.push({
+				type: EntityModelType.Action,
+				id: a.id,
+				connectionId: a.instance,
+				definitionId: a.action,
+				options: wrapOptions(a.options) as any,
+				upgradeIndex: undefined,
+				...(a.disabled != null ? { disabled: a.disabled } : {}),
+			})
+		}
+		prevMs = a.delay || 0
+	}
+	return result
+}
+
+// ── Whole-control conversion (read) ─────────────────────────────────────────
+
+const TEXT_LAYER_TYPES = new Set(['text'])
+
+function extractStyle(model: SomeButtonModel): ButtonControl['style'] {
+	if (model.type !== 'button-layered') return {}
+	const layers = (model.style?.layers ?? []) as any[]
+	const textLayer = layers.find((l) => TEXT_LAYER_TYPES.has(l?.type))
+	const boxLayer = layers.find((l) => l?.type === 'box')
+	const unwrap = (v: any) => (v !== null && typeof v === 'object' && 'value' in v ? v.value : v)
+	return {
+		text: unwrap(textLayer?.text) ?? '',
+		color: unwrap(textLayer?.color) ?? 0xffffff,
+		bgcolor: unwrap(boxLayer?.color) ?? 0,
+		size: 'auto',
+	}
+}
+
+export function buttonModelToFlat(model: SomeButtonModel | null | undefined): ButtonControl | null {
+	if (!model || model.type !== 'button-layered') return null
+	const steps: Record<string, Step> = {}
+	for (const [stepKey, step] of Object.entries(model.steps ?? {})) {
+		if (!step) continue
+		const action_sets: ActionSets = {}
+		for (const [setId, entities] of Object.entries(step.action_sets ?? {})) {
+			action_sets[setId] = entitiesToFlatActions(entities)
+		}
+		steps[stepKey] = { action_sets, options: step.options }
+	}
+	return { type: 'button', style: extractStyle(model), steps }
+}

--- a/webui/src/Timeline/components/ActionInspector.tsx
+++ b/webui/src/Timeline/components/ActionInspector.tsx
@@ -1,0 +1,290 @@
+import React, { useCallback, useState } from 'react'
+import { triggerLabel, type CompanionAction, type CompanionInstance, type TriggerKey } from '../types.js'
+
+// Render an option value (which may be any JSON value) as editable text.
+function optionToString(val: unknown): string {
+	if (val == null) return ''
+	if (typeof val === 'string') return val
+	if (typeof val === 'number' || typeof val === 'boolean') return val.toString()
+	return JSON.stringify(val)
+}
+
+interface Props {
+	action: CompanionAction
+	triggerKey: TriggerKey
+	stepKey: string
+	instances: Record<string, CompanionInstance>
+	knownActionIds: string[]
+	waitAfterMs: number | null // null = no next action; ≥0 = current gap to next
+	onChange: (updated: CompanionAction) => void
+	onSetWaitAfter: (ms: number) => void
+	onAddActionAfter: (delayMs: number) => void
+	onDelete: () => void
+	onSyncOptionToAll?: (key: string, value: unknown) => void
+}
+
+export default function ActionInspector({
+	action,
+	triggerKey,
+	stepKey,
+	instances,
+	knownActionIds,
+	waitAfterMs,
+	onChange,
+	onSetWaitAfter,
+	onAddActionAfter,
+	onDelete,
+	onSyncOptionToAll,
+}: Props): React.JSX.Element {
+	const handleField = useCallback(
+		(field: keyof CompanionAction, value: unknown) => onChange({ ...action, [field]: value }),
+		[action, onChange]
+	)
+
+	const handleDelay = useCallback(
+		(e: React.ChangeEvent<HTMLInputElement>) => {
+			const v = parseInt(e.target.value)
+			if (!isNaN(v) && v >= 0) handleField('delay', v)
+		},
+		[handleField]
+	)
+
+	const handleOption = useCallback(
+		(key: string, raw: string) => {
+			const num = Number(raw)
+			const value = raw === '' ? '' : isNaN(num) ? raw : num
+			onChange({ ...action, options: { ...action.options, [key]: value } })
+		},
+		[action, onChange]
+	)
+
+	const [newOptKey, setNewOptKey] = useState('')
+
+	const commitNewOption = useCallback(() => {
+		const key = newOptKey.trim()
+		if (!key) return
+		setNewOptKey('')
+		onChange({ ...action, options: { ...action.options, [key]: '' } })
+	}, [newOptKey, action, onChange])
+
+	const removeOption = useCallback(
+		(key: string) => {
+			const opts = { ...action.options }
+			delete opts[key]
+			onChange({ ...action, options: opts })
+		},
+		[action, onChange]
+	)
+
+	const [waitInput, setWaitInput] = useState<string>(waitAfterMs != null && waitAfterMs > 0 ? String(waitAfterMs) : '')
+
+	// Reset input when the selected action changes
+	const prevActionId = React.useRef(action.id)
+	if (action.id !== prevActionId.current) {
+		prevActionId.current = action.id
+		// Sync waitInput to the new action's current gap
+		const next = waitAfterMs != null && waitAfterMs > 0 ? String(waitAfterMs) : ''
+		if (waitInput !== next) setWaitInput(next)
+	}
+
+	const handleWaitApply = useCallback(() => {
+		const ms = parseInt(waitInput)
+		if (!isNaN(ms) && ms >= 0) onSetWaitAfter(ms)
+	}, [waitInput, onSetWaitAfter])
+
+	const handleAddAfter = useCallback(() => {
+		const ms = parseInt(waitInput) || 500
+		onAddActionAfter(ms)
+	}, [waitInput, onAddActionAfter])
+
+	const actionSuggestions = knownActionIds
+
+	const listId = `action-list-${action.id}`
+
+	return (
+		<div className="inspector">
+			<div className="inspector-header">
+				<span className="inspector-title">Action</span>
+				<button className="inspector-delete" onClick={onDelete} title="Delete action">
+					✕
+				</button>
+			</div>
+
+			{/* Instance picker */}
+			<div className="inspector-section">
+				<div className="inspector-section-title">Connection</div>
+				<div className="inspector-row">
+					<label>Instance</label>
+					<div className="inspector-input-row">
+						<select
+							className="inspector-input inspector-select"
+							value={action.instance}
+							onChange={(e) => handleField('instance', e.target.value)}
+						>
+							{!action.instance && <option value="">— pick instance —</option>}
+							{Object.entries(instances).map(([id, inst]) => (
+								<option key={id} value={id}>
+									{inst.label} ({inst.instance_type})
+								</option>
+							))}
+							{action.instance && !instances[action.instance] && (
+								<option value={action.instance}>{action.instance} (unknown)</option>
+							)}
+						</select>
+					</div>
+				</div>
+
+				{/* Action definition picker */}
+				<div className="inspector-row">
+					<label>Action ID</label>
+					<input
+						list={listId}
+						className="inspector-input"
+						value={action.action}
+						placeholder="e.g. go, pause, play"
+						onChange={(e) => handleField('action', e.target.value)}
+					/>
+					<datalist id={listId}>
+						{actionSuggestions.map((id) => (
+							<option key={id} value={id} />
+						))}
+					</datalist>
+					<div className="inspector-hint">
+						Trigger: {triggerLabel(triggerKey)} · Step {parseInt(stepKey) + 1}
+					</div>
+				</div>
+			</div>
+
+			{/* Timing */}
+			<div className="inspector-section">
+				<div className="inspector-section-title">Timing</div>
+				<div className="inspector-row">
+					<label>Delay (ms)</label>
+					<input
+						type="number"
+						min={0}
+						step={10}
+						value={action.delay}
+						onChange={handleDelay}
+						className="inspector-input"
+					/>
+				</div>
+			</div>
+
+			{/* Wait After */}
+			<div className="inspector-section">
+				<div className="inspector-section-title">Wait After</div>
+				{waitAfterMs === null ? (
+					<div className="inspector-row">
+						<label>Add after (ms)</label>
+						<div className="inspector-input-row">
+							<input
+								type="number"
+								min={0}
+								step={50}
+								className="inspector-input"
+								placeholder="500"
+								value={waitInput}
+								onChange={(e) => setWaitInput(e.target.value)}
+								onKeyDown={(e) => {
+									if (e.key === 'Enter') handleAddAfter()
+								}}
+							/>
+							<button
+								className="modal-btn modal-btn--primary"
+								style={{ padding: '4px 10px', fontSize: 12 }}
+								onClick={handleAddAfter}
+							>
+								Add
+							</button>
+						</div>
+					</div>
+				) : (
+					<>
+						{waitAfterMs > 0 && (
+							<div className="inspector-row">
+								<label>Current gap</label>
+								<span className="inspector-value muted">{waitAfterMs}ms</span>
+							</div>
+						)}
+						<div className="inspector-row">
+							<label>Set wait (ms)</label>
+							<div className="inspector-input-row">
+								<input
+									type="number"
+									min={0}
+									step={50}
+									className="inspector-input"
+									placeholder={waitAfterMs > 0 ? String(waitAfterMs) : '0'}
+									value={waitInput}
+									onChange={(e) => setWaitInput(e.target.value)}
+									onKeyDown={(e) => {
+										if (e.key === 'Enter') handleWaitApply()
+									}}
+								/>
+								<button
+									className="modal-btn modal-btn--primary"
+									style={{ padding: '4px 10px', fontSize: 12 }}
+									onClick={handleWaitApply}
+								>
+									{waitAfterMs > 0 ? 'Update' : 'Add'}
+								</button>
+							</div>
+						</div>
+					</>
+				)}
+			</div>
+
+			{/* Options */}
+			<div className="inspector-section">
+				<div className="inspector-section-title-row">
+					<span className="inspector-section-title">Options</span>
+				</div>
+				{Object.entries(action.options).map(([key, val]) => (
+					<div key={key} className="inspector-row inspector-option-row">
+						<div className="inspector-option-key">
+							<span className="inspector-opt-label">{key}</span>
+							<button className="inspector-remove-opt" onClick={() => removeOption(key)} title="Remove">
+								×
+							</button>
+						</div>
+						<div className="inspector-input-row">
+							<input
+								className="inspector-input"
+								value={optionToString(val)}
+								onChange={(e) => handleOption(key, e.target.value)}
+							/>
+							{onSyncOptionToAll && (
+								<button
+									className="inspector-sync-opt"
+									title={`Apply ${key} = ${val} to all "${action.action}" actions on this button`}
+									onClick={() => onSyncOptionToAll(key, val)}
+								>
+									≡
+								</button>
+							)}
+						</div>
+					</div>
+				))}
+				<div className="inspector-row inspector-option-add-row">
+					<input
+						className="inspector-input"
+						placeholder="New option key…"
+						value={newOptKey}
+						onChange={(e) => setNewOptKey(e.target.value)}
+						onKeyDown={(e) => {
+							if (e.key === 'Enter') commitNewOption()
+						}}
+					/>
+					<button
+						className="modal-btn modal-btn--primary"
+						style={{ padding: '4px 10px', fontSize: 12 }}
+						onClick={commitNewOption}
+					>
+						Add
+					</button>
+				</div>
+			</div>
+		</div>
+	)
+}

--- a/webui/src/Timeline/components/AddActionModal.tsx
+++ b/webui/src/Timeline/components/AddActionModal.tsx
@@ -1,0 +1,200 @@
+import React, { useCallback, useMemo, useRef, useState } from 'react'
+import type { ActionEntry } from '../library.js'
+
+export interface ActionTemplate {
+	connectionId: string
+	definitionId: string
+	options: Record<string, unknown>
+}
+
+interface Props {
+	library: ActionEntry[]
+	onAdd: (template: ActionTemplate) => void
+	onClose: () => void
+}
+
+export default function AddActionModal({ library, onAdd, onClose }: Props): React.JSX.Element {
+	const actions = useMemo(() => library.filter((a) => !a.noActions), [library])
+	const [search, setSearch] = useState('')
+	const [selectedConnId, setSelectedConnId] = useState<string>('')
+	const [selectedDefId, setSelectedDefId] = useState<string>('')
+	const searchRef = useRef<HTMLInputElement>(null)
+
+	// Unique connections from actions list
+	const connections = useMemo(() => {
+		const map = new Map<string, { label: string; moduleId: string }>()
+		for (const a of actions) {
+			if (!map.has(a.connectionId)) map.set(a.connectionId, { label: a.connectionLabel, moduleId: a.moduleId })
+		}
+		return map
+	}, [actions])
+
+	const filtered = useMemo(() => {
+		const q = search.toLowerCase().trim()
+		return actions
+			.filter((a) => {
+				if (selectedConnId && a.connectionId !== selectedConnId) return false
+				if (!q) return true
+				return (
+					a.definitionId.toLowerCase().includes(q) ||
+					a.label.toLowerCase().includes(q) ||
+					a.connectionLabel.toLowerCase().includes(q)
+				)
+			})
+			.sort((a, b) => {
+				if (a.usedBefore !== b.usedBefore) return a.usedBefore ? -1 : 1
+				return a.label.localeCompare(b.label)
+			})
+	}, [actions, selectedConnId, search])
+
+	const grouped = useMemo(() => {
+		const map = new Map<string, ActionEntry[]>()
+		for (const a of filtered) {
+			if (!map.has(a.connectionId)) map.set(a.connectionId, [])
+			map.get(a.connectionId)!.push(a)
+		}
+		return map
+	}, [filtered])
+
+	const selected = useMemo(
+		() => actions.find((a) => a.connectionId === selectedConnId && a.definitionId === selectedDefId) ?? null,
+		[actions, selectedConnId, selectedDefId]
+	)
+
+	const handleAdd = useCallback(() => {
+		if (!selectedConnId || !selectedDefId) return
+		onAdd(selected ?? { connectionId: selectedConnId, definitionId: selectedDefId, options: {} })
+	}, [selectedConnId, selectedDefId, selected, onAdd])
+
+	const handleKeyDown = useCallback(
+		(e: React.KeyboardEvent) => {
+			if (e.key === 'Escape') {
+				e.stopPropagation()
+				onClose()
+			}
+			if (e.key === 'Enter' && selectedConnId && selectedDefId) handleAdd()
+		},
+		[onClose, handleAdd, selectedConnId, selectedDefId]
+	)
+
+	const pick = (a: ActionEntry) => {
+		setSelectedConnId(a.connectionId)
+		setSelectedDefId(a.definitionId)
+	}
+
+	return (
+		<div
+			className="modal-backdrop"
+			onClick={(e) => {
+				if (e.target === e.currentTarget) onClose()
+			}}
+		>
+			<div className="modal modal--wide" onKeyDown={handleKeyDown}>
+				<div className="modal-header">
+					<span className="modal-title">Add Action</span>
+					<button className="modal-close" onClick={onClose}>
+						✕
+					</button>
+				</div>
+
+				<div className="modal-body modal-body--actions">
+					<div className="action-conn-list">
+						<div className="action-conn-header">Connections</div>
+						<button
+							className={`action-conn-item ${!selectedConnId ? 'action-conn-item--active' : ''}`}
+							onClick={() => setSelectedConnId('')}
+						>
+							All connections
+							<span className="action-conn-count">{actions.length}</span>
+						</button>
+						{[...connections.entries()].map(([id, conn]) => {
+							const count = actions.filter((a) => a.connectionId === id).length
+							return (
+								<button
+									key={id}
+									className={`action-conn-item ${selectedConnId === id ? 'action-conn-item--active' : ''}`}
+									onClick={() => setSelectedConnId(id)}
+								>
+									<span className="action-conn-label">{conn.label}</span>
+									<span className="action-conn-module">{conn.moduleId.split('-').slice(-1)[0]}</span>
+									<span className="action-conn-count">{count}</span>
+								</button>
+							)
+						})}
+					</div>
+
+					<div className="action-pick-area">
+						<input
+							ref={searchRef}
+							className="inspector-input action-search"
+							placeholder="Search actions…"
+							value={search}
+							onChange={(e) => setSearch(e.target.value)}
+							autoFocus
+						/>
+
+						<div className="action-list action-list--tall">
+							{filtered.length === 0 && <div className="action-list-empty">No actions found</div>}
+
+							{[...grouped.entries()].map(([connId, connActions]) => {
+								const conn = connections.get(connId)
+								const showHeader = !selectedConnId || grouped.size > 1
+								return (
+									<div key={connId}>
+										{showHeader && (
+											<div className="action-group-header">
+												{conn?.label ?? connId}
+												<span className="action-group-module">{conn?.moduleId}</span>
+											</div>
+										)}
+										{connActions.map((a) => {
+											const isSelected = a.connectionId === selectedConnId && a.definitionId === selectedDefId
+											return (
+												<button
+													key={`${a.connectionId}:${a.definitionId}`}
+													className={`action-list-item ${isSelected ? 'action-list-item--selected' : ''}`}
+													onClick={() => pick(a)}
+													onDoubleClick={() => {
+														pick(a)
+														onAdd(a)
+													}}
+												>
+													<span className="action-list-id">
+														{a.label || a.definitionId}
+														{a.usedBefore && <span className="action-used-dot" title="Used on this button" />}
+													</span>
+												</button>
+											)
+										})}
+									</div>
+								)
+							})}
+						</div>
+					</div>
+				</div>
+
+				<div className="modal-footer">
+					<div className="modal-footer-hint">
+						{selected ? (
+							<span className="muted">
+								{selected.connectionLabel} · {selected.label || selected.definitionId}
+							</span>
+						) : (
+							<span className="muted">Double-click or select + Add</span>
+						)}
+					</div>
+					<button className="modal-btn modal-btn--secondary" onClick={onClose}>
+						Cancel
+					</button>
+					<button
+						className="modal-btn modal-btn--primary"
+						disabled={!selectedConnId || !selectedDefId}
+						onClick={handleAdd}
+					>
+						Add Action
+					</button>
+				</div>
+			</div>
+		</div>
+	)
+}

--- a/webui/src/Timeline/components/ButtonGrid.tsx
+++ b/webui/src/Timeline/components/ButtonGrid.tsx
@@ -1,0 +1,67 @@
+import { observer } from 'mobx-react-lite'
+import { useContext } from 'react'
+import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
+import { ButtonPreviewBase } from '~/Components/ButtonPreview.js'
+import { useButtonImageForControlId } from '~/Hooks/useButtonImageForControlId.js'
+import { RootAppStoreContext } from '~/Stores/RootAppStore.js'
+
+interface ButtonGridProps {
+	pageNumber: number
+	gridSize: { minRow: number; maxRow: number; minColumn: number; maxColumn: number }
+	selectedLocation: ControlLocation | null
+	onSelect: (location: ControlLocation) => void
+}
+
+const Cell = observer(function Cell({
+	location,
+	selected,
+	onSelect,
+}: {
+	location: ControlLocation
+	selected: boolean
+	onSelect: (location: ControlLocation) => void
+}) {
+	const { pages } = useContext(RootAppStoreContext)
+	const controlId = pages.getControlIdAtLocation(location)
+	const image = useButtonImageForControlId(controlId ?? '', !controlId)
+
+	return (
+		<ButtonPreviewBase
+			fixedSize
+			preview={image}
+			selected={selected}
+			title={`Row ${location.row} · Col ${location.column}`}
+			onClick={() => onSelect(location)}
+		/>
+	)
+})
+
+export const TimelineButtonGrid = observer(function TimelineButtonGrid({
+	pageNumber,
+	gridSize,
+	selectedLocation,
+	onSelect,
+}: ButtonGridProps) {
+	const rows: number[] = []
+	for (let r = gridSize.minRow; r <= gridSize.maxRow; r++) rows.push(r)
+	const cols: number[] = []
+	for (let c = gridSize.minColumn; c <= gridSize.maxColumn; c++) cols.push(c)
+
+	return (
+		<div className="ct-button-grid">
+			{rows.map((row) => (
+				<div key={row} className="ct-button-grid-row">
+					{cols.map((column) => {
+						const location: ControlLocation = { pageNumber, row, column }
+						const selected =
+							!!selectedLocation &&
+							selectedLocation.pageNumber === pageNumber &&
+							selectedLocation.row === row &&
+							selectedLocation.column === column
+						return <Cell key={column} location={location} selected={selected} onSelect={onSelect} />
+					})}
+				</div>
+			))}
+		</div>
+	)
+})

--- a/webui/src/Timeline/components/LibraryPanel.tsx
+++ b/webui/src/Timeline/components/LibraryPanel.tsx
@@ -1,0 +1,99 @@
+import React, { useCallback, useMemo, useState } from 'react'
+import type { ActionEntry } from '../library.js'
+
+interface Props {
+	library: ActionEntry[]
+}
+
+export default function LibraryPanel({ library }: Props): React.JSX.Element {
+	const [search, setSearch] = useState('')
+	const [collapsed, setCollapsed] = useState<Record<string, boolean>>({})
+
+	const filtered = useMemo(() => {
+		const q = search.toLowerCase().trim()
+		if (!q) return library
+		return library.filter(
+			(a) =>
+				a.definitionId.toLowerCase().includes(q) ||
+				a.label.toLowerCase().includes(q) ||
+				a.connectionLabel.toLowerCase().includes(q)
+		)
+	}, [library, search])
+
+	const grouped = useMemo(() => {
+		const map = new Map<string, { label: string; actions: ActionEntry[] }>()
+		for (const a of filtered) {
+			if (!map.has(a.connectionId)) map.set(a.connectionId, { label: a.connectionLabel, actions: [] })
+			map.get(a.connectionId)!.actions.push(a)
+		}
+		return map
+	}, [filtered])
+
+	const handleDragStart = useCallback((e: React.DragEvent, action: ActionEntry) => {
+		e.dataTransfer.setData(
+			'application/companion-action',
+			JSON.stringify({
+				connectionId: action.connectionId,
+				definitionId: action.definitionId,
+				options: action.options ?? {},
+			})
+		)
+		e.dataTransfer.effectAllowed = 'copy'
+	}, [])
+
+	const toggleGroup = useCallback((connId: string) => {
+		setCollapsed((c) => ({ ...c, [connId]: !c[connId] }))
+	}, [])
+
+	return (
+		<div className="library-panel">
+			<div className="library-header">
+				<span className="library-title">Action Library</span>
+				<span className="library-hint">drag to timeline</span>
+			</div>
+
+			<input
+				className="inspector-input library-search"
+				placeholder="Search actions…"
+				value={search}
+				onChange={(e) => setSearch(e.target.value)}
+			/>
+
+			<div className="library-list">
+				{grouped.size === 0 && <div className="library-empty">No actions found</div>}
+
+				{[...grouped.entries()].map(([connId, { label, actions: connActions }]) => (
+					<div key={connId} className="library-group">
+						<button className="library-group-header" onClick={() => toggleGroup(connId)}>
+							<span className="library-group-chevron">{collapsed[connId] ? '▶' : '▼'}</span>
+							<span className="library-group-label">{label}</span>
+							<span className="library-group-count">{connActions[0]?.noActions ? 0 : connActions.length}</span>
+						</button>
+
+						{!collapsed[connId] && (
+							<div className="library-group-items">
+								{connActions[0]?.noActions ? (
+									<div className="library-no-actions">No actions for this connection</div>
+								) : (
+									connActions.map((a) => (
+										<div
+											key={`${a.connectionId}:${a.definitionId}`}
+											className={`library-item ${a.usedBefore ? 'library-item--used' : ''}`}
+											draggable
+											onDragStart={(e) => handleDragStart(e, a)}
+											title={`${a.connectionLabel} · ${a.label || a.definitionId}`}
+										>
+											<span className="library-item-icon">⠿</span>
+											<span className="library-item-name">{a.label || a.definitionId}</span>
+											{a.usedBefore && <span className="library-item-dot" title="Used on this button" />}
+										</div>
+									))
+								)}
+							</div>
+						)}
+					</div>
+				))}
+			</div>
+		</div>
+	)
+}

--- a/webui/src/Timeline/components/Timeline.tsx
+++ b/webui/src/Timeline/components/Timeline.tsx
@@ -1,0 +1,1347 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+	triggerLabel,
+	type ButtonControl,
+	type CompanionAction,
+	type CompanionInstance,
+	type ExecutionMode,
+	type TriggerKey,
+} from '../types.js'
+
+// ---- Group traversal (defined outside component to avoid re-creation) ----
+
+export interface GroupInfo {
+	group: CompanionAction
+	triggerKey: TriggerKey
+	path: string[] // IDs root→this group (inclusive), used as update key
+	absStart: number // absolute ms when this group fires
+	depth: number
+}
+
+export function collectGroups(
+	actions: CompanionAction[],
+	triggerKey: TriggerKey,
+	ancestorPath: string[],
+	parentAbsDelay: number,
+	depth: number
+): GroupInfo[] {
+	const result: GroupInfo[] = []
+	for (const a of actions) {
+		if (a.instance === 'internal' && a.action === 'action_group') {
+			const path = [...ancestorPath, a.id]
+			const absStart = parentAbsDelay + a.delay
+			result.push({ group: a, triggerKey, path, absStart, depth })
+			result.push(...collectGroups(a.children?.default ?? [], triggerKey, path, absStart, depth + 1))
+		}
+	}
+	return result
+}
+
+export interface TimelineButton {
+	key: string
+	label: string // e.g. "My Button" or "Slot 5"
+	pageSlot: string // e.g. "Page 1 · 5"
+	control: ButtonControl
+}
+
+interface Props {
+	buttons: TimelineButton[]
+	selectedKey: string | null
+	instances: Record<string, CompanionInstance>
+	selectedActionId: string | null
+	onActionSelect: (actionId: string | null, triggerKey: TriggerKey, stepKey: string) => void
+	onActionMove: (stepKey: string, triggerKey: TriggerKey, actionId: string, newDelay: number) => void
+	onActionAdd: (stepKey: string, triggerKey: TriggerKey, delay: number) => void
+	onActionDrop: (
+		stepKey: string,
+		triggerKey: TriggerKey,
+		delay: number,
+		template: { connectionId: string; definitionId: string; options: Record<string, unknown> }
+	) => void
+	onActionDelete: (stepKey: string, triggerKey: TriggerKey, actionId: string) => void
+	playheadMs: number
+	onPlayheadChange: (ms: number) => void
+	onStepAdd: () => void
+	onStepRemove: (stepKey: string) => void
+	onTriggerAdd: (stepKey: string, holdMs: number) => void
+	onTriggerRemove: (stepKey: string, triggerKey: TriggerKey) => void
+	onActionDelayChange: (stepKey: string, triggerKey: TriggerKey, actionId: string, newDelay: number) => void
+	onExecutionModeChange: (stepKey: string, triggerKey: TriggerKey, mode: ExecutionMode) => void
+	onVisibleMsChange?: (visibleMs: number) => void
+	onChildActionMove?: (
+		stepKey: string,
+		triggerKey: TriggerKey,
+		path: string[],
+		childId: string,
+		newDelay: number
+	) => void
+	onChildActionReorder?: (
+		stepKey: string,
+		triggerKey: TriggerKey,
+		path: string[],
+		fromIdx: number,
+		toIdx: number
+	) => void
+	onChildActionAdd?: (stepKey: string, triggerKey: TriggerKey, path: string[], delay: number) => void
+	onChildActionDrop?: (
+		stepKey: string,
+		triggerKey: TriggerKey,
+		path: string[],
+		template: { connectionId: string; definitionId: string; options: Record<string, unknown> },
+		delay: number
+	) => void
+	onChildExecutionModeChange?: (
+		stepKey: string,
+		triggerKey: TriggerKey,
+		path: string[],
+		childId: string,
+		mode: ExecutionMode
+	) => void
+}
+
+const LANE_HEIGHT = 72
+const LANE_PAD = 6
+const LABEL_WIDTH = 120
+const MIN_ZOOM_MS = 500
+const MAX_ZOOM_MS = 30000
+const RULER_HEIGHT = 28
+const ACTION_MIN_WIDTH = 80
+const CLIP_EST_PX_PER_CHAR = 7
+const MIN_ACTION_WIDTH = 100
+const MIN_WAIT_PX = 54
+
+const STANDARD_TRIGGERS: TriggerKey[] = ['down', 'up']
+
+function assignLanes<T extends { id: string; delay: number; action: string }>(
+	actions: T[],
+	msToPx: (ms: number) => number,
+	getWidth?: (a: T) => number
+): { id: string; lane: number }[] {
+	const laneEdge: number[] = []
+	const result: { id: string; lane: number }[] = []
+	for (const a of [...actions].sort((x, y) => x.delay - y.delay)) {
+		const x = msToPx(a.delay)
+		const width = getWidth
+			? getWidth(a)
+			: Math.max(ACTION_MIN_WIDTH, (a.action?.length ?? 4) * CLIP_EST_PX_PER_CHAR + 20)
+		const right = x + width
+		let placed = false
+		for (let lane = 0; lane < laneEdge.length; lane++) {
+			if (x >= laneEdge[lane]) {
+				laneEdge[lane] = right
+				result.push({ id: a.id, lane })
+				placed = true
+				break
+			}
+		}
+		if (!placed) {
+			result.push({ id: a.id, lane: laneEdge.length })
+			laneEdge.push(right)
+		}
+	}
+	return result
+}
+
+// The execution mode of an action_group, defaulting to 'concurrent'.
+function execModeOf(options: Record<string, unknown> | undefined): string {
+	const v = options?.execution_mode
+	return typeof v === 'string' ? v : 'concurrent'
+}
+
+// Returns the duration in ms from timeout/duration option, or null if not present.
+function getActionDurationMs(action: CompanionAction): number | null {
+	for (const key of ['timeout', 'duration']) {
+		const v = action.options?.[key]
+		if (v != null && v !== '') {
+			const n = Number(v)
+			if (!isNaN(n) && n > 0) return n
+		}
+	}
+	return null
+}
+
+function msToLabel(ms: number): string {
+	if (ms === 0) return '0'
+	if (ms >= 1000) return `${(ms / 1000).toFixed(ms % 1000 === 0 ? 0 : 1)}s`
+	return `${ms}ms`
+}
+
+function snapToGrid(ms: number, snapMs: number): number {
+	return Math.round(ms / snapMs) * snapMs
+}
+
+function getSnapMs(visibleMs: number): number {
+	for (const s of [10, 25, 50, 100, 250, 500, 1000, 2000, 5000]) {
+		if (visibleMs / s <= 20) return s
+	}
+	return 5000
+}
+
+export default function Timeline({
+	buttons,
+	selectedKey,
+	instances,
+	selectedActionId,
+	onActionSelect,
+	onActionMove,
+	onActionAdd,
+	onActionDrop,
+	onActionDelete,
+	playheadMs,
+	onPlayheadChange,
+	onStepAdd,
+	onStepRemove,
+	onTriggerAdd,
+	onTriggerRemove,
+	onActionDelayChange,
+	onExecutionModeChange,
+	onVisibleMsChange,
+	onChildActionMove,
+	onChildActionReorder,
+	onChildActionAdd,
+	onChildActionDrop,
+	onChildExecutionModeChange,
+}: Props): React.JSX.Element {
+	const trackAreaRef = useRef<HTMLDivElement>(null)
+	const [visibleMs, setVisibleMs] = useState(5000)
+	const [scrollMs, setScrollMs] = useState(0)
+	const [activeStepKey, setActiveStepKey] = useState<string>('0')
+	const [addingHold, setAddingHold] = useState(false)
+	const [holdInput, setHoldInput] = useState('2000')
+	const [editingWaitId, setEditingWaitId] = useState<string | null>(null)
+	const [waitInput, setWaitInput] = useState('')
+	const [contextMenu, setContextMenu] = useState<{
+		x: number
+		y: number
+		stepKey: string
+		triggerKey: TriggerKey
+		actionId: string
+	} | null>(null)
+	const [dropTarget, setDropTarget] = useState<{ triggerKey: TriggerKey; x: number } | null>(null)
+	const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set())
+
+	const toggleCollapse = useCallback((id: string) => {
+		setCollapsedGroups((prev) => {
+			const next = new Set(prev)
+			if (next.has(id)) next.delete(id)
+			else next.add(id)
+			return next
+		})
+	}, [])
+
+	useEffect(() => {
+		if (!contextMenu) return
+		const close = () => setContextMenu(null)
+		window.addEventListener('mousedown', close)
+		return () => window.removeEventListener('mousedown', close)
+	}, [contextMenu])
+
+	useEffect(() => {
+		onVisibleMsChange?.(visibleMs)
+	}, [visibleMs, onVisibleMsChange])
+
+	const selectedBtn = buttons.find((b) => b.key === selectedKey) ?? null
+	const selectedControl = selectedBtn?.control ?? null
+	const stepKeys = selectedControl ? Object.keys(selectedControl.steps).sort() : []
+	const currentStepKey = stepKeys.includes(activeStepKey) ? activeStepKey : (stepKeys[0] ?? '0')
+
+	const snapMs = getSnapMs(visibleMs)
+
+	const selectedTracks = useMemo(() => {
+		if (!selectedControl) return []
+		const step = selectedControl.steps[currentStepKey]
+		if (!step) return []
+		const result: { triggerKey: TriggerKey; actions: CompanionAction[] }[] = []
+		const allTriggers = Object.keys(step.action_sets)
+		const ordered = [
+			...STANDARD_TRIGGERS.filter((t) => allTriggers.includes(t)),
+			...allTriggers
+				.filter((t) => !STANDARD_TRIGGERS.includes(t as TriggerKey))
+				.sort((a, b) => {
+					const na = parseInt(a),
+						nb = parseInt(b)
+					return isNaN(na) ? 1 : isNaN(nb) ? -1 : na - nb
+				}),
+		] as TriggerKey[]
+		for (const tKey of ordered) {
+			result.push({ triggerKey: tKey, actions: step.action_sets[tKey] ?? [] })
+		}
+		return result
+	}, [selectedControl, currentStepKey])
+
+	const handleZoomIn = useCallback(() => setVisibleMs((v) => Math.max(MIN_ZOOM_MS, Math.round(v * 0.6))), [])
+	const handleZoomOut = useCallback(() => setVisibleMs((v) => Math.min(MAX_ZOOM_MS, Math.round(v * 1.6))), [])
+	const handleZoomFit = useCallback(() => {
+		if (!selectedControl) return
+		// Use end time = start + timeout (if present), so the bar tail is included
+		let maxEndMs = MIN_ZOOM_MS
+		const actionEnd = (a: CompanionAction, parentDelayMs = 0) => {
+			const absStart = parentDelayMs + a.delay
+			const dur = getActionDurationMs(a) ?? 0
+			maxEndMs = Math.max(maxEndMs, absStart + dur)
+			for (const kids of Object.values(a.children ?? {})) {
+				for (const c of kids ?? []) actionEnd(c, absStart)
+			}
+		}
+		for (const step of Object.values(selectedControl.steps))
+			for (const actions of Object.values(step.action_sets)) for (const a of actions ?? []) actionEnd(a)
+
+		// Add ~15% padding so the last clip block isn't flush against the right edge
+		setVisibleMs(Math.max(MIN_ZOOM_MS, Math.min(MAX_ZOOM_MS, Math.round(maxEndMs * 1.15 + 400))))
+		setScrollMs(0)
+	}, [selectedControl])
+
+	const pxPerMs = useCallback((w: number) => w / visibleMs, [visibleMs])
+	const msToPx = useCallback((ms: number, w: number) => (ms - scrollMs) * pxPerMs(w), [scrollMs, pxPerMs])
+	const pxToMs = useCallback((px: number, w: number) => px / pxPerMs(w) + scrollMs, [scrollMs, pxPerMs])
+
+	const dragRef = useRef<{
+		actionId: string
+		stepKey: string
+		triggerKey: TriggerKey
+		startDelay: number
+		startX: number
+		containerWidth: number
+	} | null>(null)
+
+	const resizeRef = useRef<{
+		nextActionId: string
+		stepKey: string
+		triggerKey: TriggerKey
+		startNextDelay: number
+		minDelay: number
+		startX: number
+		containerWidth: number
+	} | null>(null)
+
+	const containerWidth = (trackAreaRef.current?.clientWidth ?? 900) - LABEL_WIDTH
+
+	const handleResizeMouseDown = useCallback(
+		(e: React.MouseEvent, nextAction: CompanionAction, minDelay: number, triggerKey: TriggerKey) => {
+			e.preventDefault()
+			e.stopPropagation()
+			const w = (trackAreaRef.current?.clientWidth ?? 900) - LABEL_WIDTH
+			resizeRef.current = {
+				nextActionId: nextAction.id,
+				stepKey: currentStepKey,
+				triggerKey,
+				startNextDelay: nextAction.delay,
+				minDelay,
+				startX: e.clientX,
+				containerWidth: w,
+			}
+			const ppm = pxPerMs(w)
+			const onMove = (ev: MouseEvent) => {
+				if (!resizeRef.current) return
+				const newDelay = Math.max(
+					resizeRef.current.minDelay,
+					snapToGrid(resizeRef.current.startNextDelay + (ev.clientX - resizeRef.current.startX) / ppm, snapMs)
+				)
+				onActionDelayChange(
+					resizeRef.current.stepKey,
+					resizeRef.current.triggerKey,
+					resizeRef.current.nextActionId,
+					newDelay
+				)
+			}
+			const onUp = () => {
+				resizeRef.current = null
+				window.removeEventListener('mousemove', onMove)
+				window.removeEventListener('mouseup', onUp)
+			}
+			window.addEventListener('mousemove', onMove)
+			window.addEventListener('mouseup', onUp)
+		},
+		[currentStepKey, pxPerMs, snapMs, onActionDelayChange]
+	)
+
+	const handleActionMouseDown = useCallback(
+		(e: React.MouseEvent, action: CompanionAction, triggerKey: TriggerKey) => {
+			e.preventDefault()
+			e.stopPropagation()
+			onActionSelect(action.id, triggerKey, currentStepKey)
+			const w = (trackAreaRef.current?.clientWidth ?? 900) - LABEL_WIDTH
+			dragRef.current = {
+				actionId: action.id,
+				stepKey: currentStepKey,
+				triggerKey,
+				startDelay: action.delay,
+				startX: e.clientX,
+				containerWidth: w,
+			}
+			const ppm = pxPerMs(w)
+			const onMove = (ev: MouseEvent) => {
+				if (!dragRef.current) return
+				onActionMove(
+					dragRef.current.stepKey,
+					dragRef.current.triggerKey,
+					dragRef.current.actionId,
+					Math.max(0, snapToGrid(dragRef.current.startDelay + (ev.clientX - dragRef.current.startX) / ppm, snapMs))
+				)
+			}
+			const onUp = () => {
+				dragRef.current = null
+				window.removeEventListener('mousemove', onMove)
+				window.removeEventListener('mouseup', onUp)
+			}
+			window.addEventListener('mousemove', onMove)
+			window.addEventListener('mouseup', onUp)
+		},
+		[onActionSelect, onActionMove, pxPerMs, snapMs, currentStepKey]
+	)
+
+	const handleTrackDoubleClick = useCallback(
+		(e: React.MouseEvent, triggerKey: TriggerKey) => {
+			const w = (trackAreaRef.current?.clientWidth ?? 900) - LABEL_WIDTH
+			const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
+			onActionAdd(currentStepKey, triggerKey, Math.max(0, snapToGrid(pxToMs(e.clientX - rect.left, w), snapMs)))
+		},
+		[pxToMs, snapMs, onActionAdd, currentStepKey]
+	)
+
+	const handleDragOver = useCallback((e: React.DragEvent, triggerKey: TriggerKey) => {
+		if (!e.dataTransfer.types.includes('application/companion-action')) return
+		e.preventDefault()
+		e.dataTransfer.dropEffect = 'copy'
+		const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
+		setDropTarget({ triggerKey, x: e.clientX - rect.left })
+	}, [])
+
+	const handleDragLeave = useCallback(() => setDropTarget(null), [])
+
+	const handlePlayheadDragStart = useCallback(
+		(e: React.MouseEvent) => {
+			e.stopPropagation()
+			e.preventDefault()
+			const trackArea = trackAreaRef.current
+			if (!trackArea) return
+			const w = trackArea.clientWidth - LABEL_WIDTH
+			const rulerRect = trackArea.querySelector('.ruler-ticks')?.getBoundingClientRect()
+			if (!rulerRect) return
+			const onMove = (ev: MouseEvent) =>
+				onPlayheadChange(Math.max(0, snapToGrid(pxToMs(ev.clientX - rulerRect.left, w), snapMs)))
+			const onUp = () => {
+				window.removeEventListener('mousemove', onMove)
+				window.removeEventListener('mouseup', onUp)
+			}
+			window.addEventListener('mousemove', onMove)
+			window.addEventListener('mouseup', onUp)
+		},
+		[pxToMs, snapMs, onPlayheadChange]
+	)
+
+	const handleRulerClick = useCallback(
+		(e: React.MouseEvent) => {
+			const trackArea = trackAreaRef.current
+			if (!trackArea) return
+			const w = trackArea.clientWidth - LABEL_WIDTH
+			const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
+			onPlayheadChange(Math.max(0, snapToGrid(pxToMs(e.clientX - rect.left, w), snapMs)))
+		},
+		[pxToMs, snapMs, onPlayheadChange]
+	)
+
+	const handleDrop = useCallback(
+		(e: React.DragEvent, triggerKey: TriggerKey) => {
+			setDropTarget(null)
+			const raw = e.dataTransfer.getData('application/companion-action')
+			if (!raw) return
+			e.preventDefault()
+			const template = JSON.parse(raw)
+			const w = (trackAreaRef.current?.clientWidth ?? 900) - LABEL_WIDTH
+			const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
+			onActionDrop(
+				currentStepKey,
+				triggerKey,
+				Math.max(0, snapToGrid(pxToMs(e.clientX - rect.left, w), snapMs)),
+				template
+			)
+		},
+		[pxToMs, snapMs, onActionDrop, currentStepKey]
+	)
+
+	const handleWheel = useCallback(
+		(e: WheelEvent) => {
+			// ⌘/Ctrl + scroll → zoom the time axis
+			if (e.metaKey || e.ctrlKey) {
+				e.preventDefault()
+				setVisibleMs((v) => Math.max(MIN_ZOOM_MS, Math.min(MAX_ZOOM_MS, v * (e.deltaY > 0 ? 1.2 : 0.8))))
+				return
+			}
+			const w = (trackAreaRef.current?.clientWidth ?? 900) - LABEL_WIDTH
+			// Shift + wheel, or a horizontal trackpad gesture → pan the time axis
+			if (e.shiftKey) {
+				e.preventDefault()
+				setScrollMs((s) => Math.max(0, s + (e.deltaY || e.deltaX) / pxPerMs(w)))
+				return
+			}
+			if (Math.abs(e.deltaX) > Math.abs(e.deltaY)) {
+				e.preventDefault()
+				setScrollMs((s) => Math.max(0, s + e.deltaX / pxPerMs(w)))
+				return
+			}
+			// Vertical gesture → let the track area scroll naturally (don't hijack it)
+		},
+		[pxPerMs]
+	)
+
+	useEffect(() => {
+		const el = trackAreaRef.current
+		if (!el) return
+		el.addEventListener('wheel', handleWheel, { passive: false })
+		return () => el.removeEventListener('wheel', handleWheel)
+	}, [handleWheel])
+
+	const renderRuler = () => {
+		const ticks: React.ReactNode[] = []
+		let t = Math.floor(scrollMs / snapMs) * snapMs
+		while (t <= scrollMs + visibleMs) {
+			const x = msToPx(t, containerWidth)
+			if (x >= 0 && x <= containerWidth) {
+				ticks.push(
+					<div key={t} className="ruler-tick" style={{ left: x }}>
+						<span className="ruler-label">{msToLabel(t)}</span>
+					</div>
+				)
+			}
+			t += snapMs
+		}
+		return ticks
+	}
+
+	const renderGridLines = (w: number) =>
+		Array.from({ length: Math.ceil(visibleMs / snapMs) + 1 }, (_, i) => {
+			const t = Math.floor(scrollMs / snapMs) * snapMs + i * snapMs
+			const x = msToPx(t, w)
+			return x >= 0 && x <= w ? <div key={t} className="grid-line" style={{ left: x }} /> : null
+		})
+
+	// Render a single trigger track for the SELECTED (editable) button
+	const renderSelectedTrack = (triggerKey: TriggerKey, actions: CompanionAction[]) => {
+		const isHoldTrack = !['down', 'up', 'rotate_left', 'rotate_right'].includes(triggerKey)
+		const hasGroups = actions.some((a) => a.instance === 'internal' && a.action === 'action_group')
+		const trackCollapseKey = `track-${currentStepKey}-${triggerKey}`
+		const isTrackCollapsed = collapsedGroups.has(trackCollapseKey)
+
+		if (isTrackCollapsed) {
+			return (
+				<div
+					key={triggerKey}
+					className="track-row track-row--collapsed"
+					style={{ display: 'flex', alignItems: 'center' }}
+				>
+					<div className="track-label" style={{ width: LABEL_WIDTH }}>
+						<button className="track-collapse-btn" onClick={() => toggleCollapse(trackCollapseKey)}>
+							▶
+						</button>
+						<span className="track-label-text">{triggerLabel(triggerKey)}</span>
+						<span className="track-label-sub">
+							{actions.length} action{actions.length !== 1 ? 's' : ''}
+						</span>
+					</div>
+					<div style={{ flex: 1, borderTop: '1px solid var(--border)' }} />
+				</div>
+			)
+		}
+
+		const sorted = [...actions].sort((a, b) => a.delay - b.delay)
+		const nextAction = new Map<string, CompanionAction>()
+		for (let i = 0; i < sorted.length - 1; i++) nextAction.set(sorted[i].id, sorted[i + 1])
+
+		const ppm = pxPerMs(containerWidth)
+		const waitPx = (action: CompanionAction) => {
+			const next = nextAction.get(action.id)
+			if (!next || next.delay <= action.delay) return 0
+			const gap = (next.delay - action.delay) * ppm
+			const waitWidth = gap - MIN_ACTION_WIDTH
+			return waitWidth >= MIN_WAIT_PX ? waitWidth : 0
+		}
+
+		const laneAssignments = assignLanes(
+			actions,
+			(ms) => ms * ppm,
+			(a) => {
+				const dur = getActionDurationMs(a)
+				return dur ? Math.max(MIN_ACTION_WIDTH, Math.round(dur * ppm)) : MIN_ACTION_WIDTH
+			}
+		)
+		const laneMap = new Map(laneAssignments.map(({ id, lane }) => [id, lane]))
+		const laneCount = Math.max(1, ...laneAssignments.map((l) => l.lane + 1))
+		const trackHeight = laneCount * LANE_HEIGHT
+
+		return (
+			<div key={triggerKey} className="track-row" style={{ height: trackHeight }}>
+				<div className="track-label" style={{ width: LABEL_WIDTH }}>
+					<button className="track-collapse-btn" onClick={() => toggleCollapse(trackCollapseKey)}>
+						▼
+					</button>
+					<span className="track-label-text">{triggerLabel(triggerKey)}</span>
+					<div className="track-label-meta">
+						{hasGroups && (
+							<span className="track-mode-badge" title="Track contains Action Groups">
+								GRP
+							</span>
+						)}
+						{isHoldTrack && (
+							<button
+								className="track-remove-btn"
+								title="Remove hold group"
+								onClick={() => onTriggerRemove(currentStepKey, triggerKey)}
+							>
+								×
+							</button>
+						)}
+					</div>
+				</div>
+				<div
+					className="track-body"
+					style={{ position: 'relative', flex: 1, height: '100%' }}
+					onDoubleClick={(e) => handleTrackDoubleClick(e, triggerKey)}
+					onDragOver={(e) => handleDragOver(e, triggerKey)}
+					onDragLeave={handleDragLeave}
+					onDrop={(e) => handleDrop(e, triggerKey)}
+				>
+					{dropTarget?.triggerKey === triggerKey && <div className="drop-indicator" style={{ left: dropTarget.x }} />}
+					{renderGridLines(containerWidth)}
+					{laneCount > 1 &&
+						Array.from({ length: laneCount - 1 }, (_, i) => (
+							<div key={`ld-${i}`} className="lane-divider" style={{ top: (i + 1) * LANE_HEIGHT }} />
+						))}
+					{actions.map((action) => {
+						const x = msToPx(action.delay, containerWidth)
+						const lane = laneMap.get(action.id) ?? 0
+						const top = lane * LANE_HEIGHT + LANE_PAD
+						const bottom = (laneCount - lane - 1) * LANE_HEIGHT + LANE_PAD
+						const next = nextAction.get(action.id)
+						const wp = waitPx(action)
+						const hasWait = wp > 0
+						const waitMs = next ? next.delay - action.delay : 0
+						const instLabel = instances[action.instance]?.label ?? action.instance?.slice(0, 6) ?? '?'
+						const isSelected = selectedActionId === action.id
+						const isEditingWait = editingWaitId === action.id
+						const isGroup = action.instance === 'internal' && action.action === 'action_group'
+						const execMode = isGroup ? execModeOf(action.options) : null
+						const childCount = isGroup ? (action.children?.default?.length ?? 0) : 0
+						const durationMs = !isGroup ? getActionDurationMs(action) : null
+						const durationPx = durationMs ? Math.max(0, Math.round(durationMs * ppm) - MIN_ACTION_WIDTH) : 0
+
+						return (
+							<div
+								key={action.id}
+								className={`clip-block ${isSelected ? 'clip-block--selected' : ''} ${isGroup ? 'clip-block--group' : ''}`}
+								style={{ left: x, top, bottom, width: MIN_ACTION_WIDTH + Math.max(wp, durationPx) }}
+								onDragOver={
+									isGroup
+										? (e) => {
+												if (e.dataTransfer.types.includes('application/companion-action')) {
+													e.preventDefault()
+													e.stopPropagation()
+													e.dataTransfer.dropEffect = 'copy'
+												}
+											}
+										: undefined
+								}
+								onDrop={
+									isGroup
+										? (e) => {
+												const raw = e.dataTransfer.getData('application/companion-action')
+												if (!raw) return
+												e.preventDefault()
+												e.stopPropagation()
+												const tmpl = JSON.parse(raw)
+												const kids = action.children?.default ?? []
+												const delay =
+													execMode === 'sequential' && kids.length > 0 ? Math.max(...kids.map((c) => c.delay)) + 500 : 0
+												onChildActionDrop?.(currentStepKey, triggerKey, [action.id], tmpl, delay)
+											}
+										: undefined
+								}
+							>
+								<div
+									className={`clip-action ${isGroup ? 'clip-action--group' : ''}`}
+									style={{ width: MIN_ACTION_WIDTH }}
+									onMouseDown={(e) => handleActionMouseDown(e, action, triggerKey)}
+									onContextMenu={(e) => {
+										e.preventDefault()
+										setContextMenu({
+											x: e.clientX,
+											y: e.clientY,
+											stepKey: currentStepKey,
+											triggerKey,
+											actionId: action.id,
+										})
+									}}
+								>
+									{isGroup ? (
+										<>
+											<span className="action-name">Action Group</span>
+											<span className="action-instance">
+												{childCount} action{childCount !== 1 ? 's' : ''}
+											</span>
+											<span className="action-exec-mode" style={{ display: 'contents' }}>
+												<select
+													className="exec-mode-select"
+													value={execMode ?? 'concurrent'}
+													onMouseDown={(e) => e.stopPropagation()}
+													onChange={(e) => {
+														e.stopPropagation()
+														onExecutionModeChange(currentStepKey, triggerKey, e.target.value as ExecutionMode)
+													}}
+												>
+													<option value="concurrent">Concurrent</option>
+													<option value="sequential">Sequential</option>
+													<option value="inherit">Inherit</option>
+												</select>
+											</span>
+										</>
+									) : (
+										<>
+											<span className="action-name">{action.action || <em>new</em>}</span>
+											<span className="action-instance">{instLabel}</span>
+											{action.delay > 0 && <span className="action-delay">{msToLabel(action.delay)}</span>}
+											{durationMs && (
+												<span className="action-duration-badge" title={`Timeout: ${durationMs}ms`}>
+													⏱ {msToLabel(durationMs)}
+												</span>
+											)}
+										</>
+									)}
+									{!hasWait && next && (
+										<button
+											className="clip-add-wait"
+											title="Add wait before next action"
+											onMouseDown={(e) => e.stopPropagation()}
+											onClick={(e) => {
+												e.stopPropagation()
+												setEditingWaitId(action.id)
+												setWaitInput('500')
+											}}
+										>
+											⏱+
+										</button>
+									)}
+								</div>
+
+								{durationPx > 0 && !hasWait && (
+									<div
+										className="clip-duration-bar"
+										style={{ width: durationPx }}
+										title={`Timeout: ${msToLabel(durationMs!)} — action active for this duration`}
+									/>
+								)}
+
+								{hasWait && (
+									<div className="clip-wait" style={{ width: wp }} onMouseDown={(e) => e.stopPropagation()}>
+										{isEditingWait ? (
+											<div className="clip-wait-editor" onMouseDown={(e) => e.stopPropagation()}>
+												<input
+													className="wait-input"
+													type="number"
+													min={0}
+													step={50}
+													value={waitInput}
+													autoFocus
+													onChange={(e) => setWaitInput(e.target.value)}
+													onKeyDown={(e) => {
+														if (e.key === 'Enter') {
+															const ms = parseInt(waitInput)
+															if (!isNaN(ms) && ms >= 0 && next)
+																onActionDelayChange(currentStepKey, triggerKey, next.id, action.delay + ms)
+															setEditingWaitId(null)
+														}
+														if (e.key === 'Escape') setEditingWaitId(null)
+													}}
+												/>
+												<span className="wait-input-unit">ms</span>
+											</div>
+										) : (
+											<button
+												className="clip-wait-label"
+												title="Click to edit wait duration"
+												onClick={(e) => {
+													e.stopPropagation()
+													setEditingWaitId(action.id)
+													setWaitInput(String(waitMs))
+												}}
+											>
+												<span>⏱</span>
+												<span>{msToLabel(waitMs)}</span>
+											</button>
+										)}
+										{next && (
+											<div
+												className="clip-resize-handle"
+												onMouseDown={(e) => handleResizeMouseDown(e, next, action.delay, triggerKey)}
+											/>
+										)}
+									</div>
+								)}
+
+								{isEditingWait && !hasWait && (
+									<div className="clip-wait clip-wait--new" onMouseDown={(e) => e.stopPropagation()}>
+										<div className="clip-wait-editor">
+											<input
+												className="wait-input"
+												type="number"
+												min={0}
+												step={50}
+												value={waitInput}
+												autoFocus
+												onChange={(e) => setWaitInput(e.target.value)}
+												onKeyDown={(e) => {
+													if (e.key === 'Enter') {
+														const ms = parseInt(waitInput)
+														if (!isNaN(ms) && ms > 0 && next)
+															onActionDelayChange(currentStepKey, triggerKey, next.id, action.delay + ms)
+														setEditingWaitId(null)
+													}
+													if (e.key === 'Escape') setEditingWaitId(null)
+												}}
+											/>
+											<span className="wait-input-unit">ms</span>
+										</div>
+									</div>
+								)}
+							</div>
+						)
+					})}
+				</div>
+			</div>
+		)
+	}
+
+	// ---- Group rendering helpers ----
+
+	// Depth colour palette — same look as main timeline, just tinted differently per level
+	const DEPTH_TINT = [
+		'rgba(74,158,255,0.05)',
+		'rgba(100,220,160,0.05)',
+		'rgba(255,180,74,0.05)',
+		'rgba(220,100,220,0.05)',
+	]
+	const DEPTH_BORDER = [
+		'rgba(74,158,255,0.3)',
+		'rgba(100,220,160,0.3)',
+		'rgba(255,180,74,0.3)',
+		'rgba(220,100,220,0.3)',
+	]
+
+	const renderSequentialSubTrack = (info: GroupInfo) => {
+		const { group, triggerKey, path, absStart, depth } = info
+		const collapsed = collapsedGroups.has(group.id)
+		const tint = DEPTH_TINT[depth % DEPTH_TINT.length]
+		const border = DEPTH_BORDER[depth % DEPTH_BORDER.length]
+		const indent = depth * 8
+		const children = [...(group.children?.default ?? [])].sort((a, b) => a.delay - b.delay)
+
+		if (collapsed) {
+			return (
+				<div
+					key={`sub-${group.id}`}
+					className="track-row track-row--subtimeline track-row--collapsed"
+					style={{ background: tint, borderTopColor: border }}
+				>
+					<div
+						className="track-label track-label--subtimeline"
+						style={{ width: LABEL_WIDTH, paddingLeft: 10 + indent }}
+					>
+						<button className="track-collapse-btn" onClick={() => toggleCollapse(group.id)}>
+							▶
+						</button>
+						<span className="track-label-text" style={{ color: border }}>
+							↓ Sequential
+						</span>
+						<span className="track-label-sub">
+							{children.length} action{children.length !== 1 ? 's' : ''}
+						</span>
+					</div>
+					<div style={{ flex: 1 }} />
+				</div>
+			)
+		}
+		const ppm = pxPerMs(containerWidth)
+		const absChildren = children.map((c) => ({ ...c, delay: absStart + c.delay }))
+		const laneAssignments = assignLanes(
+			absChildren,
+			(ms) => ms * ppm,
+			(c) => {
+				const dur = getActionDurationMs(c)
+				return dur ? Math.max(MIN_ACTION_WIDTH, Math.round(dur * ppm)) : MIN_ACTION_WIDTH
+			}
+		)
+		const laneMap = new Map(laneAssignments.map(({ id, lane }) => [id, lane]))
+		const laneCount = Math.max(1, ...laneAssignments.map((l) => l.lane + 1))
+		const trackHeight = laneCount * LANE_HEIGHT
+		const startX = msToPx(absStart, containerWidth)
+
+		return (
+			<div
+				key={`sub-${group.id}`}
+				className="track-row track-row--subtimeline"
+				style={{ height: trackHeight, background: tint, borderTopColor: border }}
+			>
+				<div className="track-label track-label--subtimeline" style={{ width: LABEL_WIDTH, paddingLeft: 10 + indent }}>
+					<button className="track-collapse-btn" onClick={() => toggleCollapse(group.id)}>
+						▼
+					</button>
+					<span className="track-label-text" style={{ color: border }}>
+						{'↓'.repeat(depth + 1)} Sequential
+					</span>
+					<span className="track-label-sub">{msToLabel(absStart)}+</span>
+				</div>
+				<div
+					className="track-body"
+					style={{ position: 'relative', flex: 1, height: '100%' }}
+					onDoubleClick={(e) => {
+						const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
+						const absMs = Math.max(0, snapToGrid(pxToMs(e.clientX - rect.left, containerWidth), snapMs))
+						onChildActionAdd?.(currentStepKey, triggerKey, path, Math.max(0, absMs - absStart))
+					}}
+					onDragOver={(e) => {
+						if (e.dataTransfer.types.includes('application/companion-action')) {
+							e.preventDefault()
+							e.dataTransfer.dropEffect = 'copy'
+						}
+					}}
+					onDrop={(e) => {
+						const raw = e.dataTransfer.getData('application/companion-action')
+						if (!raw) return
+						e.preventDefault()
+						const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
+						const absMs = Math.max(0, snapToGrid(pxToMs(e.clientX - rect.left, containerWidth), snapMs))
+						onChildActionDrop?.(currentStepKey, triggerKey, path, JSON.parse(raw), Math.max(0, absMs - absStart))
+					}}
+				>
+					{renderGridLines(containerWidth)}
+					{startX >= 0 && startX <= containerWidth && (
+						<div
+							className="subtimeline-start-line"
+							style={{ left: startX, background: DEPTH_BORDER[depth % DEPTH_BORDER.length] }}
+						/>
+					)}
+					{children.length === 0 && <div className="subtimeline-empty">double-click or drag to add</div>}
+					{children.map((child) => {
+						const x = msToPx(absStart + child.delay, containerWidth)
+						const lane = laneMap.get(child.id) ?? 0
+						const top = lane * LANE_HEIGHT + LANE_PAD
+						const bottom = (laneCount - lane - 1) * LANE_HEIGHT + LANE_PAD
+						const instLabel = instances[child.instance]?.label ?? child.instance?.slice(0, 6) ?? '?'
+						const isGroup = child.instance === 'internal' && child.action === 'action_group'
+						const childDurMs = !isGroup ? getActionDurationMs(child) : null
+						const childDurPx = childDurMs ? Math.max(0, Math.round(childDurMs * ppm) - MIN_ACTION_WIDTH) : 0
+						return (
+							<div
+								key={child.id}
+								className={`clip-block clip-block--child ${isGroup ? 'clip-block--group' : ''}`}
+								style={{ left: x, top, bottom, width: MIN_ACTION_WIDTH + childDurPx }}
+								onMouseDown={(e) => {
+									e.preventDefault()
+									e.stopPropagation()
+									const startAbsMs = absStart + child.delay
+									const sx = e.clientX
+									const onMove = (ev: MouseEvent) => {
+										const newAbsMs = Math.max(0, snapToGrid(startAbsMs + (ev.clientX - sx) / ppm, snapMs))
+										onChildActionMove?.(currentStepKey, triggerKey, path, child.id, Math.max(0, newAbsMs - absStart))
+									}
+									const onUp = () => {
+										window.removeEventListener('mousemove', onMove)
+										window.removeEventListener('mouseup', onUp)
+									}
+									window.addEventListener('mousemove', onMove)
+									window.addEventListener('mouseup', onUp)
+								}}
+								onDragOver={
+									isGroup
+										? (e) => {
+												if (e.dataTransfer.types.includes('application/companion-action')) {
+													e.preventDefault()
+													e.stopPropagation()
+													e.dataTransfer.dropEffect = 'copy'
+												}
+											}
+										: undefined
+								}
+								onDrop={
+									isGroup
+										? (e) => {
+												const raw = e.dataTransfer.getData('application/companion-action')
+												if (!raw) return
+												e.preventDefault()
+												e.stopPropagation()
+												const childPath = [...path, child.id]
+												const kids = child.children?.default ?? []
+												const childMode = execModeOf(child.options)
+												const delay =
+													childMode === 'sequential' && kids.length > 0
+														? Math.max(...kids.map((c) => c.delay)) + 500
+														: 0
+												onChildActionDrop?.(currentStepKey, triggerKey, childPath, JSON.parse(raw), delay)
+											}
+										: undefined
+								}
+							>
+								<div className="clip-action" style={{ width: MIN_ACTION_WIDTH }}>
+									{isGroup ? (
+										<>
+											<span className="action-name">Group</span>
+											<select
+												className="exec-mode-select"
+												value={execModeOf(child.options)}
+												onMouseDown={(e) => e.stopPropagation()}
+												onChange={(e) => {
+													e.stopPropagation()
+													onChildExecutionModeChange?.(
+														currentStepKey,
+														triggerKey,
+														path,
+														child.id,
+														e.target.value as ExecutionMode
+													)
+												}}
+											>
+												<option value="concurrent">Concurrent</option>
+												<option value="sequential">Sequential</option>
+												<option value="inherit">Inherit</option>
+											</select>
+										</>
+									) : (
+										<>
+											<span className="action-name">{child.action || <em>new</em>}</span>
+											<span className="action-instance">{instLabel}</span>
+											{child.delay > 0 && <span className="action-delay">+{msToLabel(child.delay)}</span>}
+											{childDurMs && (
+												<span className="action-duration-badge" title={`Timeout: ${childDurMs}ms`}>
+													⏱ {msToLabel(childDurMs)}
+												</span>
+											)}
+										</>
+									)}
+								</div>
+								{childDurPx > 0 && (
+									<div
+										className="clip-duration-bar"
+										style={{ width: childDurPx }}
+										title={`Timeout: ${msToLabel(childDurMs!)}`}
+									/>
+								)}
+							</div>
+						)
+					})}
+				</div>
+			</div>
+		)
+	}
+
+	const renderConcurrentList = (info: GroupInfo) => {
+		const { group, triggerKey, path, absStart, depth } = info
+		const collapsed = collapsedGroups.has(group.id)
+		const children = group.children?.default ?? []
+		const mode = execModeOf(group.options)
+		const indent = depth * 8
+		const tint = DEPTH_TINT[depth % DEPTH_TINT.length]
+		const border = DEPTH_BORDER[depth % DEPTH_BORDER.length]
+		const modeLabel = mode === 'inherit' ? 'Inherit' : 'Concurrent'
+
+		if (collapsed) {
+			return (
+				<div
+					key={`conc-${group.id}`}
+					className="concurrent-group-section concurrent-group-section--collapsed"
+					style={{ borderTopColor: border, background: tint }}
+				>
+					<div className="concurrent-section-label" style={{ width: LABEL_WIDTH, paddingLeft: 10 + indent }}>
+						<button className="track-collapse-btn" onClick={() => toggleCollapse(group.id)}>
+							▶
+						</button>
+						<span style={{ color: border }}>⇉ {modeLabel}</span>
+						<span className="track-label-sub">
+							{children.length} action{children.length !== 1 ? 's' : ''}
+						</span>
+					</div>
+				</div>
+			)
+		}
+
+		return (
+			<div
+				key={`conc-${group.id}`}
+				className="concurrent-group-section"
+				style={{ borderTopColor: border, background: tint }}
+			>
+				<div className="concurrent-section-label" style={{ width: LABEL_WIDTH, paddingLeft: 10 + indent }}>
+					<button className="track-collapse-btn" onClick={() => toggleCollapse(group.id)}>
+						▼
+					</button>
+					<span style={{ color: border }}>⇉ {modeLabel}</span>
+					<span className="track-label-sub">{msToLabel(absStart)}</span>
+				</div>
+				<div className="concurrent-section-body">
+					{children.map((child, idx) => {
+						const instLabel = instances[child.instance]?.label ?? child.instance?.slice(0, 6) ?? '?'
+						const isGroup = child.instance === 'internal' && child.action === 'action_group'
+						return (
+							<div
+								key={child.id}
+								className="concurrent-item"
+								draggable
+								onDragStart={(e) => {
+									e.stopPropagation()
+									e.dataTransfer.setData('application/concurrent-reorder', JSON.stringify({ groupId: group.id, idx }))
+									e.dataTransfer.effectAllowed = 'move'
+								}}
+								onDragOver={(e) => {
+									if (e.dataTransfer.types.includes('application/concurrent-reorder')) {
+										e.preventDefault()
+										e.dataTransfer.dropEffect = 'move'
+									}
+								}}
+								onDrop={(e) => {
+									const raw = e.dataTransfer.getData('application/concurrent-reorder')
+									if (!raw) return
+									e.preventDefault()
+									const { groupId, idx: fromIdx } = JSON.parse(raw)
+									if (groupId === group.id && fromIdx !== idx)
+										onChildActionReorder?.(currentStepKey, triggerKey, path, fromIdx, idx)
+								}}
+							>
+								<span className="concurrent-item-handle">⠿</span>
+								{isGroup ? (
+									<>
+										<span className="concurrent-item-name">Group</span>
+										<select
+											className="exec-mode-select"
+											value={execModeOf(child.options)}
+											onMouseDown={(e) => e.stopPropagation()}
+											onChange={(e) => {
+												e.stopPropagation()
+												onChildExecutionModeChange?.(
+													currentStepKey,
+													triggerKey,
+													path,
+													child.id,
+													e.target.value as ExecutionMode
+												)
+											}}
+										>
+											<option value="concurrent">Concurrent</option>
+											<option value="sequential">Sequential</option>
+											<option value="inherit">Inherit</option>
+										</select>
+									</>
+								) : (
+									<>
+										<span className="concurrent-item-name">{child.action || '(new)'}</span>
+										<span className="concurrent-item-inst">{instLabel}</span>
+										{(() => {
+											const d = getActionDurationMs(child)
+											return d ? (
+												<span className="action-duration-badge" title={`Timeout: ${d}ms`}>
+													⏱ {msToLabel(d)}
+												</span>
+											) : null
+										})()}
+									</>
+								)}
+							</div>
+						)
+					})}
+					<div
+						className="concurrent-item-drop"
+						onDragOver={(e) => {
+							if (e.dataTransfer.types.includes('application/companion-action')) {
+								e.preventDefault()
+								e.dataTransfer.dropEffect = 'copy'
+							}
+						}}
+						onDrop={(e) => {
+							const raw = e.dataTransfer.getData('application/companion-action')
+							if (!raw) return
+							e.preventDefault()
+							onChildActionDrop?.(currentStepKey, triggerKey, path, JSON.parse(raw), 0)
+						}}
+					>
+						+ Drop action here
+					</div>
+				</div>
+			</div>
+		)
+	}
+
+	const hasAnyContent = !!selectedControl
+
+	return (
+		<div className="timeline-wrap">
+			{/* Step bar — only shown for selected button */}
+			{selectedControl && (
+				<div className="step-bar">
+					<span className="step-bar-label">Steps</span>
+					{stepKeys.map((sk) => (
+						<button
+							key={sk}
+							className={`step-tab ${sk === currentStepKey ? 'step-tab--active' : ''}`}
+							onClick={() => setActiveStepKey(sk)}
+						>
+							{parseInt(sk) + 1}
+						</button>
+					))}
+					<button className="step-tab step-tab--add" onClick={onStepAdd} title="Add step">
+						+
+					</button>
+					{stepKeys.length > 1 && (
+						<button
+							className="step-tab step-tab--remove"
+							onClick={() => onStepRemove(currentStepKey)}
+							title="Remove current step"
+						>
+							−
+						</button>
+					)}
+
+					<div className="step-bar-divider" />
+
+					<span className="step-bar-label">Hold</span>
+					{!addingHold ? (
+						<button
+							className="step-tab step-tab--add"
+							title="Add hold duration group"
+							onClick={() => setAddingHold(true)}
+						>
+							+
+						</button>
+					) : (
+						<div className="hold-input-group">
+							<input
+								className="hold-input"
+								type="number"
+								min={100}
+								step={100}
+								value={holdInput}
+								onChange={(e) => setHoldInput(e.target.value)}
+								onKeyDown={(e) => {
+									if (e.key === 'Enter') {
+										const ms = parseInt(holdInput)
+										if (!isNaN(ms) && ms >= 100) {
+											onTriggerAdd(currentStepKey, ms)
+											setAddingHold(false)
+											setHoldInput('2000')
+										}
+									} else if (e.key === 'Escape') setAddingHold(false)
+								}}
+								autoFocus
+							/>
+							<span className="hold-input-unit">ms</span>
+							<button
+								className="step-tab step-tab--add"
+								onClick={() => {
+									const ms = parseInt(holdInput)
+									if (!isNaN(ms) && ms >= 100) {
+										onTriggerAdd(currentStepKey, ms)
+										setAddingHold(false)
+										setHoldInput('2000')
+									}
+								}}
+							>
+								✓
+							</button>
+							<button className="step-tab step-tab--remove" onClick={() => setAddingHold(false)}>
+								✕
+							</button>
+						</div>
+					)}
+
+					<div className="step-bar-divider" />
+
+					<span className="step-bar-label">Zoom</span>
+					<button className="step-tab zoom-btn" title="Zoom in (or ⌘ scroll)" onClick={handleZoomIn}>
+						+
+					</button>
+					<button className="step-tab zoom-btn" title="Zoom out (or ⌘ scroll)" onClick={handleZoomOut}>
+						−
+					</button>
+					<button className="step-tab zoom-btn zoom-btn--fit" title="Fit all actions" onClick={handleZoomFit}>
+						Fit
+					</button>
+				</div>
+			)}
+
+			<div className="timeline" ref={trackAreaRef}>
+				{/* Ruler */}
+				<div className="timeline-ruler" style={{ height: RULER_HEIGHT }}>
+					<div className="ruler-track-label" style={{ width: LABEL_WIDTH }} />
+					<div className="ruler-ticks" style={{ position: 'relative', flex: 1 }} onClick={handleRulerClick}>
+						{renderRuler()}
+						{msToPx(playheadMs, containerWidth) >= 0 && (
+							<div
+								className="playhead-ruler-marker"
+								style={{ left: msToPx(playheadMs, containerWidth) }}
+								onMouseDown={handlePlayheadDragStart}
+								onClick={(e) => e.stopPropagation()}
+							>
+								<div className="playhead-ruler-label">{msToLabel(playheadMs)}</div>
+								<div className="playhead-ruler-arrow" />
+							</div>
+						)}
+					</div>
+				</div>
+
+				{/* Full-height playhead line */}
+				<div className="playhead-line" style={{ left: msToPx(playheadMs, containerWidth) + LABEL_WIDTH }} />
+
+				{/* Selected button tracks */}
+				{selectedTracks.map(({ triggerKey, actions }) => renderSelectedTrack(triggerKey, actions))}
+
+				{/* Group sub-timelines and lists — recursive, all nesting depths */}
+				{selectedTracks.flatMap(({ triggerKey, actions }) =>
+					collectGroups(actions, triggerKey, [], 0, 0)
+						.filter((info) => execModeOf(info.group.options) === 'sequential')
+						.map((info) => renderSequentialSubTrack(info))
+				)}
+				{selectedTracks.flatMap(({ triggerKey, actions }) =>
+					collectGroups(actions, triggerKey, [], 0, 0)
+						.filter((info) => execModeOf(info.group.options) !== 'sequential')
+						.map((info) => renderConcurrentList(info))
+				)}
+
+				{!hasAnyContent && (
+					<div className="timeline-empty">
+						<p>Select a button to start editing</p>
+					</div>
+				)}
+
+				{selectedTracks.length === 0 && selectedControl && (
+					<div className="timeline-empty">
+						<p>No tracks — double-click to add an action</p>
+					</div>
+				)}
+
+				<div className="timeline-footer">
+					<span>
+						scroll ↕ tracks · shift-scroll / swipe ↔ time · ⌘ scroll to zoom · double-click to add · right-click for
+						options · ⌘Z undo
+					</span>
+					<span>
+						{msToLabel(scrollMs)} – {msToLabel(scrollMs + visibleMs)}
+					</span>
+				</div>
+			</div>
+
+			{contextMenu && (
+				<div
+					className="timeline-context-menu"
+					style={{ position: 'fixed', left: contextMenu.x, top: contextMenu.y }}
+					onMouseDown={(e) => e.stopPropagation()}
+				>
+					<button
+						className="context-menu-item context-menu-item--danger"
+						onClick={() => {
+							onActionDelete(contextMenu.stepKey, contextMenu.triggerKey, contextMenu.actionId)
+							setContextMenu(null)
+						}}
+					>
+						Delete action
+					</button>
+				</div>
+			)}
+		</div>
+	)
+}

--- a/webui/src/Timeline/library.ts
+++ b/webui/src/Timeline/library.ts
@@ -1,0 +1,59 @@
+import { EntityModelType } from '@companion-app/shared/Model/EntityModel.js'
+import type { ConnectionsStore } from '~/Stores/ConnectionsStore.js'
+import type { EntityDefinitionsStore } from '~/Stores/EntityDefinitionsStore.js'
+
+export interface ActionEntry {
+	connectionId: string
+	connectionLabel: string
+	moduleId: string
+	definitionId: string
+	label: string
+	options: Record<string, unknown>
+	usedBefore: boolean
+	noActions?: boolean
+}
+
+// Build the draggable action library from Companion's live connection + action definitions.
+// `usedKeys` is a set of `connectionId:definitionId` already present on the current button.
+export function buildActionLibrary(
+	connections: ConnectionsStore,
+	entityDefinitions: EntityDefinitionsStore,
+	usedKeys: Set<string>
+): ActionEntry[] {
+	const actionStore = entityDefinitions.getEntityDefinitionsStore(EntityModelType.Action)
+	const result: ActionEntry[] = []
+
+	for (const [connectionId, defs] of actionStore.connections.entries()) {
+		const conn = connections.connections.get(connectionId)
+		const connectionLabel = connectionId === 'internal' ? 'Internal' : (conn?.label ?? connectionId)
+		const moduleId = connectionId === 'internal' ? 'internal' : (conn?.moduleId ?? '')
+
+		if (!defs || defs.size === 0) {
+			result.push({
+				connectionId,
+				connectionLabel,
+				moduleId,
+				definitionId: '',
+				label: '',
+				options: {},
+				usedBefore: false,
+				noActions: true,
+			})
+			continue
+		}
+
+		for (const [definitionId, def] of defs.entries()) {
+			result.push({
+				connectionId,
+				connectionLabel,
+				moduleId,
+				definitionId,
+				label: def?.label ?? definitionId,
+				options: {},
+				usedBefore: usedKeys.has(`${connectionId}:${definitionId}`),
+			})
+		}
+	}
+
+	return result
+}

--- a/webui/src/Timeline/timeline.scss
+++ b/webui/src/Timeline/timeline.scss
@@ -1,0 +1,2662 @@
+// AUTO-PORTED from Companion_Timeline/src/renderer/src/styles.css
+// Scoped under .ct-root so it cannot leak into the rest of the Companion UI.
+.ct-root {
+	*,
+	*::before,
+	*::after {
+		box-sizing: border-box;
+		margin: 0;
+		padding: 0;
+	}
+
+	& {
+		--bg: #1a1a1a;
+		--bg2: #222222;
+		--bg3: #2a2a2a;
+		--bg4: #333333;
+		--border: #3a3a3a;
+		--border2: #444;
+		--text: #e8e8e8;
+		--text2: #999;
+		--text3: #666;
+		--accent: #f5a623;
+		--accent2: #e8941d;
+		--blue: #4a9eff;
+		--red: #ff4444;
+		--track-bg: #1e1e1e;
+		--clip-bg: #3a5a8a;
+		--clip-selected: #5a7aaa;
+		--clip-border: #4a6a9a;
+		--clip-selected-border: #80aaee;
+		--ruler-bg: #1a1a1a;
+		--grid-line: rgba(255, 255, 255, 0.05);
+	}
+
+	& {
+		width: 100%;
+		height: 100%;
+		overflow: hidden;
+		background: var(--bg);
+		color: var(--text);
+		font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Segoe UI', sans-serif;
+		font-size: 13px;
+		-webkit-font-smoothing: antialiased;
+	}
+
+	.app {
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+		height: 100%;
+	}
+
+	/* Live sync banner */
+	.sync-banner {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		padding: 7px 16px;
+		background: #7a4800;
+		border-bottom: 1px solid #a06000;
+		font-size: 12px;
+		color: #ffd;
+		flex-shrink: 0;
+	}
+	.sync-banner span {
+		flex: 1;
+	}
+	.sync-banner-btn {
+		background: var(--accent);
+		color: #000;
+		border: none;
+		border-radius: 4px;
+		padding: 3px 10px;
+		font-size: 12px;
+		cursor: pointer;
+		font-weight: 600;
+	}
+	.sync-banner-btn:hover {
+		background: var(--accent2);
+	}
+	.sync-banner-dismiss {
+		background: transparent;
+		color: #ffd;
+		border: 1px solid rgba(255, 220, 100, 0.3);
+		border-radius: 4px;
+		padding: 3px 8px;
+		font-size: 12px;
+		cursor: pointer;
+	}
+	.sync-banner-dismiss:hover {
+		background: rgba(255, 255, 255, 0.08);
+	}
+
+	/* Titlebar */
+	.titlebar {
+		height: 44px;
+		display: flex;
+		align-items: center;
+		background: var(--bg);
+		border-bottom: 1px solid var(--border);
+		flex-shrink: 0;
+		-webkit-app-region: drag;
+		user-select: none;
+	}
+
+	.titlebar-drag {
+		width: 80px;
+		height: 100%;
+		-webkit-app-region: drag;
+	}
+
+	.titlebar-title {
+		flex: 1;
+		text-align: center;
+		font-size: 13px;
+		font-weight: 500;
+		color: var(--text2);
+		-webkit-app-region: drag;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 6px;
+	}
+
+	.dirty-dot {
+		width: 8px;
+		height: 8px;
+		background: var(--accent);
+		border-radius: 50%;
+	}
+
+	.titlebar-actions {
+		display: flex;
+		gap: 6px;
+		padding-right: 12px;
+		-webkit-app-region: no-drag;
+	}
+
+	.toolbar-btn {
+		background: var(--bg3);
+		border: 1px solid var(--border2);
+		color: var(--text);
+		border-radius: 5px;
+		padding: 4px 10px;
+		font-size: 12px;
+		cursor: pointer;
+		transition: background 0.1s;
+	}
+
+	.toolbar-btn:hover:not(:disabled) {
+		background: var(--bg4);
+	}
+
+	.toolbar-btn:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	.toolbar-btn--companion {
+		background: var(--accent);
+		color: #000;
+		border-color: var(--accent2);
+		font-weight: 600;
+	}
+
+	.host-btn {
+		font-family: monospace;
+		font-size: 11px;
+		min-width: 70px;
+	}
+	.host-btn--remote {
+		background: #1e3a5f;
+		color: #60a5fa;
+		border-color: #2563eb;
+	}
+	.host-btn--remote:hover {
+		background: #1e4080;
+	}
+
+	.host-input-form {
+		display: flex;
+		align-items: center;
+	}
+	.host-input {
+		background: var(--bg4);
+		border: 1px solid var(--accent);
+		border-radius: 4px;
+		color: var(--text);
+		font-size: 12px;
+		font-family: monospace;
+		padding: 3px 7px;
+		height: 26px;
+		width: 140px;
+		outline: none;
+	}
+
+	.toolbar-btn--test {
+		background: #2a4a2a;
+		color: #6fcf6f;
+		border-color: #4a8a4a;
+		font-weight: 600;
+	}
+	.toolbar-btn--test:hover:not(:disabled) {
+		background: #3a6a3a;
+	}
+	.toolbar-btn--test:active {
+		background: #4a8a4a;
+		color: #fff;
+	}
+
+	.toolbar-btn--companion:hover:not(:disabled) {
+		background: var(--accent2);
+	}
+
+	.live-badge {
+		background: var(--accent);
+		color: #000;
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		padding: 2px 5px;
+		border-radius: 3px;
+		margin-right: 4px;
+	}
+
+	.save-status {
+		font-size: 11px;
+		color: #4caf50;
+		margin-left: 6px;
+	}
+
+	.app-version {
+		font-size: 10px;
+		color: var(--text3);
+		margin-left: 8px;
+		font-weight: 400;
+		opacity: 0.6;
+	}
+
+	/* Welcome screen */
+	.welcome {
+		flex: 1;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.welcome-card {
+		text-align: center;
+		max-width: 400px;
+		padding: 48px;
+	}
+
+	/* Connection picker */
+	.connection-card {
+		text-align: left;
+		max-width: 420px;
+		padding: 40px 44px;
+	}
+	.connection-card h1 {
+		text-align: center;
+	}
+	.conn-subtitle {
+		text-align: center;
+		color: var(--text2);
+		margin-bottom: 20px !important;
+	}
+	.conn-section-label {
+		font-size: 10px;
+		font-weight: 600;
+		color: var(--text3);
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		margin: 16px 0 6px;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+	}
+	.conn-clear-btn {
+		background: none;
+		border: none;
+		color: var(--text3);
+		cursor: pointer;
+		font-size: 10px;
+		padding: 0;
+		text-transform: none;
+		letter-spacing: 0;
+	}
+	.conn-clear-btn:hover {
+		color: #f87171;
+	}
+
+	.conn-option {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		width: 100%;
+		background: var(--bg3);
+		border: 1px solid var(--border2);
+		border-radius: 7px;
+		padding: 10px 14px;
+		cursor: pointer;
+		color: var(--text);
+		font-size: 13px;
+		text-align: left;
+		transition:
+			background 0.1s,
+			border-color 0.1s;
+	}
+	.conn-option:hover:not(:disabled) {
+		background: var(--bg4);
+		border-color: var(--accent);
+	}
+	.conn-option:disabled {
+		opacity: 0.5;
+		cursor: default;
+	}
+	.conn-option--local {
+		margin-bottom: 4px;
+	}
+	.conn-option-icon {
+		font-size: 16px;
+		flex-shrink: 0;
+	}
+	.conn-option-label {
+		flex: 1;
+		font-weight: 500;
+	}
+	.conn-option-addr {
+		font-size: 11px;
+		color: var(--text3);
+		font-family: monospace;
+	}
+	.conn-live-dot {
+		width: 7px;
+		height: 7px;
+		border-radius: 50%;
+		background: var(--accent);
+		flex-shrink: 0;
+		box-shadow: 0 0 5px var(--accent);
+	}
+
+	.conn-option-row {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		margin-bottom: 4px;
+	}
+	.conn-option-row .conn-option {
+		flex: 1;
+		margin-bottom: 0;
+	}
+	.conn-remove-btn {
+		background: none;
+		border: none;
+		color: var(--text3);
+		cursor: pointer;
+		font-size: 16px;
+		padding: 4px 8px;
+		border-radius: 4px;
+		flex-shrink: 0;
+		line-height: 1;
+	}
+	.conn-remove-btn:hover {
+		background: var(--bg3);
+		color: #f87171;
+	}
+
+	.conn-manual {
+		display: flex;
+		gap: 6px;
+		margin-top: 4px;
+	}
+	.conn-input {
+		flex: 1;
+		background: var(--bg3);
+		border: 1px solid var(--border2);
+		border-radius: 6px;
+		color: var(--text);
+		font-size: 13px;
+		padding: 8px 12px;
+		outline: none;
+		font-family: monospace;
+	}
+	.conn-input:focus {
+		border-color: var(--accent);
+	}
+	.conn-go-btn {
+		background: var(--accent);
+		color: #000;
+		border: none;
+		border-radius: 6px;
+		padding: 8px 16px;
+		font-size: 13px;
+		font-weight: 600;
+		cursor: pointer;
+		white-space: nowrap;
+	}
+	.conn-go-btn:hover:not(:disabled) {
+		background: var(--accent2);
+	}
+	.conn-go-btn:disabled {
+		opacity: 0.4;
+		cursor: default;
+	}
+
+	.conn-error {
+		margin-top: 10px;
+		padding: 8px 12px;
+		background: rgba(248, 113, 113, 0.1);
+		border: 1px solid rgba(248, 113, 113, 0.3);
+		border-radius: 6px;
+		color: #f87171;
+		font-size: 12px;
+	}
+	.conn-divider {
+		border: none;
+		border-top: 1px solid var(--border);
+		margin: 20px 0 0;
+	}
+
+	.welcome-icon {
+		font-size: 56px;
+		margin-bottom: 16px;
+	}
+
+	.welcome-card h1 {
+		font-size: 24px;
+		font-weight: 600;
+		color: var(--text);
+		margin-bottom: 12px;
+	}
+
+	.welcome-card p {
+		color: var(--text2);
+		line-height: 1.6;
+		margin-bottom: 24px;
+	}
+
+	.welcome-card code {
+		background: var(--bg3);
+		padding: 2px 6px;
+		border-radius: 3px;
+		font-family: 'SF Mono', Menlo, monospace;
+		font-size: 12px;
+	}
+
+	.welcome-open-btn {
+		display: block;
+		width: 100%;
+		background: var(--accent);
+		color: #000;
+		border: none;
+		border-radius: 8px;
+		padding: 10px 24px;
+		font-size: 14px;
+		font-weight: 600;
+		cursor: pointer;
+		transition: background 0.15s;
+	}
+
+	.welcome-open-btn:hover {
+		background: var(--accent2);
+	}
+
+	.welcome-open-btn--secondary {
+		background: var(--bg3);
+		color: var(--text2);
+		border: 1px solid var(--border2);
+		margin-top: 8px;
+	}
+
+	.welcome-open-btn--secondary:hover {
+		background: var(--bg4);
+		color: var(--text);
+	}
+
+	/* Workspace layout */
+	.workspace {
+		flex: 1;
+		display: flex;
+		overflow: hidden;
+	}
+
+	/* ── Action Library Panel ──────────────────────────────────────────────────── */
+	.library-panel {
+		width: 220px;
+		flex-shrink: 0;
+		border-right: 1px solid var(--border);
+		display: flex;
+		flex-direction: column;
+		background: var(--bg1);
+		overflow: hidden;
+	}
+
+	.library-header {
+		padding: 8px 10px 6px;
+		display: flex;
+		align-items: baseline;
+		gap: 6px;
+		border-bottom: 1px solid var(--border);
+	}
+
+	.library-title {
+		font-size: 11px;
+		font-weight: 600;
+		color: var(--text2);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+
+	.library-hint {
+		font-size: 9px;
+		color: var(--text3);
+		flex: 1;
+	}
+
+	.library-reload-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 6px;
+		margin: 6px 8px 2px;
+		padding: 6px 10px;
+		background: var(--bg3);
+		border: 1px solid var(--border2);
+		border-radius: 5px;
+		color: var(--text2);
+		font-size: 11px;
+		font-weight: 600;
+		cursor: pointer;
+		flex-shrink: 0;
+		transition:
+			background 0.1s,
+			color 0.1s;
+	}
+	.library-reload-btn:hover {
+		background: var(--accent);
+		color: #000;
+		border-color: var(--accent);
+	}
+	.library-reload-btn:disabled {
+		opacity: 0.45;
+		cursor: default;
+	}
+	.library-reload-icon {
+		font-size: 15px;
+		line-height: 1;
+	}
+
+	.library-error {
+		color: #f87171;
+		font-size: 10px;
+	}
+
+	.library-search {
+		margin: 6px 8px;
+		flex-shrink: 0;
+	}
+
+	.library-list {
+		flex: 1;
+		overflow-y: auto;
+		padding-bottom: 8px;
+	}
+
+	.library-list::-webkit-scrollbar {
+		width: 4px;
+	}
+	.library-list::-webkit-scrollbar-thumb {
+		background: var(--border2);
+		border-radius: 2px;
+	}
+
+	.library-empty {
+		font-size: 11px;
+		color: var(--text3);
+		padding: 12px 10px;
+	}
+
+	.library-group {
+		border-bottom: 1px solid var(--border);
+	}
+
+	.library-group-header {
+		width: 100%;
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		padding: 5px 8px;
+		background: none;
+		border: none;
+		cursor: pointer;
+		color: var(--text2);
+		font-size: 10px;
+		font-weight: 600;
+		text-align: left;
+	}
+	.library-group-header:hover {
+		background: var(--bg3);
+	}
+
+	.library-group-chevron {
+		font-size: 8px;
+		color: var(--text3);
+		width: 8px;
+	}
+	.library-group-label {
+		flex: 1;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.library-group-count {
+		font-size: 9px;
+		background: var(--bg3);
+		color: var(--text3);
+		border-radius: 8px;
+		padding: 0 5px;
+		min-width: 18px;
+		text-align: center;
+	}
+
+	.library-group-items {
+		padding: 2px 0;
+	}
+
+	.library-no-actions {
+		font-size: 10px;
+		color: var(--text3);
+		padding: 4px 20px 6px;
+		font-style: italic;
+	}
+
+	.library-item {
+		display: flex;
+		align-items: center;
+		gap: 5px;
+		padding: 4px 8px 4px 20px;
+		font-size: 11px;
+		color: var(--text);
+		cursor: grab;
+		user-select: none;
+		border-radius: 3px;
+		margin: 1px 4px;
+	}
+	.library-item:hover {
+		background: var(--bg3);
+	}
+	.library-item:active {
+		cursor: grabbing;
+	}
+	.library-item--used {
+		color: var(--accent);
+	}
+
+	.library-item-icon {
+		color: var(--text3);
+		font-size: 10px;
+		flex-shrink: 0;
+	}
+	.library-item-name {
+		flex: 1;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.library-item-dot {
+		width: 5px;
+		height: 5px;
+		background: var(--accent);
+		border-radius: 50%;
+		flex-shrink: 0;
+	}
+
+	/* ── Drop indicator on timeline tracks ────────────────────────────────────── */
+	.drop-indicator {
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		width: 2px;
+		background: var(--accent);
+		pointer-events: none;
+		z-index: 20;
+		box-shadow: 0 0 6px var(--accent);
+	}
+
+	/* Active library toggle button */
+	.toolbar-btn--active {
+		background: var(--accent) !important;
+		color: #000 !important;
+	}
+
+	/* Disabled toolbar buttons */
+	.toolbar-btn:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	/* Play button active state */
+	.toolbar-btn--playing {
+		background: #ef4444 !important;
+		color: #fff !important;
+	}
+
+	/* ── Playhead ────────────────────────────────────────────────────────────── */
+	.playhead-ruler-marker {
+		position: absolute;
+		top: 0;
+		transform: translateX(-50%);
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		cursor: ew-resize;
+		z-index: 30;
+		pointer-events: all;
+		user-select: none;
+	}
+
+	.playhead-ruler-label {
+		background: var(--accent);
+		color: #000;
+		font-size: 9px;
+		font-weight: 700;
+		padding: 1px 4px;
+		border-radius: 3px;
+		white-space: nowrap;
+	}
+
+	.playhead-ruler-arrow {
+		width: 0;
+		height: 0;
+		border-left: 5px solid transparent;
+		border-right: 5px solid transparent;
+		border-top: 6px solid var(--accent);
+	}
+
+	.playhead-line {
+		position: absolute;
+		top: 28px; /* below ruler height (RULER_HEIGHT = 28px) */
+		bottom: 30px; /* above footer */
+		width: 2px;
+		transform: translateX(-50%);
+		background: var(--accent);
+		pointer-events: none;
+		z-index: 25;
+		opacity: 0.9;
+		box-shadow: 0 0 6px var(--accent);
+	}
+
+	/* Sidebar */
+	.sidebar-panel {
+		width: 240px;
+		flex-shrink: 0;
+		border-right: 1px solid var(--border);
+		display: flex;
+		flex-direction: column;
+		overflow: hidden;
+	}
+
+	.sidebar-header {
+		padding: 8px 12px;
+		font-size: 11px;
+		font-weight: 600;
+		color: var(--text3);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		border-bottom: 1px solid var(--border);
+		flex-shrink: 0;
+	}
+
+	.sidebar {
+		flex: 1;
+		overflow-y: auto;
+		padding: 8px;
+	}
+
+	.sidebar::-webkit-scrollbar {
+		width: 4px;
+	}
+	.sidebar::-webkit-scrollbar-track {
+		background: transparent;
+	}
+	.sidebar::-webkit-scrollbar-thumb {
+		background: var(--border2);
+		border-radius: 2px;
+	}
+
+	.sidebar-empty {
+		color: var(--text3);
+		padding: 20px;
+		text-align: center;
+		font-size: 12px;
+	}
+
+	.page-section {
+		margin-bottom: 12px;
+	}
+
+	.page-label {
+		font-size: 10px;
+		font-weight: 600;
+		color: var(--text3);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		margin-bottom: 4px;
+		padding: 0 2px;
+	}
+
+	.button-grid {
+		display: grid;
+		gap: 2px;
+	}
+
+	.btn-cell {
+		aspect-ratio: 1;
+		border-radius: 4px;
+		border: 1.5px solid transparent;
+		cursor: pointer;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		padding: 2px;
+		position: relative;
+		transition:
+			border-color 0.1s,
+			transform 0.05s;
+		overflow: hidden;
+	}
+
+	.btn-cell:hover {
+		border-color: var(--text3);
+		transform: scale(1.05);
+	}
+
+	.btn-cell--empty {
+		background: var(--bg2);
+		cursor: default;
+		opacity: 0.3;
+	}
+
+	.btn-cell--selected {
+		border-color: var(--accent) !important;
+		box-shadow: 0 0 0 1px var(--accent);
+	}
+
+	.btn-bitmap {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		display: block;
+		border-radius: 2px;
+	}
+
+	.btn-cell--pressed {
+		opacity: 0.7;
+		transform: scale(0.94) !important;
+	}
+
+	.btn-image-wrap {
+		position: relative;
+		width: 100%;
+		height: 100%;
+	}
+
+	.btn-image-wrap .btn-bitmap {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		border-radius: 2px;
+	}
+
+	.btn-text {
+		font-size: 8px;
+		text-align: center;
+		white-space: pre-line;
+		line-height: 1.2;
+		word-break: break-word;
+		overflow: hidden;
+		max-height: 100%;
+	}
+
+	.btn-text--overlay {
+		position: absolute;
+		bottom: 0;
+		left: 0;
+		right: 0;
+		text-align: center;
+		font-size: 7px;
+		padding: 1px 2px;
+		background: rgba(0, 0, 0, 0.55);
+		line-height: 1.3;
+		white-space: pre-line;
+		word-break: break-word;
+	}
+
+	.btn-dot {
+		position: absolute;
+		bottom: 2px;
+		right: 2px;
+		width: 4px;
+		height: 4px;
+		background: var(--accent);
+		border-radius: 50%;
+	}
+
+	/* Main panel */
+	.main-panel {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		overflow: hidden;
+		min-width: 0;
+	}
+
+	.button-header {
+		padding: 8px 16px;
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		flex-shrink: 0;
+		border-bottom: 1px solid var(--border);
+	}
+
+	.button-header-key {
+		font-family: 'SF Mono', Menlo, monospace;
+		font-size: 11px;
+		opacity: 0.6;
+	}
+
+	.button-header-text {
+		font-size: 13px;
+		font-weight: 500;
+		white-space: pre-line;
+	}
+
+	.button-header-text--editable {
+		cursor: text;
+		border-radius: 3px;
+		padding: 2px 5px;
+		margin: -2px -5px;
+		transition: background 0.1s;
+	}
+	.button-header-text--editable:hover {
+		background: rgba(255, 255, 255, 0.15);
+	}
+
+	.button-header-label-input {
+		font-size: 13px;
+		font-weight: 500;
+		background: rgba(0, 0, 0, 0.3);
+		border: 1px solid rgba(255, 255, 255, 0.4);
+		border-radius: 3px;
+		color: inherit;
+		padding: 2px 6px;
+		outline: none;
+		flex: 1;
+		min-width: 0;
+	}
+
+	.no-selection {
+		flex: 1;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		color: var(--text3);
+	}
+
+	/* Timeline wrapper + step bar */
+	.timeline-wrap {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		overflow: hidden;
+	}
+
+	.step-bar {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		padding: 4px 10px;
+		background: var(--bg2);
+		border-bottom: 1px solid var(--border);
+		flex-shrink: 0;
+	}
+
+	.step-bar-label {
+		font-size: 10px;
+		font-weight: 600;
+		color: var(--text3);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		margin-right: 4px;
+	}
+
+	.step-tab {
+		background: var(--bg3);
+		border: 1px solid var(--border2);
+		color: var(--text2);
+		border-radius: 4px;
+		width: 26px;
+		height: 22px;
+		font-size: 11px;
+		cursor: pointer;
+		transition:
+			background 0.1s,
+			color 0.1s;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.step-tab:hover {
+		background: var(--bg4);
+		color: var(--text);
+	}
+	.step-tab--active {
+		background: var(--accent);
+		color: #000;
+		border-color: var(--accent2);
+		font-weight: 700;
+	}
+	.step-tab--add {
+		color: var(--accent);
+		border-color: var(--accent);
+	}
+	.step-tab--add:hover {
+		background: var(--accent);
+		color: #000;
+	}
+	.step-tab--remove {
+		color: var(--red);
+		border-color: var(--red);
+	}
+	.step-tab--remove:hover {
+		background: var(--red);
+		color: #fff;
+	}
+
+	.step-bar-divider {
+		width: 1px;
+		height: 18px;
+		background: var(--border2);
+		margin: 0 4px;
+		flex-shrink: 0;
+	}
+
+	.hold-input-group {
+		display: flex;
+		align-items: center;
+		gap: 3px;
+	}
+
+	.hold-input {
+		width: 60px;
+		background: var(--bg3);
+		border: 1px solid var(--accent);
+		border-radius: 4px;
+		color: var(--text);
+		padding: 2px 5px;
+		font-size: 11px;
+		outline: none;
+	}
+
+	.hold-input-unit {
+		font-size: 10px;
+		color: var(--text3);
+		margin-right: 2px;
+	}
+
+	/* Timeline */
+	.timeline {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		overflow-y: auto;
+		overflow-x: hidden;
+		background: var(--track-bg);
+		user-select: none;
+		position: relative;
+	}
+
+	.timeline::-webkit-scrollbar {
+		width: 6px;
+	}
+	.timeline::-webkit-scrollbar-track {
+		background: transparent;
+	}
+	.timeline::-webkit-scrollbar-thumb {
+		background: var(--border2);
+		border-radius: 3px;
+	}
+
+	.timeline-ruler {
+		display: flex;
+		background: var(--ruler-bg);
+		border-bottom: 1px solid var(--border);
+		flex-shrink: 0;
+		position: sticky;
+		top: 0;
+		z-index: 20;
+	}
+
+	.ruler-track-label {
+		flex-shrink: 0;
+		border-right: 1px solid var(--border);
+	}
+
+	.ruler-ticks {
+		flex: 1;
+		overflow: hidden;
+	}
+
+	.ruler-tick {
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+	}
+
+	.ruler-tick::before {
+		content: '';
+		width: 1px;
+		height: 8px;
+		background: var(--border2);
+	}
+
+	.ruler-label {
+		font-size: 9px;
+		color: var(--text3);
+		white-space: nowrap;
+		padding-left: 3px;
+		margin-top: 2px;
+	}
+
+	.track-row {
+		display: flex;
+		border-bottom: 1px solid var(--border);
+		flex-shrink: 0;
+		position: relative;
+	}
+
+	.track-row:hover {
+		background: rgba(255, 255, 255, 0.01);
+	}
+
+	.track-label {
+		flex-shrink: 0;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 0 6px 0 10px;
+		font-size: 11px;
+		font-weight: 500;
+		color: var(--text2);
+		border-right: 1px solid var(--border);
+		background: var(--bg2);
+		gap: 4px;
+	}
+
+	.track-label-text {
+		flex: 1;
+	}
+
+	.track-label-meta {
+		display: flex;
+		align-items: center;
+		gap: 3px;
+	}
+
+	.track-mode-badge {
+		font-size: 8px;
+		font-weight: 700;
+		letter-spacing: 0.04em;
+		color: var(--teal, #4ecdc4);
+		background: rgba(78, 205, 196, 0.12);
+		border: 1px solid rgba(78, 205, 196, 0.3);
+		border-radius: 3px;
+		padding: 1px 3px;
+		white-space: nowrap;
+	}
+
+	.track-remove-btn {
+		background: none;
+		border: none;
+		color: var(--text3);
+		cursor: pointer;
+		font-size: 14px;
+		line-height: 1;
+		padding: 0 2px;
+		opacity: 0;
+		transition:
+			opacity 0.1s,
+			color 0.1s;
+	}
+
+	.track-row:hover .track-remove-btn {
+		opacity: 1;
+	}
+	.track-remove-btn:hover {
+		color: var(--red);
+	}
+
+	.lane-divider {
+		position: absolute;
+		left: 0;
+		right: 0;
+		height: 1px;
+		background: var(--border);
+		pointer-events: none;
+		opacity: 0.5;
+	}
+
+	.track-body {
+		flex: 1;
+		cursor: crosshair;
+		overflow: hidden;
+	}
+
+	.grid-line {
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		width: 1px;
+		background: var(--grid-line);
+		pointer-events: none;
+	}
+
+	/* ── Combined action+wait block ── */
+	.clip-block {
+		position: absolute;
+		display: flex;
+		border-radius: 5px;
+		overflow: visible;
+		z-index: 1;
+	}
+
+	.clip-block--selected {
+		z-index: 10;
+	}
+	.clip-block--selected .clip-action {
+		border-color: var(--clip-selected-border);
+		box-shadow: 0 0 0 1px var(--clip-selected-border);
+		background: var(--clip-selected);
+	}
+	.clip-block--selected .clip-wait {
+		border-color: var(--clip-selected-border);
+		box-shadow: 0 0 0 1px var(--clip-selected-border);
+	}
+
+	/* Action section (left, blue) */
+	.clip-action {
+		flex-shrink: 0;
+		background: var(--clip-bg);
+		border: 1.5px solid var(--clip-border);
+		border-radius: 5px;
+		cursor: grab;
+		overflow: hidden;
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		padding: 3px 8px;
+		gap: 2px;
+		position: relative;
+		transition:
+			border-color 0.1s,
+			background 0.1s,
+			box-shadow 0.1s;
+	}
+
+	.clip-action:hover {
+		border-color: #6a8aba;
+	}
+	.clip-action:active {
+		cursor: grabbing;
+	}
+
+	/* Action group variant */
+	:root {
+		--teal: #4ecdc4;
+		--teal2: #3dbdb5;
+	}
+
+	.clip-block--group .clip-action,
+	.clip-action--group {
+		background: #1a4a48;
+		border-color: #3dbdb5;
+	}
+	.clip-block--group.clip-block--selected .clip-action {
+		background: #225f5c;
+		border-color: var(--teal);
+		box-shadow: 0 0 0 1px var(--teal);
+	}
+	.clip-action--group:hover {
+		border-color: var(--teal) !important;
+	}
+
+	.action-exec-mode {
+		display: flex;
+		align-items: center;
+		margin-top: 1px;
+	}
+
+	.exec-mode-select {
+		background: rgba(0, 0, 0, 0.3);
+		border: 1px solid rgba(78, 205, 196, 0.4);
+		border-radius: 3px;
+		color: var(--teal);
+		font-size: 9px;
+		font-weight: 600;
+		padding: 1px 2px;
+		outline: none;
+		cursor: pointer;
+		width: 100%;
+		appearance: none;
+		text-align: center;
+	}
+	.exec-mode-select:hover {
+		border-color: var(--teal);
+	}
+	.exec-mode-select option {
+		background: #1a2a2a;
+		color: var(--text);
+	}
+
+	/* Add-wait button (appears on hover over action section) */
+	.clip-add-wait {
+		position: absolute;
+		right: 2px;
+		bottom: 2px;
+		background: rgba(245, 166, 35, 0.18);
+		border: 1px solid rgba(245, 166, 35, 0.4);
+		border-radius: 3px;
+		color: var(--accent);
+		font-size: 9px;
+		padding: 1px 4px;
+		cursor: pointer;
+		opacity: 0;
+		transition: opacity 0.1s;
+		line-height: 1.4;
+	}
+
+	.clip-action:hover .clip-add-wait {
+		opacity: 1;
+	}
+	.clip-add-wait:hover {
+		background: rgba(245, 166, 35, 0.35);
+	}
+
+	/* Wait section (right, amber) */
+	.clip-wait {
+		background: rgba(245, 166, 35, 0.15);
+		border: 1.5px solid rgba(245, 166, 35, 0.45);
+		border-left: none;
+		border-radius: 0 5px 5px 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		position: relative;
+		overflow: hidden;
+		transition: background 0.1s;
+		min-width: 48px;
+	}
+
+	.clip-wait--new {
+		background: rgba(245, 166, 35, 0.08);
+		border-color: rgba(245, 166, 35, 0.3);
+		width: 90px !important;
+	}
+
+	.clip-wait:hover {
+		background: rgba(245, 166, 35, 0.22);
+	}
+
+	.clip-wait-label {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 1px;
+		background: none;
+		border: none;
+		cursor: pointer;
+		color: var(--accent);
+		font-size: 10px;
+		font-weight: 600;
+		width: 100%;
+		height: 100%;
+		justify-content: center;
+	}
+
+	.clip-wait-label span:first-child {
+		font-size: 12px;
+		line-height: 1;
+	}
+
+	.clip-wait-editor {
+		display: flex;
+		align-items: center;
+		gap: 2px;
+		padding: 0 4px;
+		width: 100%;
+	}
+
+	.wait-input {
+		width: 52px;
+		background: rgba(0, 0, 0, 0.3);
+		border: 1px solid var(--accent);
+		border-radius: 3px;
+		color: var(--accent);
+		font-size: 11px;
+		font-weight: 600;
+		padding: 2px 4px;
+		outline: none;
+		text-align: center;
+	}
+
+	.wait-input-unit {
+		font-size: 9px;
+		color: rgba(245, 166, 35, 0.7);
+		flex-shrink: 0;
+	}
+
+	/* Resize handle on right edge of wait section */
+	.clip-resize-handle {
+		position: absolute;
+		right: -4px;
+		top: 0;
+		bottom: 0;
+		width: 8px;
+		cursor: ew-resize;
+		z-index: 20;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.clip-resize-handle::after {
+		content: '';
+		width: 3px;
+		height: 60%;
+		background: rgba(245, 166, 35, 0.5);
+		border-radius: 2px;
+		transition:
+			background 0.1s,
+			width 0.1s;
+	}
+
+	.clip-resize-handle:hover::after {
+		background: var(--accent);
+		width: 4px;
+	}
+
+	/* Text inside action section */
+	.action-name {
+		font-size: 12px;
+		font-weight: 600;
+		color: #e0e8ff;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		line-height: 1.3;
+	}
+
+	.action-instance {
+		font-size: 10px;
+		color: rgba(200, 210, 255, 0.6);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		line-height: 1.3;
+	}
+
+	.action-delay {
+		font-size: 10px;
+		color: rgba(200, 210, 255, 0.5);
+		font-family: 'SF Mono', Menlo, monospace;
+		line-height: 1.3;
+	}
+
+	.action-duration-badge {
+		font-size: 9px;
+		color: var(--accent);
+		font-family: 'SF Mono', Menlo, monospace;
+		line-height: 1.3;
+		opacity: 0.85;
+	}
+
+	/* Timeout duration bar — sits to the right of clip-action in the flex row */
+	.clip-duration-bar {
+		flex-shrink: 0;
+		border-radius: 0 5px 5px 0;
+		background: repeating-linear-gradient(
+			90deg,
+			rgba(245, 166, 35, 0.2) 0px,
+			rgba(245, 166, 35, 0.2) 6px,
+			rgba(245, 166, 35, 0.06) 6px,
+			rgba(245, 166, 35, 0.06) 12px
+		);
+		border-top: 1.5px solid rgba(245, 166, 35, 0.45);
+		border-right: 2px solid rgba(245, 166, 35, 0.6);
+		border-bottom: 1.5px solid rgba(245, 166, 35, 0.45);
+		pointer-events: none;
+		align-self: stretch;
+	}
+
+	.timeline-empty {
+		flex: 1;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		color: var(--text3);
+		font-size: 12px;
+	}
+
+	/* Multi-button timeline: divider row between button groups */
+	.track-btn-divider {
+		display: flex;
+		align-items: center;
+		border-top: 1px solid var(--border2);
+		border-bottom: none;
+		background: var(--bg);
+		cursor: pointer;
+		flex-shrink: 0;
+	}
+	.track-btn-divider:hover {
+		background: rgba(255, 255, 255, 0.03);
+	}
+	.track-btn-divider-label {
+		flex-shrink: 0;
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		padding: 0 6px 0 10px;
+		border-right: 1px solid var(--border2);
+		background: var(--bg2);
+		height: 100%;
+		gap: 1px;
+	}
+	.track-btn-divider-name {
+		font-size: 11px;
+		font-weight: 600;
+		color: var(--text);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+	.track-btn-divider-slot {
+		font-size: 9px;
+		color: var(--text3);
+		white-space: nowrap;
+	}
+	.track-btn-divider-rule {
+		flex: 1;
+		height: 1px;
+		background: var(--border2);
+		margin: 0 8px;
+	}
+
+	/* Compact read-only tracks for non-selected buttons */
+	.track-row--other {
+		opacity: 0.7;
+		transition: opacity 0.1s;
+	}
+	.track-row--other:hover {
+		opacity: 1;
+		background: rgba(255, 255, 255, 0.02);
+	}
+	.track-label--other {
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 1px;
+	}
+	.track-label-btn-name {
+		font-weight: 600;
+		color: var(--text);
+		font-size: 11px;
+	}
+	.track-label-sub {
+		font-size: 9px;
+		color: var(--text3);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		max-width: 100%;
+	}
+	.clip-block--readonly {
+		pointer-events: none;
+		opacity: 0.75;
+	}
+	.clip-block--readonly .clip-action {
+		cursor: default;
+	}
+
+	.timeline-footer {
+		height: 22px;
+		background: var(--bg);
+		border-top: 1px solid var(--border);
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: 0 12px;
+		font-size: 10px;
+		color: var(--text3);
+		flex-shrink: 0;
+	}
+
+	/* Inspector */
+	.inspector-panel {
+		width: 240px;
+		flex-shrink: 0;
+		border-left: 1px solid var(--border);
+		overflow-y: auto;
+		background: var(--bg2);
+	}
+
+	.inspector-panel--empty {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		color: var(--text3);
+		font-size: 12px;
+	}
+
+	.inspector-panel::-webkit-scrollbar {
+		width: 4px;
+	}
+	.inspector-panel::-webkit-scrollbar-track {
+		background: transparent;
+	}
+	.inspector-panel::-webkit-scrollbar-thumb {
+		background: var(--border2);
+		border-radius: 2px;
+	}
+
+	.inspector {
+		padding: 12px;
+	}
+
+	.inspector-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: 12px;
+	}
+
+	.inspector-title {
+		font-size: 11px;
+		font-weight: 600;
+		color: var(--text3);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+
+	.inspector-delete {
+		background: none;
+		border: 1px solid var(--border2);
+		color: var(--text3);
+		border-radius: 4px;
+		width: 22px;
+		height: 22px;
+		cursor: pointer;
+		font-size: 11px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		transition:
+			background 0.1s,
+			color 0.1s;
+	}
+
+	.inspector-delete:hover {
+		background: var(--red);
+		border-color: var(--red);
+		color: white;
+	}
+
+	.inspector-section {
+		margin-bottom: 16px;
+	}
+
+	.inspector-section-title {
+		font-size: 10px;
+		font-weight: 600;
+		color: var(--text3);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		margin-bottom: 6px;
+		padding-bottom: 4px;
+		border-bottom: 1px solid var(--border);
+	}
+
+	.inspector-row {
+		display: flex;
+		flex-direction: column;
+		gap: 3px;
+		margin-bottom: 8px;
+	}
+
+	.inspector-row label {
+		font-size: 10px;
+		color: var(--text3);
+		font-weight: 500;
+	}
+
+	.inspector-value {
+		font-size: 12px;
+		color: var(--text);
+		display: flex;
+		align-items: center;
+		gap: 5px;
+		flex-wrap: wrap;
+	}
+
+	.inspector-badge {
+		background: var(--bg3);
+		border: 1px solid var(--border2);
+		border-radius: 3px;
+		padding: 1px 5px;
+		font-size: 10px;
+		color: var(--text2);
+	}
+
+	.inspector-input {
+		background: var(--bg3);
+		border: 1px solid var(--border2);
+		border-radius: 4px;
+		color: var(--text);
+		padding: 5px 8px;
+		font-size: 12px;
+		width: 100%;
+		outline: none;
+		transition: border-color 0.1s;
+	}
+
+	.inspector-input:focus {
+		border-color: var(--blue);
+	}
+
+	.mono {
+		font-family: 'SF Mono', Menlo, monospace;
+		font-size: 11px;
+	}
+
+	.muted {
+		color: var(--text3);
+	}
+
+	.inspector-select {
+		appearance: auto;
+	}
+
+	.inspector-input-row {
+		display: flex;
+		gap: 4px;
+	}
+
+	.inspector-hint {
+		font-size: 10px;
+		color: var(--text3);
+		margin-top: 2px;
+	}
+
+	.inspector-section-title-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: 6px;
+		padding-bottom: 4px;
+		border-bottom: 1px solid var(--border);
+	}
+
+	.inspector-option-add-row {
+		display: flex;
+		gap: 4px;
+		margin-top: 4px;
+	}
+
+	.inspector-add-opt {
+		background: none;
+		border: 1px solid var(--border2);
+		color: var(--accent);
+		border-radius: 3px;
+		width: 18px;
+		height: 18px;
+		font-size: 14px;
+		cursor: pointer;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		line-height: 1;
+	}
+
+	.inspector-add-opt:hover {
+		background: var(--accent);
+		color: #000;
+	}
+
+	.inspector-option-row {
+		gap: 2px;
+	}
+
+	.inspector-option-key {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+	}
+
+	.inspector-opt-label {
+		font-size: 10px;
+		color: var(--text3);
+		font-weight: 500;
+	}
+
+	.inspector-remove-opt {
+		background: none;
+		border: none;
+		color: var(--text3);
+		cursor: pointer;
+		font-size: 13px;
+		padding: 0 2px;
+		line-height: 1;
+	}
+
+	.inspector-remove-opt:hover {
+		color: var(--red);
+	}
+
+	.inspector-sync-opt {
+		background: none;
+		border: 1px solid var(--border2);
+		color: var(--text3);
+		border-radius: 4px;
+		padding: 2px 6px;
+		font-size: 13px;
+		cursor: pointer;
+		flex-shrink: 0;
+		transition:
+			background 0.1s,
+			color 0.1s,
+			border-color 0.1s;
+		line-height: 1;
+	}
+	.inspector-sync-opt:hover {
+		background: var(--accent);
+		color: #000;
+		border-color: var(--accent);
+	}
+
+	/* Add Action Modal */
+	.modal-backdrop {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.6);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 1000;
+	}
+
+	.modal {
+		background: var(--bg2);
+		border: 1px solid var(--border2);
+		border-radius: 10px;
+		width: 440px;
+		max-height: 80vh;
+		display: flex;
+		flex-direction: column;
+		box-shadow: 0 20px 60px rgba(0, 0, 0, 0.6);
+		outline: none;
+	}
+
+	.modal--wide {
+		width: 680px;
+	}
+
+	.modal-body--actions {
+		display: flex;
+		gap: 0;
+		padding: 0;
+		overflow: hidden;
+		flex: 1;
+	}
+
+	/* Connection sidebar */
+	.action-conn-list {
+		width: 180px;
+		flex-shrink: 0;
+		border-right: 1px solid var(--border);
+		overflow-y: auto;
+		background: var(--bg3);
+		display: flex;
+		flex-direction: column;
+	}
+
+	.action-conn-header {
+		font-size: 10px;
+		font-weight: 600;
+		color: var(--text3);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		padding: 8px 10px 6px;
+		flex-shrink: 0;
+		border-bottom: 1px solid var(--border);
+	}
+
+	.action-conn-item {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		padding: 7px 10px;
+		background: none;
+		border: none;
+		border-bottom: 1px solid var(--border);
+		color: var(--text2);
+		cursor: pointer;
+		text-align: left;
+		position: relative;
+		transition: background 0.1s;
+		width: 100%;
+	}
+
+	.action-conn-item:hover {
+		background: var(--bg4);
+	}
+	.action-conn-item--active {
+		background: rgba(74, 158, 255, 0.12);
+		color: var(--blue);
+	}
+
+	.action-conn-label {
+		font-size: 12px;
+		font-weight: 500;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		max-width: 140px;
+	}
+
+	.action-conn-module {
+		font-size: 9px;
+		color: var(--text3);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		max-width: 140px;
+	}
+
+	.action-conn-count {
+		position: absolute;
+		right: 8px;
+		top: 50%;
+		transform: translateY(-50%);
+		font-size: 10px;
+		color: var(--text3);
+		background: var(--bg4);
+		border-radius: 8px;
+		padding: 1px 5px;
+	}
+
+	/* Action pick area */
+	.action-pick-area {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		min-width: 0;
+		overflow: hidden;
+	}
+
+	.action-search {
+		border-radius: 0;
+		border: none;
+		border-bottom: 1px solid var(--border);
+		background: var(--bg3);
+		padding: 8px 12px;
+		flex-shrink: 0;
+	}
+
+	.action-search:focus {
+		border-color: var(--blue);
+		outline: none;
+	}
+
+	.action-list--tall {
+		max-height: none;
+		flex: 1;
+		overflow-y: auto;
+	}
+
+	.action-group-header {
+		font-size: 10px;
+		font-weight: 700;
+		color: var(--text3);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		padding: 6px 10px 4px;
+		background: var(--bg);
+		border-bottom: 1px solid var(--border);
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		position: sticky;
+		top: 0;
+		z-index: 1;
+	}
+
+	.action-group-module {
+		font-weight: 400;
+		font-size: 9px;
+		color: var(--text3);
+		opacity: 0.7;
+		text-transform: none;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		max-width: 200px;
+	}
+
+	.action-used-dot {
+		display: inline-block;
+		width: 5px;
+		height: 5px;
+		background: var(--accent);
+		border-radius: 50%;
+		margin-left: 5px;
+		vertical-align: middle;
+		flex-shrink: 0;
+	}
+
+	.modal-footer-hint {
+		flex: 1;
+		font-size: 11px;
+		padding-right: 12px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.modal-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 14px 16px 10px;
+		border-bottom: 1px solid var(--border);
+		flex-shrink: 0;
+	}
+
+	.modal-title {
+		font-size: 14px;
+		font-weight: 600;
+		color: var(--text);
+	}
+
+	.modal-close {
+		background: none;
+		border: none;
+		color: var(--text3);
+		cursor: pointer;
+		font-size: 14px;
+		padding: 2px 4px;
+	}
+
+	.modal-close:hover {
+		color: var(--text);
+	}
+
+	.modal-body {
+		padding: 12px 16px;
+		overflow-y: auto;
+		flex: 1;
+	}
+
+	.modal-body::-webkit-scrollbar {
+		width: 4px;
+	}
+	.modal-body::-webkit-scrollbar-thumb {
+		background: var(--border2);
+		border-radius: 2px;
+	}
+
+	.modal-row {
+		margin-bottom: 10px;
+	}
+
+	.modal-row label {
+		display: block;
+		font-size: 10px;
+		font-weight: 600;
+		color: var(--text3);
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		margin-bottom: 4px;
+	}
+
+	.action-list {
+		border: 1px solid var(--border);
+		border-radius: 6px;
+		overflow-y: auto;
+		max-height: 200px;
+		margin-bottom: 10px;
+		background: var(--bg3);
+	}
+
+	.action-list-empty {
+		padding: 12px;
+		color: var(--text3);
+		font-size: 12px;
+		text-align: center;
+	}
+
+	.action-list-item {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		width: 100%;
+		padding: 7px 10px;
+		background: none;
+		border: none;
+		border-bottom: 1px solid var(--border);
+		color: var(--text);
+		cursor: pointer;
+		text-align: left;
+		transition: background 0.1s;
+	}
+
+	.action-list-item:last-child {
+		border-bottom: none;
+	}
+	.action-list-item:hover {
+		background: var(--bg4);
+	}
+	.action-list-item--selected {
+		background: rgba(74, 158, 255, 0.15);
+	}
+	.action-list-item--selected:hover {
+		background: rgba(74, 158, 255, 0.2);
+	}
+
+	.action-list-id {
+		font-size: 12px;
+		font-weight: 500;
+		font-family: 'SF Mono', Menlo, monospace;
+		color: var(--text);
+	}
+
+	.action-list-conn {
+		font-size: 10px;
+		color: var(--text3);
+	}
+
+	.modal-divider {
+		font-size: 10px;
+		color: var(--text3);
+		text-align: center;
+		margin: 8px 0;
+		position: relative;
+	}
+
+	.modal-divider::before,
+	.modal-divider::after {
+		content: '';
+		position: absolute;
+		top: 50%;
+		width: 40%;
+		height: 1px;
+		background: var(--border);
+	}
+
+	.modal-divider::before {
+		left: 0;
+	}
+	.modal-divider::after {
+		right: 0;
+	}
+
+	.modal-footer {
+		display: flex;
+		justify-content: flex-end;
+		gap: 8px;
+		padding: 10px 16px 14px;
+		border-top: 1px solid var(--border);
+		flex-shrink: 0;
+	}
+
+	.modal-btn {
+		border-radius: 6px;
+		padding: 6px 16px;
+		font-size: 13px;
+		cursor: pointer;
+		font-weight: 500;
+		transition: background 0.1s;
+	}
+
+	.modal-btn--secondary {
+		background: var(--bg3);
+		border: 1px solid var(--border2);
+		color: var(--text2);
+	}
+
+	.modal-btn--secondary:hover {
+		background: var(--bg4);
+	}
+
+	.modal-btn--primary {
+		background: var(--accent);
+		border: none;
+		color: #000;
+		font-weight: 600;
+	}
+
+	.modal-btn--primary:hover:not(:disabled) {
+		background: var(--accent2);
+	}
+	.modal-btn--primary:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	.timeline-context-menu {
+		background: var(--bg2);
+		border: 1px solid var(--border2);
+		border-radius: 6px;
+		box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+		padding: 4px;
+		z-index: 9999;
+		min-width: 140px;
+	}
+
+	.context-menu-item {
+		display: block;
+		width: 100%;
+		background: none;
+		border: none;
+		border-radius: 4px;
+		padding: 6px 10px;
+		text-align: left;
+		font-size: 13px;
+		color: var(--text);
+		cursor: pointer;
+	}
+	.context-menu-item:hover {
+		background: var(--bg3);
+	}
+	.context-menu-item--danger {
+		color: #f87171;
+	}
+
+	/* ── View tab switcher (Timeline / Node) ──────────────────────────────────── */
+	.view-tabs {
+		display: flex;
+		align-items: center;
+		gap: 2px;
+		padding: 4px 10px;
+		background: var(--bg2);
+		border-bottom: 1px solid var(--border);
+		flex-shrink: 0;
+	}
+
+	.view-tab {
+		background: transparent;
+		border: 1px solid transparent;
+		color: var(--text3);
+		border-radius: 5px;
+		padding: 3px 14px;
+		font-size: 12px;
+		cursor: pointer;
+		transition:
+			background 0.1s,
+			color 0.1s;
+	}
+
+	.view-tab:hover {
+		background: var(--bg3);
+		color: var(--text2);
+	}
+
+	.view-tab--active {
+		background: var(--bg3);
+		border-color: var(--border2);
+		color: var(--text);
+		font-weight: 500;
+	}
+
+	/* ── Node editor ──────────────────────────────────────────────────────────── */
+	.ne-wrap {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		overflow: hidden;
+		min-height: 0;
+	}
+
+	.ne-canvas {
+		flex: 1;
+		overflow: hidden;
+		min-height: 0;
+		position: relative;
+	}
+
+	.ne-drop-overlay {
+		position: absolute;
+		inset: 0;
+		background: rgba(245, 166, 35, 0.06);
+		border: 2px dashed var(--accent);
+		pointer-events: none;
+		z-index: 100;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-size: 15px;
+		font-weight: 600;
+		color: var(--accent);
+		letter-spacing: 0.02em;
+	}
+
+	.ne-empty {
+		flex: 1;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		color: var(--text3);
+		font-size: 13px;
+	}
+
+	/* Strip React Flow's default node wrapper so our styles take over */
+	.ne-canvas .react-flow__node {
+		padding: 0;
+		background: transparent !important;
+		border: none !important;
+		border-radius: 0 !important;
+		box-shadow: none !important;
+		width: auto !important;
+	}
+
+	.ne-canvas .react-flow__node.selected > .ne-node {
+		box-shadow: 0 0 0 2px var(--accent) !important;
+	}
+
+	/* Override ReactFlow panel background */
+	.ne-canvas .react-flow__renderer,
+	.ne-canvas .react-flow {
+		background: var(--bg) !important;
+	}
+
+	/* Controls panel */
+	.ne-canvas .react-flow__controls {
+		background: var(--bg2);
+		border: 1px solid var(--border);
+		border-radius: 6px;
+		overflow: hidden;
+	}
+	.ne-canvas .react-flow__controls-button {
+		background: var(--bg2);
+		border-bottom: 1px solid var(--border);
+		color: var(--text2);
+		fill: var(--text2);
+	}
+	.ne-canvas .react-flow__controls-button:hover {
+		background: var(--bg3);
+	}
+	.ne-canvas .react-flow__controls-button:last-child {
+		border-bottom: none;
+	}
+
+	/* Base node */
+	.ne-node {
+		min-width: 200px;
+		font-size: 12px;
+		border-radius: 8px;
+		user-select: none;
+		position: relative;
+	}
+
+	/* ── Trigger (entry point) node — green pill ── */
+	.ne-trigger {
+		background: #162616;
+		border: 1.5px solid #2d6a2d;
+		padding: 10px 16px;
+		text-align: center;
+		border-radius: 22px;
+	}
+
+	.ne-trigger-label {
+		font-weight: 700;
+		font-size: 13px;
+		color: #6fcf6f;
+		letter-spacing: 0.03em;
+	}
+
+	/* ── Action node — blue-gray card ── */
+	.ne-action {
+		background: var(--bg3);
+		border: 1.5px solid var(--border2);
+		padding: 8px 12px;
+	}
+
+	.ne-action--selected {
+		border-color: var(--accent) !important;
+		background: #2b1f00;
+		box-shadow: 0 0 0 1px var(--accent);
+	}
+
+	.ne-action-name {
+		font-size: 11px;
+		font-weight: 500;
+		color: var(--text);
+		margin-bottom: 4px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.ne-action-inst {
+		font-size: 10px;
+		color: var(--text3);
+	}
+
+	/* ── Wait node — amber pill ── */
+	.ne-wait {
+		background: #231a00;
+		border: 1.5px solid #5a4200;
+		padding: 7px 16px;
+		text-align: center;
+		border-radius: 18px;
+		min-width: 120px !important;
+	}
+
+	.ne-wait-label {
+		font-size: 11px;
+		font-weight: 600;
+		color: var(--accent);
+	}
+
+	/* ── Group header node — compact mode pill ── */
+	.ne-group-hdr {
+		background: #1a1230;
+		border: 1.5px solid #3a2a5a;
+		padding: 8px 14px;
+		display: flex;
+		align-items: center;
+		gap: 7px;
+		border-radius: 20px;
+		min-width: 160px !important;
+	}
+
+	.ne-group-hdr--selected {
+		border-color: var(--accent) !important;
+		background: #2b1f00;
+		box-shadow: 0 0 0 1px var(--accent);
+	}
+
+	.ne-group-hdr-icon {
+		font-size: 13px;
+		color: #a87fea;
+	}
+
+	.ne-group-hdr-label {
+		font-size: 11px;
+		font-weight: 600;
+		color: #c4a0f0;
+	}
+
+	/* ── Child action node — read-only, dashed border ── */
+	.ne-child-action {
+		background: #232323;
+		border: 1.5px dashed #3a3a3a;
+		padding: 6px 10px;
+		opacity: 0.8;
+		min-width: 160px !important;
+	}
+	.context-menu-item--danger:hover {
+		background: rgba(248, 113, 113, 0.12);
+	}
+
+	/* ── Sequential group sub-timeline ──────────────────────────────────────────── */
+	.track-row--subtimeline {
+		background: rgba(74, 158, 255, 0.04);
+		border-top: 1px dashed rgba(74, 158, 255, 0.25);
+	}
+
+	.track-label--subtimeline .track-label-text {
+		color: var(--blue);
+		font-size: 10px;
+		font-weight: 600;
+	}
+
+	.subtimeline-empty {
+		position: absolute;
+		top: 50%;
+		left: 20px;
+		transform: translateY(-50%);
+		font-size: 11px;
+		color: var(--text3);
+		pointer-events: none;
+		font-style: italic;
+	}
+
+	/* Collapse toggle button on sub-timelines and concurrent lists */
+	.track-collapse-btn {
+		background: none;
+		border: none;
+		color: var(--text3);
+		cursor: pointer;
+		font-size: 9px;
+		padding: 0 4px 0 0;
+		line-height: 1;
+		flex-shrink: 0;
+	}
+	.track-collapse-btn:hover {
+		color: var(--text2);
+	}
+
+	/* Collapsed row — minimal height */
+	.track-row--collapsed {
+		height: 22px !important;
+		align-items: center;
+		display: flex;
+	}
+	.track-row--collapsed .track-label--subtimeline {
+		display: flex;
+		align-items: center;
+		gap: 2px;
+		height: 100%;
+	}
+
+	.concurrent-group-section--collapsed {
+		min-height: 24px;
+		align-items: center;
+	}
+	.concurrent-group-section--collapsed .concurrent-section-label {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		padding: 4px 6px 4px 10px;
+	}
+
+	/* Zoom buttons in step bar */
+	.zoom-btn {
+		font-size: 13px;
+		font-weight: 600;
+		line-height: 1;
+	}
+	.zoom-btn--fit {
+		font-size: 10px;
+		font-weight: 600;
+		width: auto !important;
+		padding: 0 7px;
+	}
+
+	.subtimeline-start-line {
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		width: 2px;
+		background: rgba(74, 158, 255, 0.35);
+		pointer-events: none;
+		z-index: 5;
+	}
+
+	.clip-block--child {
+		background: #2a3f5f;
+		border-color: #3a5a8a;
+		opacity: 0.9;
+		cursor: grab;
+	}
+	.clip-block--child:active {
+		cursor: grabbing;
+	}
+
+	/* ── Concurrent group list ───────────────────────────────────────────────────── */
+	.concurrent-group-section {
+		display: flex;
+		align-items: stretch;
+		border-top: 1px dashed rgba(168, 127, 234, 0.3);
+		background: rgba(168, 127, 234, 0.04);
+		flex-shrink: 0;
+		min-height: 40px;
+	}
+
+	.concurrent-section-label {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		justify-content: center;
+		padding: 4px 6px 4px 10px;
+		border-right: 1px solid var(--border2);
+		font-size: 11px;
+		color: #a87fea;
+		font-weight: 600;
+		flex-shrink: 0;
+		gap: 1px;
+	}
+
+	.concurrent-section-body {
+		flex: 1;
+		display: flex;
+		flex-wrap: wrap;
+		gap: 4px;
+		padding: 6px 10px;
+		align-items: center;
+	}
+
+	.concurrent-item {
+		display: flex;
+		align-items: center;
+		gap: 5px;
+		background: var(--bg3);
+		border: 1px solid var(--border2);
+		border-radius: 5px;
+		padding: 3px 8px;
+		font-size: 11px;
+		cursor: grab;
+		user-select: none;
+		transition: border-color 0.1s;
+	}
+	.concurrent-item:hover {
+		border-color: var(--border);
+	}
+	.concurrent-item:active {
+		cursor: grabbing;
+	}
+
+	.concurrent-item-handle {
+		color: var(--text3);
+		font-size: 12px;
+		cursor: grab;
+		flex-shrink: 0;
+	}
+
+	.concurrent-item-name {
+		color: var(--text);
+		font-weight: 500;
+		max-width: 120px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.concurrent-item-inst {
+		color: var(--text3);
+		font-size: 10px;
+	}
+
+	.concurrent-item-drop {
+		border: 1px dashed var(--border2);
+		border-radius: 5px;
+		padding: 3px 10px;
+		font-size: 11px;
+		color: var(--text3);
+		cursor: default;
+		transition:
+			border-color 0.1s,
+			color 0.1s;
+	}
+	.concurrent-item-drop:hover {
+		border-color: var(--accent);
+		color: var(--accent);
+	}
+}

--- a/webui/src/Timeline/types.ts
+++ b/webui/src/Timeline/types.ts
@@ -1,0 +1,97 @@
+// Flattened timeline data model, ported from the standalone Companion Timeline app.
+//
+// The standalone app projected Companion's action lists into a flat `{ action, delay }`
+// model where consecutive `internal: wait` actions are collapsed into a `delay` offset on
+// the following action. This module keeps that projection; `adapter.ts` converts to/from
+// Companion v5's real entity model.
+
+export type ExecutionMode = 'concurrent' | 'sequential' | 'inherit'
+
+export interface CompanionAction {
+	id: string
+	action: string // == entity definitionId
+	instance: string // == entity connectionId
+	options: Record<string, unknown>
+	delay: number
+	disabled?: boolean
+	// action_group: nested child actions keyed by set name (always "default")
+	children?: Record<string, CompanionAction[]>
+}
+
+export interface ActionSets {
+	down?: CompanionAction[]
+	up?: CompanionAction[]
+	rotate_left?: CompanionAction[]
+	rotate_right?: CompanionAction[]
+	[holdMs: string]: CompanionAction[] | undefined
+}
+
+export interface StepOptions {
+	runWhileHeld?: number[]
+	name?: string
+}
+
+export interface Step {
+	action_sets: ActionSets
+	options?: StepOptions
+}
+
+export interface ButtonStyle {
+	text?: string
+	size?: string | number
+	image?: string | null
+	color?: number
+	bgcolor?: number
+}
+
+export interface ButtonControl {
+	type: 'button'
+	style: ButtonStyle
+	steps: Record<string, Step>
+}
+
+export interface CompanionInstance {
+	instance_type: string
+	label: string
+	enabled?: boolean
+}
+
+export interface PageInfo {
+	name?: string
+	id?: string
+}
+
+export interface CompanionConfig {
+	controls: Record<string, ButtonControl>
+	page?: Record<string, PageInfo>
+	instances?: Record<string, CompanionInstance>
+	gridSize?: { columns: number; rows: number }
+}
+
+export function intToColor(n: number): string {
+	const hex = (n >>> 0).toString(16).padStart(6, '0')
+	return `#${hex}`
+}
+
+// A trigger key (hold duration or named event) for a track row
+export type TriggerKey = 'down' | 'up' | 'rotate_left' | 'rotate_right' | `${number}`
+
+export function triggerLabel(key: TriggerKey): string {
+	if (key === 'down') return 'Press'
+	if (key === 'up') return 'Release'
+	if (key === 'rotate_left') return 'Rotate ←'
+	if (key === 'rotate_right') return 'Rotate →'
+	const ms = parseInt(key)
+	if (!isNaN(ms)) {
+		if (ms >= 1000) return `Hold ${ms / 1000}s`
+		return `Hold ${ms}ms`
+	}
+	return key
+}
+
+// The setId Companion uses for an action set: named triggers are strings, holds are numbers.
+export function triggerKeyToSetId(key: TriggerKey): string | number {
+	if (key === 'down' || key === 'up' || key === 'rotate_left' || key === 'rotate_right') return key
+	const n = Number(key)
+	return Number.isFinite(n) && String(n) === key ? n : key
+}

--- a/webui/src/Timeline/useTimelineData.ts
+++ b/webui/src/Timeline/useTimelineData.ts
@@ -1,0 +1,225 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { SomeButtonModel } from '@companion-app/shared/Model/ButtonModel.js'
+import type { SomeEntityModel } from '@companion-app/shared/Model/EntityModel.js'
+import { trpcClient } from '~/Resources/TRPC'
+import { buttonModelToFlat, flatActionsToEntities } from './adapter.js'
+import { triggerKeyToSetId, type ButtonControl, type CompanionAction } from './types.js'
+
+const SYNC_DEBOUNCE_MS = 450
+const MAX_UNDO = 20
+
+interface BackendEntityRef {
+	id: string
+}
+
+// A `${stepKey}::${setId}` map of the entity ids we believe are live on the backend.
+type BackendSets = Map<string, BackendEntityRef[]>
+
+function setKey(stepKey: string, setId: string): string {
+	return `${stepKey}::${setId}`
+}
+
+// Top-level entity ids per set, taken straight from the live Companion model.
+function backendSetsFromModel(model: SomeButtonModel | null | undefined): BackendSets {
+	const out: BackendSets = new Map()
+	if (!model || model.type !== 'button-layered') return out
+	for (const [stepKey, step] of Object.entries(model.steps ?? {})) {
+		if (!step) continue
+		for (const [sid, entities] of Object.entries(step.action_sets ?? {})) {
+			out.set(
+				setKey(stepKey, sid),
+				(entities ?? []).map((e) => ({ id: e.id }))
+			)
+		}
+	}
+	return out
+}
+
+// Normalised (id-free) projection of a set's actions, for change detection.
+function stripIds(actions: CompanionAction[] | undefined): unknown {
+	return (actions ?? []).map((a) => ({
+		instance: a.instance,
+		action: a.action,
+		delay: a.delay,
+		disabled: a.disabled ?? false,
+		options: a.options,
+		children: a.children ? Object.fromEntries(Object.entries(a.children).map(([k, v]) => [k, stripIds(v)])) : undefined,
+	}))
+}
+
+function wrapOptionValue(v: unknown): { value: unknown; isExpression: boolean } {
+	return v !== null && typeof v === 'object' && 'value' in v
+		? (v as { value: unknown; isExpression: boolean })
+		: { value: v, isExpression: false }
+}
+
+// Add an entity to a control's action set, then recurse into its children.
+// Stateless (only uses the tRPC client), so it lives at module scope.
+async function pushEntity(
+	cId: string,
+	location: { stepId: string; setId: string | number },
+	ownerId: string | null,
+	entity: SomeEntityModel
+): Promise<string | null> {
+	const newId = await trpcClient.controls.entities.add.mutate({
+		controlId: cId,
+		entityLocation: location,
+		ownerId: ownerId ? { parentId: ownerId, childGroup: 'default' } : null,
+		connectionId: entity.connectionId,
+		entityType: entity.type,
+		entityDefinition: entity.definitionId,
+	})
+	if (!newId) return null
+	for (const [key, val] of Object.entries(entity.options ?? {})) {
+		await trpcClient.controls.entities.setOption.mutate({
+			controlId: cId,
+			entityLocation: location,
+			entityId: newId,
+			key,
+			value: wrapOptionValue(val),
+		})
+	}
+	for (const kids of Object.values(entity.children ?? {})) {
+		for (const child of kids ?? []) {
+			await pushEntity(cId, location, newId, child)
+		}
+	}
+	return newId
+}
+
+export interface UseTimelineDataResult {
+	control: ButtonControl | null
+	dirty: boolean
+	saveStatus: string | null
+	updateButton: (updater: (ctrl: ButtonControl) => ButtonControl) => void
+	undo: () => void
+}
+
+/**
+ * Holds an editable draft projection of a single Companion control and syncs edits back
+ * to Companion via the existing entity tRPC mutations. The draft is seeded from the live
+ * model whenever there are no pending local edits.
+ */
+export function useTimelineData(controlId: string | null, liveModel: SomeButtonModel | null): UseTimelineDataResult {
+	const [control, setControl] = useState<ButtonControl | null>(null)
+	const [dirty, setDirty] = useState(false)
+	const [saveStatus, setSaveStatus] = useState<string | null>(null)
+
+	const controlRef = useRef<ButtonControl | null>(null)
+	const dirtyRef = useRef(false)
+	const lastSyncedRef = useRef<ButtonControl | null>(null)
+	const backendSetsRef = useRef<BackendSets>(new Map())
+	const historyRef = useRef<ButtonControl[]>([])
+	const syncTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+	const syncTailRef = useRef<Promise<void>>(Promise.resolve())
+	const controlIdRef = useRef<string | null>(controlId)
+
+	controlRef.current = control
+	dirtyRef.current = dirty
+
+	// Reset everything when the selected control changes
+	useEffect(() => {
+		controlIdRef.current = controlId
+		setControl(null)
+		setDirty(false)
+		setSaveStatus(null)
+		controlRef.current = null
+		lastSyncedRef.current = null
+		backendSetsRef.current = new Map()
+		historyRef.current = []
+	}, [controlId])
+
+	// Seed/refresh the draft from the live model whenever there are no pending edits
+	useEffect(() => {
+		if (dirtyRef.current) return
+		const flat = buttonModelToFlat(liveModel)
+		setControl(flat)
+		controlRef.current = flat
+		lastSyncedRef.current = flat
+		backendSetsRef.current = backendSetsFromModel(liveModel)
+	}, [liveModel])
+
+	// Rebuild the changed action sets on the backend: remove the entities we know are there,
+	// then add the freshly-projected ones, keeping our authoritative id map in lockstep.
+	const performSync = useCallback(async () => {
+		const cId = controlIdRef.current
+		const draft = controlRef.current
+		const lastSynced = lastSyncedRef.current
+		if (!cId || !draft) return
+
+		for (const [stepKey, step] of Object.entries(draft.steps)) {
+			for (const [sid, actions] of Object.entries(step.action_sets)) {
+				const prevActions = lastSynced?.steps?.[stepKey]?.action_sets?.[sid]
+				if (JSON.stringify(stripIds(actions)) === JSON.stringify(stripIds(prevActions))) continue
+
+				const location = { stepId: stepKey, setId: triggerKeyToSetId(sid as any) }
+				const sk = setKey(stepKey, sid)
+				const existing = backendSetsRef.current.get(sk) ?? []
+
+				// Remove existing top-level entities (removing a group removes its children)
+				for (const ent of existing) {
+					await trpcClient.controls.entities.remove
+						.mutate({ controlId: cId, entityLocation: location, entityId: ent.id })
+						.catch(() => undefined)
+				}
+
+				// Add the projected entities and record their real backend ids
+				const target = flatActionsToEntities(actions ?? [])
+				const added: BackendEntityRef[] = []
+				for (const ent of target) {
+					const id = await pushEntity(cId, location, null, ent).catch(() => null)
+					if (id) added.push({ id })
+				}
+				backendSetsRef.current.set(sk, added)
+			}
+		}
+
+		lastSyncedRef.current = draft
+		setDirty(false)
+		dirtyRef.current = false
+		setSaveStatus('Synced ✓')
+		setTimeout(() => setSaveStatus((s) => (s === 'Synced ✓' ? null : s)), 2000)
+	}, [])
+
+	const scheduleSync = useCallback(() => {
+		if (syncTimerRef.current) clearTimeout(syncTimerRef.current)
+		syncTimerRef.current = setTimeout(() => {
+			// Serialise syncs so a burst of edits never overlaps mid-flight
+			syncTailRef.current = syncTailRef.current.then(async () => performSync()).catch(() => undefined)
+		}, SYNC_DEBOUNCE_MS)
+	}, [performSync])
+
+	const updateButton = useCallback(
+		(updater: (ctrl: ButtonControl) => ButtonControl) => {
+			const current = controlRef.current
+			if (!current) return
+			historyRef.current = [...historyRef.current.slice(-MAX_UNDO), current]
+			const next = updater(current)
+			controlRef.current = next
+			setControl(next)
+			setDirty(true)
+			dirtyRef.current = true
+			scheduleSync()
+		},
+		[scheduleSync]
+	)
+
+	const undo = useCallback(() => {
+		const prev = historyRef.current[historyRef.current.length - 1]
+		if (!prev) return
+		historyRef.current = historyRef.current.slice(0, -1)
+		controlRef.current = prev
+		setControl(prev)
+		setDirty(true)
+		dirtyRef.current = true
+		scheduleSync()
+	}, [scheduleSync])
+
+	useEffect(() => {
+		return () => {
+			if (syncTimerRef.current) clearTimeout(syncTimerRef.current)
+		}
+	}, [])
+
+	return { control, dirty, saveStatus, updateButton, undo }
+}

--- a/webui/src/routeTree.gen.ts
+++ b/webui/src/routeTree.gen.ts
@@ -24,6 +24,7 @@ import { Route as AppRouteImport } from './routes/_app.tsx'
 import { Route as AppIndexRouteImport } from './routes/_app/index.tsx'
 import { Route as StandaloneEmulatorRouteImport } from './routes/_standalone/emulator.tsx'
 import { Route as AppTriggersRouteImport } from './routes/_app/triggers.tsx'
+import { Route as AppTimelineRouteImport } from './routes/_app/timeline.tsx'
 import { Route as AppSurfacesRouteImport } from './routes/_app/surfaces.tsx'
 import { Route as AppModulesRouteImport } from './routes/_app/modules.tsx'
 import { Route as AppLogRouteImport } from './routes/_app/log.tsx'
@@ -151,6 +152,11 @@ const StandaloneEmulatorRoute = StandaloneEmulatorRouteImport.update({
 const AppTriggersRoute = AppTriggersRouteImport.update({
   id: '/triggers',
   path: '/triggers',
+  getParentRoute: () => AppRoute,
+} as any)
+const AppTimelineRoute = AppTimelineRouteImport.update({
+  id: '/timeline',
+  path: '/timeline',
   getParentRoute: () => AppRoute,
 } as any)
 const AppSurfacesRoute = AppSurfacesRouteImport.update({
@@ -449,6 +455,7 @@ export interface FileRoutesByFullPath {
   '/log': typeof AppLogRoute
   '/modules': typeof AppModulesRouteWithChildren
   '/surfaces': typeof AppSurfacesRouteWithChildren
+  '/timeline': typeof AppTimelineRoute
   '/triggers': typeof AppTriggersRouteWithChildren
   '/emulator': typeof StandaloneEmulatorRouteWithChildren
   '/tablet': typeof StandaloneTabletDotlazyRoute
@@ -510,6 +517,7 @@ export interface FileRoutesByTo {
   '/cloud': typeof AppCloudRoute
   '/import-export': typeof AppImportExportRoute
   '/log': typeof AppLogRoute
+  '/timeline': typeof AppTimelineRoute
   '/tablet': typeof StandaloneTabletDotlazyRoute
   '/': typeof AppIndexRoute
   '/buttons/$page': typeof AppButtonsPageRoute
@@ -573,6 +581,7 @@ export interface FileRoutesById {
   '/_app/log': typeof AppLogRoute
   '/_app/modules': typeof AppModulesRouteWithChildren
   '/_app/surfaces': typeof AppSurfacesRouteWithChildren
+  '/_app/timeline': typeof AppTimelineRoute
   '/_app/triggers': typeof AppTriggersRouteWithChildren
   '/_standalone/emulator': typeof StandaloneEmulatorRouteWithChildren
   '/_standalone/tablet': typeof StandaloneTabletDotlazyRoute
@@ -642,6 +651,7 @@ export interface FileRouteTypes {
     | '/log'
     | '/modules'
     | '/surfaces'
+    | '/timeline'
     | '/triggers'
     | '/emulator'
     | '/tablet'
@@ -703,6 +713,7 @@ export interface FileRouteTypes {
     | '/cloud'
     | '/import-export'
     | '/log'
+    | '/timeline'
     | '/tablet'
     | '/'
     | '/buttons/$page'
@@ -765,6 +776,7 @@ export interface FileRouteTypes {
     | '/_app/log'
     | '/_app/modules'
     | '/_app/surfaces'
+    | '/_app/timeline'
     | '/_app/triggers'
     | '/_standalone/emulator'
     | '/_standalone/tablet'
@@ -928,6 +940,13 @@ declare module '@tanstack/react-router' {
       path: '/triggers'
       fullPath: '/triggers'
       preLoaderRoute: typeof AppTriggersRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/_app/timeline': {
+      id: '/_app/timeline'
+      path: '/timeline'
+      fullPath: '/timeline'
+      preLoaderRoute: typeof AppTimelineRouteImport
       parentRoute: typeof AppRoute
     }
     '/_app/surfaces': {
@@ -1454,6 +1473,7 @@ interface AppRouteChildren {
   AppLogRoute: typeof AppLogRoute
   AppModulesRoute: typeof AppModulesRouteWithChildren
   AppSurfacesRoute: typeof AppSurfacesRouteWithChildren
+  AppTimelineRoute: typeof AppTimelineRoute
   AppTriggersRoute: typeof AppTriggersRouteWithChildren
   AppIndexRoute: typeof AppIndexRoute
   AppSettingsAdvancedRoute: typeof AppSettingsAdvancedRoute
@@ -1480,6 +1500,7 @@ const AppRouteChildren: AppRouteChildren = {
   AppLogRoute: AppLogRoute,
   AppModulesRoute: AppModulesRouteWithChildren,
   AppSurfacesRoute: AppSurfacesRouteWithChildren,
+  AppTimelineRoute: AppTimelineRoute,
   AppTriggersRoute: AppTriggersRouteWithChildren,
   AppIndexRoute: AppIndexRoute,
   AppSettingsAdvancedRoute: AppSettingsAdvancedRoute,

--- a/webui/src/routes/_app/timeline.tsx
+++ b/webui/src/routes/_app/timeline.tsx
@@ -1,0 +1,27 @@
+import { createFileRoute } from '@tanstack/react-router'
+import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
+import { TimelinePage } from '~/Timeline/TimelinePage.js'
+
+interface TimelineSearch {
+	page?: number
+	row?: number
+	column?: number
+}
+
+export const Route = createFileRoute('/_app/timeline')({
+	validateSearch: (search: Record<string, unknown>): TimelineSearch => {
+		const num = (v: unknown): number | undefined => {
+			const n = Number(v)
+			return Number.isFinite(n) ? n : undefined
+		}
+		return { page: num(search.page), row: num(search.row), column: num(search.column) }
+	},
+	component: TimelineRouteComponent,
+})
+
+function TimelineRouteComponent(): React.JSX.Element {
+	const { page, row, column } = Route.useSearch()
+	const initialLocation: ControlLocation | undefined =
+		page != null && row != null && column != null ? { pageNumber: page, row, column } : undefined
+	return <TimelinePage initialLocation={initialLocation} />
+}


### PR DESCRIPTION
Native port of the standalone Companion Timeline app into webui as a "Timeline" sidebar page. Projects a control's action entities into a flat {action, delay} timeline (collapsing internal:wait entities into delays) and syncs edits back through the existing controls.entities tRPC mutations.

- New /timeline route + sidebar nav item
- "Timeline" button in the button editor jumps to that button's timeline
- Reuses live control subscription, button previews, connections and entity definitions; test/play via controls.hotPressControl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Timeline editor for visual button action editing with drag-and-drop timeline interface, action library panel, and property inspector
  * Added Timeline navigation menu item in sidebar
  * Added "Open in Timeline" button in Edit view for quick access to timeline editor

<!-- end of auto-generated comment: release notes by coderabbit.ai -->