### PR TITLE
refactor: Look up variables by `${connectionLabel}:${variableId}` without enclosing `$()`

### DIFF
--- a/companion/lib/Controls/ControlTypes/Button/Base.ts
+++ b/companion/lib/Controls/ControlTypes/Button/Base.ts
@@ -83,12 +83,12 @@ export abstract class ButtonControlBase<TJson, TOptions extends ButtonOptionsBas
 				pageStore: deps.pageStore,
 			},
 			this.sendRuntimePropsChange.bind(this),
-			(expression, requiredType, injectedVariableValues) =>
+			(expression, requiredType) =>
 				deps.variableValues
 					.createVariablesAndExpressionParser(
 						deps.pageStore.getLocationOfControlId(this.controlId),
 						this.entities.getLocalVariableEntities(),
-						injectedVariableValues ?? null
+						null
 					)
 					.executeExpression(expression, requiredType),
 			isLayered

--- a/companion/lib/Controls/ControlTypes/Button/Layered.ts
+++ b/companion/lib/Controls/ControlTypes/Button/Layered.ts
@@ -259,7 +259,7 @@ export class ControlButtonLayered
 		if (location) {
 			// Ensure we don't enter into an infinite loop
 			// TODO - legacy location variables?
-			// injectedVariableValues[`$(internal:b_text_${location.pageNumber}_${location.row}_${location.column})`] = '$RE'
+			// injectedVariableValues[`internal:b_text_${location.pageNumber}_${location.row}_${location.column}`] = '$RE'
 		}
 
 		const parser = this.deps.variableValues.createVariablesAndExpressionParser(

--- a/companion/lib/Controls/ControlTypes/Button/Preset.ts
+++ b/companion/lib/Controls/ControlTypes/Button/Preset.ts
@@ -131,12 +131,12 @@ export class ControlButtonPreset
 				pageStore: deps.pageStore,
 			},
 			this.sendRuntimePropsChange.bind(this),
-			(expression, requiredType, injectedVariableValues) =>
+			(expression, requiredType) =>
 				deps.variableValues
 					.createVariablesAndExpressionParser(
 						deps.pageStore.getLocationOfControlId(this.controlId),
 						null, // This doesn't support local variables
-						injectedVariableValues ?? null
+						null
 					)
 					.executeExpression(expression, requiredType),
 			false

--- a/companion/lib/Controls/Controller.ts
+++ b/companion/lib/Controls/Controller.ts
@@ -679,10 +679,7 @@ export class ControlsController {
 		}
 	}
 
-	createVariablesAndExpressionParser(
-		controlId: string | null | undefined,
-		overrideVariableValues: VariableValues | null
-	): VariablesAndExpressionParser {
-		return this.#store.createVariablesAndExpressionParser(controlId, overrideVariableValues)
+	createVariablesAndExpressionParser(controlId: string | null | undefined): VariablesAndExpressionParser {
+		return this.#store.createVariablesAndExpressionParser(controlId, null)
 	}
 }

--- a/companion/lib/Controls/Entities/EntityListPoolButton.ts
+++ b/companion/lib/Controls/Entities/EntityListPoolButton.ts
@@ -10,7 +10,7 @@ import {
 	type SomeSocketEntityLocation,
 } from '@companion-app/shared/Model/EntityModel.js'
 import type { ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
-import { stringifyVariableValue, type VariableValues } from '@companion-app/shared/Model/Variables.js'
+import { stringifyVariableValue } from '@companion-app/shared/Model/Variables.js'
 import { assertNever } from '@companion-app/shared/Util.js'
 import { GetLegacyStyleProperty, ParseLegacyStyle } from '../../Resources/ConvertLegacyStyleToElements.js'
 import type { ControlActionSetAndStepsManager } from './ControlActionSetAndStepsManager.js'
@@ -47,11 +47,7 @@ export class ControlEntityListPoolButton extends ControlEntityListPoolBase imple
 
 	readonly #steps = new Map<string, ControlEntityListActionStep>()
 
-	readonly #executeExpressionInControl: (
-		expression: string,
-		requiredType?: string,
-		injectedVariableValues?: VariableValues
-	) => ExecuteExpressionResult
+	readonly #executeExpressionInControl: (expression: string, requiredType?: string) => ExecuteExpressionResult
 	readonly #sendRuntimePropsChange: () => void
 
 	/**
@@ -76,11 +72,7 @@ export class ControlEntityListPoolButton extends ControlEntityListPoolBase imple
 	constructor(
 		props: ControlEntityListPoolProps,
 		sendRuntimePropsChange: () => void,
-		executeExpressionInControl: (
-			expression: string,
-			requiredType?: string,
-			injectedVariableValues?: VariableValues
-		) => ExecuteExpressionResult,
+		executeExpressionInControl: (expression: string, requiredType?: string) => ExecuteExpressionResult,
 		isLayeredButton: boolean
 	) {
 		super(props, isLayeredButton)

--- a/companion/lib/Graphics/ConvertGraphicsElements.ts
+++ b/companion/lib/Graphics/ConvertGraphicsElements.ts
@@ -432,7 +432,7 @@ function parseCompositeElementChildOptions(
 
 	for (const option of elementDefinition.options) {
 		const optionKey: CompositeElementOptionKey = `opt:${option.id}`
-		const overrideKey = `$(options:${option.id})`
+		const overrideKey = `options:${option.id}`
 
 		switch (option.type) {
 			case 'checkbox':

--- a/companion/lib/Graphics/ConvertGraphicsElements.ts
+++ b/companion/lib/Graphics/ConvertGraphicsElements.ts
@@ -36,7 +36,11 @@ import {
 	type CompositeElementOptionKey,
 	type DrawImageBuffer,
 } from '@companion-app/shared/Model/StyleModel.js'
-import { stringifyVariableValue, type VariableValues } from '@companion-app/shared/Model/Variables.js'
+import {
+	stringifyVariableValue,
+	type VariableValue,
+	type VariableValues,
+} from '@companion-app/shared/Model/Variables.js'
 import { assertNever } from '@companion-app/shared/Util.js'
 import type {
 	CompositeElementDefinition,
@@ -432,27 +436,26 @@ function parseCompositeElementChildOptions(
 
 	for (const option of elementDefinition.options) {
 		const optionKey: CompositeElementOptionKey = `opt:${option.id}`
-		const overrideKey = `options:${option.id}`
-
+		let overrideValue: VariableValue
 		switch (option.type) {
 			case 'checkbox':
-				propOverrides[overrideKey] = helper.getBoolean(optionKey, option.default)
+				overrideValue = helper.getBoolean(optionKey, option.default)
 				break
 
 			case 'textinput': {
 				const rawValue = element[optionKey]
 				if (!rawValue) {
-					propOverrides[overrideKey] = option.default ?? ''
+					overrideValue = option.default ?? ''
 				} else if (rawValue.isExpression) {
 					const res = helper.executeExpressionAndTrackVariables(rawValue.value, undefined)
-					propOverrides[overrideKey] = res.ok ? res.value : option.default
+					overrideValue = res.ok ? res.value : option.default
 				} else if (option.useVariables) {
-					propOverrides[overrideKey] = helper.parseVariablesInString(
+					overrideValue = helper.parseVariablesInString(
 						stringifyVariableValue(rawValue.value) ?? '',
 						option.default ?? ''
 					)
 				} else {
-					propOverrides[overrideKey] = stringifyVariableValue(rawValue.value) ?? ''
+					overrideValue = stringifyVariableValue(rawValue.value) ?? ''
 				}
 				break
 			}
@@ -460,20 +463,20 @@ function parseCompositeElementChildOptions(
 			case 'expression': {
 				const rawValue = element[optionKey]
 				if (!rawValue) {
-					propOverrides[overrideKey] = option.default ?? ''
+					overrideValue = option.default ?? ''
 				} else {
 					const res = helper.executeExpressionAndTrackVariables(stringifyVariableValue(rawValue.value) ?? '', undefined)
-					propOverrides[overrideKey] = res.ok ? res.value : option.default
+					overrideValue = res.ok ? res.value : option.default
 				}
 				break
 			}
 
 			case 'number':
-				propOverrides[overrideKey] = helper.getNumber(optionKey, option.default ?? 0, 1)
+				overrideValue = helper.getNumber(optionKey, option.default ?? 0, 1)
 				break
 
 			case 'dropdown':
-				propOverrides[overrideKey] = helper.getEnum(
+				overrideValue = helper.getEnum(
 					optionKey,
 					option.choices.map((c) => c.id),
 					option.default
@@ -482,9 +485,9 @@ function parseCompositeElementChildOptions(
 
 			case 'colorpicker':
 				if (option.returnType === 'string') {
-					propOverrides[overrideKey] = helper.getString(optionKey, String(option.default))
+					overrideValue = helper.getString(optionKey, String(option.default))
 				} else {
-					propOverrides[overrideKey] = helper.getNumber(optionKey, Number(option.default) || 0, 1)
+					overrideValue = helper.getNumber(optionKey, Number(option.default) || 0, 1)
 				}
 				break
 
@@ -508,12 +511,14 @@ function parseCompositeElementChildOptions(
 			case 'custom-variable':
 			case 'bonjour-device':
 				// Not supported
-				break
+				continue
 			default:
 				assertNever(option)
 				// Ignore unknown type
-				break
+				continue
 		}
+
+		propOverrides[`options:${option.id}`] = overrideValue
 	}
 
 	return propOverrides

--- a/companion/lib/Internal/Controller.ts
+++ b/companion/lib/Internal/Controller.ts
@@ -463,7 +463,7 @@ export class InternalController {
 			if (!entityDefinition) return
 
 			const overrideVariableValues: VariableValues = {
-				'$(this:surface_id)': extras.surfaceId,
+				'this:surface_id': extras.surfaceId,
 			}
 			const parser = this.#controlsStore.createVariablesAndExpressionParser(extras.controlId, overrideVariableValues)
 

--- a/companion/lib/Preview/ElementStream.ts
+++ b/companion/lib/Preview/ElementStream.ts
@@ -251,7 +251,7 @@ export class PreviewElementStream {
 			}
 		}
 
-		const parser = this.#controlsController.createVariablesAndExpressionParser(controlId, null)
+		const parser = this.#controlsController.createVariablesAndExpressionParser(controlId)
 
 		const controlLocation = this.#pageStore.getLocationOfControlId(controlId)
 		const currentLocationStr = controlLocation ? formatLocation(controlLocation) : null

--- a/companion/lib/Preview/ExpressionStream.ts
+++ b/companion/lib/Preview/ExpressionStream.ts
@@ -104,14 +104,14 @@ export class PreviewExpressionStream {
 		controlId: string | null,
 		requiredType: string | undefined
 	): ExecuteExpressionResult => {
-		const parser = this.#controlsController.createVariablesAndExpressionParser(controlId, null)
+		const parser = this.#controlsController.createVariablesAndExpressionParser(controlId)
 
 		// TODO - make reactive to control moving?
 		return parser.executeExpression(expression, requiredType)
 	}
 
 	#parseVariables = (str: string, controlId: string | null): ExecuteExpressionResult => {
-		const parser = this.#controlsController.createVariablesAndExpressionParser(controlId, null)
+		const parser = this.#controlsController.createVariablesAndExpressionParser(controlId)
 
 		// TODO - make reactive to control moving?
 		const res = parser.parseVariables(str)

--- a/companion/lib/Preview/Graphics.ts
+++ b/companion/lib/Preview/Graphics.ts
@@ -217,7 +217,7 @@ export class PreviewGraphics {
 						const changes = toIterable(self.#renderEvents, `reference:${id}`, signal)
 
 						const location = self.#pageStore.getLocationOfControlId(controlId)
-						const parser = self.#controlsController.createVariablesAndExpressionParser(controlId, null)
+						const parser = self.#controlsController.createVariablesAndExpressionParser(controlId)
 
 						// Do a resolve of the reference for the starting image
 						const locationValue = parser.parseEntityOption(options.location, {
@@ -289,7 +289,7 @@ export class PreviewGraphics {
 	#triggerRecheck(previewSession: PreviewSession): void {
 		try {
 			const location = this.#pageStore.getLocationOfControlId(previewSession.controlId)
-			const parser = this.#controlsController.createVariablesAndExpressionParser(previewSession.controlId, null)
+			const parser = this.#controlsController.createVariablesAndExpressionParser(previewSession.controlId)
 
 			// Resolve the new location
 			const locationValue = parser.parseEntityOption(previewSession.options.location, {

--- a/companion/lib/Surface/Controller.ts
+++ b/companion/lib/Surface/Controller.ts
@@ -1434,13 +1434,13 @@ export class SurfaceController extends EventEmitter<SurfaceControllerEvents> {
 		const pageNumber = this.devicePageGet(surfaceId)
 
 		return {
-			'$(this:surface_id)': surfaceId,
+			'this:surface_id': surfaceId,
 
 			// Reactivity is triggered manually
-			'$(this:page)': pageNumber,
+			'this:page': pageNumber,
 
 			// Reactivity happens for these because of references to the inner variables
-			'$(this:page_name)': pageNumber ? `$(internal:page_number_${pageNumber}_name)` : VARIABLE_UNKNOWN_VALUE,
+			'this:page_name': pageNumber ? `$(internal:page_number_${pageNumber}_name)` : VARIABLE_UNKNOWN_VALUE,
 		}
 	}
 

--- a/companion/lib/Surface/Controller.ts
+++ b/companion/lib/Surface/Controller.ts
@@ -1414,15 +1414,12 @@ export class SurfaceController extends EventEmitter<SurfaceControllerEvents> {
 		this.triggerUpdateDevicesList()
 	}
 
-	surfaceExecuteExpression(
-		str: string,
-		surfaceId: string,
-		injectedVariableValues: VariableValues | undefined
-	): ExecuteExpressionResult {
-		const parser = this.#handlerDependencies.variables.values.createVariablesAndExpressionParser(null, null, {
-			...injectedVariableValues,
-			...this.#getInjectedVariablesForSurfaceId(surfaceId),
-		})
+	surfaceExecuteExpression(str: string, surfaceId: string): ExecuteExpressionResult {
+		const parser = this.#handlerDependencies.variables.values.createVariablesAndExpressionParser(
+			null,
+			null,
+			this.#getInjectedVariablesForSurfaceId(surfaceId)
+		)
 
 		return parser.executeExpression(str, undefined)
 	}

--- a/companion/lib/Surface/IP/Satellite.ts
+++ b/companion/lib/Surface/IP/Satellite.ts
@@ -466,7 +466,7 @@ export class SurfaceIPSatellite extends EventEmitter<SurfacePanelEvents> impleme
 					let expressionResult: VariableValue | undefined = VARIABLE_UNKNOWN_VALUE
 
 					const expressionText = this.#config[outputVariable.id]
-					const parseResult = this.#executeExpression(expressionText ?? '', this.info.surfaceId, undefined)
+					const parseResult = this.#executeExpression(expressionText ?? '', this.info.surfaceId)
 					if (parseResult.ok) {
 						expressionResult = parseResult.value
 					} else {

--- a/companion/lib/Surface/PluginPanel.ts
+++ b/companion/lib/Surface/PluginPanel.ts
@@ -350,7 +350,7 @@ export class SurfacePluginPanel extends EventEmitter<SurfacePanelEvents> impleme
 					let expressionResult: VariableValue | undefined = VARIABLE_UNKNOWN_VALUE
 
 					const expressionText = this.#config[outputVariable.id]
-					const parseResult = this.#executeExpression(expressionText ?? '', this.info.surfaceId, undefined)
+					const parseResult = this.#executeExpression(expressionText ?? '', this.info.surfaceId)
 					if (parseResult.ok) {
 						expressionResult = parseResult.value
 					} else {

--- a/companion/lib/Surface/Types.ts
+++ b/companion/lib/Surface/Types.ts
@@ -9,7 +9,7 @@ import type {
 	SurfaceGroupConfig,
 	SurfacesUpdate,
 } from '@companion-app/shared/Model/Surfaces.js'
-import type { VariableValue, VariableValues } from '@companion-app/shared/Model/Variables.js'
+import type { VariableValue } from '@companion-app/shared/Model/Variables.js'
 import type { IControlStore } from '../Controls/IControlStore.js'
 import type { DataUserConfig } from '../Data/UserConfig.js'
 import type { GraphicsController } from '../Graphics/Controller.js'
@@ -18,11 +18,7 @@ import type { IPageStore } from '../Page/Store.js'
 import type { VariablesController } from '../Variables/Controller.js'
 import type { EmulatorUpdateEvents } from './IP/ElgatoEmulator.js'
 
-export type SurfaceExecuteExpressionFn = (
-	str: string,
-	surfaceId: string,
-	injectedVariableValues?: VariableValues
-) => ExecuteExpressionResult
+export type SurfaceExecuteExpressionFn = (str: string, surfaceId: string) => ExecuteExpressionResult
 
 export interface SurfacePanelInfo {
 	surfaceId: string

--- a/companion/lib/Variables/Util.ts
+++ b/companion/lib/Variables/Util.ts
@@ -34,7 +34,7 @@ import LogController from '../Log/Controller.js'
 import type { VariablesBlinker } from './VariablesBlinker.js'
 
 // Everybody stand back. I know regular expressions. - xckd #208 /ck/kc/
-const VARIABLE_REGEX = /\$\(([^:$)]+):([^)$]+)\)/
+const VARIABLE_REGEX = /\$\((([^:$)]+):([^)$]+))\)/
 // Like VARIABLE_REGEX but allows $ in the variable name part, to support nested variables
 const REPLACE_VARIABLE_REGEX = /\$\(([^:$)]+):([^)]+)\)/
 
@@ -138,9 +138,10 @@ export function parseVariablesInString(
 			break
 		}
 
-		const fullId = matches[0]
-		let connectionLabel = matches[1]
-		let variableId = matches[2]
+		const fullReference = matches[0]
+		const fullId = matches[1]
+		let connectionLabel = matches[2]
+		let variableId = matches[3]
 
 		if (connectionLabel === 'internal' && variableId.substring(0, 7) === 'custom_') {
 			connectionLabel = 'custom'
@@ -185,7 +186,7 @@ export function parseVariablesInString(
 
 		// Pass a function, to avoid special interpreting of `$$` and other sequences
 		const cachedValueConst = stringifyVariableValue(value) ?? ''
-		string = string.replace(fullId, () => cachedValueConst)
+		string = string.replace(fullReference, () => cachedValueConst)
 	}
 
 	return {
@@ -212,7 +213,7 @@ export function replaceAllVariables(string: string, newLabel: string, preserveLa
 			// ensure we don't try and match the same thing again
 			fromIndex = matches.index + fromIndex + 1
 
-			if (matches[2] !== undefined && !preserveLabels.has(matches[1])) {
+			if (!preserveLabels.has(matches[1])) {
 				string = string.replace(matches[0], `$(${newLabel}:${matches[2]})`)
 			}
 		}
@@ -222,7 +223,11 @@ export function replaceAllVariables(string: string, newLabel: string, preserveLa
 }
 
 /**
- * A view of a simple cache for variable values, allowing for lazy evaluation and writing back of lazily computed values
+ * A view of a simple cache for variable values, allowing for lazy evaluation
+ * and writing back of lazily computed values.
+ *
+ * Variable ids in this interface have type `${connectionLabel}:${variableId}`,
+ * e.g. `"custom:foo"`.  They are not enclosed in `$()`.
  */
 export interface VariableValueCache {
 	has(id: string): boolean
@@ -250,7 +255,7 @@ export function executeExpression(
 		const getVariableValue = (props: GetVariableValueProps): VariableValue | undefined => {
 			referencedVariableIds.add(props.variableId)
 
-			const fullId = `$(${props.variableId})`
+			const fullId = props.variableId
 			// First check for an injected value
 			let value: VariableValue | undefined
 			if (cachedVariableValues.has(fullId)) {
@@ -280,9 +285,9 @@ export function executeExpression(
 				const valueMatch = value.match(VARIABLE_REGEX)
 				if (valueMatch && valueMatch[0] === value) {
 					return getVariableValue({
-						variableId: `${valueMatch[1]}:${valueMatch[2]}`,
-						label: valueMatch[1],
-						name: valueMatch[2],
+						variableId: valueMatch[1],
+						label: valueMatch[2],
+						name: valueMatch[3],
 					})
 				} else {
 					// Wrap the cache, to inject $RE for this variable to avoid unbound recursion

--- a/companion/lib/Variables/Values.ts
+++ b/companion/lib/Variables/Values.ts
@@ -71,11 +71,12 @@ const ThisLocationVariables: Record<
 const ThisLocationVariablesSet: ReadonlySet<string> = new Set(Object.keys(ThisLocationVariables))
 
 export function InjectedVariablesForLocation(controlLocation: ControlLocation | null | undefined): VariablesCache {
-	const injectedVariables: VariablesCache = new Map()
-	for (const [variableId, computeVariable] of Object.entries(ThisLocationVariables)) {
-		injectedVariables.set(`$(${variableId})`, computeVariable(controlLocation))
-	}
-	return injectedVariables
+	return new Map(
+		Object.entries(ThisLocationVariables).map(([variableId, computeVariable]) => [
+			variableId,
+			computeVariable(controlLocation),
+		])
+	)
 }
 
 export class VariablesValues extends EventEmitter<VariablesValuesEvents> {

--- a/companion/lib/Variables/VariablesAndExpressionParser.ts
+++ b/companion/lib/Variables/VariablesAndExpressionParser.ts
@@ -80,7 +80,7 @@ export class VariablesAndExpressionParser {
 
 		// Manual clone the localValues
 		for (const [key, value] of this.#localValues) {
-			if (key.startsWith('$(local:')) childParser.#localValues.set(key, value)
+			if (key.startsWith('local:')) childParser.#localValues.set(key, value)
 		}
 
 		return childParser
@@ -93,7 +93,7 @@ export class VariablesAndExpressionParser {
 
 			// Push the cached values to the store
 			this.#localValues.set(
-				`$(${variableName})`,
+				variableName,
 				isInternalLogicFeedback(entity) ? entity.getBooleanFeedbackValue() : entity.feedbackValue
 			)
 		}

--- a/companion/test/Variables/Values.test.ts
+++ b/companion/test/Variables/Values.test.ts
@@ -323,16 +323,16 @@ describe('VariablesValues', () => {
 		test('sets all ten $(this:*) keys for a valid location', () => {
 			const cache: VariablesCache = InjectedVariablesForLocation({ pageNumber: 2, row: 3, column: 4 })
 			const expectedKeys = [
-				'$(this:page)',
-				'$(this:column)',
-				'$(this:row)',
-				'$(this:location)',
-				'$(this:page_name)',
-				'$(this:active)',
-				'$(this:step)',
-				'$(this:step_count)',
-				'$(this:actions_running)',
-				'$(this:button_status)',
+				'this:page',
+				'this:column',
+				'this:row',
+				'this:location',
+				'this:page_name',
+				'this:active',
+				'this:step',
+				'this:step_count',
+				'this:actions_running',
+				'this:button_status',
 			]
 			for (const key of expectedKeys) {
 				expect(cache.has(key), `expected cache to have key "${key}"`).toBe(true)
@@ -341,43 +341,43 @@ describe('VariablesValues', () => {
 
 		test('sets page, row, and column to the correct numeric values', () => {
 			const cache: VariablesCache = InjectedVariablesForLocation({ pageNumber: 5, row: 2, column: 7 })
-			expect(cache.get('$(this:page)')).toBe(5)
-			expect(cache.get('$(this:row)')).toBe(2)
-			expect(cache.get('$(this:column)')).toBe(7)
+			expect(cache.get('this:page')).toBe(5)
+			expect(cache.get('this:row')).toBe(2)
+			expect(cache.get('this:column')).toBe(7)
 		})
 
 		test('sets $(this:page_name) to the correct $(internal:page_number_N_name) reference', () => {
 			const cache: VariablesCache = InjectedVariablesForLocation({ pageNumber: 3, row: 1, column: 2 })
-			expect(cache.get('$(this:page_name)')).toBe('$(internal:page_number_3_name)')
+			expect(cache.get('this:page_name')).toBe('$(internal:page_number_3_name)')
 		})
 
 		test('sets button dynamic variables to the correct $(internal:b_*) reference strings', () => {
 			const cache: VariablesCache = InjectedVariablesForLocation({ pageNumber: 2, row: 4, column: 6 })
-			expect(cache.get('$(this:active)')).toBe('$(internal:b_active_2_4_6)')
-			expect(cache.get('$(this:step)')).toBe('$(internal:b_step_2_4_6)')
-			expect(cache.get('$(this:step_count)')).toBe('$(internal:b_step_count_2_4_6)')
-			expect(cache.get('$(this:actions_running)')).toBe('$(internal:b_actions_running_2_4_6)')
-			expect(cache.get('$(this:button_status)')).toBe('$(internal:b_status_2_4_6)')
+			expect(cache.get('this:active')).toBe('$(internal:b_active_2_4_6)')
+			expect(cache.get('this:step')).toBe('$(internal:b_step_2_4_6)')
+			expect(cache.get('this:step_count')).toBe('$(internal:b_step_count_2_4_6)')
+			expect(cache.get('this:actions_running')).toBe('$(internal:b_actions_running_2_4_6)')
+			expect(cache.get('this:button_status')).toBe('$(internal:b_status_2_4_6)')
 		})
 
 		test.each([[null], [undefined]])('$0 location: primitive this:* variables are undefined', (controlLocation) => {
 			const cache: VariablesCache = InjectedVariablesForLocation(controlLocation)
-			expect(cache.get('$(this:page)')).toBeUndefined()
-			expect(cache.get('$(this:row)')).toBeUndefined()
-			expect(cache.get('$(this:column)')).toBeUndefined()
-			expect(cache.get('$(this:location)')).toBeUndefined()
+			expect(cache.get('this:page')).toBeUndefined()
+			expect(cache.get('this:row')).toBeUndefined()
+			expect(cache.get('this:column')).toBeUndefined()
+			expect(cache.get('this:location')).toBeUndefined()
 		})
 
 		test.each([[null], [undefined]])(
 			'$0 location: complex this:* variables resolve to VARIABLE_UNKNOWN_VALUE',
 			(controlLocation) => {
 				const cache: VariablesCache = InjectedVariablesForLocation(controlLocation)
-				expect(cache.get('$(this:page_name)')).toBe(VARIABLE_UNKNOWN_VALUE)
-				expect(cache.get('$(this:active)')).toBe(VARIABLE_UNKNOWN_VALUE)
-				expect(cache.get('$(this:step)')).toBe(VARIABLE_UNKNOWN_VALUE)
-				expect(cache.get('$(this:step_count)')).toBe(VARIABLE_UNKNOWN_VALUE)
-				expect(cache.get('$(this:actions_running)')).toBe(VARIABLE_UNKNOWN_VALUE)
-				expect(cache.get('$(this:button_status)')).toBe(VARIABLE_UNKNOWN_VALUE)
+				expect(cache.get('this:page_name')).toBe(VARIABLE_UNKNOWN_VALUE)
+				expect(cache.get('this:active')).toBe(VARIABLE_UNKNOWN_VALUE)
+				expect(cache.get('this:step')).toBe(VARIABLE_UNKNOWN_VALUE)
+				expect(cache.get('this:step_count')).toBe(VARIABLE_UNKNOWN_VALUE)
+				expect(cache.get('this:actions_running')).toBe(VARIABLE_UNKNOWN_VALUE)
+				expect(cache.get('this:button_status')).toBe(VARIABLE_UNKNOWN_VALUE)
 			}
 		)
 	})

--- a/companion/test/Variables/VariablesAndExpressionParser.test.ts
+++ b/companion/test/Variables/VariablesAndExpressionParser.test.ts
@@ -1056,7 +1056,7 @@ describe('VariablesAndExpressionParser', () => {
 
 	describe('thisValues and overrideValues', () => {
 		it('should use thisValues when available', () => {
-			const thisValues: VariablesCache = new Map([['$(custom:val)', 'from-this']])
+			const thisValues: VariablesCache = new Map([['custom:val', 'from-this']])
 
 			const parser = createParser({}, thisValues)
 			const result = parser.parseVariables('$(custom:val)')
@@ -1066,7 +1066,7 @@ describe('VariablesAndExpressionParser', () => {
 		})
 
 		it('should prefer thisValues over rawVariables', () => {
-			const thisValues: VariablesCache = new Map([['$(test:var1)', 'overridden']])
+			const thisValues: VariablesCache = new Map([['test:var1', 'overridden']])
 
 			const parser = createParser(defaultVariables, thisValues)
 			const result = parser.parseVariables('$(test:var1)')
@@ -1188,7 +1188,7 @@ describe('VariablesAndExpressionParser', () => {
 		})
 
 		it('child inherits thisValues from parent', () => {
-			const thisValues: VariablesCache = new Map([['$(custom:val)', 'from-this']])
+			const thisValues: VariablesCache = new Map([['custom:val', 'from-this']])
 			const parser = new VariablesAndExpressionParser(null as any, {}, thisValues, null, null)
 			const child = parser.createChildParser({})
 
@@ -1198,7 +1198,7 @@ describe('VariablesAndExpressionParser', () => {
 
 		it('child inherits parent override values', () => {
 			const parser = new VariablesAndExpressionParser(null as any, {}, new Map(), null, {
-				'$(override:val)': 'parent-override',
+				'override:val': 'parent-override',
 			})
 			const child = parser.createChildParser({})
 
@@ -1208,9 +1208,9 @@ describe('VariablesAndExpressionParser', () => {
 
 		it('child new overrides take precedence over parent overrides', () => {
 			const parser = new VariablesAndExpressionParser(null as any, {}, new Map(), null, {
-				'$(override:val)': 'parent-override',
+				'override:val': 'parent-override',
 			})
-			const child = parser.createChildParser({ '$(override:val)': 'child-override' })
+			const child = parser.createChildParser({ 'override:val': 'child-override' })
 
 			const result = child.parseVariables('$(override:val)')
 			expect(result.text).toBe('child-override')
@@ -1218,9 +1218,9 @@ describe('VariablesAndExpressionParser', () => {
 
 		it('non-overlapping parent overrides remain accessible in child', () => {
 			const parser = new VariablesAndExpressionParser(null as any, {}, new Map(), null, {
-				'$(override:parent-only)': 'parent-value',
+				'override:parent-only': 'parent-value',
 			})
-			const child = parser.createChildParser({ '$(override:child-only)': 'child-value' })
+			const child = parser.createChildParser({ 'override:child-only': 'child-value' })
 
 			expect(child.parseVariables('$(override:parent-only)').text).toBe('parent-value')
 			expect(child.parseVariables('$(override:child-only)').text).toBe('child-value')
@@ -1228,7 +1228,7 @@ describe('VariablesAndExpressionParser', () => {
 
 		it('child overrides do not affect parent', () => {
 			const parser = new VariablesAndExpressionParser(null as any, {}, new Map(), null, null)
-			const child = parser.createChildParser({ '$(override:new)': 'child-value' })
+			const child = parser.createChildParser({ 'override:new': 'child-value' })
 
 			expect(parser.parseVariables('$(override:new)').text).toBe('$NA')
 			expect(child.parseVariables('$(override:new)').text).toBe('child-value')
@@ -1259,7 +1259,7 @@ describe('VariablesAndExpressionParser', () => {
 				definitionId: 'some-def',
 			} as unknown as ControlEntityInstance
 			const parser = new VariablesAndExpressionParser(null as any, {}, new Map(), [mockEntity], null)
-			const child = parser.createChildParser({ '$(local:myvar)': 'override-value' })
+			const child = parser.createChildParser({ 'local:myvar': 'override-value' })
 
 			// localValues (inherited) take priority over overrideVariableValues
 			const result = child.parseVariables('$(local:myvar)')
@@ -1277,7 +1277,7 @@ describe('VariablesAndExpressionParser', () => {
 
 		it('child executeExpression uses child override values', () => {
 			const parser = new VariablesAndExpressionParser(null as any, {}, new Map(), null, null)
-			const child = parser.createChildParser({ '$(custom:num)': 100 })
+			const child = parser.createChildParser({ 'custom:num': 100 })
 
 			const result = child.executeExpression('$(custom:num) * 2', undefined)
 			expect(result.ok).toBe(true)
@@ -1286,7 +1286,7 @@ describe('VariablesAndExpressionParser', () => {
 
 		it('child override shadows parent raw variable', () => {
 			const parser = new VariablesAndExpressionParser(null as any, defaultVariables, new Map(), null, null)
-			const child = parser.createChildParser({ '$(test:var1)': 'shadowed' })
+			const child = parser.createChildParser({ 'test:var1': 'shadowed' })
 
 			expect(child.parseVariables('$(test:var1)').text).toBe('shadowed')
 			expect(parser.parseVariables('$(test:var1)').text).toBe('value1')

--- a/companion/test/Variables/executeExpression.test.ts
+++ b/companion/test/Variables/executeExpression.test.ts
@@ -46,8 +46,8 @@ describe('executeExpression', () => {
 
 	test('injected variables', () => {
 		const injectedVariableValues: VariableValueCache = new Map()
-		injectedVariableValues.set('$(test:something)', 'val1')
-		injectedVariableValues.set('$(another:value)', 'bbb')
+		injectedVariableValues.set('test:something', 'val1')
+		injectedVariableValues.set('another:value', 'bbb')
 
 		const res = executeExpression(
 			mockBlinker,
@@ -61,8 +61,8 @@ describe('executeExpression', () => {
 
 	test('nested variable names', () => {
 		const injectedVariableValues: VariableValueCache = new Map()
-		injectedVariableValues.set('$(test:something)', 'val1')
-		injectedVariableValues.set('$(another:value)', 'something')
+		injectedVariableValues.set('test:something', 'val1')
+		injectedVariableValues.set('another:value', 'something')
 
 		const res = executeExpression(
 			mockBlinker,
@@ -76,7 +76,7 @@ describe('executeExpression', () => {
 
 	test('array variable', () => {
 		const injectedVariableValues: VariableValueCache = new Map()
-		injectedVariableValues.set('$(test:something)', [1, 2, 3] as any)
+		injectedVariableValues.set('test:something', [1, 2, 3] as any)
 
 		const res = executeExpression(mockBlinker, '$(test:something)[1]', {}, undefined, injectedVariableValues)
 		expect(res).toMatchObject({ value: 2, variableIds: new Set(['test:something']) })
@@ -84,7 +84,7 @@ describe('executeExpression', () => {
 
 	test('object variable', () => {
 		const injectedVariableValues: VariableValueCache = new Map()
-		injectedVariableValues.set('$(test:something)', { a: 1, b: '123' } as any)
+		injectedVariableValues.set('test:something', { a: 1, b: '123' } as any)
 
 		const res = executeExpression(mockBlinker, '$(test:something)["b"]', {}, undefined, injectedVariableValues)
 		expect(res).toMatchObject({ value: '123', variableIds: new Set(['test:something']) })
@@ -92,8 +92,8 @@ describe('executeExpression', () => {
 
 	test('chained variables', () => {
 		const injectedVariableValues: VariableValueCache = new Map()
-		injectedVariableValues.set('$(test:something)', '$(another:value)')
-		injectedVariableValues.set('$(another:value)', 'something')
+		injectedVariableValues.set('test:something', '$(another:value)')
+		injectedVariableValues.set('another:value', 'something')
 
 		const res = executeExpression(
 			mockBlinker,
@@ -107,8 +107,8 @@ describe('executeExpression', () => {
 
 	test('chained variables 2', () => {
 		const injectedVariableValues: VariableValueCache = new Map()
-		injectedVariableValues.set('$(test:something)', '$(another:value)')
-		injectedVariableValues.set('$(another:value)', 'something')
+		injectedVariableValues.set('test:something', '$(another:value)')
+		injectedVariableValues.set('another:value', 'something')
 
 		const res = executeExpression(mockBlinker, '$(test:something)', {}, undefined, injectedVariableValues)
 		expect(res).toMatchObject({ value: 'something', variableIds: new Set(['test:something', 'another:value']) })
@@ -116,8 +116,8 @@ describe('executeExpression', () => {
 
 	test('chained array variable', () => {
 		const injectedVariableValues: VariableValueCache = new Map()
-		injectedVariableValues.set('$(test:something)', '$(another:value)')
-		injectedVariableValues.set('$(another:value)', [1, 2, 3] as any)
+		injectedVariableValues.set('test:something', '$(another:value)')
+		injectedVariableValues.set('another:value', [1, 2, 3] as any)
 
 		const res = executeExpression(mockBlinker, 'join($(test:something), "/")', {}, undefined, injectedVariableValues)
 		expect(res).toMatchObject({ value: '1/2/3', variableIds: new Set(['test:something', 'another:value']) })
@@ -125,8 +125,8 @@ describe('executeExpression', () => {
 
 	test('undefined variables', () => {
 		const injectedVariableValues: VariableValueCache = new Map()
-		injectedVariableValues.set('$(test:something)', '$(another:value)')
-		injectedVariableValues.set('$(another:value)', undefined)
+		injectedVariableValues.set('test:something', '$(another:value)')
+		injectedVariableValues.set('another:value', undefined)
 
 		const res = executeExpression(
 			mockBlinker,
@@ -218,8 +218,8 @@ describe('executeExpression', () => {
 
 	test('getVariable chained resolution', () => {
 		const injectedVariableValues: VariableValueCache = new Map()
-		injectedVariableValues.set('$(test:something)', '$(another:value)')
-		injectedVariableValues.set('$(another:value)', 'something')
+		injectedVariableValues.set('test:something', '$(another:value)')
+		injectedVariableValues.set('another:value', 'something')
 
 		const res = executeExpression(mockBlinker, "getVariable('test:something')", {}, undefined, injectedVariableValues)
 		expect(res).toMatchObject({ value: 'something', variableIds: new Set(['test:something', 'another:value']) })

--- a/companion/test/Variables/parse.test.ts
+++ b/companion/test/Variables/parse.test.ts
@@ -158,4 +158,41 @@ describe('variable parsing', () => {
 			variableIds: new Set(['abc:third', 'abc:nope']),
 		})
 	})
+
+	test('internal:custom_* -> custom:* mapping and rewriting', () => {
+		const variables = {
+			custom: {
+				textual: 'hello',
+				numeric: 42,
+				bool: false,
+			},
+		}
+
+		expect(parseVariablesInString('$(internal:custom_textual)', variables, new Map(), VARIABLE_UNKNOWN_VALUE)).toEqual({
+			text: 'hello',
+			variableIds: new Set(['custom:textual']),
+		})
+		expect(
+			parseVariablesInString(
+				'The answer to the Ultimate Question of Life, the Universe and Everything: $(internal:custom_numeric)',
+				variables,
+				new Map(),
+				VARIABLE_UNKNOWN_VALUE
+			)
+		).toEqual({
+			text: 'The answer to the Ultimate Question of Life, the Universe and Everything: 42',
+			variableIds: new Set(['custom:numeric']),
+		})
+		expect(
+			parseVariablesInString(
+				'$(internal:custom_bool): now place variable ref at start',
+				variables,
+				new Map(),
+				VARIABLE_UNKNOWN_VALUE
+			)
+		).toEqual({
+			text: 'false: now place variable ref at start',
+			variableIds: new Set(['custom:bool']),
+		})
+	})
 })


### PR DESCRIPTION
Having to look up variables using identifiers enclosed in variable syntax creates an impedance mismatch, because callers may naturally have access to `${connectionLabel}:${variableId}` forcing them to go out of their way to tack on `$()`.  Everything should just use the un-enclosed form.

I did my best to work through the actual callers when doing all this, to ensure I got everything, but there's enough sprawl to create a small chance I missed something in the process.

I presume you don't have future plans for those `injectedVariableValues` trailing arguments when all callers inject no variables -- but kept those changes separate for readability and just in case you actually do.

I expect this to be a prerequisite of building these builtin variables directly into parsing so they don't have to be fully computed in parser creation, but I haven't completed that subsequent work yet to be certain.  Seems like this mild increase in simplicity is desirable regardless.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Normalized internal variable reference format and simplified expression-evaluation interfaces across the app; parsing and preview behavior remain unchanged for end users.

* **Tests**
  * Updated and added tests to validate the revised variable parsing, override semantics, and expression evaluation to ensure compatibility and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->