### PR TITLE
fix: add connect timeout to webui WebSocket to unwedge Safari reconnects

### DIFF
--- a/companion/lib/UI/Express.ts
+++ b/companion/lib/UI/Express.ts
@@ -16,6 +16,7 @@ import cors from 'cors'
 import Express from 'express'
 // @ts-expect-error no types for this package
 import serveZip from 'express-serve-zip'
+import onHeaders from 'on-headers'
 import { isPackaged } from '../Resources/Util.js'
 import { createRewriteMiddleware, getCustomPrefixHeader } from './middleware/rewriteRootUrl.js'
 
@@ -53,6 +54,33 @@ function createServeStatic(
 
 		// Failed to find a folder to use
 		throw new Error('Failed to find static files to serve over http')
+	}
+}
+
+/**
+ * Create a middleware that fixes up the Cache-Control header of static responses just before
+ * headers are sent, based on the final Content-Type/path:
+ * - HTML must always be revalidated (cheap 304s via the existing ETags). Safari and iOS
+ *   home-screen web apps otherwise cache index.html beyond its 1 hour maxAge, leaving it
+ *   referencing content-hashed chunks deleted by a Companion upgrade (broken/blank page
+ *   until the cache is manually cleared).
+ * - Content-hashed build assets (vite output under assets/) never change, so are safe to
+ *   cache forever.
+ * - Everything else keeps the maxAge computed by the static server.
+ */
+function createCacheControlMiddleware(): Express.RequestHandler {
+	return (req, res, next) => {
+		onHeaders(res, () => {
+			const contentType = String(res.getHeader('content-type') || '').toLowerCase()
+			if (contentType.includes('text/html')) {
+				// no-cache (not no-store) keeps 304 revalidation working
+				res.setHeader('Cache-Control', 'no-cache')
+			} else if (req.path.startsWith('/assets/')) {
+				// Vite content-hashed filenames - safe to cache forever
+				res.setHeader('Cache-Control', 'public, max-age=31536000, immutable')
+			}
+		})
+		next()
 	}
 }
 
@@ -120,18 +148,21 @@ export class UIExpress {
 		// Create rewrite middleware to replace ROOT_URL_HERE in HTML/CSS/JS files
 		const rewriteMiddleware = createRewriteMiddleware()
 
+		// Create middleware to fix up the Cache-Control header of static responses
+		const cacheControlMiddleware = createCacheControlMiddleware()
+
 		// Serve user-guide folder as static and public
-		this.app.use('/user-guide', compression(), rewriteMiddleware, docsServer)
+		this.app.use('/user-guide', compression(), cacheControlMiddleware, rewriteMiddleware, docsServer)
 		this.app.get('/user-guide', (req, res) => {
 			// Redirect to add trailing slash
 			res.redirect(301, path.join(getCustomPrefixHeader(req), '/user-guide/'))
 		})
 
 		// Serve the webui directory
-		this.app.use(compression(), rewriteMiddleware, webuiServer)
+		this.app.use(compression(), cacheControlMiddleware, rewriteMiddleware, webuiServer)
 
 		// Handle all unknown urls as accessing index.html
-		this.app.get('*all', compression(), rewriteMiddleware, async (req, res, next) => {
+		this.app.get('*all', compression(), cacheControlMiddleware, rewriteMiddleware, async (req, res, next) => {
 			if (req.url.startsWith('/user-guide/')) {
 				req.url = '/404.html'
 				res.status(404)

--- a/companion/lib/UI/Handler.ts
+++ b/companion/lib/UI/Handler.ts
@@ -18,6 +18,21 @@ import LogController from '../Log/Controller.js'
 import type { AppInfo } from '../Registry.js'
 import { createTrpcWsContext, type AppRouter } from './TRPC.js'
 
+/**
+ * Check whether an HTTP upgrade request url is for the trpc WebSocket endpoint.
+ * Matches on the pathname only, so query strings and a trailing slash are accepted.
+ */
+export function matchUpgradePathname(url: string | undefined): boolean {
+	let pathname: string | null = null
+	try {
+		pathname = new URL(url ?? '', 'http://localhost').pathname
+	} catch (_e) {
+		pathname = null
+	}
+
+	return pathname === '/trpc' || pathname === '/trpc/'
+}
+
 export class UIHandler {
 	readonly #logger = LogController.createLogger('UI/Handler')
 
@@ -81,11 +96,19 @@ export class UIHandler {
 
 	#bindToHttpServer(httpServer: HttpServer): void {
 		httpServer.on('upgrade', (request, socket, head) => {
-			// TODO - is this guard needed?
-			if (request.url === '/trpc') {
+			if (matchUpgradePathname(request.url)) {
 				this.#wss.handleUpgrade(request, socket, head, (websocket) => {
 					this.#wss.emit('connection', websocket, request)
 				})
+			} else {
+				// Reject unknown upgrade requests instead of leaving the socket hanging,
+				// which leaves browser clients stuck in CONNECTING forever
+				try {
+					if (socket.writable) socket.write('HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n')
+				} catch (_e) {
+					// Socket may already be destroyed
+				}
+				socket.destroy()
 			}
 		})
 	}

--- a/companion/test/UI/Handler.test.ts
+++ b/companion/test/UI/Handler.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'vitest'
+import { matchUpgradePathname } from '../../lib/UI/Handler.js'
+
+describe('matchUpgradePathname', () => {
+	test('matches plain /trpc', () => {
+		expect(matchUpgradePathname('/trpc')).toBe(true)
+	})
+
+	test('matches /trpc with trailing slash', () => {
+		expect(matchUpgradePathname('/trpc/')).toBe(true)
+	})
+
+	test('matches /trpc with query string', () => {
+		expect(matchUpgradePathname('/trpc?foo=1')).toBe(true)
+		expect(matchUpgradePathname('/trpc/?foo=1&bar=2')).toBe(true)
+	})
+
+	test('rejects other paths', () => {
+		expect(matchUpgradePathname('/')).toBe(false)
+		expect(matchUpgradePathname('/other')).toBe(false)
+		expect(matchUpgradePathname('/trpc2')).toBe(false)
+		expect(matchUpgradePathname('/trpc/extra')).toBe(false)
+		expect(matchUpgradePathname('/api/trpc')).toBe(false)
+	})
+
+	test('rejects missing url', () => {
+		expect(matchUpgradePathname(undefined)).toBe(false)
+		expect(matchUpgradePathname('')).toBe(false)
+	})
+})

--- a/webui/src/Resources/ConnectionLifecycle.ts
+++ b/webui/src/Resources/ConnectionLifecycle.ts
@@ -2,6 +2,9 @@ import type { createWSClient } from '@trpc/client'
 
 type TRPCWebSocketClient = ReturnType<typeof createWSClient>
 
+/** How long after a resume trigger to wait for the connection to become healthy before kicking it */
+const WATCHDOG_GRACE_MS = 5_000
+
 /**
  * Wire up page lifecycle handling for the tRPC WebSocket connection.
  *
@@ -30,4 +33,53 @@ export function setupConnectionLifecycle(trpcWsClient: TRPCWebSocketClient): voi
 			window.location.reload()
 		}
 	})
+
+	// Watchdog: when the page resumes (becomes visible, regains network/focus), verify the
+	// connection is actually healthy within a grace period, and if not force-close the raw
+	// WebSocket so the trpc client's reconnect logic runs immediately. This recovers both
+	// "zombie OPEN" sockets (readyState OPEN but TCP dead after device sleep) and sockets
+	// stuck in CONNECTING, without waiting for keepalive timeouts or - in the wedged case -
+	// forever.
+
+	let watchdogTimer: ReturnType<typeof setTimeout> | undefined
+
+	const isHealthy = (): boolean => {
+		// 'pending' is the trpc ws client state meaning connected & ready
+		// (connectionState accessor verified against @trpc/client 11.17.0)
+		return trpcWsClient.connectionState.get().state === 'pending'
+	}
+
+	const kickConnection = (reason: string): void => {
+		// `connection` is the backward-compat accessor exposing the raw ws
+		// (verified against @trpc/client 11.17.0)
+		const conn = trpcWsClient.connection
+		console.warn(`Connection watchdog: forcing socket close (${reason})`, conn?.state)
+		try {
+			// Closing a CONNECTING socket aborts the handshake; closing an OPEN one fires the
+			// client's close handler - both trigger the trpc client's reconnect immediately.
+			conn?.ws.close()
+		} catch (_e) {
+			// ignore
+		}
+		// If there is no raw ws to kick, the client's own retry timer will fire; nothing else to do.
+		// Never call trpcWsClient.close() here - that permanently disables reconnection.
+	}
+
+	const scheduleCheck = (trigger: string): void => {
+		if (document.visibilityState !== 'visible') return
+		if (watchdogTimer) clearTimeout(watchdogTimer)
+		if (isHealthy()) return
+
+		watchdogTimer = setTimeout(() => {
+			watchdogTimer = undefined
+			if (!isHealthy()) kickConnection(trigger)
+		}, WATCHDOG_GRACE_MS)
+	}
+
+	document.addEventListener('visibilitychange', () => {
+		if (document.visibilityState === 'visible') scheduleCheck('visibilitychange')
+	})
+	window.addEventListener('online', () => scheduleCheck('online'))
+	window.addEventListener('pageshow', () => scheduleCheck('pageshow'))
+	window.addEventListener('focus', () => scheduleCheck('focus'))
 }

--- a/webui/src/Resources/ConnectionLifecycle.ts
+++ b/webui/src/Resources/ConnectionLifecycle.ts
@@ -1,0 +1,33 @@
+import type { createWSClient } from '@trpc/client'
+
+type TRPCWebSocketClient = ReturnType<typeof createWSClient>
+
+/**
+ * Wire up page lifecycle handling for the tRPC WebSocket connection.
+ *
+ * Safari (and other browsers) may put the page into the back/forward cache (bfcache)
+ * instead of destroying it on navigation. When that happens the JS heap is frozen and
+ * later restored verbatim, so we must be careful not to permanently disable the ws
+ * client on the way out, and must recover the (dead) connection on the way back in.
+ */
+export function setupConnectionLifecycle(trpcWsClient: TRPCWebSocketClient): void {
+	// Close the connection only when the page is genuinely being unloaded.
+	// On bfcache entry (persisted === true) we must NOT call close(), because
+	// trpcWsClient.close() permanently disables reconnection and Safari may
+	// restore this exact JS heap later.
+	window.addEventListener('pagehide', (event) => {
+		if (!event.persisted) {
+			trpcWsClient.close().catch((err) => {
+				console.error('Error closing TRPC WebSocket client on unload:', err)
+			})
+		}
+	})
+
+	// If Safari restores the page from bfcache, the WebSocket is dead (and the
+	// client state may be stale). A full reload is the most reliable recovery.
+	window.addEventListener('pageshow', (event) => {
+		if (event.persisted) {
+			window.location.reload()
+		}
+	})
+}

--- a/webui/src/Resources/TRPC.tsx
+++ b/webui/src/Resources/TRPC.tsx
@@ -21,8 +21,40 @@ export const queryClient = new QueryClient()
 let trpcUrl = window.location.origin + makeAbsolutePath(`/trpc`)
 if (trpcUrl.startsWith('http')) trpcUrl = 'ws' + trpcUrl.slice(4)
 
+const WS_CONNECT_TIMEOUT_MS = 10_000
+
+/**
+ * WebSocket subclass that self-aborts if the connection handshake does not
+ * complete within a timeout. Works around Safari/iOS leaving sockets in
+ * CONNECTING forever (no open/error event), which permanently wedges the
+ * trpc ws client's reconnect loop (it has no connect timeout of its own).
+ * Verified against @trpc/client 11.17.0.
+ */
+class WebSocketWithConnectTimeout extends WebSocket {
+	constructor(url: string | URL, protocols?: string | string[]) {
+		super(url, protocols)
+
+		const timeout = setTimeout(() => {
+			if (this.readyState === WebSocket.CONNECTING) {
+				console.warn('WebSocket connect timed out, aborting')
+				try {
+					this.close()
+				} catch (_e) {
+					// ignore
+				}
+			}
+		}, WS_CONNECT_TIMEOUT_MS)
+
+		const clear = () => clearTimeout(timeout)
+		this.addEventListener('open', clear)
+		this.addEventListener('close', clear)
+		this.addEventListener('error', clear)
+	}
+}
+
 export const trpcWsClient = createWSClient({
 	url: trpcUrl,
+	WebSocket: WebSocketWithConnectTimeout,
 	keepAlive: {
 		enabled: true,
 	},

--- a/webui/src/Resources/TRPC.tsx
+++ b/webui/src/Resources/TRPC.tsx
@@ -11,6 +11,7 @@ import { createTRPCOptionsProxy } from '@trpc/tanstack-react-query'
 import { useMemo } from 'react'
 import type { AppRouter } from '../../../companion/lib/UI/TRPC.js' // Type only import the router
 
+import { setupConnectionLifecycle } from './ConnectionLifecycle.js'
 import { makeAbsolutePath } from './util.js'
 
 export type { AppRouter, RouterInput, RouterOutput } from '../../../companion/lib/UI/TRPC.js' // Type only import the router
@@ -64,12 +65,8 @@ export const trpcWsClient = createWSClient({
 	},
 })
 
-// Close the WebSocket connection when the page is unloading to prevent wasteful reconnection attempts
-window.addEventListener('beforeunload', () => {
-	trpcWsClient.close().catch((err) => {
-		console.error('Error closing TRPC WebSocket client on unload:', err)
-	})
-})
+// Close the WebSocket connection on real unloads, and recover it after bfcache restores
+setupConnectionLifecycle(trpcWsClient)
 
 export const trpcClient = createTRPCClient<AppRouter>({
 	links: [


### PR DESCRIPTION
Another attempt at #3853 and #3773

Lots of ideas from Claude that seem sensible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented cache control optimization: HTML pages revalidate on each load while static assets cache permanently for better performance.
  * Enhanced WebSocket stability with connection timeout protection and improved page lifecycle handling to prevent stuck connections.

* **Bug Fixes**
  * WebSocket upgrade requests now properly validated; non-matching requests are rejected instead of hanging indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->