### PR TITLE
feat: support internal actions and feedbacks in presets #2166

### DIFF
--- a/companion/lib/Instance/Connection/PresetsLegacy.ts
+++ b/companion/lib/Instance/Connection/PresetsLegacy.ts
@@ -16,6 +16,7 @@ import type {
 import type { Complete } from '@companion-module/host'
 import type { Logger } from '../../Log/Controller.js'
 import { ConvertLegacyStyleToElements } from '../../Resources/ConvertLegacyStyleToElements.js'
+import type { PresetEntryConversionContext } from './Thread/PresetInternalEntities.js'
 import {
 	convertActionsDelay,
 	convertPresetFeedbacksToEntities,
@@ -143,9 +144,18 @@ function ConvertPresetDefinition(
 	try {
 		if (rawPreset.type !== 'button') return null
 
+		// Legacy modules predate `internal:*` preset entries and have no host-side validation of them,
+		// so they must never be translated to internal entities
+		const entryCtx: PresetEntryConversionContext = {
+			logger,
+			connectionId,
+			connectionUpgradeIndex,
+			allowInternalEntities: false,
+		}
+
 		const parsedStyle = ConvertLegacyStyleToElements(
 			ConvertPresetStyleToDrawStyle(rawPreset.style),
-			convertPresetFeedbacksToEntities(rawPreset.feedbacks, connectionId, connectionUpgradeIndex),
+			convertPresetFeedbacksToEntities(rawPreset.feedbacks, entryCtx),
 			rawPreset.previewStyle
 		)
 
@@ -204,12 +214,7 @@ function ConvertPresetDefinition(
 					if (!isNaN(Number(setId)) && set.options?.runWhileHeld) newStep.options.runWhileHeld.push(Number(setId))
 
 					if (setActions) {
-						newStep.action_sets[setIdSafe] = convertActionsDelay(
-							setActions,
-							connectionId,
-							rawPreset.options?.relativeDelay,
-							connectionUpgradeIndex
-						)
+						newStep.action_sets[setIdSafe] = convertActionsDelay(setActions, rawPreset.options?.relativeDelay, entryCtx)
 					}
 				}
 			}

--- a/companion/lib/Instance/Connection/Thread/PresetInternalEntities.ts
+++ b/companion/lib/Instance/Connection/Thread/PresetInternalEntities.ts
@@ -1,0 +1,476 @@
+import { nanoid } from 'nanoid'
+import type { JsonValue } from 'type-fest'
+import { ControlLocationOption } from '@companion-app/shared/ControlLocation.js'
+import {
+	EntityModelType,
+	type ActionEntityModel,
+	type FeedbackEntityModel,
+	type SomeEntityModel,
+} from '@companion-app/shared/Model/EntityModel.js'
+import {
+	exprExpr,
+	exprVal,
+	isExpressionOrValue,
+	optionsObjectToExpressionOptions,
+	type ExpressionableOptionsObject,
+	type ExpressionOrValue,
+} from '@companion-app/shared/Model/Options.js'
+import type {
+	CompanionInternalActionSchemas,
+	CompanionInternalFeedbackSchemas,
+	CompanionInternalLogicActionSchemas,
+	CompanionInternalLogicFeedbackSchemas,
+	CompanionPresetAction,
+	CompanionPresetFeedback,
+	ModuleLogger,
+	SomePresetActionEntry,
+	SomePresetConditionEntry,
+	SomePresetLayeredFeedbackEntry,
+	SomePresetSimpleFeedbackEntry,
+} from '@companion-module/host'
+
+/**
+ * Translation of the reserved `internal:*` preset action/feedback ids (defined by `@companion-module/base`)
+ * into entities on the `internal` connection.
+ *
+ * The catalog in module-base is a stable vocabulary; this file owns the mapping to the current internal
+ * definition ids and option keys. When an internal action/feedback is refactored, update the translation
+ * here and existing module presets keep working.
+ *
+ * The host has already dropped any internal ids the module is too old to use or that the host doesn't
+ * know. Unknown ids are still skipped (with a warning) here, in case a newer module-base/host forwards
+ * ids this build doesn't know yet.
+ */
+
+/** A logger that can emit warnings. Satisfied by both ModuleLogger (thread) and winston Logger (legacy) */
+export type PresetEntryWarnLogger = Pick<ModuleLogger, 'warn'>
+
+export interface PresetEntryConversionContext {
+	logger: PresetEntryWarnLogger
+	connectionId: string
+	connectionUpgradeIndex: number | undefined
+	/**
+	 * Whether `internal:*` entries may be translated to internal entities. Only allowed for new-api
+	 * modules, whose host has validated and version-gated the entries. For legacy modules this must be
+	 * false: their entries are converted as plain module entities, as they were before this existed.
+	 */
+	allowInternalEntities: boolean
+}
+
+/** Matches MAX_PRESET_NESTING_DEPTH enforced by @companion-module/host (not exported there) */
+const MAX_PRESET_ENTRY_DEPTH = 10
+
+/**
+ * How a wire option value is converted for the internal field it targets:
+ * - `passthrough`: literals are wrapped as plain values, ExpressionOrValue wrappers are kept as-is
+ * - `expression`: the value is always stored as an expression ('expression'-type internal fields
+ *   evaluate their value as an expression regardless of the isExpression flag)
+ * - `noExpression`: the internal field has disableAutoExpression and is read without expression
+ *   evaluation, so an expression wrapper is replaced (with a warning) by the field default
+ */
+type OptionConversion =
+	| { mode: 'passthrough' }
+	| { mode: 'expression' }
+	| { mode: 'noExpression'; defaultValue: JsonValue }
+
+interface InternalEntityTranslation {
+	definitionId: string
+	/** Wire option key -> internal option id + value conversion */
+	options: Record<string, { id: string; convert: OptionConversion }>
+	/** Internal options not present on the wire, injected unconditionally */
+	injectOptions?: Record<string, () => ExpressionOrValue<any>>
+	/** For building blocks: wire child slot -> internal child group */
+	childGroups?: Record<string, { groupId: string; kind: 'actions' | 'conditions' }>
+}
+
+/** The "this button" location, resolving to wherever the preset is imported */
+const selfLocation = (): ExpressionOrValue<string> => exprVal(ControlLocationOption.default)
+
+type InternalPresetActionId = keyof CompanionInternalActionSchemas | keyof CompanionInternalLogicActionSchemas
+type InternalPresetFeedbackId = keyof CompanionInternalFeedbackSchemas | keyof CompanionInternalLogicFeedbackSchemas
+
+// The `satisfies` clauses make these tables exhaustive against the module-base catalog:
+// adding an id to the catalog fails compilation here until a translation is added.
+
+const InternalActionTranslations = {
+	'internal:wait': {
+		definitionId: 'wait',
+		options: { time: { id: 'time', convert: { mode: 'expression' } } },
+	},
+	'internal:customLog': {
+		definitionId: 'custom_log',
+		options: { message: { id: 'message', convert: { mode: 'passthrough' } } },
+	},
+	'internal:abortButton': {
+		definitionId: 'panic_bank',
+		options: { skipReleaseActions: { id: 'unlatch', convert: { mode: 'noExpression', defaultValue: false } } },
+		injectOptions: { location: selfLocation },
+	},
+	'internal:localVariableSet': {
+		definitionId: 'local_variable_set_value',
+		options: {
+			name: { id: 'name', convert: { mode: 'passthrough' } },
+			value: { id: 'value', convert: { mode: 'passthrough' } },
+		},
+		injectOptions: { location: selfLocation },
+	},
+	'internal:actionGroup': {
+		definitionId: 'action_group',
+		options: {
+			executionMode: { id: 'execution_mode', convert: { mode: 'noExpression', defaultValue: 'inherit' } },
+		},
+		childGroups: { default: { groupId: 'default', kind: 'actions' } },
+	},
+	'internal:logicIf': {
+		definitionId: 'logic_if',
+		options: {},
+		childGroups: {
+			condition: { groupId: 'condition', kind: 'conditions' },
+			actions: { groupId: 'actions', kind: 'actions' },
+			elseActions: { groupId: 'else_actions', kind: 'actions' },
+		},
+	},
+	'internal:logicWhile': {
+		definitionId: 'logic_while',
+		options: {},
+		childGroups: {
+			condition: { groupId: 'condition', kind: 'conditions' },
+			actions: { groupId: 'actions', kind: 'actions' },
+		},
+	},
+} satisfies Record<InternalPresetActionId, InternalEntityTranslation>
+
+const InternalFeedbackTranslations = {
+	'internal:checkExpression': {
+		definitionId: 'check_expression',
+		options: { expression: { id: 'expression', convert: { mode: 'expression' } } },
+	},
+	'internal:buttonPushed': {
+		definitionId: 'bank_pushed',
+		options: {
+			treatSteppedAsPressed: { id: 'latch_compatability', convert: { mode: 'noExpression', defaultValue: false } },
+		},
+		injectOptions: { location: selfLocation },
+	},
+	'internal:buttonCurrentStep': {
+		definitionId: 'bank_current_step',
+		options: { step: { id: 'step', convert: { mode: 'passthrough' } } },
+		injectOptions: { location: selfLocation },
+	},
+	'internal:logicOperator': {
+		definitionId: 'logic_operator',
+		options: { operation: { id: 'operation', convert: { mode: 'noExpression', defaultValue: 'and' } } },
+		childGroups: { default: { groupId: 'default', kind: 'conditions' } },
+	},
+} satisfies Record<InternalPresetFeedbackId, InternalEntityTranslation>
+
+/** Whether an action/feedback id references one of Companion's built-in internal definitions */
+export function isInternalPresetEntryId(id: unknown): id is string {
+	return typeof id === 'string' && id.startsWith('internal:')
+}
+
+/**
+ * Structural view of an `internal:*` preset entry. The wire unions don't narrow on the id prefix,
+ * so internal entries are handled structurally after the `isInternalPresetEntryId` dispatch; the
+ * `satisfies` exhaustiveness on the translation tables provides the catalog-level type safety.
+ */
+interface RawInternalEntry {
+	options?: Record<string, unknown>
+	children?: Record<string, unknown>
+	headline?: string
+	isInverted?: boolean
+}
+
+function convertOptionValue(
+	rawValue: unknown,
+	convert: OptionConversion,
+	wireKey: string,
+	entryDescription: string,
+	ctx: PresetEntryConversionContext
+): ExpressionOrValue<any> | undefined {
+	switch (convert.mode) {
+		case 'passthrough':
+			if (rawValue === undefined) return undefined
+			return isExpressionOrValue(rawValue) ? structuredClone(rawValue) : exprVal(rawValue as JsonValue)
+		case 'expression': {
+			if (rawValue === undefined) return undefined
+			const value = isExpressionOrValue(rawValue) ? rawValue.value : rawValue
+			return exprExpr(String(value ?? ''))
+		}
+		case 'noExpression': {
+			if (isExpressionOrValue(rawValue)) {
+				if (rawValue.isExpression) {
+					ctx.logger.warn(
+						`Option "${wireKey}" of preset ${entryDescription} does not support expressions, using the default value`
+					)
+					return exprVal(structuredClone(convert.defaultValue))
+				}
+				return exprVal(structuredClone(rawValue.value))
+			}
+			if (rawValue === undefined) return exprVal(structuredClone(convert.defaultValue))
+			return exprVal(rawValue as JsonValue)
+		}
+	}
+}
+
+function buildInternalEntityOptions(
+	translation: InternalEntityTranslation,
+	rawOptions: Record<string, unknown> | undefined,
+	entryDescription: string,
+	ctx: PresetEntryConversionContext
+): ExpressionableOptionsObject {
+	const options: ExpressionableOptionsObject = {}
+
+	for (const [wireKey, field] of Object.entries(translation.options)) {
+		const converted = convertOptionValue(rawOptions?.[wireKey], field.convert, wireKey, entryDescription, ctx)
+		if (converted !== undefined) options[field.id] = converted
+	}
+
+	// Wire option keys not in the translation table map 1:1, in case a newer module-base
+	// added an option to an existing id that this build doesn't know yet
+	for (const [wireKey, rawValue] of Object.entries(rawOptions ?? {})) {
+		if (wireKey in translation.options || wireKey in options) continue
+		const converted = convertOptionValue(rawValue, { mode: 'passthrough' }, wireKey, entryDescription, ctx)
+		if (converted !== undefined) options[wireKey] = converted
+	}
+
+	for (const [id, makeValue] of Object.entries(translation.injectOptions ?? {})) {
+		options[id] = makeValue()
+	}
+
+	return options
+}
+
+/**
+ * Build the children groups for a building-block entry, translating each wire child slot to its
+ * internal group id and recursing into the entries. Returns null when nested too deeply.
+ */
+function buildInternalEntityChildren(
+	translation: InternalEntityTranslation,
+	rawChildren: Record<string, unknown> | undefined,
+	entryDescription: string,
+	ctx: PresetEntryConversionContext,
+	depth: number
+): Record<string, SomeEntityModel[]> | null {
+	if (depth >= MAX_PRESET_ENTRY_DEPTH) {
+		ctx.logger.warn(`Ignoring preset ${entryDescription}: nested too deeply`)
+		return null
+	}
+
+	const children: Record<string, SomeEntityModel[]> = {}
+	for (const [wireSlot, group] of Object.entries(translation.childGroups ?? {})) {
+		const rawEntries = rawChildren?.[wireSlot]
+		const childEntries = Array.isArray(rawEntries) ? rawEntries : []
+
+		children[group.groupId] =
+			group.kind === 'actions'
+				? convertPresetActionEntries(childEntries as SomePresetActionEntry[], ctx, depth + 1)
+				: convertPresetConditionEntries(childEntries as SomePresetConditionEntry[], ctx, depth + 1)
+	}
+	return children
+}
+
+function tryConvertInternalActionEntry(
+	actionId: string,
+	entry: RawInternalEntry,
+	ctx: PresetEntryConversionContext,
+	depth: number
+): ActionEntityModel | null {
+	const translation: InternalEntityTranslation | undefined =
+		InternalActionTranslations[actionId as InternalPresetActionId]
+	if (!translation) {
+		ctx.logger.warn(`Ignoring unknown internal action "${actionId}" in preset`)
+		return null
+	}
+
+	const entryDescription = `action "${actionId}"`
+
+	const entity: ActionEntityModel = {
+		type: EntityModelType.Action,
+		id: nanoid(),
+		connectionId: 'internal',
+		definitionId: translation.definitionId,
+		options: buildInternalEntityOptions(translation, entry.options, entryDescription, ctx),
+		headline: entry.headline,
+		upgradeIndex: undefined,
+	}
+
+	if (translation.childGroups) {
+		const children = buildInternalEntityChildren(translation, entry.children, entryDescription, ctx, depth)
+		if (!children) return null
+		entity.children = children
+	}
+
+	return entity
+}
+
+/**
+ * Convert an `internal:*` feedback entry to an entity, without any style payload.
+ * The simple/layered wrappers below attach `style`/`styleOverrides`; condition children use this as-is.
+ */
+function tryConvertInternalFeedbackEntry(
+	feedbackId: string,
+	entry: RawInternalEntry,
+	ctx: PresetEntryConversionContext,
+	depth: number
+): FeedbackEntityModel | null {
+	const translation: InternalEntityTranslation | undefined =
+		InternalFeedbackTranslations[feedbackId as InternalPresetFeedbackId]
+	if (!translation) {
+		ctx.logger.warn(`Ignoring unknown internal feedback "${feedbackId}" in preset`)
+		return null
+	}
+
+	const entryDescription = `feedback "${feedbackId}"`
+
+	const entity: FeedbackEntityModel = {
+		type: EntityModelType.Feedback,
+		id: nanoid(),
+		connectionId: 'internal',
+		definitionId: translation.definitionId,
+		options: buildInternalEntityOptions(translation, entry.options, entryDescription, ctx),
+		isInverted: exprVal(!!entry.isInverted),
+		headline: entry.headline,
+		upgradeIndex: undefined,
+	}
+
+	if (translation.childGroups) {
+		const children = buildInternalEntityChildren(translation, entry.children, entryDescription, ctx, depth)
+		if (!children) return null
+		entity.children = children
+	}
+
+	return entity
+}
+
+/** Moved from PresetUtils (was toActionInstance): convert a module-defined preset action to an entity */
+export function convertModulePresetAction(
+	action: CompanionPresetAction,
+	connectionId: string,
+	connectionUpgradeIndex: number | undefined
+): ActionEntityModel {
+	return {
+		type: EntityModelType.Action,
+		id: nanoid(),
+		connectionId: connectionId,
+		definitionId: action.actionId,
+		options: structuredClone(optionsObjectToExpressionOptions(action.options ?? {}, true)),
+		headline: action.headline,
+		upgradeIndex: connectionUpgradeIndex,
+	}
+}
+
+export function createWaitAction(delay: number): ActionEntityModel {
+	return {
+		type: EntityModelType.Action,
+		id: nanoid(),
+		connectionId: 'internal',
+		definitionId: 'wait',
+		options: {
+			time: exprExpr(delay + ''),
+		},
+		upgradeIndex: undefined,
+	}
+}
+
+/**
+ * Convert a list of preset action entries (module actions, internal actions and building blocks) to
+ * entities, expanding the relative `delay` of each entry into a preceding internal `wait` action.
+ * Also the recursion entry point for the action child groups of building blocks.
+ */
+export function convertPresetActionEntries(
+	entries: SomePresetActionEntry[],
+	ctx: PresetEntryConversionContext,
+	depth = 0
+): ActionEntityModel[] {
+	const newActions: ActionEntityModel[] = []
+
+	for (const entry of entries) {
+		if (!entry || typeof entry !== 'object') continue
+
+		const delay = Number(entry.delay)
+		if (!isNaN(delay) && delay > 0) {
+			newActions.push(createWaitAction(delay))
+		}
+
+		if (ctx.allowInternalEntities && isInternalPresetEntryId(entry.actionId)) {
+			const entity = tryConvertInternalActionEntry(entry.actionId, entry, ctx, depth)
+			if (entity) newActions.push(entity)
+		} else {
+			newActions.push(convertModulePresetAction(entry, ctx.connectionId, ctx.connectionUpgradeIndex))
+		}
+	}
+
+	return newActions
+}
+
+/**
+ * Convert the condition children of a building block: boolean feedbacks (module or internal,
+ * including nested logic operators), which never carry a style payload.
+ */
+export function convertPresetConditionEntries(
+	entries: SomePresetConditionEntry[],
+	ctx: PresetEntryConversionContext,
+	depth: number
+): FeedbackEntityModel[] {
+	const feedbacks: FeedbackEntityModel[] = []
+
+	for (const entry of entries) {
+		if (!entry || typeof entry !== 'object') continue
+
+		if (ctx.allowInternalEntities && isInternalPresetEntryId(entry.feedbackId)) {
+			const entity = tryConvertInternalFeedbackEntry(entry.feedbackId, entry, ctx, depth)
+			if (entity) feedbacks.push(entity)
+		} else {
+			feedbacks.push({
+				type: EntityModelType.Feedback,
+				id: nanoid(),
+				connectionId: ctx.connectionId,
+				definitionId: entry.feedbackId,
+				options: structuredClone(optionsObjectToExpressionOptions(entry.options ?? {}, true)),
+				isInverted: exprVal(!!entry.isInverted),
+				headline: entry.headline,
+				upgradeIndex: ctx.connectionUpgradeIndex,
+			})
+		}
+	}
+
+	return feedbacks
+}
+
+/**
+ * Convert an `internal:*` feedback at the top level of a simple preset, attaching its boolean style.
+ * Returns null when the entry was skipped (already warned).
+ */
+export function tryConvertInternalSimpleFeedbackEntry(
+	entry: SomePresetSimpleFeedbackEntry & { feedbackId: string },
+	ctx: PresetEntryConversionContext
+): FeedbackEntityModel | null {
+	const entity = tryConvertInternalFeedbackEntry(entry.feedbackId, entry, ctx, 0)
+	if (!entity) return null
+
+	// `style` is carried outside the FeedbackEntityModel type, to be converted to style overrides
+	// by ConvertLegacyStyleToElements - same as module feedbacks in convertPresetFeedbacksToEntities
+	return {
+		...entity,
+		style: structuredClone((entry as CompanionPresetFeedback).style),
+	} as FeedbackEntityModel
+}
+
+/**
+ * Convert an `internal:*` feedback at the top level of a layered preset. The caller computes and
+ * filters the style overrides (and skips the entry entirely when none are valid, as for module feedbacks).
+ */
+export function tryConvertInternalLayeredFeedbackEntry(
+	entry: SomePresetLayeredFeedbackEntry & { feedbackId: string },
+	styleOverrides: FeedbackEntityModel['styleOverrides'],
+	ctx: PresetEntryConversionContext
+): FeedbackEntityModel | null {
+	const entity = tryConvertInternalFeedbackEntry(entry.feedbackId, entry, ctx, 0)
+	if (!entity) return null
+
+	return {
+		...entity,
+		styleOverrides: structuredClone(styleOverrides),
+	}
+}

--- a/companion/lib/Instance/Connection/Thread/PresetUtils.ts
+++ b/companion/lib/Instance/Connection/Thread/PresetUtils.ts
@@ -4,32 +4,33 @@ import {
 	type ActionEntityModel,
 	type FeedbackEntityModel,
 } from '@companion-app/shared/Model/EntityModel.js'
-import { exprExpr, exprVal, optionsObjectToExpressionOptions } from '@companion-app/shared/Model/Options.js'
+import { exprVal, optionsObjectToExpressionOptions } from '@companion-app/shared/Model/Options.js'
 import type { ButtonStyleProperties } from '@companion-app/shared/Model/StyleModel.js'
-import type { CompanionButtonStyleProps, CompanionPresetAction, CompanionPresetFeedback } from '@companion-module/base'
+import type {
+	CompanionButtonStyleProps,
+	CompanionPresetFeedback,
+	SomePresetActionEntry,
+	SomePresetSimpleFeedbackEntry,
+} from '@companion-module/host'
+import {
+	convertModulePresetAction,
+	convertPresetActionEntries,
+	createWaitAction,
+	isInternalPresetEntryId,
+	tryConvertInternalSimpleFeedbackEntry,
+	type PresetEntryConversionContext,
+} from './PresetInternalEntities.js'
 
 export function convertActionsDelay(
-	actions: CompanionPresetAction[],
-	connectionId: string,
+	actions: SomePresetActionEntry[],
 	relativeDelays: boolean | undefined,
-	connectionUpgradeIndex: number | undefined
+	ctx: PresetEntryConversionContext
 ): ActionEntityModel[] {
 	if (relativeDelays) {
-		const newActions: ActionEntityModel[] = []
-
-		for (const action of actions) {
-			const delay = Number(action.delay)
-
-			// Add the wait action
-			if (!isNaN(delay) && delay > 0) {
-				newActions.push(createWaitAction(delay))
-			}
-
-			newActions.push(toActionInstance(action, connectionId, connectionUpgradeIndex))
-		}
-
-		return newActions
+		return convertPresetActionEntries(actions, ctx)
 	} else {
+		// Note: only reachable for legacy modules, which are too old to use `internal:*` entries
+
 		let currentDelay = 0
 		let currentDelayGroupChildren: ActionEntityModel[] = []
 
@@ -53,7 +54,7 @@ export function convertActionsDelay(
 				currentDelay = delay
 			}
 
-			currentDelayGroupChildren.push(toActionInstance(action, connectionId, connectionUpgradeIndex))
+			currentDelayGroupChildren.push(convertModulePresetAction(action, ctx.connectionId, ctx.connectionUpgradeIndex))
 		}
 
 		if (delayGroups.length > 1) {
@@ -81,37 +82,37 @@ function wrapActionsInGroup(actions: ActionEntityModel[]): ActionEntityModel {
 		upgradeIndex: undefined,
 	}
 }
-function createWaitAction(delay: number): ActionEntityModel {
-	return {
-		type: EntityModelType.Action,
-		id: nanoid(),
-		connectionId: 'internal',
-		definitionId: 'wait',
-		options: {
-			time: exprExpr(delay + ''),
-		},
-		upgradeIndex: undefined,
-	}
-}
 
 export function convertPresetFeedbacksToEntities(
-	rawFeedbacks: CompanionPresetFeedback[] | undefined,
-	connectionId: string,
-	connectionUpgradeIndex: number | undefined
+	rawFeedbacks: SomePresetSimpleFeedbackEntry[] | undefined,
+	ctx: PresetEntryConversionContext
 ): FeedbackEntityModel[] {
 	if (!rawFeedbacks) return []
 
-	return rawFeedbacks.map((feedback) => ({
-		type: EntityModelType.Feedback,
-		id: nanoid(),
-		connectionId: connectionId,
-		definitionId: feedback.feedbackId,
-		options: structuredClone(optionsObjectToExpressionOptions(feedback.options ?? {}, true)),
-		isInverted: exprVal(!!feedback.isInverted),
-		style: structuredClone(feedback.style),
-		headline: feedback.headline,
-		upgradeIndex: connectionUpgradeIndex,
-	}))
+	const feedbacks: FeedbackEntityModel[] = []
+
+	for (const feedback of rawFeedbacks) {
+		if (ctx.allowInternalEntities && isInternalPresetEntryId(feedback.feedbackId)) {
+			const entity = tryConvertInternalSimpleFeedbackEntry(feedback, ctx)
+			if (entity) feedbacks.push(entity)
+		} else {
+			// `style` is carried outside the FeedbackEntityModel type, to be converted to style
+			// overrides by ConvertLegacyStyleToElements
+			feedbacks.push({
+				type: EntityModelType.Feedback,
+				id: nanoid(),
+				connectionId: ctx.connectionId,
+				definitionId: feedback.feedbackId,
+				options: structuredClone(optionsObjectToExpressionOptions(feedback.options ?? {}, true)),
+				isInverted: exprVal(!!feedback.isInverted),
+				style: structuredClone((feedback as CompanionPresetFeedback).style),
+				headline: feedback.headline,
+				upgradeIndex: ctx.connectionUpgradeIndex,
+			} as FeedbackEntityModel)
+		}
+	}
+
+	return feedbacks
 }
 
 export function ConvertPresetStyleToDrawStyle(rawStyle: CompanionButtonStyleProps): ButtonStyleProperties {
@@ -123,21 +124,5 @@ export function ConvertPresetStyleToDrawStyle(rawStyle: CompanionButtonStyleProp
 		pngalignment: rawStyle.pngalignment ?? 'center:center',
 		png64: rawStyle.png64 ?? null,
 		show_topbar: rawStyle.show_topbar ?? 'default',
-	}
-}
-
-function toActionInstance(
-	action: CompanionPresetAction,
-	connectionId: string,
-	connectionUpgradeIndex: number | undefined
-): ActionEntityModel {
-	return {
-		type: EntityModelType.Action,
-		id: nanoid(),
-		connectionId: connectionId,
-		definitionId: action.actionId,
-		options: structuredClone(optionsObjectToExpressionOptions(action.options ?? {}, true)),
-		headline: action.headline,
-		upgradeIndex: connectionUpgradeIndex,
 	}
 }

--- a/companion/lib/Instance/Connection/Thread/PresetUtils.ts
+++ b/companion/lib/Instance/Connection/Thread/PresetUtils.ts
@@ -8,7 +8,6 @@ import { exprVal, optionsObjectToExpressionOptions } from '@companion-app/shared
 import type { ButtonStyleProperties } from '@companion-app/shared/Model/StyleModel.js'
 import type {
 	CompanionButtonStyleProps,
-	CompanionPresetFeedback,
 	SomePresetActionEntry,
 	SomePresetSimpleFeedbackEntry,
 } from '@companion-module/host'
@@ -105,7 +104,7 @@ export function convertPresetFeedbacksToEntities(
 				definitionId: feedback.feedbackId,
 				options: structuredClone(optionsObjectToExpressionOptions(feedback.options ?? {}, true)),
 				isInverted: exprVal(!!feedback.isInverted),
-				style: structuredClone((feedback as CompanionPresetFeedback).style),
+				style: structuredClone(feedback.style),
 				headline: feedback.headline,
 				upgradeIndex: ctx.connectionUpgradeIndex,
 			} as FeedbackEntityModel)

--- a/companion/lib/Instance/Connection/Thread/Presets.ts
+++ b/companion/lib/Instance/Connection/Thread/Presets.ts
@@ -27,9 +27,9 @@ import type {
 	SomePresetActionEntry,
 } from '@companion-module/host'
 import { ConvertLegacyStyleToElements } from '../../../Resources/ConvertLegacyStyleToElements.js'
-import type { PresetEntryConversionContext } from './PresetInternalEntities.js'
+import { convertPresetActionEntries, type PresetEntryConversionContext } from './PresetInternalEntities.js'
 import { ConvertLayeredPresetFeedbacksToEntities, ConvertLayerPresetElements } from './PresetsLayered.js'
-import { convertActionsDelay, convertPresetFeedbacksToEntities, ConvertPresetStyleToDrawStyle } from './PresetUtils.js'
+import { convertPresetFeedbacksToEntities, ConvertPresetStyleToDrawStyle } from './PresetUtils.js'
 
 const DefaultStepOptions: Complete<ActionStepOptions> = {
 	runWhileHeld: [],
@@ -427,11 +427,7 @@ function ConvertStepsForPreset(
 				if (!isNaN(Number(setId)) && set.options?.runWhileHeld) newStep.options.runWhileHeld.push(Number(setId))
 
 				if (setActions) {
-					newStep.action_sets[setIdSafe] = convertActionsDelay(
-						setActions,
-						true, // Always relative now
-						ctx
-					)
+					newStep.action_sets[setIdSafe] = convertPresetActionEntries(setActions, ctx)
 				}
 			}
 		}

--- a/companion/lib/Instance/Connection/Thread/Presets.ts
+++ b/companion/lib/Instance/Connection/Thread/Presets.ts
@@ -16,7 +16,6 @@ import { stringifyError } from '@companion-app/shared/Stringify.js'
 import { assertNever } from '@companion-app/shared/Util.js'
 import type {
 	CompanionButtonStepActions,
-	CompanionPresetAction,
 	CompanionPresetDefinition,
 	CompanionPresetDefinitions,
 	CompanionPresetGroup,
@@ -25,8 +24,10 @@ import type {
 	CompanionPresetSection,
 	Complete,
 	ModuleLogger,
+	SomePresetActionEntry,
 } from '@companion-module/host'
 import { ConvertLegacyStyleToElements } from '../../../Resources/ConvertLegacyStyleToElements.js'
+import type { PresetEntryConversionContext } from './PresetInternalEntities.js'
 import { ConvertLayeredPresetFeedbacksToEntities, ConvertLayerPresetElements } from './PresetsLayered.js'
 import { convertActionsDelay, convertPresetFeedbacksToEntities, ConvertPresetStyleToDrawStyle } from './PresetUtils.js'
 
@@ -287,20 +288,23 @@ function ConvertPresetDefinition(
 		const presetType = rawPreset.type
 		const presetName = rawPreset.name
 
+		// `internal:*` entries are allowed: the host has validated and version-gated them for new-api modules
+		const entryCtx: PresetEntryConversionContext = {
+			logger,
+			connectionId,
+			connectionUpgradeIndex,
+			allowInternalEntities: true,
+		}
+
 		switch (rawPreset.type) {
 			case 'simple': {
 				const parsedStyle = ConvertLegacyStyleToElements(
 					ConvertPresetStyleToDrawStyle(rawPreset.style),
-					convertPresetFeedbacksToEntities(rawPreset.feedbacks, connectionId, connectionUpgradeIndex),
+					convertPresetFeedbacksToEntities(rawPreset.feedbacks, entryCtx),
 					rawPreset.previewStyle
 				)
 
-				const { steps, hasRotaryActions } = ConvertStepsForPreset(
-					logger,
-					connectionId,
-					connectionUpgradeIndex,
-					rawPreset.steps
-				)
+				const { steps, hasRotaryActions } = ConvertStepsForPreset(entryCtx, rawPreset.steps)
 
 				const presetDefinition: PresetDefinition = {
 					id: presetId,
@@ -335,12 +339,7 @@ function ConvertPresetDefinition(
 				return presetDefinition
 			}
 			case 'layered': {
-				const { steps, hasRotaryActions } = ConvertStepsForPreset(
-					logger,
-					connectionId,
-					connectionUpgradeIndex,
-					rawPreset.steps
-				)
+				const { steps, hasRotaryActions } = ConvertStepsForPreset(entryCtx, rawPreset.steps)
 
 				const presetDefinition: PresetDefinition = {
 					id: presetId,
@@ -357,11 +356,7 @@ function ConvertPresetDefinition(
 						style: {
 							layers: ConvertLayerPresetElements(logger, connectionId, rawPreset.canvas, rawPreset.elements),
 						},
-						feedbacks: ConvertLayeredPresetFeedbacksToEntities(
-							rawPreset.feedbacks,
-							connectionId,
-							connectionUpgradeIndex
-						),
+						feedbacks: ConvertLayeredPresetFeedbacksToEntities(rawPreset.feedbacks, entryCtx),
 
 						steps,
 						localVariables: ConvertLocalVariablesForPreset(
@@ -390,9 +385,7 @@ function ConvertPresetDefinition(
 }
 
 function ConvertStepsForPreset(
-	logger: ModuleLogger,
-	connectionId: string,
-	connectionUpgradeIndex: number | undefined,
+	ctx: PresetEntryConversionContext,
 	rawSteps: CompanionButtonStepActions[] | undefined
 ): { steps: NormalButtonSteps; hasRotaryActions: boolean } {
 	const steps: NormalButtonSteps = {}
@@ -421,7 +414,7 @@ function ConvertStepsForPreset(
 
 				const setIdSafe = validateActionSetId(setId as any)
 				if (setIdSafe === undefined) {
-					logger.warn(`Invalid set id: ${setId}`)
+					ctx.logger.warn(`Invalid set id: ${setId}`)
 					continue
 				}
 
@@ -430,15 +423,14 @@ function ConvertStepsForPreset(
 					hasRotaryActions = true
 				}
 
-				const setActions: CompanionPresetAction[] = Array.isArray(set) ? set : set.actions
+				const setActions: SomePresetActionEntry[] = Array.isArray(set) ? set : set.actions
 				if (!isNaN(Number(setId)) && set.options?.runWhileHeld) newStep.options.runWhileHeld.push(Number(setId))
 
 				if (setActions) {
 					newStep.action_sets[setIdSafe] = convertActionsDelay(
 						setActions,
-						connectionId,
 						true, // Always relative now
-						connectionUpgradeIndex
+						ctx
 					)
 				}
 			}

--- a/companion/lib/Instance/Connection/Thread/PresetsLayered.ts
+++ b/companion/lib/Instance/Connection/Thread/PresetsLayered.ts
@@ -35,24 +35,28 @@ import type {
 	ButtonGraphicsCanvasElement as ButtonGraphicsCanvasElementModule,
 	ButtonGraphicsDrawBounds as ButtonGraphicsDrawBoundsModule,
 	ButtonGraphicsElementBase as ButtonGraphicsElementBaseModule,
-	CompanionPresetLayeredFeedback,
 	ExpressionOrValue as ExpressionOrValueModule,
 	JsonValue,
 	ModuleLogger,
 	SomeButtonGraphicsElement as SomeButtonGraphicsElementModule,
+	SomePresetLayeredFeedbackEntry,
 } from '@companion-module/host'
+import {
+	isInternalPresetEntryId,
+	tryConvertInternalLayeredFeedbackEntry,
+	type PresetEntryConversionContext,
+} from './PresetInternalEntities.js'
 
 export function ConvertLayeredPresetFeedbacksToEntities(
-	rawFeedbacks: CompanionPresetLayeredFeedback[] | undefined,
-	connectionId: string,
-	connectionUpgradeIndex: number | undefined
+	rawFeedbacks: SomePresetLayeredFeedbackEntry[] | undefined,
+	ctx: PresetEntryConversionContext
 ): FeedbackEntityModel[] {
 	if (!rawFeedbacks) return []
 
 	const feedbacks: FeedbackEntityModel[] = []
 
 	for (const feedback of rawFeedbacks) {
-		const styleOverrides: FeedbackEntityStyleOverride[] = feedback.styleOverrides
+		const styleOverrides: FeedbackEntityStyleOverride[] = (feedback.styleOverrides ?? [])
 			.filter((override) => isExpressionOrValue(override.override))
 			.map((override) => ({
 				overrideId: nanoid(),
@@ -62,17 +66,22 @@ export function ConvertLayeredPresetFeedbacksToEntities(
 			}))
 		if (styleOverrides.length === 0) continue
 
-		feedbacks.push({
-			type: EntityModelType.Feedback,
-			id: nanoid(),
-			connectionId: connectionId,
-			definitionId: feedback.feedbackId,
-			options: structuredClone(optionsObjectToExpressionOptions(feedback.options ?? {}, false)),
-			isInverted: exprVal(!!feedback.isInverted),
-			styleOverrides: structuredClone(styleOverrides),
-			headline: feedback.headline,
-			upgradeIndex: connectionUpgradeIndex,
-		})
+		if (ctx.allowInternalEntities && isInternalPresetEntryId(feedback.feedbackId)) {
+			const entity = tryConvertInternalLayeredFeedbackEntry(feedback, styleOverrides, ctx)
+			if (entity) feedbacks.push(entity)
+		} else {
+			feedbacks.push({
+				type: EntityModelType.Feedback,
+				id: nanoid(),
+				connectionId: ctx.connectionId,
+				definitionId: feedback.feedbackId,
+				options: structuredClone(optionsObjectToExpressionOptions(feedback.options ?? {}, true)),
+				isInverted: exprVal(!!feedback.isInverted),
+				styleOverrides: structuredClone(styleOverrides),
+				headline: feedback.headline,
+				upgradeIndex: ctx.connectionUpgradeIndex,
+			})
+		}
 	}
 
 	return feedbacks

--- a/companion/test/Instance/Connection/PresetInternalEntities.test.ts
+++ b/companion/test/Instance/Connection/PresetInternalEntities.test.ts
@@ -12,8 +12,11 @@ import {
 	convertPresetConditionEntries,
 	type PresetEntryConversionContext,
 } from '../../../lib/Instance/Connection/Thread/PresetInternalEntities.js'
-import { convertActionsDelay, convertPresetFeedbacksToEntities } from '../../../lib/Instance/Connection/Thread/PresetUtils.js'
 import { ConvertLayeredPresetFeedbacksToEntities } from '../../../lib/Instance/Connection/Thread/PresetsLayered.js'
+import {
+	convertActionsDelay,
+	convertPresetFeedbacksToEntities,
+} from '../../../lib/Instance/Connection/Thread/PresetUtils.js'
 
 // Deterministic nanoid
 let nanoidCounter = 0
@@ -107,7 +110,12 @@ describe('PresetInternalEntities', () => {
 
 		it('rejects an expression wrapper on a non-expression option with a warning', () => {
 			const entities = convertPresetActionEntries(
-				[{ actionId: 'internal:abortButton', options: { skipReleaseActions: { value: '1 > 0', isExpression: true } } } as any],
+				[
+					{
+						actionId: 'internal:abortButton',
+						options: { skipReleaseActions: { value: '1 > 0', isExpression: true } },
+					} as any,
+				],
 				ctx
 			)
 
@@ -153,7 +161,11 @@ describe('PresetInternalEntities', () => {
 			)
 
 			expect(entities).toHaveLength(4)
-			expect(entities[0]).toMatchObject({ definitionId: 'wait', connectionId: 'internal', options: { time: exprExpr('250') } })
+			expect(entities[0]).toMatchObject({
+				definitionId: 'wait',
+				connectionId: 'internal',
+				options: { time: exprExpr('250') },
+			})
 			expect(entities[1]).toMatchObject({
 				definitionId: 'mod_action',
 				connectionId: 'conn01',

--- a/companion/test/Instance/Connection/PresetInternalEntities.test.ts
+++ b/companion/test/Instance/Connection/PresetInternalEntities.test.ts
@@ -1,0 +1,588 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ControlLocationOption } from '@companion-app/shared/ControlLocation.js'
+import {
+	EntityModelType,
+	type ActionEntityModel,
+	type FeedbackEntityModel,
+} from '@companion-app/shared/Model/EntityModel.js'
+import { exprExpr, exprVal } from '@companion-app/shared/Model/Options.js'
+import type { SomePresetActionEntry, SomePresetConditionEntry } from '@companion-module/host'
+import {
+	convertPresetActionEntries,
+	convertPresetConditionEntries,
+	type PresetEntryConversionContext,
+} from '../../../lib/Instance/Connection/Thread/PresetInternalEntities.js'
+import { convertActionsDelay, convertPresetFeedbacksToEntities } from '../../../lib/Instance/Connection/Thread/PresetUtils.js'
+import { ConvertLayeredPresetFeedbacksToEntities } from '../../../lib/Instance/Connection/Thread/PresetsLayered.js'
+
+// Deterministic nanoid
+let nanoidCounter = 0
+vi.mock('nanoid', () => ({
+	nanoid: vi.fn(() => `mock-id-${++nanoidCounter}`),
+}))
+
+const SELF_LOCATION = exprVal(ControlLocationOption.default)
+
+describe('PresetInternalEntities', () => {
+	const logger = { warn: vi.fn() }
+	const ctx: PresetEntryConversionContext = {
+		logger,
+		connectionId: 'conn01',
+		connectionUpgradeIndex: 5,
+		allowInternalEntities: true,
+	}
+
+	beforeEach(() => {
+		nanoidCounter = 0
+		logger.warn.mockClear()
+	})
+
+	describe('flat internal actions', () => {
+		it('translates internal:wait with a literal time to an expression', () => {
+			const entities = convertPresetActionEntries(
+				[{ actionId: 'internal:wait', options: { time: 100 } } as SomePresetActionEntry],
+				ctx
+			)
+
+			expect(entities).toHaveLength(1)
+			expect(entities[0]).toMatchObject({
+				type: EntityModelType.Action,
+				connectionId: 'internal',
+				definitionId: 'wait',
+				options: { time: exprExpr('100') },
+				upgradeIndex: undefined,
+			})
+		})
+
+		it('translates internal:wait with an expression wrapper', () => {
+			const entities = convertPresetActionEntries(
+				[{ actionId: 'internal:wait', options: { time: { value: '$(foo) * 2', isExpression: true } } } as any],
+				ctx
+			)
+
+			expect(entities[0].options).toEqual({ time: exprExpr('$(foo) * 2') })
+		})
+
+		it('translates internal:customLog, passing option values through', () => {
+			const entities = convertPresetActionEntries(
+				[
+					{ actionId: 'internal:customLog', options: { message: 'hello' }, headline: 'Log it' },
+					{ actionId: 'internal:customLog', options: { message: { value: '`v=${$(foo)}`', isExpression: true } } },
+				] as any[],
+				ctx
+			)
+
+			expect(entities).toHaveLength(2)
+			expect(entities[0]).toMatchObject({
+				definitionId: 'custom_log',
+				connectionId: 'internal',
+				options: { message: exprVal('hello') },
+				headline: 'Log it',
+			})
+			expect(entities[1].options).toEqual({ message: { value: '`v=${$(foo)}`', isExpression: true } })
+		})
+
+		it('translates internal:abortButton, remapping keys and injecting the self location', () => {
+			const entities = convertPresetActionEntries(
+				[{ actionId: 'internal:abortButton', options: { skipReleaseActions: true } } as any],
+				ctx
+			)
+
+			expect(entities[0]).toMatchObject({
+				definitionId: 'panic_bank',
+				connectionId: 'internal',
+				options: {
+					unlatch: exprVal(true),
+					location: SELF_LOCATION,
+				},
+			})
+		})
+
+		it('defaults internal:abortButton skipReleaseActions when absent', () => {
+			const entities = convertPresetActionEntries([{ actionId: 'internal:abortButton', options: {} } as any], ctx)
+
+			expect(entities[0].options).toEqual({ unlatch: exprVal(false), location: SELF_LOCATION })
+			expect(logger.warn).not.toHaveBeenCalled()
+		})
+
+		it('rejects an expression wrapper on a non-expression option with a warning', () => {
+			const entities = convertPresetActionEntries(
+				[{ actionId: 'internal:abortButton', options: { skipReleaseActions: { value: '1 > 0', isExpression: true } } } as any],
+				ctx
+			)
+
+			expect(entities[0].options.unlatch).toEqual(exprVal(false))
+			expect(logger.warn).toHaveBeenCalledTimes(1)
+		})
+
+		it('translates internal:localVariableSet, injecting the self location', () => {
+			const entities = convertPresetActionEntries(
+				[{ actionId: 'internal:localVariableSet', options: { name: 'myvar', value: '42' } } as any],
+				ctx
+			)
+
+			expect(entities[0]).toMatchObject({
+				definitionId: 'local_variable_set_value',
+				connectionId: 'internal',
+				options: {
+					name: exprVal('myvar'),
+					value: exprVal('42'),
+					location: SELF_LOCATION,
+				},
+			})
+		})
+
+		it('maps unknown option keys 1:1 for forward compatibility', () => {
+			const entities = convertPresetActionEntries(
+				[{ actionId: 'internal:wait', options: { time: 100, futureOption: 'abc' } } as any],
+				ctx
+			)
+
+			expect(entities[0].options.futureOption).toEqual(exprVal('abc'))
+		})
+	})
+
+	describe('delay handling', () => {
+		it('expands delay on internal and module entries into wait actions', () => {
+			const entities = convertPresetActionEntries(
+				[
+					{ actionId: 'mod_action', options: { a: 1 }, delay: 250 },
+					{ actionId: 'internal:customLog', options: { message: 'x' }, delay: 500 },
+				] as any[],
+				ctx
+			)
+
+			expect(entities).toHaveLength(4)
+			expect(entities[0]).toMatchObject({ definitionId: 'wait', connectionId: 'internal', options: { time: exprExpr('250') } })
+			expect(entities[1]).toMatchObject({
+				definitionId: 'mod_action',
+				connectionId: 'conn01',
+				options: { a: exprVal(1) },
+				upgradeIndex: 5,
+			})
+			expect(entities[2]).toMatchObject({ definitionId: 'wait', options: { time: exprExpr('500') } })
+			expect(entities[3]).toMatchObject({ definitionId: 'custom_log' })
+		})
+
+		it('dispatches internal entries via convertActionsDelay with relative delays', () => {
+			const entities = convertActionsDelay([{ actionId: 'internal:wait', options: { time: 10 } } as any], true, ctx)
+
+			expect(entities).toHaveLength(1)
+			expect(entities[0]).toMatchObject({ definitionId: 'wait', connectionId: 'internal' })
+		})
+	})
+
+	describe('building blocks', () => {
+		it('translates internal:actionGroup with defaults', () => {
+			const entities = convertPresetActionEntries([{ actionId: 'internal:actionGroup', options: {} } as any], ctx)
+
+			expect(entities[0]).toMatchObject({
+				definitionId: 'action_group',
+				connectionId: 'internal',
+				options: { execution_mode: exprVal('inherit') },
+				children: { default: [] },
+			})
+		})
+
+		it('warns and uses the default for an expression executionMode', () => {
+			const entities = convertPresetActionEntries(
+				[{ actionId: 'internal:actionGroup', options: { executionMode: { value: 'x', isExpression: true } } } as any],
+				ctx
+			)
+
+			expect(entities[0].options.execution_mode).toEqual(exprVal('inherit'))
+			expect(logger.warn).toHaveBeenCalledTimes(1)
+		})
+
+		it('translates mixed children of internal:actionGroup, including nested groups and delays', () => {
+			const entities = convertPresetActionEntries(
+				[
+					{
+						actionId: 'internal:actionGroup',
+						options: { executionMode: 'sequential' },
+						children: {
+							default: [
+								{ actionId: 'mod_action', options: { a: 1 }, delay: 100 },
+								{
+									actionId: 'internal:actionGroup',
+									options: {},
+									children: { default: [{ actionId: 'internal:wait', options: { time: 5 } }] },
+								},
+							],
+						},
+					},
+				] as any[],
+				ctx
+			)
+
+			expect(entities).toHaveLength(1)
+			expect(entities[0].options.execution_mode).toEqual(exprVal('sequential'))
+
+			const children = entities[0].children?.default ?? []
+			expect(children).toHaveLength(3)
+			// delay on the module child becomes a wait inside the group
+			expect(children[0]).toMatchObject({ definitionId: 'wait', connectionId: 'internal' })
+			expect(children[1]).toMatchObject({ definitionId: 'mod_action', connectionId: 'conn01', upgradeIndex: 5 })
+			expect(children[2]).toMatchObject({ definitionId: 'action_group', connectionId: 'internal' })
+			expect(children[2].children?.default?.[0]).toMatchObject({ definitionId: 'wait' })
+		})
+
+		it('translates internal:logicIf, remapping child slots and always emitting else_actions', () => {
+			const entities = convertPresetActionEntries(
+				[
+					{
+						actionId: 'internal:logicIf',
+						options: {},
+						children: {
+							condition: [
+								{ feedbackId: 'mod_fb', options: { x: 1 }, isInverted: true },
+								{ feedbackId: 'internal:checkExpression', options: { expression: '1 > 0' } },
+							],
+							actions: [{ actionId: 'internal:customLog', options: { message: 'then' } }],
+						},
+					},
+				] as any[],
+				ctx
+			)
+
+			const entity = entities[0]
+			expect(entity).toMatchObject({ definitionId: 'logic_if', connectionId: 'internal', options: {} })
+			expect(Object.keys(entity.children ?? {}).sort()).toEqual(['actions', 'condition', 'else_actions'])
+			expect(entity.children?.else_actions).toEqual([])
+
+			const conditions = (entity.children?.condition ?? []) as FeedbackEntityModel[]
+			expect(conditions).toHaveLength(2)
+			expect(conditions[0]).toMatchObject({
+				type: EntityModelType.Feedback,
+				definitionId: 'mod_fb',
+				connectionId: 'conn01',
+				isInverted: exprVal(true),
+				upgradeIndex: 5,
+			})
+			// condition feedbacks never carry a style
+			expect('style' in conditions[0]).toBe(false)
+			expect(conditions[1]).toMatchObject({
+				definitionId: 'check_expression',
+				connectionId: 'internal',
+				options: { expression: exprExpr('1 > 0') },
+				isInverted: exprVal(false),
+				upgradeIndex: undefined,
+			})
+
+			expect(entity.children?.actions?.[0]).toMatchObject({ definitionId: 'custom_log' })
+		})
+
+		it('translates internal:logicWhile', () => {
+			const entities = convertPresetActionEntries(
+				[
+					{
+						actionId: 'internal:logicWhile',
+						options: {},
+						children: {
+							condition: [{ feedbackId: 'internal:buttonPushed', options: {} }],
+							actions: [{ actionId: 'internal:wait', options: { time: 1 } }],
+						},
+					},
+				] as any[],
+				ctx
+			)
+
+			const entity = entities[0]
+			expect(entity).toMatchObject({ definitionId: 'logic_while', connectionId: 'internal' })
+			expect(Object.keys(entity.children ?? {}).sort()).toEqual(['actions', 'condition'])
+			expect(entity.children?.condition?.[0]).toMatchObject({
+				definitionId: 'bank_pushed',
+				options: { latch_compatability: exprVal(false), location: SELF_LOCATION },
+			})
+		})
+
+		it('translates a nested internal:logicOperator as a condition', () => {
+			const conditions = convertPresetConditionEntries(
+				[
+					{
+						feedbackId: 'internal:logicOperator',
+						options: { operation: 'or' },
+						children: { default: [{ feedbackId: 'internal:checkExpression', options: { expression: '2 > 1' } }] },
+						isInverted: true,
+					},
+				] as SomePresetConditionEntry[],
+				ctx,
+				0
+			)
+
+			expect(conditions).toHaveLength(1)
+			expect(conditions[0]).toMatchObject({
+				definitionId: 'logic_operator',
+				connectionId: 'internal',
+				options: { operation: exprVal('or') },
+				isInverted: exprVal(true),
+			})
+			expect('style' in conditions[0]).toBe(false)
+			expect('styleOverrides' in conditions[0]).toBe(false)
+			expect(conditions[0].children?.default?.[0]).toMatchObject({ definitionId: 'check_expression' })
+		})
+	})
+
+	describe('simple preset feedbacks', () => {
+		it('translates flat internal feedbacks, attaching the style', () => {
+			const style = { bgcolor: 16711680 }
+			const entities = convertPresetFeedbacksToEntities(
+				[
+					{ feedbackId: 'internal:buttonPushed', options: { treatSteppedAsPressed: true }, style, isInverted: true },
+					{ feedbackId: 'internal:buttonCurrentStep', options: { step: 2 }, style },
+				] as any[],
+				ctx
+			)
+
+			expect(entities).toHaveLength(2)
+			expect(entities[0]).toMatchObject({
+				definitionId: 'bank_pushed',
+				connectionId: 'internal',
+				options: { latch_compatability: exprVal(true), location: SELF_LOCATION },
+				isInverted: exprVal(true),
+				upgradeIndex: undefined,
+			})
+			expect((entities[0] as any).style).toEqual(style)
+			expect(entities[1]).toMatchObject({
+				definitionId: 'bank_current_step',
+				options: { step: exprVal(2), location: SELF_LOCATION },
+				isInverted: exprVal(false),
+			})
+		})
+
+		it('translates internal:checkExpression', () => {
+			const entities = convertPresetFeedbacksToEntities(
+				[{ feedbackId: 'internal:checkExpression', options: { expression: '$(foo) > 1' }, style: {} }] as any[],
+				ctx
+			)
+
+			expect(entities[0]).toMatchObject({
+				definitionId: 'check_expression',
+				options: { expression: exprExpr('$(foo) > 1') },
+			})
+		})
+
+		it('translates a top-level internal:logicOperator with a style', () => {
+			const style = { color: 255 }
+			const entities = convertPresetFeedbacksToEntities(
+				[
+					{
+						feedbackId: 'internal:logicOperator',
+						options: {},
+						children: { default: [{ feedbackId: 'mod_fb', options: {} }] },
+						style,
+					},
+				] as any[],
+				ctx
+			)
+
+			expect(entities[0]).toMatchObject({
+				definitionId: 'logic_operator',
+				options: { operation: exprVal('and') },
+			})
+			expect((entities[0] as any).style).toEqual(style)
+			expect(entities[0].children?.default?.[0]).toMatchObject({ definitionId: 'mod_fb', connectionId: 'conn01' })
+		})
+
+		it('still converts module feedbacks unchanged', () => {
+			const entities = convertPresetFeedbacksToEntities(
+				[{ feedbackId: 'mod_fb', options: { x: 1 }, style: { bgcolor: 2 }, isInverted: false }] as any[],
+				ctx
+			)
+
+			expect(entities[0]).toMatchObject({
+				definitionId: 'mod_fb',
+				connectionId: 'conn01',
+				options: { x: exprVal(1) },
+				upgradeIndex: 5,
+			})
+			expect((entities[0] as any).style).toEqual({ bgcolor: 2 })
+		})
+	})
+
+	describe('layered preset feedbacks', () => {
+		const override = {
+			elementId: 'el1',
+			elementProperty: 'color',
+			override: { value: 255, isExpression: false },
+		}
+
+		it('translates an internal feedback with style overrides', () => {
+			const entities = ConvertLayeredPresetFeedbacksToEntities(
+				[
+					{
+						feedbackId: 'internal:logicOperator',
+						options: { operation: 'xor' },
+						children: { default: [{ feedbackId: 'internal:checkExpression', options: { expression: '1 > 0' } }] },
+						styleOverrides: [override],
+					},
+				] as any[],
+				ctx
+			)
+
+			expect(entities).toHaveLength(1)
+			expect(entities[0]).toMatchObject({
+				definitionId: 'logic_operator',
+				connectionId: 'internal',
+				options: { operation: exprVal('xor') },
+			})
+			expect(entities[0].styleOverrides).toHaveLength(1)
+			expect(entities[0].styleOverrides?.[0]).toMatchObject({
+				elementId: 'el1',
+				elementProperty: 'color',
+				override: { value: 255, isExpression: false },
+			})
+		})
+
+		it('skips an internal feedback with no valid style overrides', () => {
+			const entities = ConvertLayeredPresetFeedbacksToEntities(
+				[{ feedbackId: 'internal:logicOperator', options: {}, children: { default: [] }, styleOverrides: [] }] as any[],
+				ctx
+			)
+
+			expect(entities).toHaveLength(0)
+		})
+
+		it('still converts module feedbacks unchanged', () => {
+			const entities = ConvertLayeredPresetFeedbacksToEntities(
+				[{ feedbackId: 'mod_fb', options: { x: 1 }, styleOverrides: [override] }] as any[],
+				ctx
+			)
+
+			expect(entities[0]).toMatchObject({
+				definitionId: 'mod_fb',
+				connectionId: 'conn01',
+				options: { x: exprVal(1) },
+				upgradeIndex: 5,
+			})
+		})
+
+		it('keeps expression wrappers in module feedback options', () => {
+			const entities = ConvertLayeredPresetFeedbacksToEntities(
+				[
+					{
+						feedbackId: 'mod_fb',
+						options: { x: { value: '$(foo) + 1', isExpression: true } },
+						styleOverrides: [override],
+					},
+				] as any[],
+				ctx
+			)
+
+			expect(entities[0].options).toEqual({ x: { value: '$(foo) + 1', isExpression: true } })
+		})
+	})
+
+	describe('unknown internal ids', () => {
+		it('skips an unknown internal action, keeping its siblings', () => {
+			const entities = convertPresetActionEntries(
+				[
+					{ actionId: 'internal:doesNotExist', options: {} },
+					{ actionId: 'internal:customLog', options: { message: 'x' } },
+				] as any[],
+				ctx
+			)
+
+			expect(entities).toHaveLength(1)
+			expect(entities[0]).toMatchObject({ definitionId: 'custom_log' })
+			expect(logger.warn).toHaveBeenCalledTimes(1)
+			expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('internal:doesNotExist'))
+		})
+
+		it('skips an unknown internal feedback inside building-block children', () => {
+			const entities = convertPresetActionEntries(
+				[
+					{
+						actionId: 'internal:logicIf',
+						options: {},
+						children: {
+							condition: [
+								{ feedbackId: 'internal:doesNotExist', options: {} },
+								{ feedbackId: 'internal:checkExpression', options: { expression: '1 > 0' } },
+							],
+							actions: [],
+						},
+					},
+				] as any[],
+				ctx
+			)
+
+			expect(entities[0].children?.condition).toHaveLength(1)
+			expect(logger.warn).toHaveBeenCalledTimes(1)
+		})
+
+		it('skips an unknown internal feedback at the top level of a preset', () => {
+			const entities = convertPresetFeedbacksToEntities(
+				[{ feedbackId: 'internal:doesNotExist', options: {}, style: {} }] as any[],
+				ctx
+			)
+
+			expect(entities).toHaveLength(0)
+			expect(logger.warn).toHaveBeenCalledTimes(1)
+		})
+	})
+
+	describe('legacy modules (allowInternalEntities: false)', () => {
+		const legacyCtx: PresetEntryConversionContext = { ...ctx, allowInternalEntities: false }
+
+		it('does not translate internal action ids, leaving them as module entities', () => {
+			const entities = convertActionsDelay(
+				[{ actionId: 'internal:wait', options: { time: 100 } } as any],
+				true,
+				legacyCtx
+			)
+
+			expect(entities).toHaveLength(1)
+			expect(entities[0]).toMatchObject({
+				definitionId: 'internal:wait',
+				connectionId: 'conn01',
+				upgradeIndex: 5,
+			})
+			expect(logger.warn).not.toHaveBeenCalled()
+		})
+
+		it('does not translate internal feedback ids, leaving them as module entities', () => {
+			const entities = convertPresetFeedbacksToEntities(
+				[{ feedbackId: 'internal:checkExpression', options: { expression: '1 > 0' }, style: {} }] as any[],
+				legacyCtx
+			)
+
+			expect(entities).toHaveLength(1)
+			expect(entities[0]).toMatchObject({
+				definitionId: 'internal:checkExpression',
+				connectionId: 'conn01',
+				options: { expression: exprVal('1 > 0') },
+				upgradeIndex: 5,
+			})
+			expect(logger.warn).not.toHaveBeenCalled()
+		})
+	})
+
+	describe('depth guard', () => {
+		function makeNestedGroups(levels: number): any {
+			const entry: any = { actionId: 'internal:actionGroup', options: {}, children: { default: [] } }
+			if (levels > 1) entry.children.default.push(makeNestedGroups(levels - 1))
+			return entry
+		}
+
+		function measureDepth(entity: ActionEntityModel | undefined): number {
+			if (!entity) return 0
+			return 1 + measureDepth(entity.children?.default?.[0] as ActionEntityModel | undefined)
+		}
+
+		it('keeps nesting up to 10 levels', () => {
+			const entities = convertPresetActionEntries([makeNestedGroups(10)], ctx)
+
+			expect(measureDepth(entities[0])).toBe(10)
+			expect(logger.warn).not.toHaveBeenCalled()
+		})
+
+		it('drops entries nested too deeply, with a warning', () => {
+			const entities = convertPresetActionEntries([makeNestedGroups(11)], ctx)
+
+			expect(measureDepth(entities[0])).toBe(10)
+			expect(logger.warn).toHaveBeenCalledTimes(1)
+			expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('nested too deeply'))
+		})
+	})
+})

--- a/package.json
+++ b/package.json
@@ -88,13 +88,12 @@
   "resolutions": {
     "osc/serialport": "npm:empty-npm-package@1.0.0",
     "app-builder-lib@npm:26.9.1": "patch:app-builder-lib@npm%3A26.9.1#~/.yarn/patches/app-builder-lib-npm-26.1.0-3323342f9a.patch",
-    "@xkeys-lib/core@npm:3.3.0": "patch:@xkeys-lib/core@npm%3A3.3.0#~/.yarn/patches/@xkeys-lib-core-npm-3.3.0-1a65b6423b.patch",
     "unix-dgram": "npm:empty-npm-package@1.0.0",
     "bare-fs": "npm:empty-npm-package@1.0.0",
     "bare-path": "npm:empty-npm-package@1.0.0",
     "@types/express-serve-static-core": "^5.1.0",
-    "@companion-module/base": "2.1.0-0-nightly-feat-internal-entities-in-presets-20260612-212853-9a4d1c0",
-    "@companion-module/host": "1.0.3-nightly-feat-internal-entities-in-presets-20260612-214837-b7419f7",
+    "@companion-module/base": "2.1.0-0-nightly-main-20260612-220203-a5e55f1",
+    "@companion-module/host": "1.0.3-nightly-main-20260612-220344-a5e55f1",
     "node-gyp": "^12.3.0",
     "monaco-editor/dompurify": "npm:dompurify@^3.3.3"
   },

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "bare-path": "npm:empty-npm-package@1.0.0",
     "@types/express-serve-static-core": "^5.1.0",
     "@companion-module/base": "2.1.0-0-nightly-feat-internal-entities-in-presets-20260612-212853-9a4d1c0",
-    "@companion-module/host": "1.0.3-nightly-feat-internal-entities-in-presets-20260612-213333-9a4d1c0",
+    "@companion-module/host": "1.0.3-nightly-feat-internal-entities-in-presets-20260612-214837-b7419f7",
     "node-gyp": "^12.3.0",
     "monaco-editor/dompurify": "npm:dompurify@^3.3.3"
   },

--- a/package.json
+++ b/package.json
@@ -93,8 +93,8 @@
     "bare-fs": "npm:empty-npm-package@1.0.0",
     "bare-path": "npm:empty-npm-package@1.0.0",
     "@types/express-serve-static-core": "^5.1.0",
-    "@companion-module/base": "2.1.0-0-nightly-main-20260606-145024-187a8f4",
-    "@companion-module/host": "1.0.3-nightly-main-20260523-215208-95c00ff",
+    "@companion-module/base": "2.1.0-0-nightly-feat-internal-entities-in-presets-20260612-212853-9a4d1c0",
+    "@companion-module/host": "1.0.3-nightly-feat-internal-entities-in-presets-20260612-213333-9a4d1c0",
     "node-gyp": "^12.3.0",
     "monaco-editor/dompurify": "npm:dompurify@^3.3.3"
   },

--- a/shared-lib/lib/ModuleApiVersionCheck.ts
+++ b/shared-lib/lib/ModuleApiVersionCheck.ts
@@ -5,7 +5,7 @@ import { assertNever } from './Util.js'
 export const MODULE_BASE_VERSIONS = [
 	'1.14.0',
 	'2.0.0',
-	'2.1.0-0-nightly-main-20260606-145024-187a8f4', // DEV version
+	'2.1.0-0-nightly-feat-internal-entities-in-presets-20260612-212853-9a4d1c0', // DEV version
 ]
 export const SURFACE_BASE_VERSION = '1.2.0'
 

--- a/shared-lib/lib/ModuleApiVersionCheck.ts
+++ b/shared-lib/lib/ModuleApiVersionCheck.ts
@@ -5,7 +5,7 @@ import { assertNever } from './Util.js'
 export const MODULE_BASE_VERSIONS = [
 	'1.14.0',
 	'2.0.0',
-	'2.1.0-0-nightly-feat-internal-entities-in-presets-20260612-212853-9a4d1c0', // DEV version
+	'2.1.0-0-nightly-main-20260612-220203-a5e55f1', // DEV version
 ]
 export const SURFACE_BASE_VERSION = '1.2.0'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1911,19 +1911,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@companion-module/base@npm:2.1.0-0-nightly-feat-internal-entities-in-presets-20260612-212853-9a4d1c0":
-  version: 2.1.0-0-nightly-feat-internal-entities-in-presets-20260612-212853-9a4d1c0
-  resolution: "@companion-module/base@npm:2.1.0-0-nightly-feat-internal-entities-in-presets-20260612-212853-9a4d1c0"
+"@companion-module/base@npm:2.1.0-0-nightly-main-20260612-220203-a5e55f1":
+  version: 2.1.0-0-nightly-main-20260612-220203-a5e55f1
+  resolution: "@companion-module/base@npm:2.1.0-0-nightly-main-20260612-220203-a5e55f1"
   dependencies:
     colord: "npm:^2.9.3"
     tslib: "npm:^2.8.1"
-  checksum: 10c0/200049a2de4b6e7b2fb286d91fefba843fc0c1254b479fb999c7e5f44062d005b4631ce0f6e0eafe3b1ab2abfdb34c18f0d2c277a98a748f34502779c99dae1e
+  checksum: 10c0/e37321fec7047c776119bbe8a4d37d1b650c38f1783565fe32d80e86f2a888be0fafe38c5c175ea72b7edd32e1e1a53b7faedd297d413a995e609966caacadf8
   languageName: node
   linkType: hard
 
-"@companion-module/host@npm:1.0.3-nightly-feat-internal-entities-in-presets-20260612-214837-b7419f7":
-  version: 1.0.3-nightly-feat-internal-entities-in-presets-20260612-214837-b7419f7
-  resolution: "@companion-module/host@npm:1.0.3-nightly-feat-internal-entities-in-presets-20260612-214837-b7419f7"
+"@companion-module/host@npm:1.0.3-nightly-main-20260612-220344-a5e55f1":
+  version: 1.0.3-nightly-main-20260612-220344-a5e55f1
+  resolution: "@companion-module/host@npm:1.0.3-nightly-main-20260612-220344-a5e55f1"
   dependencies:
     "@companion-module/base": "npm:~2.1.0-0"
     debounce-fn: "npm:^6.0.0"
@@ -1931,7 +1931,7 @@ __metadata:
     semver: "npm:^7.7.4"
     tslib: "npm:^2.8.1"
     zod: "npm:^4.3.6"
-  checksum: 10c0/0a888d7af6a3f983620a2f301d943e46b0d8093f154b5fc67ec75b00f7f43db021b1cb947c0fac7027803cb889a93b7984a9081e953ad9695fbb23f19837cc10
+  checksum: 10c0/ac6abc958f9f704e5ff37f4b9cce3220d96d64537d36d22301a16c827651c1409d639c53cebe3917cf01f88fa6c8cdaa10e5dff1a4c1f4d34e4d9082635a1100
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1921,9 +1921,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@companion-module/host@npm:1.0.3-nightly-feat-internal-entities-in-presets-20260612-213333-9a4d1c0":
-  version: 1.0.3-nightly-feat-internal-entities-in-presets-20260612-213333-9a4d1c0
-  resolution: "@companion-module/host@npm:1.0.3-nightly-feat-internal-entities-in-presets-20260612-213333-9a4d1c0"
+"@companion-module/host@npm:1.0.3-nightly-feat-internal-entities-in-presets-20260612-214837-b7419f7":
+  version: 1.0.3-nightly-feat-internal-entities-in-presets-20260612-214837-b7419f7
+  resolution: "@companion-module/host@npm:1.0.3-nightly-feat-internal-entities-in-presets-20260612-214837-b7419f7"
   dependencies:
     "@companion-module/base": "npm:~2.1.0-0"
     debounce-fn: "npm:^6.0.0"
@@ -1931,7 +1931,7 @@ __metadata:
     semver: "npm:^7.7.4"
     tslib: "npm:^2.8.1"
     zod: "npm:^4.3.6"
-  checksum: 10c0/99ccfe94771fd40e162fcc13d4287e867c551bb370dfc014a3f60b127e31103e8c52503c399f9b2dadaafa4fbf96648408ba757d9777699609abbe56cda3b121
+  checksum: 10c0/0a888d7af6a3f983620a2f301d943e46b0d8093f154b5fc67ec75b00f7f43db021b1cb947c0fac7027803cb889a93b7984a9081e953ad9695fbb23f19837cc10
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1911,19 +1911,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@companion-module/base@npm:2.1.0-0-nightly-main-20260606-145024-187a8f4":
-  version: 2.1.0-0-nightly-main-20260606-145024-187a8f4
-  resolution: "@companion-module/base@npm:2.1.0-0-nightly-main-20260606-145024-187a8f4"
+"@companion-module/base@npm:2.1.0-0-nightly-feat-internal-entities-in-presets-20260612-212853-9a4d1c0":
+  version: 2.1.0-0-nightly-feat-internal-entities-in-presets-20260612-212853-9a4d1c0
+  resolution: "@companion-module/base@npm:2.1.0-0-nightly-feat-internal-entities-in-presets-20260612-212853-9a4d1c0"
   dependencies:
     colord: "npm:^2.9.3"
     tslib: "npm:^2.8.1"
-  checksum: 10c0/e1d83cc003aa6a848ebdd55699be5607ad1f2529c291574a5e8de6fbe03c36f55a5f05b5e8d0ecbe75f853b761ebba8749f753b883c37c127c8ac574d5ca93b4
+  checksum: 10c0/200049a2de4b6e7b2fb286d91fefba843fc0c1254b479fb999c7e5f44062d005b4631ce0f6e0eafe3b1ab2abfdb34c18f0d2c277a98a748f34502779c99dae1e
   languageName: node
   linkType: hard
 
-"@companion-module/host@npm:1.0.3-nightly-main-20260523-215208-95c00ff":
-  version: 1.0.3-nightly-main-20260523-215208-95c00ff
-  resolution: "@companion-module/host@npm:1.0.3-nightly-main-20260523-215208-95c00ff"
+"@companion-module/host@npm:1.0.3-nightly-feat-internal-entities-in-presets-20260612-213333-9a4d1c0":
+  version: 1.0.3-nightly-feat-internal-entities-in-presets-20260612-213333-9a4d1c0
+  resolution: "@companion-module/host@npm:1.0.3-nightly-feat-internal-entities-in-presets-20260612-213333-9a4d1c0"
   dependencies:
     "@companion-module/base": "npm:~2.1.0-0"
     debounce-fn: "npm:^6.0.0"
@@ -1931,7 +1931,7 @@ __metadata:
     semver: "npm:^7.7.4"
     tslib: "npm:^2.8.1"
     zod: "npm:^4.3.6"
-  checksum: 10c0/6f7caedd78aa45472155f4af70b5535bc30f36368e4e0b3497f85dd2935e292febb7cc9a1613bdd98c07b32c145079a9c42530f41ef69ac940d99d75057abed3
+  checksum: 10c0/99ccfe94771fd40e162fcc13d4287e867c551bb370dfc014a3f60b127e31103e8c52503c399f9b2dadaafa4fbf96648408ba757d9777699609abbe56cda3b121
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #2166 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preset conversion now uses a unified conversion context, adding support for internal preset entries and richer layered feedback style handling.
  * Improved action delay handling and grouping; building-block preset nesting is limited with warnings when exceeded.

* **Tests**
  * Added comprehensive tests for internal preset conversions, delay expansion, nesting limits, and style override behaviors.

* **Chores**
  * Updated dev dependency build identifiers and the module API compatibility list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->