### PR TITLE
feat: linux desktop udev sync

### DIFF
--- a/assets/linux/README
+++ b/assets/linux/README
@@ -67,5 +67,11 @@ Below are the setup steps for each. Section 4 (dependencies) and section 5 (udev
    You need to repeat this whenever the generated file changes (i.e. after enabling or disabling a surface module).
 
    Automating this:
-   - Desktop: Not yet supported
+   - Desktop: Companion shows a prompt in its interface when the installed rules are out of date, and can apply them for you (it will ask for your password).
    - Headless: set the environment variable COMPANION_SYNC_UDEV_RULES_COMMAND to a command that installs and reloads the rules, and Companion will run it automatically whenever the rules change. The install script in section 1 configures this for you.
+
+6. Launching
+
+   To run companion, either run companion-launcher to get the desktop build, or run the ./companion_headless.sh script to start it headless.
+
+   If when launching it gives an error "Using GTK 2/3 and GTK 4 in the same process is not supported", you can resolve this by appending the argument: --gtk-version=3

--- a/assets/linux/README
+++ b/assets/linux/README
@@ -29,7 +29,7 @@ Below are the setup steps for each. Section 4 (dependencies) and section 5 (udev
 
    If you'd rather not install, you can extract the download and run `companion-launcher` directly from wherever you unpacked it.
 
-   Before USB surfaces (Stream Decks, Loupedecks, X-keys, etc.) will work, you need the udev rules from section 5 installed. You currently need to perform this manually, they get generated for you into your config folder $HOME/.config/companion-nodejs/udev-rules/
+   Before USB surfaces (Stream Decks, Loupedecks, X-keys, etc.) will work, you need the udev rules from section 5 installed. Companion detects when this is needed and shows a prompt in its interface; on a desktop it can apply the rules for you with a single click.
 
    If launching fails with "Using GTK 2/3 and GTK 4 in the same process is not supported", append the argument: --gtk-version=3
 

--- a/companion/lib/Instance/Controller.ts
+++ b/companion/lib/Instance/Controller.ts
@@ -9,14 +9,9 @@
  * this program.
  */
 
-import { exec } from 'node:child_process'
 import { EventEmitter } from 'node:events'
-import path from 'node:path'
-import { promisify } from 'node:util'
 import express from 'express'
-import fs from 'fs-extra'
-import pDebounce from 'p-debounce'
-import { UdevRuleGenerator } from 'udev-generator'
+import { type UdevRuleDefinition } from 'udev-generator'
 import z from 'zod'
 import { isLabelValid, makeLabelSafe } from '@companion-app/shared/Label.js'
 import type { ClientConnectionConfig, ClientConnectionsUpdate } from '@companion-app/shared/Model/Connections.js'
@@ -56,11 +51,7 @@ import { InstanceProcessManager } from './ProcessManager.js'
 import { InstanceStatus } from './Status.js'
 import { SurfaceInstanceCollections } from './Surface/Collections.js'
 import { createSurfacesTrpcRouter } from './Surface/TrpcRouter.js'
-
-const execAsync = promisify(exec)
-
-// This environment variable can be set to a command that will be run whenever udev rules are regenerated
-const SYNC_UDEV_RULES_COMMAND = process.env.COMPANION_SYNC_UDEV_RULES_COMMAND
+import { InstanceUdevRulesController } from './UdevRules.js'
 
 type CreateConnectionData = {
 	type: string
@@ -91,7 +82,7 @@ export class InstanceController extends EventEmitter<InstanceControllerEvents> {
 	readonly #surfacesController: SurfaceController
 	readonly #connectionCollectionsController: ConnectionsCollections
 	readonly #surfaceInstanceCollectionsController: SurfaceInstanceCollections
-	readonly #udevRulesDir: string
+	readonly #udevRules: InstanceUdevRulesController
 
 	readonly #configStore: InstanceConfigStore
 
@@ -131,7 +122,7 @@ export class InstanceController extends EventEmitter<InstanceControllerEvents> {
 		this.#variablesController = variables
 		this.#surfacesController = surfaces
 		this.#controlsStore = controlsStore
-		this.#udevRulesDir = appInfo.udevRulesDir
+		this.#udevRules = new InstanceUdevRulesController(appInfo.udevRulesDir, () => this.#collectSurfaceUsbIds())
 
 		this.#configStore = new InstanceConfigStore(db, (instanceIds, updateProcessManager) => {
 			// Ensure any changes to collectionId update the enabled state
@@ -231,7 +222,7 @@ export class InstanceController extends EventEmitter<InstanceControllerEvents> {
 		this.#broadcastConnectionChanges(this.#configStore.getAllInstanceIdsOfType(ModuleInstanceType.Connection))
 		this.#broadcastSurfaceInstanceChanges(this.#configStore.getAllInstanceIdsOfType(ModuleInstanceType.Surface))
 
-		this.#triggerRegenerateUdevRules()
+		this.#udevRules.triggerRegenerate()
 	}
 
 	getAllConnectionIds(): string[] {
@@ -722,7 +713,7 @@ export class InstanceController extends EventEmitter<InstanceControllerEvents> {
 		this.#logger.silly(`surface_instance_added: ${id}`)
 		this.emit('surface_instance_added', id)
 
-		this.#triggerRegenerateUdevRules()
+		this.#udevRules.triggerRegenerate()
 
 		return [id, config]
 	}
@@ -772,7 +763,7 @@ export class InstanceController extends EventEmitter<InstanceControllerEvents> {
 
 		this.status.forgetInstanceStatus(instanceId)
 		this.#configStore.forgetInstance(instanceId)
-		this.#triggerRegenerateUdevRules()
+		this.#udevRules.triggerRegenerate()
 
 		this.emit('surface_instance_deleted', instanceId)
 
@@ -944,7 +935,7 @@ export class InstanceController extends EventEmitter<InstanceControllerEvents> {
 		if (config.enabled) {
 			this.#queueUpdateInstanceState(instanceId, false, true)
 		} else if (config.moduleInstanceType === ModuleInstanceType.Surface) {
-			this.#triggerRegenerateUdevRules()
+			this.#udevRules.triggerRegenerate()
 		}
 
 		return true
@@ -1092,7 +1083,7 @@ export class InstanceController extends EventEmitter<InstanceControllerEvents> {
 			}
 		} else if (config.moduleInstanceType === ModuleInstanceType.Surface) {
 			// Ensure the udev rules are up to date
-			this.#triggerRegenerateUdevRules()
+			this.#udevRules.triggerRegenerate()
 		}
 
 		if (changed || forceCommitChanges) {
@@ -1158,6 +1149,8 @@ export class InstanceController extends EventEmitter<InstanceControllerEvents> {
 						yield { time, source, level, message }
 					}
 				}),
+
+			udevRules: this.#udevRules.createTrpcRouter(),
 		})
 	}
 
@@ -1179,81 +1172,24 @@ export class InstanceController extends EventEmitter<InstanceControllerEvents> {
 		return result
 	}
 
-	#triggerRegenerateUdevRules = (): void => {
-		if (process.platform !== 'linux') return
-		this.#regenerateUdevRules().catch((e) => {
-			this.#logger.warn(`Error regenerating udev rules: `, e)
-		})
-	}
+	/** Gather the USB ids of all enabled surface modules, used to generate the udev rules */
+	#collectSurfaceUsbIds(): UdevRuleDefinition[] {
+		const usbIds: UdevRuleDefinition[] = []
 
-	#regenerateUdevRules = pDebounce(
-		async () => {
-			if (process.platform !== 'linux') return
+		for (const config of this.#configStore.getAllInstanceConfigs().values()) {
+			if (config.moduleInstanceType !== ModuleInstanceType.Surface) continue
 
-			this.#logger.info('Regenerating udev rules for surface modules')
+			// Find the manifest of the module
+			const manifest = this.modules.getModuleManifest(
+				ModuleInstanceType.Surface,
+				config.moduleId,
+				config.moduleVersionId
+			)
+			if (!manifest || manifest.manifest.type !== 'surface') continue
 
-			const generator = new UdevRuleGenerator()
-
-			for (const config of this.#configStore.getAllInstanceConfigs().values()) {
-				if (config.moduleInstanceType !== ModuleInstanceType.Surface) continue
-
-				// Find the manifest of the module
-				const manifest = this.modules.getModuleManifest(
-					ModuleInstanceType.Surface,
-					config.moduleId,
-					config.moduleVersionId
-				)
-				if (!manifest || manifest.manifest.type !== 'surface') continue
-
-				// Add the rules
-				generator.addRules(manifest.manifest.usbIds || [])
-			}
-
-			const desktopFile = generator.generateFile({ mode: 'desktop' })
-			const headlessFile = generator.generateFile({ mode: 'headless', userGroup: 'companion' })
-
-			await fs.mkdirp(this.#udevRulesDir)
-
-			// Read existing files to check for changes
-			const headlessPath = path.join(this.#udevRulesDir, '50-companion-headless.rules')
-			const desktopPath = path.join(this.#udevRulesDir, '50-companion-desktop.rules')
-
-			const [existingHeadless, existingDesktop] = await Promise.all([
-				fs.readFile(headlessPath, 'utf8').catch(() => ''),
-				fs.readFile(desktopPath, 'utf8').catch(() => ''),
-			])
-
-			// Only write files if they have changed
-			let hasChanges = false
-			if (existingHeadless !== headlessFile) {
-				await fs.writeFile(headlessPath, headlessFile, 'utf8')
-				hasChanges = true
-			}
-			if (existingDesktop !== desktopFile) {
-				await fs.writeFile(desktopPath, desktopFile, 'utf8')
-				hasChanges = true
-			}
-
-			if (hasChanges) {
-				this.#logger.debug('Udev rules for surface modules regenerated')
-
-				// If setup, run the sync command to apply the new rules
-				if (SYNC_UDEV_RULES_COMMAND) {
-					try {
-						this.#logger.info(`Running udev sync command: ${SYNC_UDEV_RULES_COMMAND}`)
-						await execAsync(SYNC_UDEV_RULES_COMMAND)
-						this.#logger.info('Udev rules synced successfully')
-					} catch (e) {
-						this.#logger.error(`Failed to sync udev rules: ${stringifyError(e)}`)
-					}
-				}
-			} else {
-				this.#logger.debug('Udev rules unchanged, skipping regeneration')
-			}
-		},
-		50,
-		{
-			before: false,
+			if (manifest.manifest.usbIds) usbIds.push(...manifest.manifest.usbIds)
 		}
-	)
+
+		return usbIds
+	}
 }

--- a/companion/lib/Instance/Controller.ts
+++ b/companion/lib/Instance/Controller.ts
@@ -11,7 +11,7 @@
 
 import { EventEmitter } from 'node:events'
 import express from 'express'
-import { type UdevRuleDefinition } from 'udev-generator'
+import type { UdevRuleDefinition } from 'udev-generator'
 import z from 'zod'
 import { isLabelValid, makeLabelSafe } from '@companion-app/shared/Label.js'
 import type { ClientConnectionConfig, ClientConnectionsUpdate } from '@companion-app/shared/Model/Connections.js'

--- a/companion/lib/Instance/UdevRules.ts
+++ b/companion/lib/Instance/UdevRules.ts
@@ -1,0 +1,285 @@
+import { exec } from 'node:child_process'
+import { EventEmitter } from 'node:events'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import fs from 'fs-extra'
+import pDebounce from 'p-debounce'
+import { UdevRuleGenerator, type UdevRuleDefinition } from 'udev-generator'
+import type { UdevRulesStatus } from '@companion-app/shared/Model/Common.js'
+import { stringifyError } from '@companion-app/shared/Stringify.js'
+import LogController from '../Log/Controller.js'
+import { publicProcedure, router, toIterable } from '../UI/TRPC.js'
+
+const defaultExecAsync = promisify(exec)
+
+const UDEV_RULES_FILENAME_DESKTOP = '50-companion-desktop.rules'
+const UDEV_RULES_FILENAME_HEADLESS = '50-companion-headless.rules'
+const DEFAULT_SYSTEM_UDEV_RULES_DIR = '/etc/udev/rules.d'
+
+/** A subset of `promisify(child_process.exec)`, injectable for testing */
+export type ExecAsyncFn = (command: string) => Promise<{ stdout: string; stderr: string }>
+
+export interface InstanceUdevRulesControllerOptions {
+	/**
+	 * Whether this is the desktop (electron) build, which can apply rules itself via pkexec.
+	 * Defaults to the `COMPANION_IPC_PARENT` env var being set (the electron launcher sets it).
+	 */
+	isDesktopBuild?: boolean
+	/**
+	 * A command to run to apply the rules automatically whenever they change (used by the headless tooling).
+	 * Defaults to the `COMPANION_SYNC_UDEV_RULES_COMMAND` env var.
+	 */
+	syncCommand?: string | undefined
+	/** The current platform. Defaults to `process.platform`. */
+	platform?: NodeJS.Platform
+	/** The directory the rules must be installed to. Defaults to `/etc/udev/rules.d`. */
+	systemRulesDir?: string
+	/** Runs a shell command. Injectable for testing. */
+	execAsync?: ExecAsyncFn
+}
+
+interface InstanceUdevRulesEvents {
+	status: [status: UdevRulesStatus]
+}
+
+/** Wrap a string in single quotes for safe use in a `sh -c` command */
+function singleQuote(str: string): string {
+	return `'${str.replace(/'/g, `'\\''`)}'`
+}
+
+/**
+ * Manages the Linux udev rules that grant access to USB surfaces.
+ *
+ * Since 4.3 surfaces are modules, so the required USB ids change as modules are enabled/disabled and
+ * we cannot ship a static rules file. This regenerates the rules on the fly, tracks whether the installed
+ * copy is out of date, and (on the desktop build) can apply them via pkexec.
+ */
+export class InstanceUdevRulesController extends EventEmitter<InstanceUdevRulesEvents> {
+	readonly #logger = LogController.createLogger('Instance/UdevRules')
+
+	readonly #udevRulesDir: string
+	/** Gathers the USB ids of all enabled surface modules, used to generate the rules */
+	readonly #collectSurfaceUsbIds: () => UdevRuleDefinition[]
+
+	readonly #isDesktopBuild: boolean
+	readonly #syncCommand: string | undefined
+	readonly #platform: NodeJS.Platform
+	readonly #systemRulesDir: string
+	readonly #execAsync: ExecAsyncFn
+
+	#lastStatus: UdevRulesStatus | null = null
+	#pkexecAvailablePromise: Promise<boolean> | null = null
+
+	constructor(
+		udevRulesDir: string,
+		collectSurfaceUsbIds: () => UdevRuleDefinition[],
+		options: InstanceUdevRulesControllerOptions = {}
+	) {
+		super()
+		this.setMaxListeners(0)
+
+		this.#udevRulesDir = udevRulesDir
+		this.#collectSurfaceUsbIds = collectSurfaceUsbIds
+
+		this.#isDesktopBuild = options.isDesktopBuild ?? !!process.env.COMPANION_IPC_PARENT
+		this.#syncCommand = options.syncCommand ?? process.env.COMPANION_SYNC_UDEV_RULES_COMMAND
+		this.#platform = options.platform ?? process.platform
+		this.#systemRulesDir = options.systemRulesDir ?? DEFAULT_SYSTEM_UDEV_RULES_DIR
+		this.#execAsync = options.execAsync ?? defaultExecAsync
+	}
+
+	/** Trigger a (debounced) regeneration of the udev rules. Safe to call on any platform. */
+	triggerRegenerate = (): void => {
+		if (this.#platform !== 'linux') return
+		this.#regenerate().catch((e) => {
+			this.#logger.warn(`Error regenerating udev rules: `, e)
+		})
+	}
+
+	#regenerate = pDebounce(
+		async () => {
+			if (this.#platform !== 'linux') return
+
+			this.#logger.info('Regenerating udev rules for surface modules')
+
+			const generator = new UdevRuleGenerator()
+			generator.addRules(this.#collectSurfaceUsbIds())
+
+			const desktopFile = generator.generateFile({ mode: 'desktop' })
+			const headlessFile = generator.generateFile({ mode: 'headless', userGroup: 'companion' })
+
+			await fs.mkdirp(this.#udevRulesDir)
+
+			// Read existing files to check for changes
+			const headlessPath = path.join(this.#udevRulesDir, UDEV_RULES_FILENAME_HEADLESS)
+			const desktopPath = path.join(this.#udevRulesDir, UDEV_RULES_FILENAME_DESKTOP)
+
+			const [existingHeadless, existingDesktop] = await Promise.all([
+				fs.readFile(headlessPath, 'utf8').catch(() => ''),
+				fs.readFile(desktopPath, 'utf8').catch(() => ''),
+			])
+
+			// Only write files if they have changed
+			let hasChanges = false
+			if (existingHeadless !== headlessFile) {
+				await fs.writeFile(headlessPath, headlessFile, 'utf8')
+				hasChanges = true
+			}
+			if (existingDesktop !== desktopFile) {
+				await fs.writeFile(desktopPath, desktopFile, 'utf8')
+				hasChanges = true
+			}
+
+			if (hasChanges) {
+				this.#logger.debug('Udev rules for surface modules regenerated')
+
+				// If setup, run the sync command to apply the new rules
+				if (this.#syncCommand) {
+					try {
+						this.#logger.info(`Running udev sync command: ${this.#syncCommand}`)
+						await this.#execAsync(this.#syncCommand)
+						this.#logger.info('Udev rules synced successfully')
+					} catch (e) {
+						this.#logger.error(`Failed to sync udev rules: ${stringifyError(e)}`)
+					}
+				}
+			} else {
+				this.#logger.debug('Udev rules unchanged, skipping regeneration')
+			}
+
+			// Recompute whether the rules need applying, so the UI can prompt if needed
+			await this.#refreshStatus()
+		},
+		50,
+		{
+			before: false,
+		}
+	)
+
+	/**
+	 * Compute the current status of the udev rules for the active build (desktop or headless).
+	 * Compares the generated rules file against the copy installed in the system rules directory.
+	 */
+	async #computeStatus(): Promise<UdevRulesStatus> {
+		const mode = this.#isDesktopBuild ? 'desktop' : 'headless'
+		const filename = this.#isDesktopBuild ? UDEV_RULES_FILENAME_DESKTOP : UDEV_RULES_FILENAME_HEADLESS
+		const generatedPath = path.join(this.#udevRulesDir, filename)
+		const installedPath = path.join(this.#systemRulesDir, filename)
+		const applyCommand = `sudo cp ${singleQuote(generatedPath)} ${singleQuote(installedPath)} && sudo udevadm control --reload-rules && sudo udevadm trigger`
+
+		// canAutoApply is overridden per-connection in the subscription
+		const base: UdevRulesStatus = {
+			supported: this.#platform === 'linux',
+			mode,
+			needsApply: false,
+			generatedPath,
+			installedPath,
+			applyCommand,
+			canAutoApply: false,
+		}
+
+		if (!base.supported) return base
+
+		const [generated, installed] = await Promise.all([
+			fs.readFile(generatedPath, 'utf8').catch(() => ''),
+			fs.readFile(installedPath, 'utf8').catch(() => ''),
+		])
+
+		// The generator always emits a header line; only device-specific (hidraw) rules require action
+		const hasDeviceRules = generated.includes('hidraw')
+		base.needsApply = hasDeviceRules && installed !== generated
+
+		return base
+	}
+
+	/** Recompute and broadcast the udev rules status */
+	#refreshStatus = async (): Promise<void> => {
+		try {
+			const status = await this.#computeStatus()
+			this.#lastStatus = status
+			this.emit('status', status)
+		} catch (e) {
+			this.#logger.warn(`Error computing udev rules status: `, e)
+		}
+	}
+
+	/** Get the current udev rules status, computing it if not yet cached */
+	async #getStatus(): Promise<UdevRulesStatus> {
+		if (!this.#lastStatus) {
+			this.#lastStatus = await this.#computeStatus()
+		}
+		return this.#lastStatus
+	}
+
+	/** Whether the `pkexec` command is available, used for one-click applying of udev rules */
+	async #isPkexecAvailable(): Promise<boolean> {
+		if (!this.#pkexecAvailablePromise) {
+			this.#pkexecAvailablePromise = this.#execAsync('command -v pkexec')
+				.then(() => true)
+				.catch(() => false)
+		}
+		return this.#pkexecAvailablePromise
+	}
+
+	/**
+	 * Whether Companion can apply the udev rules itself for this client.
+	 * Only on the desktop build, on linux, with pkexec available, and when the client is on the same machine
+	 * (the graphical pkexec prompt only appears on the host's own display).
+	 */
+	async #canAutoApply(isLocalClient: boolean): Promise<boolean> {
+		if (this.#platform !== 'linux' || !this.#isDesktopBuild || !isLocalClient) return false
+		return this.#isPkexecAvailable()
+	}
+
+	/** Apply the generated udev rules using pkexec. Caller must verify the client is permitted. */
+	async #applyRules(): Promise<void> {
+		const status = await this.#getStatus()
+
+		const inner = `cp ${singleQuote(status.generatedPath)} ${singleQuote(status.installedPath)} && udevadm control --reload-rules && udevadm trigger`
+		const command = `pkexec sh -c ${singleQuote(inner)}`
+
+		this.#logger.info('Applying udev rules via pkexec')
+		await this.#execAsync(command)
+		this.#logger.info('Udev rules applied successfully')
+
+		await this.#refreshStatus()
+	}
+
+	createTrpcRouter() {
+		const self = this
+		const selfEvents: EventEmitter<InstanceUdevRulesEvents> = this
+
+		return router({
+			status: publicProcedure.subscription(async function* ({ signal, ctx }) {
+				// canAutoApply depends on the connecting client, so decorate the shared status per-connection
+				const decorate = async (status: UdevRulesStatus): Promise<UdevRulesStatus> => ({
+					...status,
+					canAutoApply: await self.#canAutoApply(ctx.isLocalClient()),
+				})
+
+				yield await decorate(await self.#getStatus())
+
+				const changes = toIterable(selfEvents, 'status', signal)
+				for await (const [status] of changes) {
+					yield await decorate(status)
+				}
+			}),
+
+			recheck: publicProcedure.mutation(async () => {
+				await self.#refreshStatus()
+			}),
+
+			applyRules: publicProcedure.mutation(async ({ ctx }) => {
+				if (!(await self.#canAutoApply(ctx.isLocalClient()))) {
+					throw new Error('USB permissions can only be applied automatically from the machine running Companion')
+				}
+
+				try {
+					await self.#applyRules()
+				} catch (e) {
+					throw new Error(`Failed to apply USB permissions: ${stringifyError(e)}`)
+				}
+			}),
+		})
+	}
+}

--- a/companion/lib/UI/TRPC.ts
+++ b/companion/lib/UI/TRPC.ts
@@ -1,4 +1,5 @@
 import { on, type EventEmitter } from 'node:events'
+import os from 'node:os'
 import { trpcMiddleware as sentryTrpcMiddleware } from '@sentry/node'
 import { initTRPC, TRPCError, type inferRouterInputs, type inferRouterOutputs } from '@trpc/server'
 import type * as trpcExpress from '@trpc/server/adapters/express'
@@ -13,6 +14,13 @@ export interface TrpcContext {
 	clientId: string
 	clientIp: string | undefined
 
+	/**
+	 * Whether this client is connecting from the same machine as Companion.
+	 * Lazily evaluated and cached for the lifetime of the context.
+	 * Note: This is not guaranteed to be 100% accurate at all times.
+	 */
+	isLocalClient: () => boolean
+
 	pendingImport?: {
 		object: ExportFullv6 | ExportPageModelv6
 		timeout: null
@@ -22,11 +30,47 @@ export interface TrpcContext {
 export const createTrpcExpressContext = ({ req, res: _res }: trpcExpress.CreateExpressContextOptions): TrpcContext => ({
 	clientId: nanoid(),
 	clientIp: req.ip,
+	isLocalClient: makeIsLocalClient(req.ip),
 }) // no context
 export const createTrpcWsContext = ({ req, res: _res }: trpcWs.CreateWSSContextFnOptions): TrpcContext => ({
 	clientId: nanoid(),
 	clientIp: req.socket.remoteAddress,
+	isLocalClient: makeIsLocalClient(req.socket.remoteAddress),
 }) // no context
+
+/**
+ * Build a lazily-cached predicate for whether `clientIp` is on the same machine as Companion.
+ * Returns true for loopback addresses and for any address belonging to one of this machine's own
+ * network interfaces (so opening the UI on the host's LAN address still counts as local).
+ */
+function makeIsLocalClient(clientIp: string | undefined): () => boolean {
+	let cached: boolean | undefined
+	return () => {
+		if (cached === undefined) cached = computeIsLocalClient(clientIp)
+		return cached
+	}
+}
+export function computeIsLocalClient(clientIp: string | undefined): boolean {
+	if (!clientIp) return false
+
+	try {
+		const normalize = (ip: string) => ip.replace(/^::ffff:/, '').replace(/%.*$/, '')
+		const normalized = normalize(clientIp)
+		if (normalized === '127.0.0.1' || normalized === '::1') return true
+
+		const interfaces = os.networkInterfaces()
+		for (const addresses of Object.values(interfaces)) {
+			if (!addresses) continue
+			for (const addr of addresses) {
+				if (normalize(addr.address) === normalized) return true
+			}
+		}
+		return false
+	} catch {
+		// If we fail to get the network interfaces for some reason, assume it's not local.
+		return false
+	}
+}
 
 /**
  * Initialization of tRPC backend

--- a/companion/test/Instance/Definitions.test.ts
+++ b/companion/test/Instance/Definitions.test.ts
@@ -22,6 +22,7 @@ import type { InstanceConfigStore } from '../../lib/Instance/ConfigStore.js'
 import { InstanceDefinitions } from '../../lib/Instance/Definitions.js'
 import { EventDefinitions } from '../../lib/Resources/EventDefinitions.js'
 import type { TrpcContext } from '../../lib/UI/TRPC.js'
+import { createMockTrpcContext } from '../Util.js'
 import { SubscriptionTester } from '../utils/SubscriptionTester.js'
 
 // Deterministic nanoid
@@ -1096,7 +1097,7 @@ describe('InstanceDefinitions', () => {
 
 	describe('createTrpcRouter', () => {
 		const t = initTRPC.context<TrpcContext>().create()
-		const testCtx: TrpcContext = { clientId: 'test-client', clientIp: '127.0.0.1' }
+		const testCtx: TrpcContext = createMockTrpcContext()
 
 		function createCaller(defs: InstanceDefinitions) {
 			const trpcRouter = defs.createTrpcRouter()
@@ -1366,7 +1367,7 @@ describe('InstanceDefinitions', () => {
 
 	describe('no-op and diff event emission', () => {
 		const t = initTRPC.context<TrpcContext>().create()
-		const testCtx: TrpcContext = { clientId: 'test-client', clientIp: '127.0.0.1' }
+		const testCtx: TrpcContext = createMockTrpcContext()
 
 		it('setActionDefinitions with identical data does not emit an update', async () => {
 			const { defs } = createInstanceDefinitions()
@@ -1474,7 +1475,7 @@ describe('InstanceDefinitions', () => {
 
 	describe('simplifyPresetsForUi (via TRPC)', () => {
 		const t = initTRPC.context<TrpcContext>().create()
-		const testCtx: TrpcContext = { clientId: 'test-client', clientIp: '127.0.0.1' }
+		const testCtx: TrpcContext = createMockTrpcContext()
 
 		it('assigns sequential order values to presets', async () => {
 			const { defs } = createInstanceDefinitions()
@@ -1506,7 +1507,7 @@ describe('InstanceDefinitions', () => {
 
 	describe('forgetConnection events via TRPC', () => {
 		const t = initTRPC.context<TrpcContext>().create()
-		const testCtx: TrpcContext = { clientId: 'test-client', clientIp: '127.0.0.1' }
+		const testCtx: TrpcContext = createMockTrpcContext()
 
 		it('emits forget-connection on feedbacks subscription', async () => {
 			const { defs } = createInstanceDefinitions()

--- a/companion/test/Instance/UdevRules.test.ts
+++ b/companion/test/Instance/UdevRules.test.ts
@@ -1,0 +1,228 @@
+import os from 'node:os'
+import path from 'node:path'
+import { initTRPC } from '@trpc/server'
+import fs from 'fs-extra'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { UdevRuleDefinition } from 'udev-generator'
+import {
+	InstanceUdevRulesController,
+	type ExecAsyncFn,
+	type InstanceUdevRulesControllerOptions,
+} from '../../lib/Instance/UdevRules.js'
+import type { TrpcContext } from '../../lib/UI/TRPC.js'
+import { createMockTrpcContext, SuppressLogging } from '../Util.js'
+import { SubscriptionTester } from '../utils/SubscriptionTester.js'
+
+const HEADLESS_FILENAME = '50-companion-headless.rules'
+const DESKTOP_FILENAME = '50-companion-desktop.rules'
+const SAMPLE_RULES = 'KERNEL=="hidraw*", ATTRS{idVendor}=="1234", ATTRS{idProduct}=="5678", MODE:="660"\n'
+
+const t = initTRPC.context<TrpcContext>().create()
+
+const tempDirs: string[] = []
+afterEach(async () => {
+	vi.restoreAllMocks()
+	await Promise.all(tempDirs.splice(0).map((dir) => fs.remove(dir).catch(() => null)))
+})
+
+async function setup(
+	options: Partial<InstanceUdevRulesControllerOptions> & { usbIds?: UdevRuleDefinition[] } = {}
+) {
+	const { usbIds, ...controllerOptions } = options
+
+	const generatedDir = await fs.mkdtemp(path.join(os.tmpdir(), 'companion-udev-gen-'))
+	const systemDir = await fs.mkdtemp(path.join(os.tmpdir(), 'companion-udev-sys-'))
+	tempDirs.push(generatedDir, systemDir)
+
+	const execAsync = vi.fn<ExecAsyncFn>().mockResolvedValue({ stdout: '', stderr: '' })
+
+	const controller = new InstanceUdevRulesController(
+		generatedDir,
+		() => usbIds ?? [{ vendorId: 0x1234, productIds: [0x5678] }],
+		{
+			platform: 'linux',
+			isDesktopBuild: false,
+			systemRulesDir: systemDir,
+			execAsync,
+			...controllerOptions,
+		}
+	)
+
+	return { controller, generatedDir, systemDir, execAsync }
+}
+
+/** Read the first status value yielded by the `status` subscription */
+async function readStatus(controller: InstanceUdevRulesController, ctx: TrpcContext = createMockTrpcContext()) {
+	const caller = t.createCallerFactory(controller.createTrpcRouter())(ctx)
+	const sub = new SubscriptionTester(await caller.status())
+	try {
+		return await sub.next()
+	} finally {
+		await sub.cleanup()
+	}
+}
+
+describe('InstanceUdevRulesController', () => {
+	SuppressLogging()
+
+	describe('status', () => {
+		it('reports needsApply when the installed rules are missing', async () => {
+			const { controller, generatedDir } = await setup()
+			await fs.writeFile(path.join(generatedDir, HEADLESS_FILENAME), SAMPLE_RULES)
+
+			const status = await readStatus(controller)
+
+			expect(status.supported).toBe(true)
+			expect(status.mode).toBe('headless')
+			expect(status.needsApply).toBe(true)
+			expect(status.generatedPath).toBe(path.join(generatedDir, HEADLESS_FILENAME))
+		})
+
+		it('reports needsApply when the installed rules differ', async () => {
+			const { controller, generatedDir, systemDir } = await setup()
+			await fs.writeFile(path.join(generatedDir, HEADLESS_FILENAME), SAMPLE_RULES)
+			await fs.writeFile(path.join(systemDir, HEADLESS_FILENAME), 'KERNEL=="hidraw*", something-stale\n')
+
+			const status = await readStatus(controller)
+			expect(status.needsApply).toBe(true)
+		})
+
+		it('does not need applying when the installed rules already match', async () => {
+			const { controller, generatedDir, systemDir } = await setup()
+			await fs.writeFile(path.join(generatedDir, HEADLESS_FILENAME), SAMPLE_RULES)
+			await fs.writeFile(path.join(systemDir, HEADLESS_FILENAME), SAMPLE_RULES)
+
+			const status = await readStatus(controller)
+			expect(status.needsApply).toBe(false)
+		})
+
+		it('does not need applying when there are no device rules', async () => {
+			const { controller, generatedDir } = await setup()
+			// A file with only the header line (no hidraw device rules)
+			await fs.writeFile(path.join(generatedDir, HEADLESS_FILENAME), 'SUBSYSTEM=="input", GROUP="input"\n')
+
+			const status = await readStatus(controller)
+			expect(status.needsApply).toBe(false)
+		})
+
+		it('uses the desktop file for the desktop build', async () => {
+			const { controller, generatedDir } = await setup({ isDesktopBuild: true })
+			await fs.writeFile(path.join(generatedDir, DESKTOP_FILENAME), SAMPLE_RULES)
+
+			const status = await readStatus(controller)
+			expect(status.mode).toBe('desktop')
+			expect(status.generatedPath).toBe(path.join(generatedDir, DESKTOP_FILENAME))
+			expect(status.needsApply).toBe(true)
+		})
+
+		it('is not supported on a non-linux platform', async () => {
+			const { controller, generatedDir } = await setup({ platform: 'darwin' })
+			await fs.writeFile(path.join(generatedDir, HEADLESS_FILENAME), SAMPLE_RULES)
+
+			const status = await readStatus(controller)
+			expect(status.supported).toBe(false)
+			expect(status.needsApply).toBe(false)
+		})
+	})
+
+	describe('canAutoApply', () => {
+		async function readCanAutoApply(
+			options: Partial<InstanceUdevRulesControllerOptions>,
+			ctx: TrpcContext
+		): Promise<boolean> {
+			const { controller, generatedDir } = await setup(options)
+			await fs.writeFile(path.join(generatedDir, options.isDesktopBuild ? DESKTOP_FILENAME : HEADLESS_FILENAME), SAMPLE_RULES)
+			const status = await readStatus(controller, ctx)
+			return status.canAutoApply
+		}
+
+		it('is true on the desktop build for a local client with pkexec available', async () => {
+			expect(await readCanAutoApply({ isDesktopBuild: true }, createMockTrpcContext({ isLocalClient: () => true }))).toBe(
+				true
+			)
+		})
+
+		it('is false for a remote client', async () => {
+			expect(
+				await readCanAutoApply({ isDesktopBuild: true }, createMockTrpcContext({ isLocalClient: () => false }))
+			).toBe(false)
+		})
+
+		it('is false on the headless build', async () => {
+			expect(
+				await readCanAutoApply({ isDesktopBuild: false }, createMockTrpcContext({ isLocalClient: () => true }))
+			).toBe(false)
+		})
+
+		it('is false when pkexec is not available', async () => {
+			const { controller, generatedDir } = await setup({
+				isDesktopBuild: true,
+				execAsync: vi.fn<ExecAsyncFn>().mockRejectedValue(new Error('not found')),
+			})
+			await fs.writeFile(path.join(generatedDir, DESKTOP_FILENAME), SAMPLE_RULES)
+
+			const status = await readStatus(controller, createMockTrpcContext({ isLocalClient: () => true }))
+			expect(status.canAutoApply).toBe(false)
+		})
+	})
+
+	describe('apply', () => {
+		it('runs pkexec to install and reload the rules for a permitted client', async () => {
+			const { controller, generatedDir, systemDir, execAsync } = await setup({ isDesktopBuild: true })
+			await fs.writeFile(path.join(generatedDir, DESKTOP_FILENAME), SAMPLE_RULES)
+
+			const caller = t.createCallerFactory(controller.createTrpcRouter())(
+				createMockTrpcContext({ isLocalClient: () => true })
+			)
+			await caller.applyRules()
+
+			const pkexecCall = execAsync.mock.calls.map((c) => c[0]).find((cmd) => cmd.includes('pkexec sh -c'))
+			expect(pkexecCall).toBeDefined()
+			expect(pkexecCall).toContain(path.join(generatedDir, DESKTOP_FILENAME))
+			expect(pkexecCall).toContain(path.join(systemDir, DESKTOP_FILENAME))
+			expect(pkexecCall).toContain('udevadm control --reload-rules')
+		})
+
+		it('rejects when the client is not on the same machine', async () => {
+			const { controller, execAsync } = await setup({ isDesktopBuild: true })
+
+			const caller = t.createCallerFactory(controller.createTrpcRouter())(
+				createMockTrpcContext({ isLocalClient: () => false })
+			)
+
+			await expect(caller.applyRules()).rejects.toThrow(/machine running Companion/)
+			expect(execAsync).not.toHaveBeenCalledWith(expect.stringContaining('pkexec'))
+		})
+	})
+
+	describe('triggerRegenerate', () => {
+		it('writes both rules files and runs the sync command when set', async () => {
+			const { controller, generatedDir, execAsync } = await setup({ syncCommand: 'my-sync-command' })
+
+			controller.triggerRegenerate()
+
+			await vi.waitFor(async () => {
+				expect(await fs.pathExists(path.join(generatedDir, HEADLESS_FILENAME))).toBe(true)
+				expect(await fs.pathExists(path.join(generatedDir, DESKTOP_FILENAME))).toBe(true)
+			})
+			await vi.waitFor(() => {
+				expect(execAsync).toHaveBeenCalledWith('my-sync-command')
+			})
+
+			// The generated headless file should contain the device rule for the collected usb id
+			const written = await fs.readFile(path.join(generatedDir, HEADLESS_FILENAME), 'utf8')
+			expect(written).toContain('hidraw')
+		})
+
+		it('does nothing on a non-linux platform', async () => {
+			const { controller, generatedDir, execAsync } = await setup({ platform: 'darwin', syncCommand: 'my-sync-command' })
+
+			controller.triggerRegenerate()
+			// Give any (incorrectly scheduled) async work a chance to run
+			await new Promise((resolve) => setTimeout(resolve, 80))
+
+			expect(await fs.pathExists(path.join(generatedDir, HEADLESS_FILENAME))).toBe(false)
+			expect(execAsync).not.toHaveBeenCalled()
+		})
+	})
+})

--- a/companion/test/Instance/UdevRules.test.ts
+++ b/companion/test/Instance/UdevRules.test.ts
@@ -2,8 +2,8 @@ import os from 'node:os'
 import path from 'node:path'
 import { initTRPC } from '@trpc/server'
 import fs from 'fs-extra'
-import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { UdevRuleDefinition } from 'udev-generator'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
 	InstanceUdevRulesController,
 	type ExecAsyncFn,
@@ -25,9 +25,7 @@ afterEach(async () => {
 	await Promise.all(tempDirs.splice(0).map((dir) => fs.remove(dir).catch(() => null)))
 })
 
-async function setup(
-	options: Partial<InstanceUdevRulesControllerOptions> & { usbIds?: UdevRuleDefinition[] } = {}
-) {
+async function setup(options: Partial<InstanceUdevRulesControllerOptions> & { usbIds?: UdevRuleDefinition[] } = {}) {
 	const { usbIds, ...controllerOptions } = options
 
 	const generatedDir = await fs.mkdtemp(path.join(os.tmpdir(), 'companion-udev-gen-'))
@@ -131,15 +129,18 @@ describe('InstanceUdevRulesController', () => {
 			ctx: TrpcContext
 		): Promise<boolean> {
 			const { controller, generatedDir } = await setup(options)
-			await fs.writeFile(path.join(generatedDir, options.isDesktopBuild ? DESKTOP_FILENAME : HEADLESS_FILENAME), SAMPLE_RULES)
+			await fs.writeFile(
+				path.join(generatedDir, options.isDesktopBuild ? DESKTOP_FILENAME : HEADLESS_FILENAME),
+				SAMPLE_RULES
+			)
 			const status = await readStatus(controller, ctx)
 			return status.canAutoApply
 		}
 
 		it('is true on the desktop build for a local client with pkexec available', async () => {
-			expect(await readCanAutoApply({ isDesktopBuild: true }, createMockTrpcContext({ isLocalClient: () => true }))).toBe(
-				true
-			)
+			expect(
+				await readCanAutoApply({ isDesktopBuild: true }, createMockTrpcContext({ isLocalClient: () => true }))
+			).toBe(true)
 		})
 
 		it('is false for a remote client', async () => {
@@ -215,7 +216,10 @@ describe('InstanceUdevRulesController', () => {
 		})
 
 		it('does nothing on a non-linux platform', async () => {
-			const { controller, generatedDir, execAsync } = await setup({ platform: 'darwin', syncCommand: 'my-sync-command' })
+			const { controller, generatedDir, execAsync } = await setup({
+				platform: 'darwin',
+				syncCommand: 'my-sync-command',
+			})
 
 			controller.triggerRegenerate()
 			// Give any (incorrectly scheduled) async work a chance to run

--- a/companion/test/Preview/ExpressionStream.test.ts
+++ b/companion/test/Preview/ExpressionStream.test.ts
@@ -8,12 +8,13 @@ import type { TrpcContext } from '../../lib/UI/TRPC.js'
 import type { LocalVariablesController } from '../../lib/Variables/LocalVariablesController.js'
 import type { VariableValueData } from '../../lib/Variables/Util.js'
 import { VariablesAndExpressionParser } from '../../lib/Variables/VariablesAndExpressionParser.js'
+import { createMockTrpcContext } from '../Util.js'
 import { SubscriptionTester } from '../utils/SubscriptionTester.js'
 
 // ── test infrastructure ──────────────────────────────────────────────────────
 
 const t = initTRPC.context<TrpcContext>().create()
-const testCtx: TrpcContext = { clientId: 'test-client', clientIp: '127.0.0.1' }
+const testCtx: TrpcContext = createMockTrpcContext()
 
 function createParser(
 	variables: VariableValueData = {},

--- a/companion/test/UI/TRPC.test.ts
+++ b/companion/test/UI/TRPC.test.ts
@@ -1,0 +1,58 @@
+import os from 'node:os'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { computeIsLocalClient } from '../../lib/UI/TRPC.js'
+
+describe('computeIsLocalClient', () => {
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	function mockInterfaces(addresses: string[]): void {
+		vi.spyOn(os, 'networkInterfaces').mockReturnValue({
+			eth0: addresses.map((address) => ({
+				address,
+				netmask: '255.255.255.0',
+				family: address.includes(':') ? 'IPv6' : 'IPv4',
+				mac: '00:00:00:00:00:00',
+				internal: false,
+				cidr: null,
+			})) as os.NetworkInterfaceInfo[],
+		})
+	}
+
+	it('returns false for an undefined address', () => {
+		expect(computeIsLocalClient(undefined)).toBe(false)
+	})
+
+	it.each(['127.0.0.1', '::1', '::ffff:127.0.0.1'])('treats loopback %s as local', (ip) => {
+		mockInterfaces([])
+		expect(computeIsLocalClient(ip)).toBe(true)
+	})
+
+	it('treats an address belonging to a local interface as local', () => {
+		mockInterfaces(['192.168.1.50'])
+		expect(computeIsLocalClient('192.168.1.50')).toBe(true)
+	})
+
+	it('matches the IPv4-mapped IPv6 form against a local interface', () => {
+		mockInterfaces(['192.168.1.50'])
+		expect(computeIsLocalClient('::ffff:192.168.1.50')).toBe(true)
+	})
+
+	it('strips an IPv6 zone id before comparing', () => {
+		mockInterfaces(['fe80::1'])
+		expect(computeIsLocalClient('fe80::1%eth0')).toBe(true)
+	})
+
+	it('returns false for a remote address', () => {
+		mockInterfaces(['192.168.1.50'])
+		expect(computeIsLocalClient('10.0.0.99')).toBe(false)
+	})
+
+	it('returns false when reading the network interfaces throws', () => {
+		vi.spyOn(os, 'networkInterfaces').mockImplementation(() => {
+			throw new Error('boom')
+		})
+		expect(computeIsLocalClient('192.168.1.50')).toBe(false)
+	})
+})

--- a/companion/test/Util.ts
+++ b/companion/test/Util.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll } from 'vitest'
 import LogController from '../lib/Log/Controller.js'
+import type { TrpcContext } from '../lib/UI/TRPC.js'
 
 export function SuppressLogging() {
 	let originalLogLevel: string = 'silly'
@@ -10,4 +11,14 @@ export function SuppressLogging() {
 	afterAll(() => {
 		LogController.setLogLevel(originalLogLevel)
 	})
+}
+
+/** Build a mock TrpcContext for tests, with sensible defaults that can be overridden. */
+export function createMockTrpcContext(overrides?: Partial<TrpcContext>): TrpcContext {
+	return {
+		clientId: 'test-client',
+		clientIp: '127.0.0.1',
+		isLocalClient: () => true,
+		...overrides,
+	}
 }

--- a/docs/user-guide/1_getting-started/Installation.md
+++ b/docs/user-guide/1_getting-started/Installation.md
@@ -56,7 +56,7 @@ The Linux download contains both a **desktop** build and a **headless** build. P
 
 Extract the download and run `companion-launcher`.
 
-To use Stream Decks and other USB surfaces, Linux needs some udev rules installed. You currently need to manually sync these when changing or update modules.
+To use Stream Decks and other USB surfaces, Linux needs some udev rules installed. Companion will prompt you inside its interface when this needs doing, and on a desktop it can apply them for you. See the `README` for details.
 
 If launching fails with _"Using GTK 2/3 and GTK 4 in the same process is not supported"_, add the argument `--gtk-version=3`.
 

--- a/shared-lib/lib/Model/Common.ts
+++ b/shared-lib/lib/Model/Common.ts
@@ -17,6 +17,27 @@ export interface AppUpdateInfo {
 	link: string | undefined
 }
 
+/**
+ * Status of the Linux udev rules that grant access to USB surfaces.
+ * On non-Linux platforms `supported` is false and nothing else is meaningful.
+ */
+export interface UdevRulesStatus {
+	/** Whether udev rules are relevant on this platform (linux only) */
+	supported: boolean
+	/** Which build/file is in use */
+	mode: 'desktop' | 'headless'
+	/** Whether the installed rules are out of date and need (re)applying */
+	needsApply: boolean
+	/** Absolute path to the generated rules file */
+	generatedPath: string
+	/** Absolute path the rules should be installed to */
+	installedPath: string
+	/** A shell command the user can run manually to apply the rules */
+	applyCommand: string
+	/** Whether Companion can apply the rules itself (desktop, pkexec available, local client) */
+	canAutoApply: boolean
+}
+
 export interface ControlLocation {
 	pageNumber: number
 	row: number

--- a/webui/src/Hooks/useUdevRulesStatus.ts
+++ b/webui/src/Hooks/useUdevRulesStatus.ts
@@ -1,0 +1,23 @@
+import { useSubscription } from '@trpc/tanstack-react-query'
+import { useState } from 'react'
+import type { UdevRulesStatus } from '@companion-app/shared/Model/Common.js'
+import { trpc } from '~/Resources/TRPC'
+
+/**
+ * Subscribe to the status of the Linux udev rules that grant access to USB surfaces.
+ * Returns null until the first value is received (and on non-Linux platforms `supported` will be false).
+ */
+export function useUdevRulesStatus(): UdevRulesStatus | null {
+	const [status, setStatus] = useState<UdevRulesStatus | null>(null)
+
+	useSubscription(
+		trpc.instances.udevRules.status.subscriptionOptions(undefined, {
+			onData: (data) => setStatus(data),
+			onError: (error) => {
+				console.error('Failed to subscribe to udev rules status:', error)
+			},
+		})
+	)
+
+	return status
+}

--- a/webui/src/Surfaces/MainSurfacesPage.tsx
+++ b/webui/src/Surfaces/MainSurfacesPage.tsx
@@ -16,6 +16,7 @@ import { trpc } from '~/Resources/TRPC'
 import { AddEmulatorModal, type AddEmulatorModalRef } from './AddEmulatorModal'
 import { AddSurfaceGroupModal, type AddSurfaceGroupModalRef } from './AddGroupModal'
 import { KnownSurfacesTable } from './KnownSurfacesTable'
+import { UdevRulesAlert } from './UdevRulesAlert'
 
 export const MainSurfacesPage = observer(function MainSurfacesPage(): React.JSX.Element {
 	const twoPanelMode = useTwoPanelMode()
@@ -120,6 +121,8 @@ export const MainSurfacesPage = observer(function MainSurfacesPage(): React.JSX.
 							{scanError}
 						</StaticAlert>
 					)}
+
+					<UdevRulesAlert />
 
 					<ButtonGroup>
 						<Button color="warning" size="sm" onClick={refreshUSB}>

--- a/webui/src/Surfaces/TabNotifyIcon.tsx
+++ b/webui/src/Surfaces/TabNotifyIcon.tsx
@@ -1,6 +1,7 @@
 import { observer } from 'mobx-react-lite'
 import { useContext } from 'react'
 import { ModuleInstanceType } from '@companion-app/shared/Model/Instance.js'
+import { useUdevRulesStatus } from '~/Hooks/useUdevRulesStatus'
 import { useMissingVersionsCount } from '~/Instances/MissingVersionsWarning'
 import { RootAppStoreContext } from '~/Stores/RootAppStore.js'
 
@@ -10,16 +11,21 @@ export const SurfacesTabNotifyIcon = observer(function SurfacesTabNotifyIcon(): 
 	const updateCount = surfaces.countFirmwareUpdates()
 	const missingCount = useMissingVersionsCount(ModuleInstanceType.Surface, surfaceInstances.instances)
 
-	if (updateCount === 0 && missingCount === 0) return null
+	const udevStatus = useUdevRulesStatus()
+	const udevNeedsApply = !!udevStatus?.supported && udevStatus.needsApply
+
+	const count = updateCount + missingCount + (udevNeedsApply ? 1 : 0)
+	if (count === 0) return null
 
 	const lines = [
 		updateCount > 0 ? `${updateCount} surfaces have firmware updates available` : null,
 		missingCount > 0 ? `Missing ${missingCount} needed modules` : null,
+		udevNeedsApply ? `USB permissions need updating` : null,
 	].filter(Boolean)
 
 	return (
 		<span className="notification-count" title={lines.join(', ')}>
-			{updateCount + missingCount}
+			{count}
 		</span>
 	)
 })

--- a/webui/src/Surfaces/UdevRulesAlert.tsx
+++ b/webui/src/Surfaces/UdevRulesAlert.tsx
@@ -29,26 +29,27 @@ export const UdevRulesAlert = observer(function UdevRulesAlert(): React.JSX.Elem
 	if (!status || !status.supported || !status.needsApply) return null
 
 	// When Companion can apply the rules itself, the Apply button is the primary action and it re-checks
-	// automatically on success. Otherwise the user applies manually, so we offer the command and a re-check.
+	// automatically on success. Otherwise the user applies manually, so we offer the command and a "I've done
+	// this" re-check. Either way the actions sit in a right-aligned row below the command.
 	return (
 		<StaticAlert color="warning" role="alert">
 			<p>
-				To use your USB surfaces, the system USB permissions need updating. This is needed because the connected surface
-				modules have changed.
+				To use your USB surfaces, the system USB permissions need updating. This is needed because the configured
+				surface modules have changed.
 			</p>
 
 			{status.canAutoApply ? (
 				<>
-					<div className="mb-2">
+					<p className="mb-1">Apply them automatically below, or run this command manually:</p>
+					<pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-all', marginBottom: '0.5rem' }}>
+						{status.applyCommand}
+					</pre>
+					<div className="d-flex justify-content-end gap-2">
+						<CopyButton text={status.applyCommand} color="secondary" />
 						<Button color="primary" size="sm" onClick={applyRules} disabled={applyMutation.isPending}>
 							{applyMutation.isPending ? 'Applying…' : 'Apply USB permissions'}
 						</Button>
 					</div>
-					<p className="mb-1">Or apply them manually by running:</p>
-					<pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-all', marginBottom: '0.5rem' }}>
-						{status.applyCommand}
-					</pre>
-					<CopyButton text={status.applyCommand} color="secondary" />
 				</>
 			) : (
 				<>
@@ -56,10 +57,10 @@ export const UdevRulesAlert = observer(function UdevRulesAlert(): React.JSX.Elem
 					<pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-all', marginBottom: '0.5rem' }}>
 						{status.applyCommand}
 					</pre>
-					<div className="d-flex gap-2">
+					<div className="d-flex justify-content-end gap-2">
 						<CopyButton text={status.applyCommand} color="secondary" />
 						<Button color="secondary" size="sm" onClick={() => recheckMutation.mutate()}>
-							I've done this
+							Recheck status
 						</Button>
 					</div>
 				</>

--- a/webui/src/Surfaces/UdevRulesAlert.tsx
+++ b/webui/src/Surfaces/UdevRulesAlert.tsx
@@ -1,0 +1,69 @@
+import { useMutation } from '@tanstack/react-query'
+import { observer } from 'mobx-react-lite'
+import { useCallback, useContext } from 'react'
+import { StaticAlert } from '~/Components/Alert'
+import { Button } from '~/Components/Button'
+import { CopyButton } from '~/Components/CopyButton'
+import { useUdevRulesStatus } from '~/Hooks/useUdevRulesStatus'
+import { trpc } from '~/Resources/TRPC'
+import { RootAppStoreContext } from '~/Stores/RootAppStore'
+
+/**
+ * Warns the user when the Linux udev rules that grant access to USB surfaces are out of date,
+ * and offers to apply them. Renders nothing when not applicable.
+ */
+export const UdevRulesAlert = observer(function UdevRulesAlert(): React.JSX.Element | null {
+	const { notifier } = useContext(RootAppStoreContext)
+	const status = useUdevRulesStatus()
+
+	const recheckMutation = useMutation(trpc.instances.udevRules.recheck.mutationOptions())
+	const applyMutation = useMutation(trpc.instances.udevRules.applyRules.mutationOptions())
+	const applyMutationAsync = applyMutation.mutateAsync
+
+	const applyRules = useCallback(() => {
+		applyMutationAsync().catch((e) => {
+			notifier.show('Failed to apply USB permissions', e?.message ?? 'Unknown error')
+		})
+	}, [applyMutationAsync, notifier])
+
+	if (!status || !status.supported || !status.needsApply) return null
+
+	// When Companion can apply the rules itself, the Apply button is the primary action and it re-checks
+	// automatically on success. Otherwise the user applies manually, so we offer the command and a re-check.
+	return (
+		<StaticAlert color="warning" role="alert">
+			<p>
+				To use your USB surfaces, the system USB permissions need updating. This is needed because the connected surface
+				modules have changed.
+			</p>
+
+			{status.canAutoApply ? (
+				<>
+					<div className="mb-2">
+						<Button color="primary" size="sm" onClick={applyRules} disabled={applyMutation.isPending}>
+							{applyMutation.isPending ? 'Applying…' : 'Apply USB permissions'}
+						</Button>
+					</div>
+					<p className="mb-1">Or apply them manually by running:</p>
+					<pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-all', marginBottom: '0.5rem' }}>
+						{status.applyCommand}
+					</pre>
+					<CopyButton text={status.applyCommand} color="secondary" />
+				</>
+			) : (
+				<>
+					<p className="mb-1">Run the following command, then reconnect your surfaces:</p>
+					<pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-all', marginBottom: '0.5rem' }}>
+						{status.applyCommand}
+					</pre>
+					<div className="d-flex gap-2">
+						<CopyButton text={status.applyCommand} color="secondary" />
+						<Button color="secondary" size="sm" onClick={() => recheckMutation.mutate()}>
+							I've done this
+						</Button>
+					</div>
+				</>
+			)}
+		</StaticAlert>
+	)
+})


### PR DESCRIPTION
Playing around with better handling of udev rules on linux desktop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Linux Desktop builds now detect outdated USB permission (udev) rules and can apply updates via system authentication.
  * Added an on-page USB permissions alert with actions to apply updates (or recheck status when auto-apply isn’t available).
  * Surfaces tab notification now includes USB permission updates in its count and tooltip.

* **Documentation**
  * Updated Linux USB surface installation guidance to reflect the new prompt and automated udev rule handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->