### PR TITLE
feat: headless config tool

### DIFF
--- a/companion/lib/LaunchOptionsCli.ts
+++ b/companion/lib/LaunchOptionsCli.ts
@@ -1,0 +1,23 @@
+import type { Command } from 'commander'
+import { LAUNCH_OPTIONS } from '@companion-app/shared/LaunchOptions.js'
+
+/**
+ * Register every launch option that has a cli flag onto the commander program.
+ *
+ * The option list (names, descriptions, defaults, order) lives in
+ * `@companion-app/shared/LaunchOptions.js` so it stays in sync with the standalone
+ * `config-tool` package. This replaces the previously hand-written `.option()` chain.
+ */
+export function registerLaunchOptions(program: Command): void {
+	for (const option of LAUNCH_OPTIONS) {
+		if (!option.cliFlag) continue
+
+		// Only non-boolean options carried a commander default historically (just --admin-port).
+		// Booleans must not be given a default so commander's negation/absence behaviour is unchanged.
+		if (option.type !== 'boolean' && option.default !== undefined && option.default !== null) {
+			program.option(option.cliFlag, option.short, String(option.default))
+		} else {
+			program.option(option.cliFlag, option.short)
+		}
+	}
+}

--- a/companion/lib/main.ts
+++ b/companion/lib/main.ts
@@ -19,6 +19,7 @@ import { nanoid } from 'nanoid'
 import { type SyslogTransportOptions } from 'winston-syslog'
 import { ModuleInstanceType } from '@companion-app/shared/Model/Instance.js'
 import { ConfigReleaseDirs } from '@companion-app/shared/Paths.js'
+import { registerLaunchOptions } from './LaunchOptionsCli.js'
 import { Registry } from './Registry.js'
 import { DISABLE_IPv6, GLOBAL_BIND_ADDRESS } from './Resources/Constants.js'
 import { isPackaged } from './Resources/Util.js'
@@ -31,40 +32,20 @@ program.command('check-launches', { hidden: true }).action(() => {
 	process.exit(89)
 })
 
+// Server-only flags that the headless `config-tool` does not manage. These are declared here
+// rather than in the shared list, since the config tool never reads or generates them.
 program
 	.option('--list-interfaces', 'List the available network interfaces that can be passed to --admin-interface')
-	.option('--admin-port <number>', 'Set the port the admin ui should bind to', '8000')
-	.option(
-		'--admin-interface <string>',
-		'Set the interface the admin ui should bind to. The first ip on this interface will be used'
-	)
-	.option('--admin-address <string>', 'Set the ip address the admin ui should bind to (default: "0.0.0.0")')
 	.option(
 		'--config-dir <string>',
 		'Use the specified directory for storing configuration. The default path varies by system, and is different to 2.2 (the old path will be used if existing config is found)'
 	)
-	.option('--extra-module-path <string>', 'Search an extra directory for modules to load')
 	.option('--machine-id <string>', 'Unique id for this installation')
-	.option('--log-level <string>', 'Log level to output to console')
 	.option('--disable-admin-password', 'Disables password lockout for the admin UI')
-	.option('--syslog-enable', 'Enable syslog transport')
-	.option('--syslog-host <string>', 'Syslog server to write to (default: localhost)')
-	.option('--syslog-port <string>', 'Port on syslog server to write to')
-	.option('--syslog-tcp', 'Use TCP for transport (default: udp)')
-	.option('--syslog-localhost <string>', 'Hostname of this machine')
-	.option(
-		'--enable-shell-command-support',
-		'Allow running shell commands on this computer (e.g. the internal "run shell command" action)'
-	)
-	.option(
-		'--enable-restricted-modules',
-		'Allow loading modules that are otherwise held back for safety, e.g. importing custom modules from remote (non-loopback) clients. Local clients can always import'
-	)
-	.option(
-		'--trusted-proxies <value>',
-		'Configure the Express "trust proxy" setting so the real client ip is used when running behind a reverse proxy'
-	)
-	.option('--no-notifications', "Don't show version-related notifications in the header.")
+
+// Register the config-tool-managed options from the shared single-source-of-truth list. This
+// keeps the flags the server accepts in sync with what the `config-tool` package generates.
+registerLaunchOptions(program)
 
 program.command('start', { isDefault: true, hidden: true }).action(() => {
 	const options = program.opts()

--- a/companion/test/LaunchOptionsCli.test.ts
+++ b/companion/test/LaunchOptionsCli.test.ts
@@ -1,0 +1,31 @@
+import { Command } from 'commander'
+import { describe, expect, it } from 'vitest'
+import { registerLaunchOptions } from '../lib/LaunchOptionsCli.js'
+
+function parse(args: string[]): Record<string, unknown> {
+	const program = new Command()
+	program.exitOverride() // throw instead of process.exit on parse errors
+	registerLaunchOptions(program)
+	program.parse(args, { from: 'user' })
+	return program.opts()
+}
+
+describe('registerLaunchOptions', () => {
+	// SECURITY: the server must not enable these unless the flag is explicitly passed, regardless
+	// of the config-tool defaults in the shared list. Guards against a boolean default leaking
+	// through registerLaunchOptions and silently enabling them for the desktop app / direct launch.
+	it('does NOT enable security-sensitive flags by default', () => {
+		const opts = parse([])
+		expect(opts.enableRestrictedModules, 'enableRestrictedModules').toBeFalsy()
+		expect(opts.enableShellCommandSupport, 'enableShellCommandSupport').toBeFalsy()
+	})
+
+	it('enables a flag only when it is explicitly passed', () => {
+		expect(parse(['--enable-restricted-modules']).enableRestrictedModules).toBe(true)
+		expect(parse(['--enable-shell-command-support']).enableShellCommandSupport).toBe(true)
+	})
+
+	it('preserves the historical non-boolean default (admin port 8000)', () => {
+		expect(parse([]).adminPort).toBe('8000')
+	})
+})

--- a/config-tool/lib/ConfigFile.ts
+++ b/config-tool/lib/ConfigFile.ts
@@ -1,0 +1,107 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { Document, Pair, parseDocument, YAMLMap } from 'yaml'
+import { LAUNCH_OPTIONS, type LaunchOption } from '@companion-app/shared/LaunchOptions.js'
+import { optionFileDefault } from './options.js'
+
+const BANNER = [
+	' Companion headless launch configuration.',
+	'',
+	' This file is read by the companion-pi launch tooling to start the headless server.',
+	' It is safe to edit by hand - comments and formatting are preserved when the',
+	' `config-tool` rewrites it. Unknown keys are left untouched.',
+	'',
+	' Remove a key (or set it to null) to fall back to the built-in default.',
+].join('\n')
+
+export class ConfigFile {
+	readonly path: string
+	readonly existed: boolean
+	private readonly doc: Document
+
+	private constructor(filePath: string, existed: boolean, doc: Document) {
+		this.path = filePath
+		this.existed = existed
+		this.doc = doc
+	}
+
+	/** Load the config file, or start a new in-memory document if it does not exist yet. */
+	static load(filePath: string): ConfigFile {
+		if (fs.existsSync(filePath)) {
+			const text = fs.readFileSync(filePath, 'utf8')
+			const doc = parseDocument(text)
+			// Empty or non-map document: start fresh (an empty file has no comments to preserve anyway)
+			if (!(doc.contents instanceof YAMLMap)) {
+				return new ConfigFile(filePath, true, new Document(new YAMLMap()))
+			}
+			return new ConfigFile(filePath, true, doc)
+		}
+
+		const doc = new Document(new YAMLMap())
+		doc.commentBefore = BANNER
+		return new ConfigFile(filePath, false, doc)
+	}
+
+	/** The raw value stored for an option key (undefined when absent). */
+	get(key: string): unknown {
+		return this.doc.get(key)
+	}
+
+	has(key: string): boolean {
+		return this.doc.has(key)
+	}
+
+	/** Set the value for an option, preserving any existing comment on the key. Adds the option (with comment) if missing. */
+	set(option: LaunchOption, value: string | number | boolean | null): void {
+		if (this.doc.has(option.key)) {
+			this.doc.set(option.key, value)
+		} else {
+			this.addWithComment(option, value)
+		}
+	}
+
+	/**
+	 * Add any managed options not already present, each annotated with its description comment.
+	 * `seeds` provides initial values for newly-added options (used by install tooling to supply
+	 * platform defaults); it never affects options already in the file.
+	 */
+	mergeMissingOptions(seeds: Record<string, string | number | boolean | null> = {}): string[] {
+		const added: string[] = []
+		for (const option of LAUNCH_OPTIONS) {
+			if (this.doc.has(option.key)) continue
+			const value = option.key in seeds ? seeds[option.key] : optionFileDefault(option)
+			this.addWithComment(option, value)
+			added.push(option.key)
+		}
+		return added
+	}
+
+	private addWithComment(option: LaunchOption, value: string | number | boolean | null): void {
+		const map = this.doc.contents as YAMLMap
+		const keyNode = this.doc.createNode(option.key)
+		keyNode.commentBefore = ` ${option.short}`
+		const valueNode = this.doc.createNode(value)
+		map.add(new Pair(keyNode, valueNode))
+	}
+
+	serialize(): string {
+		return this.doc.toString()
+	}
+
+	/** Write the document atomically (temp file in the same directory, then rename), preserving file mode. */
+	write(): void {
+		const dir = path.dirname(this.path)
+		fs.mkdirSync(dir, { recursive: true })
+
+		let mode = 0o644
+		try {
+			mode = fs.statSync(this.path).mode
+		} catch {
+			// new file - keep default mode
+		}
+
+		const tmpPath = path.join(dir, `.${path.basename(this.path)}.tmp`)
+		fs.writeFileSync(tmpPath, this.serialize(), { mode })
+		fs.renameSync(tmpPath, this.path)
+	}
+}

--- a/config-tool/lib/ConfigFile.ts
+++ b/config-tool/lib/ConfigFile.ts
@@ -32,7 +32,10 @@ export class ConfigFile {
 			const doc = parseDocument(text)
 			// Empty or non-map document: start fresh (an empty file has no comments to preserve anyway)
 			if (!(doc.contents instanceof YAMLMap)) {
-				return new ConfigFile(filePath, true, new Document(new YAMLMap()))
+				if (text.trim() === '') {
+					return new ConfigFile(filePath, true, new Document(new YAMLMap()))
+				}
+				throw new Error(`Invalid config at ${filePath}: top-level YAML node must be a mapping/object`)
 			}
 			return new ConfigFile(filePath, true, doc)
 		}

--- a/config-tool/lib/Launch.ts
+++ b/config-tool/lib/Launch.ts
@@ -1,0 +1,52 @@
+import { LAUNCH_OPTIONS, launchOptionFlagName, launchOptionTakesValue } from '@companion-app/shared/LaunchOptions.js'
+import type { ConfigFile } from './ConfigFile.js'
+import { resolveValue, validateValue } from './options.js'
+
+/** Single-quote a value for safe `source`-ing in bash; only quote when needed for readability. */
+function shellQuote(value: string): string {
+	if (/^[A-Za-z0-9._/:=-]+$/.test(value)) return value
+	return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+/**
+ * Build the bash-sourceable launch snippet from the config file.
+ *
+ * Options that have a cli flag are emitted as flags (in a single `set --`), so they take the
+ * precedence the server expects. Env-only options are emitted as `export`s. Throws if any value
+ * is invalid, so the caller can fail loudly before the server is launched.
+ */
+export function generateLaunchSnippet(config: ConfigFile): string {
+	const exports: string[] = []
+	const args: string[] = []
+
+	for (const option of LAUNCH_OPTIONS) {
+		const value = resolveValue(option, config.get(option.key))
+
+		const validationError = validateValue(option, value)
+		if (validationError) throw new Error(`Invalid value for "${option.key}": ${validationError}`)
+
+		if (value === null) continue
+
+		if (option.cliFlag) {
+			const flag = launchOptionFlagName(option)!
+			if (option.type === 'boolean') {
+				// Negated flags (e.g. --no-notifications) are emitted when the value is false.
+				if (option.cliNegated ? value === false : value === true) args.push(flag)
+			} else if (launchOptionTakesValue(option)) {
+				args.push(flag, shellQuote(String(value)))
+			} else {
+				args.push(flag)
+			}
+		} else if (option.envVar) {
+			if (option.type === 'boolean') {
+				if (value === true) exports.push(`export ${option.envVar}=1`)
+			} else {
+				exports.push(`export ${option.envVar}=${shellQuote(String(value))}`)
+			}
+		}
+	}
+
+	const lines = [...exports]
+	if (args.length > 0) lines.push(`set -- ${args.join(' ')}`)
+	return lines.join('\n') + '\n'
+}

--- a/config-tool/lib/edit.ts
+++ b/config-tool/lib/edit.ts
@@ -52,8 +52,16 @@ async function editOne(config: ConfigFile, option: LaunchOption): Promise<boolea
 	let value: string | number | boolean | null
 
 	if (option.type === 'boolean') {
-		const current = typeof raw === 'boolean' ? raw : option.default === true
-		value = await confirm({ message: meta.label, default: current })
+		// A three-way choice so the value can be returned to "default" (unset), like the other types.
+		value = await select<boolean | null>({
+			message: meta.label,
+			default: typeof raw === 'boolean' ? raw : null,
+			choices: [
+				{ name: `default (${option.default === true ? 'enabled' : 'disabled'})`, value: null },
+				{ name: 'enabled', value: true },
+				{ name: 'disabled', value: false },
+			],
+		})
 	} else if (option.type === 'enum' && option.enumValues) {
 		value = await select<string | null>({
 			message: meta.label,

--- a/config-tool/lib/edit.ts
+++ b/config-tool/lib/edit.ts
@@ -1,0 +1,123 @@
+/* eslint-disable @typescript-eslint/no-base-to-string */
+import { confirm, input, number, select, Separator } from '@inquirer/prompts'
+import { LAUNCH_OPTIONS, type LaunchOption } from '@companion-app/shared/LaunchOptions.js'
+import type { ConfigFile } from './ConfigFile.js'
+import { coerceValue, validateValue } from './options.js'
+import { PAGE_ORDER, PRESENTATION } from './presentation.js'
+
+const byKey = new Map(LAUNCH_OPTIONS.map((opt) => [opt.key, opt]))
+
+// Sentinel menu values (not valid option keys).
+const SAVE = ' save'
+const QUIT = ' quit'
+
+function displayValue(config: ConfigFile, option: LaunchOption): string {
+	const raw = config.get(option.key)
+	if (raw === null || raw === undefined || raw === '') return 'default'
+	return String(raw)
+}
+
+/** Build the single home menu: every setting (grouped by page) plus save/quit rows. */
+function buildMenuChoices(config: ConfigFile, dirty: boolean) {
+	const choices: Array<Separator | { name: string; value: string; description: string }> = []
+
+	for (const page of PAGE_ORDER) {
+		const options = LAUNCH_OPTIONS.filter((opt) => PRESENTATION[opt.key]?.page === page)
+		if (options.length === 0) continue
+
+		choices.push(new Separator(`-- ${page} --`))
+		for (const option of options) {
+			const meta = PRESENTATION[option.key]
+			choices.push({
+				name: `${meta.label}: ${displayValue(config, option)}`,
+				value: option.key,
+				description: meta.help,
+			})
+		}
+	}
+
+	choices.push(new Separator())
+	choices.push({ name: dirty ? 'Save and exit' : 'Exit', value: SAVE, description: '' })
+	choices.push({ name: 'Quit without saving', value: QUIT, description: '' })
+	return choices
+}
+
+/** Prompt for a single setting's value. Returns true if the stored value changed. */
+async function editOne(config: ConfigFile, option: LaunchOption): Promise<boolean> {
+	console.clear()
+	const meta = PRESENTATION[option.key]
+	const raw = config.get(option.key)
+	const before = JSON.stringify(raw ?? null)
+
+	let value: string | number | boolean | null
+
+	if (option.type === 'boolean') {
+		const current = typeof raw === 'boolean' ? raw : option.default === true
+		value = await confirm({ message: meta.label, default: current })
+	} else if (option.type === 'enum' && option.enumValues) {
+		value = await select<string | null>({
+			message: meta.label,
+			default: typeof raw === 'string' ? raw : null,
+			choices: [{ name: 'default', value: null }, ...option.enumValues.map((v) => ({ name: v, value: v }))],
+		})
+	} else if (option.type === 'number') {
+		const answer = await number({
+			message: `${meta.label} (blank for default)`,
+			default: typeof raw === 'number' ? raw : undefined,
+			validate: (value) => (value === undefined ? true : (validateValue(option, value) ?? true)),
+		})
+		value = answer ?? null
+	} else {
+		const answer = await input({
+			message: `${meta.label} (blank for default)`,
+			default: typeof raw === 'string' ? raw : undefined,
+			validate: (value) => {
+				const coerced = coerceValue(option, value)
+				if (coerced.error) return coerced.error
+				return validateValue(option, coerced.value) ?? true
+			},
+		})
+		const coerced = coerceValue(option, answer)
+		value = coerced.error ? null : coerced.value
+	}
+
+	config.set(option, value)
+	return JSON.stringify(value) !== before
+}
+
+/**
+ * Run the interactive editor: a single home menu of all settings. Enter edits the highlighted
+ * setting and returns to the menu; the help for the highlighted setting is shown beneath the list.
+ * Returns true if changes were saved.
+ */
+export async function runEdit(config: ConfigFile): Promise<boolean> {
+	let dirty = false
+	let cursor: string | undefined // the menu item to re-highlight, so editing does not jump to the top
+
+	for (;;) {
+		console.clear()
+		const answer = await select({
+			message: 'Companion configuration (up/down to move, Enter to edit; help shown below)',
+			choices: buildMenuChoices(config, dirty),
+			default: cursor,
+			pageSize: 20,
+			loop: false,
+		})
+		cursor = answer
+
+		if (answer === SAVE) {
+			if (dirty) config.write()
+			return dirty
+		}
+
+		if (answer === QUIT) {
+			if (!dirty) return false
+			const discard = await confirm({ message: 'Discard unsaved changes?', default: false })
+			if (discard) return false
+			continue
+		}
+
+		const option = byKey.get(answer)
+		if (option && (await editOne(config, option))) dirty = true
+	}
+}

--- a/config-tool/lib/main.ts
+++ b/config-tool/lib/main.ts
@@ -1,0 +1,176 @@
+import { LAUNCH_OPTIONS } from '@companion-app/shared/LaunchOptions.js'
+import { ConfigFile } from './ConfigFile.js'
+import { generateLaunchSnippet } from './Launch.js'
+import { coerceValue, resolveValue, validateValue } from './options.js'
+import { assertPresentationComplete } from './presentation.js'
+
+const USAGE = `Companion headless configuration tool
+
+Usage: config-tool <command>
+
+Commands:
+  edit                   Interactively edit the configuration (default; requires a terminal)
+  init [--set key=value] Create the config file if missing, and add any new options to an existing file
+  generate               Print a bash-sourceable launch snippet (env exports + a 'set --' of cli flags)
+  validate               Check that every configured value is valid
+
+  --set key=value can be repeated; it seeds the initial value for an option when it is first
+  added to the file (it never overwrites a value already present). Used by install tooling to
+  provide platform defaults, e.g. --set extraModulePath=/opt/companion-module-dev
+
+The config file path is taken from the COMPANION_CONFIG_FILE environment variable.`
+
+class UserError extends Error {}
+
+/** Parse repeated `--set key=value` arguments into validated, coerced seed values. */
+function parseSeedOverrides(args: string[]): Record<string, string | number | boolean | null> {
+	const seeds: Record<string, string | number | boolean | null> = {}
+
+	for (let i = 0; i < args.length; i++) {
+		if (args[i] !== '--set') continue
+
+		const pair = args[++i]
+		const eq = pair?.indexOf('=') ?? -1
+		if (!pair || eq < 1) throw new UserError(`--set expects key=value`)
+
+		const key = pair.slice(0, eq)
+		const option = LAUNCH_OPTIONS.find((o) => o.key === key)
+		if (!option) throw new UserError(`--set: unknown option "${key}"`)
+
+		const coerced = coerceValue(option, pair.slice(eq + 1))
+		if (coerced.error) throw new UserError(`--set ${key}: ${coerced.error}`)
+		const validationError = validateValue(option, coerced.value)
+		if (validationError) throw new UserError(`--set ${key}: ${validationError}`)
+
+		seeds[key] = coerced.value
+	}
+
+	return seeds
+}
+
+function getConfigPath(): string {
+	const configPath = process.env.COMPANION_CONFIG_FILE
+	if (!configPath) {
+		throw new UserError(
+			'COMPANION_CONFIG_FILE is not set. Set it to the path of the config file, e.g. /etc/companion/config.yaml'
+		)
+	}
+	return configPath
+}
+
+function cmdInit(args: string[]): void {
+	const seeds = parseSeedOverrides(args)
+	const config = ConfigFile.load(getConfigPath())
+	const added = config.mergeMissingOptions(seeds)
+	config.write()
+
+	if (!config.existed) {
+		console.error(`Created ${config.path} with ${added.length} option(s).`)
+	} else if (added.length > 0) {
+		console.error(`Updated ${config.path}: added ${added.length} new option(s) (${added.join(', ')}).`)
+	} else {
+		console.error(`${config.path} is already up to date.`)
+	}
+}
+
+function cmdGenerate(): void {
+	const config = ConfigFile.load(getConfigPath())
+	let snippet: string
+	try {
+		snippet = generateLaunchSnippet(config)
+	} catch (e) {
+		throw new UserError(e instanceof Error ? e.message : String(e))
+	}
+	// Snippet goes to stdout (for `source <(...)`); nothing else may be written there.
+	process.stdout.write(snippet)
+}
+
+function cmdValidate(): void {
+	const config = ConfigFile.load(getConfigPath())
+
+	const errors: string[] = []
+	for (const option of LAUNCH_OPTIONS) {
+		try {
+			const value = resolveValue(option, config.get(option.key))
+			const error = validateValue(option, value)
+			if (error) errors.push(`  ${option.key}: ${error}`)
+		} catch (e) {
+			errors.push(`  ${option.key}: ${e instanceof Error ? e.message : String(e)}`)
+		}
+	}
+
+	if (errors.length > 0) {
+		throw new UserError(`Configuration is invalid:\n${errors.join('\n')}`)
+	}
+	console.error(`${config.path} is valid.`)
+}
+
+async function cmdEdit(): Promise<void> {
+	const configPath = getConfigPath()
+
+	if (!process.stdin.isTTY || !process.stdout.isTTY) {
+		throw new UserError(
+			`Interactive editing needs a terminal. The config file at ${configPath} can be edited manually instead.`
+		)
+	}
+
+	const config = ConfigFile.load(configPath)
+	config.mergeMissingOptions() // surface any newly-added options in the editor
+
+	const { runEdit } = await import('./edit.js')
+
+	// Run the editor in the terminal's alternate screen buffer (like vim/htop), so it behaves
+	// as a full-screen app and the user's normal scrollback is restored untouched on exit.
+	const enterAltScreen = '\x1b[?1049h'
+	const leaveAltScreen = '\x1b[?1049l'
+	process.stdout.write(enterAltScreen)
+	let saved = false
+	try {
+		saved = await runEdit(config)
+	} catch (e) {
+		// Ctrl-C (inquirer's ExitPromptError) exits cleanly, like "quit without saving".
+		if (!(e instanceof Error && e.name === 'ExitPromptError')) throw e
+	} finally {
+		process.stdout.write(leaveAltScreen)
+	}
+
+	console.error(saved ? `Saved ${config.path}` : 'No changes made.')
+}
+
+async function main(): Promise<void> {
+	assertPresentationComplete()
+
+	const args = process.argv.slice(2)
+	const command = args.find((arg) => !arg.startsWith('-')) ?? 'edit'
+
+	if (args.includes('--help') || args.includes('-h')) {
+		console.log(USAGE)
+		return
+	}
+
+	switch (command) {
+		case 'edit':
+			await cmdEdit()
+			break
+		case 'init':
+			cmdInit(args)
+			break
+		case 'generate':
+			cmdGenerate()
+			break
+		case 'validate':
+			cmdValidate()
+			break
+		default:
+			throw new UserError(`Unknown command "${command}".\n\n${USAGE}`)
+	}
+}
+
+main().catch((e) => {
+	if (e instanceof UserError) {
+		console.error(`Error: ${e.message}`)
+	} else {
+		console.error(e instanceof Error ? (e.stack ?? e.message) : String(e))
+	}
+	process.exitCode = 1
+})

--- a/config-tool/lib/options.ts
+++ b/config-tool/lib/options.ts
@@ -18,6 +18,10 @@ export interface CoerceResult {
 export function coerceValue(option: LaunchOption, raw: unknown): CoerceResult {
 	if (raw === null || raw === undefined || raw === '') return { value: null }
 
+	// No option accepts a structured value; reject lists/objects rather than stringifying them
+	// into nonsense like "[object Object]" that would silently become an invalid launch argument.
+	if (typeof raw === 'object') return { value: null, error: `Expected a single value, not a list or object` }
+
 	switch (option.type) {
 		case 'boolean': {
 			if (typeof raw === 'boolean') return { value: raw }

--- a/config-tool/lib/options.ts
+++ b/config-tool/lib/options.ts
@@ -1,0 +1,62 @@
+/* eslint-disable @typescript-eslint/no-base-to-string */
+import type { LaunchOption } from '@companion-app/shared/LaunchOptions.js'
+
+/** The value written to a fresh config file for an option (its default, or null when unset). */
+export function optionFileDefault(option: LaunchOption): string | number | boolean | null {
+	return option.default ?? null
+}
+
+export interface CoerceResult {
+	value: string | number | boolean | null
+	error?: string
+}
+
+/**
+ * Coerce a raw value (from the yaml file or a prompt) into the option's declared type.
+ * On failure `value` is null and `error` describes the problem.
+ */
+export function coerceValue(option: LaunchOption, raw: unknown): CoerceResult {
+	if (raw === null || raw === undefined || raw === '') return { value: null }
+
+	switch (option.type) {
+		case 'boolean': {
+			if (typeof raw === 'boolean') return { value: raw }
+			const str = String(raw).toLowerCase().trim()
+			if (['1', 'true', 'yes', 'on'].includes(str)) return { value: true }
+			if (['0', 'false', 'no', 'off'].includes(str)) return { value: false }
+			return { value: null, error: `Expected a boolean (true/false)` }
+		}
+		case 'number': {
+			const num = Number(raw)
+			if (!Number.isFinite(num)) return { value: null, error: `Expected a number` }
+			return { value: num }
+		}
+		case 'enum': {
+			const str = String(raw)
+			if (option.enumValues && !option.enumValues.includes(str)) {
+				return { value: null, error: `Expected one of: ${option.enumValues.join(', ')}` }
+			}
+			return { value: str }
+		}
+		case 'string':
+		default:
+			return { value: String(raw) }
+	}
+}
+
+/**
+ * Validate a coerced value against the option's optional validator.
+ * Returns an error message, or undefined when valid.
+ */
+export function validateValue(option: LaunchOption, value: string | number | boolean | null): string | undefined {
+	if (value === null) return undefined
+	return option.validate?.(value)
+}
+
+/** The effective value used to launch: the file value when set, otherwise the option default. */
+export function resolveValue(option: LaunchOption, fileValue: unknown): string | number | boolean | null {
+	const coerced = coerceValue(option, fileValue)
+	if (coerced.error) throw new Error(`Invalid value for "${option.key}": ${coerced.error}`)
+	if (coerced.value !== null) return coerced.value
+	return option.default ?? null
+}

--- a/config-tool/lib/presentation.ts
+++ b/config-tool/lib/presentation.ts
@@ -1,0 +1,107 @@
+import { LAUNCH_OPTIONS } from '@companion-app/shared/LaunchOptions.js'
+
+/** Rich UI metadata for an option, kept out of the shared mapping so that stays lean. */
+export interface OptionPresentation {
+	page: string
+	label: string
+	help: string
+}
+
+/** Page display order. */
+export const PAGE_ORDER = ['Network', 'Logging', 'Syslog', 'Security', 'Paths', 'Advanced'] as const
+
+export const PRESENTATION: Record<string, OptionPresentation> = {
+	adminPort: {
+		page: 'Network',
+		label: 'Admin UI port',
+		help: 'TCP port the web admin interface and API listen on. Default 8000.',
+	},
+	adminAddress: {
+		page: 'Network',
+		label: 'Admin UI bind address',
+		help: 'IP address to bind the admin interface to. Leave unset to bind to all interfaces (0.0.0.0 / ::). Cannot be combined with a bind interface.',
+	},
+	adminInterface: {
+		page: 'Network',
+		label: 'Admin UI bind interface',
+		help: 'Bind the admin interface to the first IPv4 address of this named network interface (e.g. eth0). Leave unset to use a bind address instead.',
+	},
+	trustedProxies: {
+		page: 'Network',
+		label: 'Trusted reverse proxies',
+		help: "Use this when Companion runs behind a reverse proxy, so the real visitor IP is detected instead of the proxy's. Set to 'loopback', or a comma/semicolon separated list of proxy IP addresses or subnets to trust.",
+	},
+	disableIpv6: {
+		page: 'Network',
+		label: 'Disable IPv6',
+		help: 'Disable IPv6 support. When enabled the various api and web interface ports in Companion bind to IPv4 (0.0.0.0) by default instead of ::.',
+	},
+	logLevel: {
+		page: 'Logging',
+		label: 'Console log level',
+		help: 'How verbose console logging is. One of error, warn, info, http, verbose, debug, silly. Leave unset for the default (info).',
+	},
+	syslogEnable: {
+		page: 'Syslog',
+		label: 'Enable syslog',
+		help: 'Forward logs to a syslog server. The remaining syslog options only apply when this is enabled.',
+	},
+	syslogHost: {
+		page: 'Syslog',
+		label: 'Syslog server host',
+		help: 'Hostname or IP of the syslog server to write to. Default localhost.',
+	},
+	syslogPort: {
+		page: 'Syslog',
+		label: 'Syslog server port',
+		help: 'Port on the syslog server to write to. Default 514.',
+	},
+	syslogTcp: {
+		page: 'Syslog',
+		label: 'Use TCP for syslog',
+		help: 'Use TCP transport for syslog instead of the default UDP.',
+	},
+	syslogLocalhost: {
+		page: 'Syslog',
+		label: 'Reported hostname',
+		help: 'Hostname this machine reports to the syslog server. Leave unset to use the system hostname.',
+	},
+	enableShellCommandSupport: {
+		page: 'Security',
+		label: 'Allow shell commands',
+		help: 'Allow running shell commands on this computer (e.g. the internal "run shell command" action). Disabled by default.',
+	},
+	enableRestrictedModules: {
+		page: 'Security',
+		label: 'Allow restricted modules',
+		help: 'Allow loading modules otherwise held back for safety, e.g. importing custom modules from remote (non-loopback) clients. Enabled by default.',
+	},
+	extraModulePath: {
+		page: 'Paths',
+		label: 'Extra module path',
+		help: 'An additional directory to search for in-development modules to be loaded from.',
+	},
+	notifications: {
+		page: 'Advanced',
+		label: 'Show version notifications',
+		help: 'Show version-related notifications in the admin UI header. Enabled by default.',
+	},
+}
+
+/**
+ * Throws if any managed launch option is missing a presentation entry, or if any presentation
+ * entry uses a page not listed in PAGE_ORDER (which would silently drop it from the editor).
+ */
+export function assertPresentationComplete(): void {
+	const missing = LAUNCH_OPTIONS.map((opt) => opt.key).filter((key) => !PRESENTATION[key])
+	if (missing.length > 0) {
+		throw new Error(`Missing presentation metadata for launch option(s): ${missing.join(', ')}`)
+	}
+
+	const badPages = Object.entries(PRESENTATION)
+		.filter(([, meta]) => !(PAGE_ORDER as readonly string[]).includes(meta.page))
+		.map(([key, meta]) => `${key} (page "${meta.page}")`)
+	if (badPages.length > 0) {
+		throw new Error(`Presentation page not listed in PAGE_ORDER: ${badPages.join(', ')}`)
+	}
+}

--- a/config-tool/package.json
+++ b/config-tool/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@companion-app/config-tool",
+  "version": "5.0.0",
+  "description": "Interactive configuration tool for headless Companion installs",
+  "type": "module",
+  "private": true,
+  "main": "lib/main.ts",
+  "scripts": {
+    "build:typecheck": "tsc --noEmit",
+    "dev": "COMPANION_CONFIG_FILE=../.cache/config-tool/config.yaml run -TB tsx lib/main.ts",
+    "dev:init": "run dev init",
+    "dev:generate": "run dev generate",
+    "dev:validate": "run dev validate"
+  },
+  "engines": {
+    "node": ">=26.3.0 <27"
+  },
+  "author": "Bitfocus AS",
+  "license": "MIT",
+  "devDependencies": {
+    "typescript": "~6.0.3"
+  },
+  "dependencies": {
+    "@companion-app/shared": "*",
+    "@inquirer/prompts": "^7.2.0",
+    "yaml": "^2.9.0"
+  }
+}

--- a/config-tool/test/ConfigFile.test.ts
+++ b/config-tool/test/ConfigFile.test.ts
@@ -1,0 +1,98 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { LAUNCH_OPTIONS } from '@companion-app/shared/LaunchOptions.js'
+import { ConfigFile } from '../lib/ConfigFile.js'
+
+const tmpDirs: string[] = []
+afterEach(() => {
+	for (const dir of tmpDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true })
+})
+
+function tmpFile(name = 'config.yaml'): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cfgtool-'))
+	tmpDirs.push(dir)
+	return path.join(dir, name)
+}
+
+describe('ConfigFile', () => {
+	it('reports whether the file already existed', () => {
+		const file = tmpFile()
+		expect(ConfigFile.load(file).existed).toBe(false)
+		fs.writeFileSync(file, '{}\n')
+		expect(ConfigFile.load(file).existed).toBe(true)
+	})
+
+	it('init merge writes every configurable option (commented) and is idempotent', () => {
+		const file = tmpFile()
+		const config = ConfigFile.load(file)
+		const added = config.mergeMissingOptions()
+		config.write()
+
+		const expectedKeys = LAUNCH_OPTIONS.map((o) => o.key)
+		expect(added.sort()).toEqual([...expectedKeys].sort())
+
+		// every option is present with a preceding comment line
+		const text = fs.readFileSync(file, 'utf8')
+		for (const opt of LAUNCH_OPTIONS) {
+			expect(text, opt.key).toContain(`${opt.key}:`)
+		}
+		expect(text).toMatch(/#.*\nadminPort:/)
+
+		// re-running adds nothing
+		const reload = ConfigFile.load(file)
+		expect(reload.mergeMissingOptions()).toEqual([])
+	})
+
+	it('seeds initial values for newly-added options but never clobbers existing ones', () => {
+		const file = tmpFile()
+
+		// First init seeds the value
+		const first = ConfigFile.load(file)
+		first.mergeMissingOptions({ extraModulePath: '/opt/companion-module-dev' })
+		first.write()
+		expect(fs.readFileSync(file, 'utf8')).toContain('extraModulePath: /opt/companion-module-dev')
+
+		// User edits it, then a re-init with the same seed must not overwrite the edit
+		const edited = ConfigFile.load(file)
+		const extraModulePath = LAUNCH_OPTIONS.find((o) => o.key === 'extraModulePath')!
+		edited.set(extraModulePath, '/home/me/mods')
+		edited.write()
+
+		const reinit = ConfigFile.load(file)
+		expect(reinit.mergeMissingOptions({ extraModulePath: '/opt/companion-module-dev' })).toEqual([])
+		reinit.write()
+		expect(fs.readFileSync(file, 'utf8')).toContain('extraModulePath: /home/me/mods')
+	})
+
+	it('preserves unknown keys and hand-written comments across a round-trip', () => {
+		const file = tmpFile()
+		fs.writeFileSync(file, ['# my banner', 'adminPort: 9000', '# keep this', 'someFutureKey: keep-me', ''].join('\n'))
+
+		const config = ConfigFile.load(file)
+		const adminPort = LAUNCH_OPTIONS.find((o) => o.key === 'adminPort')!
+		config.set(adminPort, 7000)
+		config.mergeMissingOptions()
+		config.write()
+
+		const text = fs.readFileSync(file, 'utf8')
+		expect(text).toContain('# my banner')
+		expect(text).toContain('# keep this')
+		expect(text).toContain('someFutureKey: keep-me')
+		expect(text).toContain('adminPort: 7000')
+		// merged-in option is present too
+		expect(text).toContain('syslogHost:')
+	})
+
+	it('creates parent directories and writes atomically', () => {
+		const file = path.join(tmpFile('x'), 'nested', 'config.yaml')
+		const config = ConfigFile.load(file)
+		config.mergeMissingOptions()
+		config.write()
+		expect(fs.existsSync(file)).toBe(true)
+		// no leftover temp file
+		const leftovers = fs.readdirSync(path.dirname(file)).filter((f) => f.includes('.tmp'))
+		expect(leftovers).toEqual([])
+	})
+})

--- a/config-tool/test/Launch.test.ts
+++ b/config-tool/test/Launch.test.ts
@@ -1,0 +1,72 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { ConfigFile } from '../lib/ConfigFile.js'
+import { generateLaunchSnippet } from '../lib/Launch.js'
+
+const tmpDirs: string[] = []
+afterEach(() => {
+	for (const dir of tmpDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true })
+})
+
+function configFrom(yaml: string): ConfigFile {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cfgtool-'))
+	tmpDirs.push(dir)
+	const file = path.join(dir, 'config.yaml')
+	fs.writeFileSync(file, yaml)
+	return ConfigFile.load(file)
+}
+
+describe('generateLaunchSnippet', () => {
+	it('emits the defaulted flags for an empty config', () => {
+		const snippet = generateLaunchSnippet(configFrom('{}\n'))
+		// adminPort defaults to 8000 and enableRestrictedModules defaults to true (headless default)
+		expect(snippet).toBe('set -- --admin-port 8000 --enable-restricted-modules\n')
+	})
+
+	it('emits flags for cli options and exports for env-only options', () => {
+		const snippet = generateLaunchSnippet(
+			configFrom(
+				[
+					'adminPort: 9000',
+					'adminAddress: 192.168.1.5',
+					'logLevel: debug',
+					'enableShellCommandSupport: true',
+					'trustedProxies: loopback, 10.0.0.0/8',
+					'disableIpv6: true',
+					'notifications: false',
+				].join('\n')
+			)
+		)
+		const lines = snippet.trimEnd().split('\n')
+		// env-only option becomes an export
+		expect(lines).toContain('export DISABLE_IPV6=1')
+		// flags collected into a single set --
+		const setLine = lines.find((l) => l.startsWith('set -- '))!
+		expect(setLine).toContain('--admin-port 9000')
+		expect(setLine).toContain('--admin-address 192.168.1.5')
+		expect(setLine).toContain('--log-level debug')
+		expect(setLine).toContain('--enable-shell-command-support')
+		// value with spaces/special chars is shell-quoted
+		expect(setLine).toContain(`--trusted-proxies 'loopback, 10.0.0.0/8'`)
+		// negated boolean emitted when false
+		expect(setLine).toContain('--no-notifications')
+	})
+
+	it('does not emit a flag for a false (non-negated) boolean or an unset value', () => {
+		const snippet = generateLaunchSnippet(configFrom('syslogEnable: false\nconfigDir: null\n'))
+		expect(snippet).not.toContain('--syslog-enable')
+		expect(snippet).not.toContain('--config-dir')
+	})
+
+	it('does not emit excluded options (machineId)', () => {
+		const snippet = generateLaunchSnippet(configFrom('machineId: abc123\n'))
+		expect(snippet).not.toContain('--machine-id')
+		expect(snippet).not.toContain('abc123')
+	})
+
+	it('throws on an invalid value', () => {
+		expect(() => generateLaunchSnippet(configFrom('adminPort: 70000\n'))).toThrow()
+	})
+})

--- a/config-tool/test/options.test.ts
+++ b/config-tool/test/options.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import type { LaunchOption } from '@companion-app/shared/LaunchOptions.js'
+import { coerceValue, optionFileDefault, resolveValue, validateValue } from '../lib/options.js'
+
+const numberOpt: LaunchOption = {
+	key: 'adminPort',
+	type: 'number',
+	default: 8000,
+	short: '',
+	cliFlag: '--admin-port <number>',
+	validate: (v) => (Number(v) > 65535 ? 'Must be a port number between 1 and 65535' : undefined),
+}
+const boolOpt: LaunchOption = { key: 'syslogTcp', type: 'boolean', default: false, short: '', cliFlag: '--syslog-tcp' }
+const enumOpt: LaunchOption = {
+	key: 'logLevel',
+	type: 'enum',
+	enumValues: ['info', 'debug'],
+	short: '',
+	cliFlag: '--log-level <string>',
+}
+const stringOpt: LaunchOption = { key: 'configDir', type: 'string', short: '', cliFlag: '--config-dir <string>' }
+
+describe('coerceValue', () => {
+	it('treats empty/null as unset', () => {
+		expect(coerceValue(stringOpt, '')).toEqual({ value: null })
+		expect(coerceValue(stringOpt, null)).toEqual({ value: null })
+		expect(coerceValue(stringOpt, undefined)).toEqual({ value: null })
+	})
+
+	it('parses booleans from common strings', () => {
+		expect(coerceValue(boolOpt, 'true').value).toBe(true)
+		expect(coerceValue(boolOpt, 'no').value).toBe(false)
+		expect(coerceValue(boolOpt, true).value).toBe(true)
+		expect(coerceValue(boolOpt, 'maybe').error).toBeDefined()
+	})
+
+	it('parses and rejects numbers', () => {
+		expect(coerceValue(numberOpt, '9000').value).toBe(9000)
+		expect(coerceValue(numberOpt, 'abc').error).toBeDefined()
+	})
+
+	it('validates enum membership', () => {
+		expect(coerceValue(enumOpt, 'debug').value).toBe('debug')
+		expect(coerceValue(enumOpt, 'silly').error).toBeDefined()
+	})
+})
+
+describe('validateValue', () => {
+	it('runs the option validator and skips null', () => {
+		expect(validateValue(numberOpt, 70000)).toBeDefined()
+		expect(validateValue(numberOpt, 8000)).toBeUndefined()
+		expect(validateValue(numberOpt, null)).toBeUndefined()
+	})
+})
+
+describe('resolveValue', () => {
+	it('uses the file value when set, otherwise the default', () => {
+		expect(resolveValue(numberOpt, 9000)).toBe(9000)
+		expect(resolveValue(numberOpt, null)).toBe(8000)
+		expect(resolveValue(stringOpt, undefined)).toBe(null)
+	})
+
+	it('throws on an invalid file value', () => {
+		expect(() => resolveValue(numberOpt, 'nope')).toThrow()
+	})
+})
+
+describe('optionFileDefault', () => {
+	it('is the declared default, or null when unset', () => {
+		expect(optionFileDefault(numberOpt)).toBe(8000)
+		expect(optionFileDefault(boolOpt)).toBe(false)
+		expect(optionFileDefault(stringOpt)).toBe(null)
+	})
+})

--- a/config-tool/test/options.test.ts
+++ b/config-tool/test/options.test.ts
@@ -43,6 +43,12 @@ describe('coerceValue', () => {
 		expect(coerceValue(enumOpt, 'debug').value).toBe('debug')
 		expect(coerceValue(enumOpt, 'silly').error).toBeDefined()
 	})
+
+	it('rejects lists and objects instead of stringifying them', () => {
+		expect(coerceValue(stringOpt, { a: 1 }).error).toBeDefined()
+		expect(coerceValue(stringOpt, ['a', 'b']).error).toBeDefined()
+		expect(coerceValue(numberOpt, [5]).error).toBeDefined()
+	})
 })
 
 describe('validateValue', () => {

--- a/config-tool/test/schema.test.ts
+++ b/config-tool/test/schema.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { LAUNCH_OPTIONS, launchOptionFlagName } from '@companion-app/shared/LaunchOptions.js'
+import { assertPresentationComplete, PAGE_ORDER, PRESENTATION } from '../lib/presentation.js'
+
+/** Reproduce the key name commander derives from a flag, to guard against mapping mistakes. */
+function commanderKey(cliFlag: string, negated: boolean): string {
+	let name = cliFlag.split(/\s+/)[0].replace(/^--/, '')
+	if (negated) name = name.replace(/^no-/, '')
+	return name.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase())
+}
+
+describe('launch options schema', () => {
+	it('every cli flag derives the declared key (no drift vs main.ts commander parsing)', () => {
+		for (const option of LAUNCH_OPTIONS) {
+			if (!option.cliFlag) continue
+			expect(commanderKey(option.cliFlag, !!option.cliNegated), `flag ${option.cliFlag}`).toBe(option.key)
+		}
+	})
+
+	it('has unique keys', () => {
+		const keys = LAUNCH_OPTIONS.map((o) => o.key)
+		expect(new Set(keys).size).toBe(keys.length)
+	})
+
+	it('enum options declare their allowed values', () => {
+		for (const option of LAUNCH_OPTIONS) {
+			if (option.type === 'enum') expect(option.enumValues?.length, option.key).toBeGreaterThan(0)
+		}
+	})
+
+	it('flag names are well-formed', () => {
+		for (const option of LAUNCH_OPTIONS) {
+			if (!option.cliFlag) continue
+			expect(launchOptionFlagName(option)).toMatch(/^--[a-z][a-z-]*$/)
+		}
+	})
+})
+
+describe('presentation metadata', () => {
+	it('covers every managed option and nothing more', () => {
+		expect(() => assertPresentationComplete()).not.toThrow()
+
+		const managedKeys = new Set(LAUNCH_OPTIONS.map((o) => o.key))
+		for (const key of Object.keys(PRESENTATION)) {
+			expect(managedKeys.has(key), `presentation for non-managed "${key}"`).toBe(true)
+		}
+	})
+
+	it('every presentation page is listed in PAGE_ORDER (else it is dropped from the editor)', () => {
+		for (const [key, meta] of Object.entries(PRESENTATION)) {
+			expect(PAGE_ORDER, key).toContain(meta.page)
+		}
+	})
+
+	it('does not manage server-only options (machineId, configDir, etc.)', () => {
+		const keys = LAUNCH_OPTIONS.map((o) => o.key)
+		for (const serverOnly of ['machineId', 'configDir', 'listInterfaces', 'disableAdminPassword']) {
+			expect(keys, serverOnly).not.toContain(serverOnly)
+			expect(PRESENTATION[serverOnly]).toBeUndefined()
+		}
+	})
+})

--- a/config-tool/test/schema.test.ts
+++ b/config-tool/test/schema.test.ts
@@ -34,6 +34,17 @@ describe('launch options schema', () => {
 			expect(launchOptionFlagName(option)).toMatch(/^--[a-z][a-z-]*$/)
 		}
 	})
+
+	it('admin port rejects privileged (<1024) ports; syslog port rejects values the server ignores (<=100)', () => {
+		const adminPort = LAUNCH_OPTIONS.find((o) => o.key === 'adminPort')!
+		expect(adminPort.validate?.(80), 'privileged port').toBeDefined()
+		expect(adminPort.validate?.(8000)).toBeUndefined()
+		expect(adminPort.validate?.(70000)).toBeDefined()
+
+		const syslogPort = LAUNCH_OPTIONS.find((o) => o.key === 'syslogPort')!
+		expect(syslogPort.validate?.(50)).toBeDefined()
+		expect(syslogPort.validate?.(514)).toBeUndefined()
+	})
 })
 
 describe('presentation metadata', () => {

--- a/config-tool/tsconfig.json
+++ b/config-tool/tsconfig.json
@@ -1,0 +1,36 @@
+{
+	"include": ["lib/**/*.ts"],
+	"exclude": ["node_modules/**"],
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./lib",
+		"paths": {
+			"*": ["./node_modules/*"]
+		},
+		"module": "Node16",
+		"moduleResolution": "Node16",
+		"composite": true,
+
+		"target": "es2024",
+		"noImplicitAny": true,
+		"sourceMap": true,
+		"declaration": true,
+		"declarationMap": true,
+		"importHelpers": false,
+		"listFiles": false,
+		"traceResolution": false,
+		"pretty": true,
+		"lib": ["es2024"],
+		"types": ["node"],
+		"strict": true,
+		"forceConsistentCasingInFileNames": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"skipLibCheck": true,
+		"allowSyntheticDefaultImports": true,
+		"esModuleInterop": true
+	},
+	"references": [{ "path": "../shared-lib" }]
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -136,6 +136,18 @@ export default [
 			'n/prefer-node-protocol': 'error',
 		},
 	},
+	{
+		files: ['config-tool/**/*.ts'],
+		rules: {
+			// Confusing import issues currently
+			'n/no-missing-import': [
+				'error',
+				{
+					allowModules: ['@companion-app/shared'],
+				},
+			],
+		},
+	},
 
 	// Add prettier at the end to give it final say on formatting
 	eslintPluginPrettierRecommended,
@@ -167,6 +179,7 @@ export default [
 			// TMP
 			'companion/lib/Cloud/**/*',
 			'companion/test/**/*',
+			'config-tool/test/**/*',
 			'webui/test/**/*',
 			'.cache/*',
 		],

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "packageManager": "yarn@4.17.0",
   "workspaces": [
     "companion",
+    "config-tool",
     "shared-lib",
     "webui",
     "launcher",

--- a/shared-lib/lib/LaunchOptions.ts
+++ b/shared-lib/lib/LaunchOptions.ts
@@ -39,12 +39,21 @@ export interface LaunchOption {
 
 const LOG_LEVELS = ['error', 'warn', 'info', 'http', 'verbose', 'debug', 'silly'] as const
 
-function validatePort(value: unknown): string | undefined {
-	if (value === null || value === undefined || value === '') return undefined
-	const port = Number(value)
-	if (!Number.isInteger(port) || port <= 0 || port > 65535) return `Must be a port number between 1 and 65535`
-	return undefined
+function makePortValidator(min: number, max = 65535, note = ''): (value: unknown) => string | undefined {
+	return (value) => {
+		if (value === null || value === undefined || value === '') return undefined
+		const port = Number(value)
+		if (!Number.isInteger(port) || port < min || port > max)
+			return `Must be a port number between ${min} and ${max}${note}`
+		return undefined
+	}
 }
+
+// The admin ui binds/listens on this port. Headless installs run as an unprivileged user, so
+// ports below 1024 (the privileged range) cannot be bound.
+const validateAdminPort = makePortValidator(1024, 65535, ' (ports below 1024 require root privileges)')
+// The server ignores syslog ports of 100 or below (companion/lib/main.ts), so reject them here too.
+const validateSyslogPort = makePortValidator(101)
 
 /** The config-tool-managed launch options. Order here is the order they appear in `--help` and the config file. */
 export const LAUNCH_OPTIONS: readonly LaunchOption[] = [
@@ -54,7 +63,7 @@ export const LAUNCH_OPTIONS: readonly LaunchOption[] = [
 		default: 8000,
 		short: 'Set the port the admin ui should bind to',
 		cliFlag: '--admin-port <number>',
-		validate: validatePort,
+		validate: validateAdminPort,
 	},
 	{
 		key: 'adminInterface',
@@ -99,7 +108,7 @@ export const LAUNCH_OPTIONS: readonly LaunchOption[] = [
 		type: 'number',
 		short: 'Port on syslog server to write to',
 		cliFlag: '--syslog-port <string>',
-		validate: validatePort,
+		validate: validateSyslogPort,
 	},
 	{
 		key: 'syslogTcp',

--- a/shared-lib/lib/LaunchOptions.ts
+++ b/shared-lib/lib/LaunchOptions.ts
@@ -1,0 +1,170 @@
+/**
+ * The launch options that the headless `config-tool` manages.
+ *
+ * This is the single source of truth for those options: the server entrypoint
+ * (companion/lib/main.ts, via registerLaunchOptions) registers them as cli flags, and the
+ * standalone `config-tool` package reads/persists/generates them. Keeping them in one place
+ * means the flags the server accepts can never drift from what the config tool generates.
+ *
+ * Server-only flags that the config tool does NOT manage are intentionally NOT here - they
+ * are declared directly in main.ts, since putting them here would only need filtering back
+ * out again.
+ */
+
+export type LaunchOptionType = 'string' | 'number' | 'boolean' | 'enum'
+
+export interface LaunchOption {
+	/** Canonical key. Must equal the name commander derives from `cliFlag` (e.g. '--admin-port' -> 'adminPort'). */
+	key: string
+	type: LaunchOptionType
+	/** Allowed values for `type: 'enum'`. */
+	enumValues?: readonly string[]
+	/**
+	 * Semantic default.
+	 * - Only passed to commander for non-boolean options (to preserve the exact existing cli behaviour).
+	 * - Used by the config tool as the file/ui default and by `generate` to decide whether a flag is emitted.
+	 */
+	default?: string | number | boolean
+	/** One-line description. Used verbatim as the commander option description and the yaml comment. */
+	short: string
+	/** Full commander flags string, verbatim (e.g. '--admin-port <number>'). Omit for env-only options. */
+	cliFlag?: string
+	/** True for negated flags like '--no-notifications' (commander stores the value under the positive `key`). */
+	cliNegated?: boolean
+	/** Environment variable this maps to. Set for env-only options, and for flag+env options. */
+	envVar?: string
+	/** Optional validation; return an error message string, or undefined when valid. */
+	validate?: (value: unknown) => string | undefined
+}
+
+const LOG_LEVELS = ['error', 'warn', 'info', 'http', 'verbose', 'debug', 'silly'] as const
+
+function validatePort(value: unknown): string | undefined {
+	if (value === null || value === undefined || value === '') return undefined
+	const port = Number(value)
+	if (!Number.isInteger(port) || port <= 0 || port > 65535) return `Must be a port number between 1 and 65535`
+	return undefined
+}
+
+/** The config-tool-managed launch options. Order here is the order they appear in `--help` and the config file. */
+export const LAUNCH_OPTIONS: readonly LaunchOption[] = [
+	{
+		key: 'adminPort',
+		type: 'number',
+		default: 8000,
+		short: 'Set the port the admin ui should bind to',
+		cliFlag: '--admin-port <number>',
+		validate: validatePort,
+	},
+	{
+		key: 'adminInterface',
+		type: 'string',
+		short: 'Set the interface the admin ui should bind to. The first ip on this interface will be used',
+		cliFlag: '--admin-interface <string>',
+	},
+	{
+		key: 'adminAddress',
+		type: 'string',
+		short: 'Set the ip address the admin ui should bind to (default: "0.0.0.0")',
+		cliFlag: '--admin-address <string>',
+	},
+	{
+		key: 'extraModulePath',
+		type: 'string',
+		short: 'Search an extra directory for modules to load',
+		cliFlag: '--extra-module-path <string>',
+	},
+	{
+		key: 'logLevel',
+		type: 'enum',
+		enumValues: LOG_LEVELS,
+		short: 'Log level to output to console',
+		cliFlag: '--log-level <string>',
+	},
+	{
+		key: 'syslogEnable',
+		type: 'boolean',
+		default: false,
+		short: 'Enable syslog transport',
+		cliFlag: '--syslog-enable',
+	},
+	{
+		key: 'syslogHost',
+		type: 'string',
+		short: 'Syslog server to write to (default: localhost)',
+		cliFlag: '--syslog-host <string>',
+	},
+	{
+		key: 'syslogPort',
+		type: 'number',
+		short: 'Port on syslog server to write to',
+		cliFlag: '--syslog-port <string>',
+		validate: validatePort,
+	},
+	{
+		key: 'syslogTcp',
+		type: 'boolean',
+		default: false,
+		short: 'Use TCP for transport (default: udp)',
+		cliFlag: '--syslog-tcp',
+	},
+	{
+		key: 'syslogLocalhost',
+		type: 'string',
+		short: 'Hostname of this machine',
+		cliFlag: '--syslog-localhost <string>',
+	},
+	{
+		key: 'enableShellCommandSupport',
+		type: 'boolean',
+		default: false,
+		short: 'Allow running shell commands on this computer (e.g. the internal "run shell command" action)',
+		cliFlag: '--enable-shell-command-support',
+		envVar: 'COMPANION_ENABLE_SHELL_COMMAND_SUPPORT',
+	},
+	{
+		// Defaults to true for headless installs (this tool): importing modules is a common,
+		// expected workflow there. The desktop app's own default stays false - registerLaunchOptions
+		// does not pass boolean defaults to commander, so this only affects config-tool output.
+		key: 'enableRestrictedModules',
+		type: 'boolean',
+		default: true,
+		short:
+			'Allow loading modules that are otherwise held back for safety, e.g. importing custom modules from remote (non-loopback) clients. Local clients can always import',
+		cliFlag: '--enable-restricted-modules',
+		envVar: 'COMPANION_ENABLE_RESTRICTED_MODULES',
+	},
+	{
+		key: 'trustedProxies',
+		type: 'string',
+		short:
+			'Trust a reverse proxy in front of the admin UI, so the real client ip is detected instead of the proxy address',
+		cliFlag: '--trusted-proxies <value>',
+		envVar: 'COMPANION_TRUSTED_PROXIES',
+	},
+	{
+		key: 'notifications',
+		type: 'boolean',
+		default: true,
+		short: "Don't show version-related notifications in the header.",
+		cliFlag: '--no-notifications',
+		cliNegated: true,
+	},
+	{
+		key: 'disableIpv6',
+		type: 'boolean',
+		default: false,
+		short: 'Disable IPv6 support, binding the admin ui to IPv4 (0.0.0.0) by default',
+		envVar: 'DISABLE_IPV6',
+	},
+]
+
+/** The bare long flag name for an option (e.g. '--admin-port <number>' -> '--admin-port'). */
+export function launchOptionFlagName(option: LaunchOption): string | undefined {
+	return option.cliFlag?.split(/\s+/)[0]
+}
+
+/** Whether a cli flag takes a value (has a <required> or [optional] placeholder). */
+export function launchOptionTakesValue(option: LaunchOption): boolean {
+	return !!option.cliFlag && /[<[]/.test(option.cliFlag)
+}

--- a/tools/build/dist.mts
+++ b/tools/build/dist.mts
@@ -142,6 +142,9 @@ await fs.copy(path.join('assets', 'Fonts'), 'dist/assets/Fonts')
 // Do this last so webpack can find resources (esp. package.json)
 // (note currently this isn't needed since we've disabled URL processing, but in the future this may help...)
 // Build application
+// Tell the esbuild step which platform we are targeting, so the linux-only headless
+// config-tool is only bundled for linux builds.
+process.env.COMPANION_BUILD_PLATFORM = platformInfo.nodePlatform
 await $`yarn workspace @companion-app/shared build:ts`
 await $`yarn workspace companion build`
 

--- a/tools/build_esbuild.mts
+++ b/tools/build_esbuild.mts
@@ -9,6 +9,7 @@ const devMode = process.env.ESBUILD_IN_DEV_MODE === '1'
 console.log(`Running esbuild in ${devMode ? 'development' : 'production'} mode.`)
 
 const companionDir = path.resolve(import.meta.dirname, '../companion')
+const configToolDir = path.resolve(import.meta.dirname, '../config-tool')
 const distPath = path.resolve(import.meta.dirname, '../dist')
 const buildFile = fs.readFileSync(path.resolve(import.meta.dirname, '../BUILD'), 'utf8').trim()
 const sentryAuthToken = process.env.SENTRY_AUTH_TOKEN
@@ -39,28 +40,30 @@ const sharedOptions: BuildOptions = {
 			`const __dirname = __esbuild_dirname(__filename);`,
 		].join('\n'),
 	},
-	// Sentry source-map uploads: each build invocation uploads its own output files to the
-	// same release. Builds run sequentially so there is no race on release creation/finalization.
-	plugins: sentryAuthToken
-		? [
-				sentryEsbuildPlugin({
-					authToken: sentryAuthToken,
-					org: 'bitfocus',
-					project: 'companion',
-					release: {
-						name: `companion@${buildFile}`,
-					},
-					errorHandler: (err) => {
-						console.warn('Sentry error', err)
-					},
-				}),
-			]
-		: [],
 }
+
+// Sentry source-map uploads: each build invocation uploads its own output files to the
+// same release. Builds run sequentially so there is no race on release creation/finalization.
+const sentryPlugins: BuildOptions['plugins'] = sentryAuthToken
+	? [
+			sentryEsbuildPlugin({
+				authToken: sentryAuthToken,
+				org: 'bitfocus',
+				project: 'companion',
+				release: {
+					name: `companion@${buildFile}`,
+				},
+				errorHandler: (err) => {
+					console.warn('Sentry error', err)
+				},
+			}),
+		]
+	: []
 
 // Node.js 26: main application and internal worker threads
 await esbuild.build({
 	...sharedOptions,
+	plugins: sentryPlugins,
 	target: 'node26',
 	entryPoints: [
 		{ in: 'lib/main.ts', out: 'main' },
@@ -69,9 +72,23 @@ await esbuild.build({
 	],
 })
 
+// Node.js 26: standalone headless config tool (companion-pi launch tooling).
+// This is a linux-only headless tool, so only bundle it for linux builds
+const targetBuildPlatform = process.env.COMPANION_BUILD_PLATFORM
+if (!targetBuildPlatform || targetBuildPlatform === 'linux') {
+	await esbuild.build({
+		...sharedOptions,
+		plugins: [],
+		absWorkingDir: configToolDir,
+		target: 'node26',
+		entryPoints: [{ in: 'lib/main.ts', out: 'config-tool' }],
+	})
+}
+
 // Node.js 22: module host threads (must match user-module targets)
 await esbuild.build({
 	...sharedOptions,
+	plugins: sentryPlugins,
 	target: 'node22',
 	entryPoints: [
 		{ in: 'lib/Instance/Surface/Thread/Entrypoint.ts', out: 'SurfaceThread' },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
 		{ "path": "./tsconfig.tools.json" },
 		{ "path": "./companion" },
 		{ "path": "./shared-lib" },
+		{ "path": "./config-tool" },
 		{ "path": "./webui" },
 		{ "path": "./launcher-ui" },
 		{ "path": "./docs" }

--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -3,6 +3,7 @@
 	"include": [
 		"vitest.config.mts",
 		"companion/test/**/*",
+		"config-tool/test/**/*",
 		"shared-lib/lib/**/*spec.ts",
 		"shared-lib/lib/**/*test.ts",
 		"shared-lib/lib/**/__tests__/*",
@@ -23,5 +24,5 @@
 		"noEmit": true,
 		"skipLibCheck": true
 	},
-	"references": [{ "path": "./companion" }, { "path": "./shared-lib" }]
+	"references": [{ "path": "./companion" }, { "path": "./config-tool" }, { "path": "./shared-lib" }]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -37,6 +37,14 @@ export default defineConfig({
 					],
 				},
 			},
+
+			{
+				test: {
+					name: 'config-tool',
+					root: 'config-tool',
+					exclude: ['**/node_modules/**', '**/dist/**', '**/build/**', '**/coverage/**'],
+				},
+			},
 		],
 		// reporters: ['default', 'html'],
 		// coverage: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -463,7 +463,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-plugin-utils@npm:^7.0.0, @babel/helper-plugin-utils@npm:^7.18.6, @babel/helper-plugin-utils@npm:^7.27.1, @babel/helper-plugin-utils@npm:^7.28.6, @babel/helper-plugin-utils@npm:^7.29.7, @babel/helper-plugin-utils@npm:^7.8.0":
+"@babel/helper-plugin-utils@npm:^7.0.0, @babel/helper-plugin-utils@npm:^7.18.6, @babel/helper-plugin-utils@npm:^7.27.1, @babel/helper-plugin-utils@npm:^7.28.6, @babel/helper-plugin-utils@npm:^7.8.0":
+  version: 7.28.6
+  resolution: "@babel/helper-plugin-utils@npm:7.28.6"
+  checksum: 10c0/3f5f8acc152fdbb69a84b8624145ff4f9b9f6e776cb989f9f968f8606eb7185c5c3cfcf3ba08534e37e1e0e1c118ac67080610333f56baa4f7376c99b5f1143d
+  languageName: node
+  linkType: hard
+
+"@babel/helper-plugin-utils@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/helper-plugin-utils@npm:7.29.7"
   checksum: 10c0/380477a06133274a2759f9355929cb60a95e8b8fee624a1ae1fa349e1d1645b89daca456f72833f6d1062bffa12ee4271c5bf0cc5a61c0166cdc24c7591e2408
@@ -1649,6 +1656,17 @@ __metadata:
   checksum: 10c0/9328a0778a5b0db243af54455b79a69e3fb21122d6c15ef9e9fcc94881d8d17352d8b2b2590f9bdd46fac5c2d6c1636dcfc14358a20c70e22daf89e1a759b629
   languageName: node
   linkType: hard
+
+"@companion-app/config-tool@workspace:config-tool":
+  version: 0.0.0-use.local
+  resolution: "@companion-app/config-tool@workspace:config-tool"
+  dependencies:
+    "@companion-app/shared": "npm:*"
+    "@inquirer/prompts": "npm:^7.2.0"
+    typescript: "npm:~6.0.3"
+    yaml: "npm:^2.9.0"
+  languageName: unknown
+  linkType: soft
 
 "@companion-app/docs@workspace:docs":
   version: 0.0.0-use.local
@@ -4145,6 +4163,253 @@ __metadata:
     prettier-plugin-ember-template-tag:
       optional: true
   checksum: 10c0/5a897a5263db3b91b698d5c59aa0397bb3440fc1a7610d8e35e1aacb8154a4d24e1489e25155dfa5a202bbf62ca10969d19a42d73c24c97bcdef1d7030bd150c
+  languageName: node
+  linkType: hard
+
+"@inquirer/ansi@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@inquirer/ansi@npm:1.0.2"
+  checksum: 10c0/8e408cc628923aa93402e66657482ccaa2ad5174f9db526d9a8b443f9011e9cd8f70f0f534f5fe3857b8a9df3bce1e25f66c96f666d6750490bd46e2b4f3b829
+  languageName: node
+  linkType: hard
+
+"@inquirer/checkbox@npm:^4.3.2":
+  version: 4.3.2
+  resolution: "@inquirer/checkbox@npm:4.3.2"
+  dependencies:
+    "@inquirer/ansi": "npm:^1.0.2"
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/figures": "npm:^1.0.15"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/771d23bc6b16cd5c21a4f1073e98e306147f90c0e2487fe887ee054b8bf86449f1f9e6e6f9c218c1aa45ae3be2533197d53654abe9c0545981aebb0920d5f471
+  languageName: node
+  linkType: hard
+
+"@inquirer/confirm@npm:^5.1.21":
+  version: 5.1.21
+  resolution: "@inquirer/confirm@npm:5.1.21"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/a95bbdbb17626c484735a4193ed6b6a6fbb078cf62116ec8e1667f647e534dd6618e688ecc7962585efcc56881b544b8c53db3914599bbf2ab842e7f224b0fca
+  languageName: node
+  linkType: hard
+
+"@inquirer/core@npm:^10.3.2":
+  version: 10.3.2
+  resolution: "@inquirer/core@npm:10.3.2"
+  dependencies:
+    "@inquirer/ansi": "npm:^1.0.2"
+    "@inquirer/figures": "npm:^1.0.15"
+    "@inquirer/type": "npm:^3.0.10"
+    cli-width: "npm:^4.1.0"
+    mute-stream: "npm:^2.0.0"
+    signal-exit: "npm:^4.1.0"
+    wrap-ansi: "npm:^6.2.0"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/f0f27e07fe288e01e3949b4ad216c19751f025ce77c610366e08d8b0f7a135d064dc074732031d251584b454c576f1e5c849e4abe259186dd5d4974c8f85c13e
+  languageName: node
+  linkType: hard
+
+"@inquirer/editor@npm:^4.2.23":
+  version: 4.2.23
+  resolution: "@inquirer/editor@npm:4.2.23"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/external-editor": "npm:^1.0.3"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/aa02028ee35ae039a4857b6a9490d295a1b3558f042e7454dee0aa36fbc83ac25586a2dfe0b46a5ea7ea151e3f5cb97a8ee6229131b4619f3b3466ad74b9519f
+  languageName: node
+  linkType: hard
+
+"@inquirer/expand@npm:^4.0.23":
+  version: 4.0.23
+  resolution: "@inquirer/expand@npm:4.0.23"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/294c92652760c3d1a46c4b900a99fd553ea9e5734ba261d4e71d7b8499d86a8b15e38a2467ddb7c95c197daf7e472bdab209fc3f7c38cbc70842cd291f4ce39d
+  languageName: node
+  linkType: hard
+
+"@inquirer/external-editor@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "@inquirer/external-editor@npm:1.0.3"
+  dependencies:
+    chardet: "npm:^2.1.1"
+    iconv-lite: "npm:^0.7.0"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/82951cb7f3762dd78cca2ea291396841e3f4adfe26004b5badfed1cec4b6a04bb567dff94d0e41b35c61bdd7957317c64c22f58074d14b238d44e44d9e420019
+  languageName: node
+  linkType: hard
+
+"@inquirer/figures@npm:^1.0.15":
+  version: 1.0.15
+  resolution: "@inquirer/figures@npm:1.0.15"
+  checksum: 10c0/6e39a040d260ae234ae220180b7994ff852673e20be925f8aa95e78c7934d732b018cbb4d0ec39e600a410461bcb93dca771e7de23caa10630d255692e440f69
+  languageName: node
+  linkType: hard
+
+"@inquirer/input@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "@inquirer/input@npm:4.3.1"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/9e81d6ae56e5b59f96475ae1327e7e7beeef0d917b83762e0c2ed5a75239ad6b1a39fc05553ce45fe6f6de49681dade8704b5f1c11c2f555663a74d0ac998af3
+  languageName: node
+  linkType: hard
+
+"@inquirer/number@npm:^3.0.23":
+  version: 3.0.23
+  resolution: "@inquirer/number@npm:3.0.23"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/3944a524be2a2e0834822a0e483f2e2fd56ad597b5feeca2155b956821f88e22e07ce3816f66113b040601636ed7146865aee7d7afb2a06939acc77491330ccc
+  languageName: node
+  linkType: hard
+
+"@inquirer/password@npm:^4.0.23":
+  version: 4.0.23
+  resolution: "@inquirer/password@npm:4.0.23"
+  dependencies:
+    "@inquirer/ansi": "npm:^1.0.2"
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/9fd3d0462d02735bb1521c4e221d057a94d9aaac308e9a192e59d6c1e8efc707c2376ab627151d589bc3633f6b14b74b60b91c3d473a32adfd100ef1f6cfdef7
+  languageName: node
+  linkType: hard
+
+"@inquirer/prompts@npm:^7.2.0":
+  version: 7.10.1
+  resolution: "@inquirer/prompts@npm:7.10.1"
+  dependencies:
+    "@inquirer/checkbox": "npm:^4.3.2"
+    "@inquirer/confirm": "npm:^5.1.21"
+    "@inquirer/editor": "npm:^4.2.23"
+    "@inquirer/expand": "npm:^4.0.23"
+    "@inquirer/input": "npm:^4.3.1"
+    "@inquirer/number": "npm:^3.0.23"
+    "@inquirer/password": "npm:^4.0.23"
+    "@inquirer/rawlist": "npm:^4.1.11"
+    "@inquirer/search": "npm:^3.2.2"
+    "@inquirer/select": "npm:^4.4.2"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/eac309cc75712bc94fc8b6761d6a736786ca1942cf9c90805b2a6049a05ce6131bcfb3aa703d1dbe66874d1b78c2b446044ad9735a2bb76743b8ddcb3dcb4d2a
+  languageName: node
+  linkType: hard
+
+"@inquirer/rawlist@npm:^4.1.11":
+  version: 4.1.11
+  resolution: "@inquirer/rawlist@npm:4.1.11"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/33792b40cd0fbf77f547c9c4805087dd1188342c6a5ca512c73b0b6c4d132225fc5ae8bc4fd5035309484da3698a90fcef17aad100b9ae57624fda7b07d92227
+  languageName: node
+  linkType: hard
+
+"@inquirer/search@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "@inquirer/search@npm:3.2.2"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/figures": "npm:^1.0.15"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/e7849663a51fe95e3ce99d274c815b8dc8933d6a5ddcaaf6130bf43f5f10316062c9f7a37c2923a14b8dcd09d202b0bb9cc3eaf0adb0336f6a704ea52e03ef8c
+  languageName: node
+  linkType: hard
+
+"@inquirer/select@npm:^4.4.2":
+  version: 4.4.2
+  resolution: "@inquirer/select@npm:4.4.2"
+  dependencies:
+    "@inquirer/ansi": "npm:^1.0.2"
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/figures": "npm:^1.0.15"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/6978a5a92928b4d439dd6b688f2db51fd49be209f24be224bb81ed8f75b76e0715e79bdb05dab2a33bbdc7091c779a99f8603fe0ca199f059528ca2b1d0d4944
+  languageName: node
+  linkType: hard
+
+"@inquirer/type@npm:^3.0.10":
+  version: 3.0.10
+  resolution: "@inquirer/type@npm:3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/a846c7a570e3bf2657d489bcc5dcdc3179d24c7323719de1951dcdb722400ac76e5b2bfe9765d0a789bc1921fac810983d7999f021f30a78a6a174c23fc78dc9
   languageName: node
   linkType: hard
 
@@ -10535,6 +10800,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chardet@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "chardet@npm:2.1.1"
+  checksum: 10c0/d8391dd412338442b3de0d3a488aa9327f8bcf74b62b8723d6bd0b85c4084d50b731320e0a7c710edb1d44de75969995d2784b80e4c13b004a6c7a0db4c6e793
+  languageName: node
+  linkType: hard
+
 "check-error@npm:^2.1.1":
   version: 2.1.3
   resolution: "check-error@npm:2.1.3"
@@ -10726,6 +10998,13 @@ __metadata:
     slice-ansi: "npm:^8.0.0"
     string-width: "npm:^8.2.0"
   checksum: 10c0/0d4ec94702ca85b64522ac93633837fb5ea7db17b79b1322a60f6045e6ae2b8cd7bd4c1d19ac7d1f9e10e3bbda1112e172e439b68c02b785ee00da8d6a5c5471
+  languageName: node
+  linkType: hard
+
+"cli-width@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "cli-width@npm:4.1.0"
+  checksum: 10c0/1fbd56413578f6117abcaf858903ba1f4ad78370a4032f916745fa2c7e390183a9d9029cf837df320b0fdce8137668e522f60a30a5f3d6529ff3872d265a955f
   languageName: node
   linkType: hard
 
@@ -18264,6 +18543,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mute-stream@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mute-stream@npm:2.0.0"
+  checksum: 10c0/2cf48a2087175c60c8dcdbc619908b49c07f7adcfc37d29236b0c5c612d6204f789104c98cc44d38acab7b3c96f4a3ec2cfdc4934d0738d876dbefa2a12c69f4
+  languageName: node
+  linkType: hard
+
 "nanoid@npm:^3.3.11, nanoid@npm:^3.3.12":
   version: 3.3.12
   resolution: "nanoid@npm:3.3.12"
@@ -20334,7 +20620,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.3.11, postcss@npm:^8.4.21, postcss@npm:^8.4.24, postcss@npm:^8.4.33, postcss@npm:^8.5.15, postcss@npm:^8.5.4, postcss@npm:^8.5.6":
+"postcss@npm:^8.3.11, postcss@npm:^8.4.21, postcss@npm:^8.4.24, postcss@npm:^8.4.33, postcss@npm:^8.5.4, postcss@npm:^8.5.6":
+  version: 8.5.10
+  resolution: "postcss@npm:8.5.10"
+  dependencies:
+    nanoid: "npm:^3.3.11"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10c0/c592dffa0c4873b401f01955b265538d9942f425040df5e2b8f0ad34c83773a792ea0fa5859ccc99cfb5b955b4ebff118ab7056315388dc83b107b0fa8313576
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.5.15":
   version: 8.5.15
   resolution: "postcss@npm:8.5.15"
   dependencies:
@@ -23705,7 +24002,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.15, tinyglobby@npm:^0.2.17, tinyglobby@npm:^0.2.9":
+"tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.15, tinyglobby@npm:^0.2.9":
+  version: 0.2.15
+  resolution: "tinyglobby@npm:0.2.15"
+  dependencies:
+    fdir: "npm:^6.5.0"
+    picomatch: "npm:^4.0.3"
+  checksum: 10c0/869c31490d0d88eedb8305d178d4c75e7463e820df5a9b9d388291daf93e8b1eb5de1dad1c1e139767e4269fe75f3b10d5009b2cc14db96ff98986920a186844
+  languageName: node
+  linkType: hard
+
+"tinyglobby@npm:^0.2.17":
   version: 0.2.17
   resolution: "tinyglobby@npm:0.2.17"
   dependencies:
@@ -25444,6 +25751,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"wrap-ansi@npm:^6.2.0":
+  version: 6.2.0
+  resolution: "wrap-ansi@npm:6.2.0"
+  dependencies:
+    ansi-styles: "npm:^4.0.0"
+    string-width: "npm:^4.1.0"
+    strip-ansi: "npm:^6.0.0"
+  checksum: 10c0/baad244e6e33335ea24e86e51868fe6823626e3a3c88d9a6674642afff1d34d9a154c917e74af8d845fd25d170c4ea9cf69a47133c3f3656e1252b3d462d9f6c
+  languageName: node
+  linkType: hard
+
 "wrap-ansi@npm:^7.0.0":
   version: 7.0.0
   resolution: "wrap-ansi@npm:7.0.0"
@@ -25722,6 +26040,13 @@ __metadata:
   version: 1.2.1
   resolution: "yocto-queue@npm:1.2.1"
   checksum: 10c0/5762caa3d0b421f4bdb7a1926b2ae2189fc6e4a14469258f183600028eb16db3e9e0306f46e8ebf5a52ff4b81a881f22637afefbef5399d6ad440824e9b27f9f
+  languageName: node
+  linkType: hard
+
+"yoctocolors-cjs@npm:^2.1.3":
+  version: 2.1.3
+  resolution: "yoctocolors-cjs@npm:2.1.3"
+  checksum: 10c0/584168ef98eb5d913473a4858dce128803c4a6cd87c0f09e954fa01126a59a33ab9e513b633ad9ab953786ed16efdd8c8700097a51635aafaeed3fef7712fa79
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
There are various config options available now in the launcher, which are not settable in our headless 'companion-pi' tooling.

This adds a new tool to the linux builds to be an interactive config editor and to generate the correct launch command.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a headless configuration tool to manage companion launch settings using YAML: interactive editing, initialization, validation, and bash snippet generation.
  * Launch settings are derived from shared option definitions, including proper handling of booleans and safe quoting for generated output.

* **Tests**
  * Expanded Vitest coverage for configuration loading/merging/writing, option parsing/coercion/validation, snippet generation, and schema invariants.

* **Chores**
  * Refactored CLI launch option registration to be fully data-driven from shared definitions.
  * Updated workspace, linting, TypeScript, and build tooling to include the new tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->