### PR TITLE
feat: more expression math utils

### DIFF
--- a/docs/user-guide/4_expressions/functions.md
+++ b/docs/user-guide/4_expressions/functions.md
@@ -114,6 +114,12 @@ Calculate the square root of a number.
 
 eg `sqrt(9)` gives `3`
 
+**pow(base, exponent)**
+
+Calculate the base raised to the power of the exponent. Equivalent to the `**` operator, but available as a function for clarity and for those used to other languages.
+
+eg `pow(2, 10)` gives `1024`
+
 The constant `PI` is also available as a value, eg `2 * PI`.
 
 ### String operations

--- a/docs/user-guide/4_expressions/functions.md
+++ b/docs/user-guide/4_expressions/functions.md
@@ -90,13 +90,31 @@ Generate a random integer in the specified range (inclusive).
 
 eg `randomInt(1, 6)` gives a dice roll between 1 and 6.
 
-**log(v)**
+**log(v, [base])**
 
-Calculate the natural logarithm of a number.
+Calculate the logarithm of a number. With no base, returns the natural logarithm (base e). With a base, returns the logarithm to that base.
+
+eg `log(8, 2)` gives `3`, `log(1000, 10)` gives `3`
 
 **log10(v)**
 
 Calculate the base 10 logarithm of a number.
+
+eg `log10(1000)` gives `3`
+
+**exp(v)**
+
+Calculate e raised to the power of a number (the inverse of the natural logarithm).
+
+eg `exp(0)` gives `1`. The value of e itself is `exp(1)`.
+
+**sqrt(v)**
+
+Calculate the square root of a number.
+
+eg `sqrt(9)` gives `3`
+
+The constant `PI` is also available as a value, eg `2 * PI`.
 
 ### String operations
 

--- a/shared-lib/lib/Expression/ExpressionFunctions.ts
+++ b/shared-lib/lib/Expression/ExpressionFunctions.ts
@@ -153,6 +153,7 @@ export const ExpressionFunctions: Record<string, (...args: any[]) => any> = {
 	log10: (v) => Math.log10(v),
 	exp: (v) => Math.exp(v),
 	sqrt: (v) => Math.sqrt(v),
+	pow: (base, exponent) => Math.pow(base, exponent),
 
 	// String operations
 	trim: (v) => toString(v).trim(),

--- a/shared-lib/lib/Expression/ExpressionFunctions.ts
+++ b/shared-lib/lib/Expression/ExpressionFunctions.ts
@@ -149,8 +149,10 @@ export const ExpressionFunctions: Record<string, (...args: any[]) => any> = {
 		// Use floor over a [0, n+1) range so that min and max are as likely as interior values
 		return min + Math.floor(Math.random() * (max - min + 1))
 	},
-	log: (v) => Math.log(v),
+	log: (v, base) => (base === undefined ? Math.log(v) : Math.log(v) / Math.log(base)),
 	log10: (v) => Math.log10(v),
+	exp: (v) => Math.exp(v),
+	sqrt: (v) => Math.sqrt(v),
 
 	// String operations
 	trim: (v) => toString(v).trim(),

--- a/shared-lib/lib/Expression/ExpressionResolve.ts
+++ b/shared-lib/lib/Expression/ExpressionResolve.ts
@@ -52,7 +52,7 @@ export function ResolveExpression(
 	}
 
 	const resolverState: ResolverState = {
-		values: Object.create(null),
+		values: Object.assign(Object.create(null), { PI: Math.PI }),
 		isComplete: false,
 	}
 

--- a/shared-lib/lib/__tests__/expressions-functions.test.ts
+++ b/shared-lib/lib/__tests__/expressions-functions.test.ts
@@ -228,6 +228,14 @@ describe('functions', () => {
 			expect(ExpressionFunctions.sqrt(-1)).toBe(NaN)
 			expect(ExpressionFunctions.sqrt(undefined)).toBe(NaN)
 		})
+
+		it('pow', () => {
+			expect(ExpressionFunctions.pow(2, 10)).toBe(1024)
+			expect(ExpressionFunctions.pow(9, 0.5)).toBe(3)
+			expect(ExpressionFunctions.pow('2', '3')).toBe(8)
+			expect(ExpressionFunctions.pow(2, -1)).toBe(0.5)
+			expect(ExpressionFunctions.pow(2, undefined)).toBe(NaN)
+		})
 	})
 
 	describe('string', () => {

--- a/shared-lib/lib/__tests__/expressions-functions.test.ts
+++ b/shared-lib/lib/__tests__/expressions-functions.test.ts
@@ -197,6 +197,13 @@ describe('functions', () => {
 			expect(ExpressionFunctions.log(undefined)).toBe(NaN)
 		})
 
+		it('log with base', () => {
+			expect(ExpressionFunctions.log(8, 2)).toBeCloseTo(3)
+			expect(ExpressionFunctions.log(1000, 10)).toBeCloseTo(3)
+			expect(ExpressionFunctions.log('100', 10)).toBeCloseTo(2)
+			expect(ExpressionFunctions.log(8)).toBeCloseTo(Math.log(8)) // base omitted = natural
+		})
+
 		it('log10', () => {
 			expect(ExpressionFunctions.log10(1)).toBe(0)
 			expect(ExpressionFunctions.log10(10)).toBe(1)
@@ -206,6 +213,20 @@ describe('functions', () => {
 			expect(ExpressionFunctions.log10(-1)).toBe(NaN)
 			expect(ExpressionFunctions.log10('100')).toBe(2)
 			expect(ExpressionFunctions.log10(undefined)).toBe(NaN)
+		})
+
+		it('exp', () => {
+			expect(ExpressionFunctions.exp(0)).toBe(1)
+			expect(ExpressionFunctions.exp(1)).toBeCloseTo(Math.E)
+			expect(ExpressionFunctions.exp('2')).toBeCloseTo(Math.E * Math.E)
+			expect(ExpressionFunctions.exp(undefined)).toBe(NaN)
+		})
+
+		it('sqrt', () => {
+			expect(ExpressionFunctions.sqrt(9)).toBe(3)
+			expect(ExpressionFunctions.sqrt('16')).toBe(4)
+			expect(ExpressionFunctions.sqrt(-1)).toBe(NaN)
+			expect(ExpressionFunctions.sqrt(undefined)).toBe(NaN)
 		})
 	})
 

--- a/shared-lib/lib/__tests__/expressions-resolver.test.ts
+++ b/shared-lib/lib/__tests__/expressions-resolver.test.ts
@@ -93,6 +93,20 @@ describe('resolver', function () {
 		})
 	})
 
+	describe('builtin constants', function () {
+		it('should resolve PI', function () {
+			expect(resolve(parse('PI'), defaultGetValue)).toBeCloseTo(Math.PI)
+		})
+
+		it('should be usable in expressions', function () {
+			expect(resolve(parse('2 * PI'), defaultGetValue)).toBeCloseTo(2 * Math.PI)
+		})
+
+		it('should be overridable by an explicit assignment', function () {
+			expect(resolve(parse('PI = 5 ; PI'), defaultGetValue)).toBe(5)
+		})
+	})
+
 	describe('expressions with symbol/variable operands', function () {
 		it('should handle symbol and literal operands', function () {
 			const postfix = parse('$(internal:a) + 1')

--- a/webui/src/Resources/Expression.monarch.ts
+++ b/webui/src/Resources/Expression.monarch.ts
@@ -76,8 +76,14 @@ export const builtinFunctionCompletions: Array<{
 		detail: 'randomInt(min, max)',
 		documentation: 'Returns a random integer between min and max',
 	},
-	{ name: 'log', detail: 'log(number)', documentation: 'Returns the natural logarithm of a number' },
+	{
+		name: 'log',
+		detail: 'log(number, [base])',
+		documentation: 'Returns the logarithm of a number (natural log if no base given)',
+	},
 	{ name: 'log10', detail: 'log10(number)', documentation: 'Returns the base-10 logarithm of a number' },
+	{ name: 'exp', detail: 'exp(number)', documentation: 'Returns e raised to the power of a number' },
+	{ name: 'sqrt', detail: 'sqrt(number)', documentation: 'Returns the square root of a number' },
 
 	// String operations
 	{ name: 'trim', detail: 'trim(string)', documentation: 'Removes whitespace from both ends of a string' },
@@ -288,7 +294,7 @@ export const builtinFunctionCompletions: Array<{
 ]
 
 const keywords = ['return', 'undefined']
-const typeKeywords = ['true', 'false', 'null']
+const typeKeywords = ['true', 'false', 'null', 'PI']
 
 const companionExpressionLanguageConfiguration: languages.LanguageConfiguration = {
 	comments: {

--- a/webui/src/Resources/Expression.monarch.ts
+++ b/webui/src/Resources/Expression.monarch.ts
@@ -84,6 +84,7 @@ export const builtinFunctionCompletions: Array<{
 	{ name: 'log10', detail: 'log10(number)', documentation: 'Returns the base-10 logarithm of a number' },
 	{ name: 'exp', detail: 'exp(number)', documentation: 'Returns e raised to the power of a number' },
 	{ name: 'sqrt', detail: 'sqrt(number)', documentation: 'Returns the square root of a number' },
+	{ name: 'pow', detail: 'pow(base, exponent)', documentation: 'Returns the base raised to the power of the exponent' },
 
 	// String operations
 	{ name: 'trim', detail: 'trim(string)', documentation: 'Removes whitespace from both ends of a string' },


### PR DESCRIPTION
I'm not 100% about any of this, so input is appreciated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended `log(v, [base])` to support optional base (defaults to natural logarithm)
  * Added `exp(v)`, `sqrt(v)`, and `pow(base, exponent)` expression functions
  * Added built-in `PI` constant support in expressions

* **Documentation**
  * Updated the expressions functions guide to reflect `log(v, [base])`, including `log10(v)`, and added references for `exp()` and `sqrt()`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->