### PR TITLE
feat: Variable for surface brightness

### DIFF
--- a/companion/lib/Internal/Surface.ts
+++ b/companion/lib/Internal/Surface.ts
@@ -109,6 +109,7 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 		})
 		this.#surfaceController.on('group_page', () => debounceUpdateVariables())
 		this.#surfaceController.on('surface_locked', () => debounceUpdateVariables())
+		this.#surfaceController.on('surface-config', () => debounceUpdateVariables())
 
 		this.#surfaceController.on('group-add', () => {
 			debounceUpdateVariableDefinitions()
@@ -208,6 +209,10 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 						name: `surface_${surfaceId}_locked`,
 					},
 					{
+						description: `Surface brightness: ${surface.displayName}`,
+						name: `surface_${surfaceId}_brightness`,
+					},
+					{
 						description: `Surface location: ${surface.displayName}`,
 						name: `surface_${surfaceId}_location`,
 					},
@@ -238,6 +243,7 @@ export class InternalSurface extends EventEmitter<InternalModuleFragmentEvents> 
 				const surfaceId = surface.id.replaceAll(':', '_') // TODO - more chars
 				values[`surface_${surfaceId}_name`] = surface.name || surface.id
 				values[`surface_${surfaceId}_locked`] = surface.locked
+				values[`surface_${surfaceId}_brightness`] = surface.brightness ?? 100
 				values[`surface_${surfaceId}_location`] = surface.location ?? 'Local'
 
 				const surfacePageId = this.#surfaceController.devicePageGet(surface.id)

--- a/companion/lib/Surface/Controller.ts
+++ b/companion/lib/Surface/Controller.ts
@@ -1035,6 +1035,7 @@ export class SurfaceController extends EventEmitter<SurfaceControllerEvents> {
 
 				size: config.gridSize || null,
 				rotation: config?.config?.rotation,
+				brightness: config?.config?.brightness,
 				offset: { columns: config?.config?.xOffset ?? 0, rows: config?.config?.yOffset ?? 0 },
 			}
 

--- a/companion/lib/Surface/Handler.ts
+++ b/companion/lib/Surface/Handler.ts
@@ -353,17 +353,18 @@ export class SurfaceHandler extends EventEmitter<SurfaceHandlerEvents> {
 	 * @param brightness 0-100
 	 */
 	setBrightness(brightness: number): void {
-		if (this.panel) {
-			if (this.panel.setConfig) {
-				const config = {
-					...this.#surfaceConfig.config,
-					brightness: brightness,
-				}
+		const config = {
+			...this.#surfaceConfig.config,
+			brightness: brightness,
+		}
+		this.#surfaceConfig.config = config
 
-				setImmediate(() => {
-					this.panel.setConfig(config)
-				})
-			}
+		this.#saveConfig()
+
+		if (this.panel && this.panel.setConfig) {
+			setImmediate(() => {
+				this.panel.setConfig(config)
+			})
 		}
 	}
 

--- a/shared-lib/lib/Model/Surfaces.ts
+++ b/shared-lib/lib/Model/Surfaces.ts
@@ -50,6 +50,7 @@ export interface ClientSurfaceItem {
 
 	size: RowsAndColumns | null
 	rotation: SurfaceRotation | null
+	brightness: number | null
 	offset: RowsAndColumns | null
 }
 


### PR DESCRIPTION
Adds a `surface_<id>_brightness` internal variable, alongside the existing
  name/locked/location/page ones, so a surface's current brightness is available
  to expressions and feedbacks.

  Use cases:
  - Show the current brightness on a button.
  - Day/night or screensaver style automations that react to brightness.
  - Pairs with a future relative "adjust brightness" action (e.g. a Stream Deck+
    dial to nudge it up and down), where this variable tracks the level.

  I also made the "Surface: Set to brightness" action persist its value. Before,
  it only pushed to the hardware, so the surfaces page (and this variable) showed
  a stale number after using the action. Now they stay in sync however brightness
  gets changed.

  Mostly mirrors the existing `surface_<id>_locked` variable (#3046). Live updates
  reuse the `surface-config` event since brightness is persisted config.

  Related to #1964 and #3284.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added brightness variable for each surface, available for dynamic control and integration.

* **Bug Fixes**
  * Surface brightness settings are now properly saved and persisted when updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->