### PR TITLE
feat: windows arm64 build #2933

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -560,7 +560,7 @@ jobs:
           api-secret: ${{ secrets.BITFOCUS_API_PROJECT_SECRET }}
 
   win32-arm64:
-    runs-on: windows-11-arm
+    runs-on: ${{ (startsWith(github.ref, 'refs/tags/') || contains(github.event.head_commit.message, '[build-signed]')) && fromJSON('["self-hosted", "Windows", "codecert", "X64"]') || 'windows-11-arm'}}
     needs: check-types
     timeout-minutes: 60
 
@@ -594,6 +594,7 @@ jobs:
           CI: 1
 
       - name: build & package (unsigned)
+        if: ${{ runner.environment != 'self-hosted' }}
         run: |
           yarn tsx tools/build/complete.mts win32-arm64
         env:
@@ -601,6 +602,23 @@ jobs:
           SENTRY_DSN: ${{ vars.SENTRY2_DSN }}
           VITE_SENTRY_DSN: ${{ vars.SENTRY2_UI_DSN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY2_AUTH_TOKEN }}
+
+      - name: build & package (signed)
+        if: ${{ runner.environment == 'self-hosted' }}
+        run: |
+          yarn tsx tools/build/complete.mts win32-arm64
+        env:
+          CI: 1
+          SENTRY_DSN: ${{ vars.SENTRY2_DSN }}
+          VITE_SENTRY_DSN: ${{ vars.SENTRY2_UI_DSN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY2_AUTH_TOKEN }}
+          CSC_LINK: c:\\actions-runner-bitfocusas\\codesign.cer
+          BF_CODECERT_KEY: ${{ secrets.BF_CODECERT_KEY }}
+          # the wincert machine has issues using the default cache location
+          ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder
+          NODE_OPTIONS: --max_old_space_size=4096
+          # x64 host cannot execute an arm64 node binary; the native windows-11-arm build is the launch gate
+          SKIP_LAUNCH_CHECK: true
 
       - name: Determine files to upload
         id: filenames

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -559,6 +559,101 @@ jobs:
           api-target: "win-x64"
           api-secret: ${{ secrets.BITFOCUS_API_PROJECT_SECRET }}
 
+  win32-arm64:
+    runs-on: windows-11-arm
+    needs: check-types
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          submodules: true
+          persist-credentials: false
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".node-version"
+
+      - name: Cache build sources
+        uses: actions/cache@v5
+        with:
+          path: .cache
+          key: windows-arm64-build-cache-${{ hashFiles('assets/nodejs-versions.json') }}
+
+      - name: install
+        shell: bash
+        run: |
+          npm install -g corepack --force
+
+          # try and avoid timeout errors
+          yarn config set httpTimeout 100000
+
+          yarn --immutable
+        env:
+          CI: 1
+
+      - name: build & package (unsigned)
+        run: |
+          yarn tsx tools/build/complete.mts win32-arm64
+        env:
+          CI: 1
+          SENTRY_DSN: ${{ vars.SENTRY2_DSN }}
+          VITE_SENTRY_DSN: ${{ vars.SENTRY2_UI_DSN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY2_AUTH_TOKEN }}
+
+      - name: Determine files to upload
+        id: filenames
+        shell: bash
+        run: |
+          VERSION=$(cat ./dist/BUILD)
+
+          echo "sourcename=electron-output/companion-winarm64.exe" >> $GITHUB_OUTPUT
+          echo "targetname=companion-winarm64-${VERSION}.exe" >> $GITHUB_OUTPUT
+          echo "longversion=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v7
+        with:
+          archive: false
+          name: ${{ steps.filenames.outputs.targetname }}
+          path: ${{ steps.filenames.outputs.sourcename }}
+          retention-days: 1
+      - name: Upload build (beta)
+        uses: bitfocus/actions/upload-and-notify-for-branch@main
+        if: ${{ github.repository_owner == 'bitfocus' && github.ref == 'refs/heads/main' }}
+        with:
+          source-filename: ${{ steps.filenames.outputs.sourcename }}
+          destination-filename: ${{ steps.filenames.outputs.targetname }}
+          s3-host: ${{ vars.S3_HOST }}
+          s3-bucket: ${{ vars.S3_BUCKET }}
+          s3-access-key: ${{ secrets.S3_KEY }}
+          s3-secret-key: ${{ secrets.S3_SECRET }}
+
+          api-version: ${{ steps.filenames.outputs.longversion }}
+          api-branch: "beta"
+          api-product: ${{ env.API_PRODUCT }}
+          api-target: "win-arm64"
+          api-secret: ${{ secrets.BITFOCUS_API_PROJECT_SECRET }}
+      - name: Upload build (stable)
+        uses: bitfocus/actions/upload-and-notify-for-branch@main
+        if: ${{ github.repository_owner == 'bitfocus' && startsWith(github.ref, 'refs/tags/') }}
+        with:
+          source-filename: ${{ steps.filenames.outputs.sourcename }}
+          destination-filename: ${{ steps.filenames.outputs.targetname }}
+          s3-host: ${{ vars.RELEASE_S3_HOST }}
+          s3-bucket: ${{ vars.RELEASE_S3_BUCKET }}/${{ env.API_PRODUCT }}
+          s3-access-key: ${{ secrets.RELEASE_S3_KEY }}
+          s3-secret-key: ${{ secrets.RELEASE_S3_SECRET }}
+
+          public-bucket-url: ${{ vars.RELEASE_S3_URL }}/${{ env.API_PRODUCT }}
+
+          api-version: ${{ github.ref_name }}
+          api-branch: "stable"
+          api-product: ${{ env.API_PRODUCT }}
+          api-target: "win-arm64"
+          api-secret: ${{ secrets.BITFOCUS_API_PROJECT_SECRET }}
+
   docker-image:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/companion/package.json
+++ b/companion/package.json
@@ -51,7 +51,7 @@
     "@companion-surface/host": "1.3.2",
     "@julusian/bonjour-service": "^1.4.2",
     "@julusian/image-rs": "^2.1.1",
-    "@julusian/segfault-raub": "^2.3.2",
+    "@julusian/segfault-raub": "^2.3.3",
     "@napi-rs/canvas": "^1.0.0",
     "@sentry/node": "^10.58.0",
     "@trpc/server": "^11.17.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
     "@companion-module/base": "2.1.0-0-nightly-main-20260619-194259-9fec278",
     "@companion-module/host": "1.0.3-nightly-main-20260619-194405-9fec278",
     "node-gyp": "^12.3.0",
-    "monaco-editor/dompurify": "npm:dompurify@^3.3.3"
+    "monaco-editor/dompurify": "npm:dompurify@^3.3.3",
+    "@napi-rs/canvas-win32-arm64-msvc@npm:1.0.0": "npm:@julusian/canvas-win32-arm64-msvc@1.0.0"
   },
   "dependenciesMeta": {
     "@sentry/cli": {

--- a/tools/build/package.mts
+++ b/tools/build/package.mts
@@ -187,7 +187,10 @@ if (process.env.ELECTRON !== '0') {
 				},
 			},
 			nsis: {
-				artifactName: 'companion-win64.exe',
+				artifactName:
+					platformInfo.electronBuilderArch === electronBuilder.Arch.arm64
+						? 'companion-winarm64.exe'
+						: 'companion-win64.exe',
 				createStartMenuShortcut: true,
 				perMachine: false,
 				oneClick: false,

--- a/tools/build/util.mts
+++ b/tools/build/util.mts
@@ -51,6 +51,14 @@ export function determinePlatformInfo(platform: string | undefined): PlatformInf
 			nodePlatform: 'win32',
 			runtimeArch: 'x64',
 		})
+	} else if (platform === 'win-arm64' || platform === 'win32-arm64') {
+		return expandMissing({
+			electronBuilderPlatform: 'win',
+			electronBuilderArch: electronBuilder.Arch.arm64,
+			runtimePlatform: 'win',
+			nodePlatform: 'win32',
+			runtimeArch: 'arm64',
+		})
 	} else if (platform === 'linux-x64') {
 		return expandMissing({
 			electronBuilderPlatform: 'linux',

--- a/tools/fetch_nodejs.mts
+++ b/tools/fetch_nodejs.mts
@@ -26,8 +26,15 @@ export async function fetchNodejs(platformInfo: PlatformInfo) {
 async function fetchSingleVersion(platformInfo: PlatformInfo, nodeVersion: string) {
 	const isZip = platformInfo.runtimePlatform === 'win'
 
+	// Node.js published no win-arm64 builds before v20; fall back to x64 (Windows emulation).
+	const majorVersion = Number(nodeVersion.split('.')[0])
+	const useX64Fallback =
+		platformInfo.runtimePlatform === 'win' && platformInfo.runtimeArch === 'arm64' && majorVersion < 20
+	const downloadArch = useX64Fallback ? 'x64' : platformInfo.runtimeArch
+	const runtimeArch = useX64Fallback ? 'x64' : platformInfo.nodeArch
+
 	// Download and cache build of nodejs
-	const tarFilename = `node-v${nodeVersion}-${platformInfo.runtimePlatform}-${platformInfo.runtimeArch}.${
+	const tarFilename = `node-v${nodeVersion}-${platformInfo.runtimePlatform}-${downloadArch}.${
 		isZip ? 'zip' : 'tar.gz'
 	}`
 	const tarPath = path.join(cacheDir, tarFilename)
@@ -48,7 +55,7 @@ async function fetchSingleVersion(platformInfo: PlatformInfo, nodeVersion: strin
 	}
 
 	// Extract nodejs and discard 'junk'
-	const runtimeDir = path.join(cacheRuntimeDir, `${platformInfo.nodePlatform}-${platformInfo.nodeArch}-${nodeVersion}`)
+	const runtimeDir = path.join(cacheRuntimeDir, `${platformInfo.nodePlatform}-${runtimeArch}-${nodeVersion}`)
 	if (!(await fs.pathExists(runtimeDir))) {
 		if (isZip) {
 			const tmpDir = path.join(cacheRuntimeDir, `tmp-${nodeVersion}`)
@@ -59,7 +66,7 @@ async function fetchSingleVersion(platformInfo: PlatformInfo, nodeVersion: strin
 				await $`unzip ${toPosix(tarPath)} -d ${toPosix(tmpDir)}`
 			}
 			await fs.move(
-				path.join(tmpDir, `node-v${nodeVersion}-${platformInfo.runtimePlatform}-${platformInfo.runtimeArch}`),
+				path.join(tmpDir, `node-v${nodeVersion}-${platformInfo.runtimePlatform}-${downloadArch}`),
 				runtimeDir
 			)
 			await fs.remove(tmpDir)

--- a/tools/fetch_nodejs.mts
+++ b/tools/fetch_nodejs.mts
@@ -34,9 +34,7 @@ async function fetchSingleVersion(platformInfo: PlatformInfo, nodeVersion: strin
 	const runtimeArch = useX64Fallback ? 'x64' : platformInfo.nodeArch
 
 	// Download and cache build of nodejs
-	const tarFilename = `node-v${nodeVersion}-${platformInfo.runtimePlatform}-${downloadArch}.${
-		isZip ? 'zip' : 'tar.gz'
-	}`
+	const tarFilename = `node-v${nodeVersion}-${platformInfo.runtimePlatform}-${downloadArch}.${isZip ? 'zip' : 'tar.gz'}`
 	const tarPath = path.join(cacheDir, tarFilename)
 	if (!(await fs.pathExists(tarPath))) {
 		const tarUrl = `https://nodejs.org/download/release/v${nodeVersion}/${tarFilename}`

--- a/yarn.lock
+++ b/yarn.lock
@@ -4554,13 +4554,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@julusian/segfault-raub@npm:^2.3.2":
-  version: 2.3.2
-  resolution: "@julusian/segfault-raub@npm:2.3.2"
+"@julusian/segfault-raub@npm:^2.3.3":
+  version: 2.3.3
+  resolution: "@julusian/segfault-raub@npm:2.3.3"
   dependencies:
     node-gyp: "npm:latest"
     pkg-prebuilds: "npm:^1.0.0"
-  checksum: 10c0/6c55e43f4cca27280b2d8e7d1b3cbee5b3c2d5c2ea58607b5d10a5f2a12d762c714e994f7571d6bc1a0eaec0f8eef5a8e4b731a32220cd19d824e44c60e58104
+  checksum: 10c0/92ba703d2ca8f749935d42c0684cb14244fbd54b4f0790e2ca6735803a51f26767dd2c0bb6ea11df1a4cdaefab912d8df34a6d6596ae33b7d4aec7bcc20b3189
   languageName: node
   linkType: hard
 
@@ -11290,7 +11290,7 @@ __metadata:
     "@companion-surface/host": "npm:1.3.2"
     "@julusian/bonjour-service": "npm:^1.4.2"
     "@julusian/image-rs": "npm:^2.1.1"
-    "@julusian/segfault-raub": "npm:^2.3.2"
+    "@julusian/segfault-raub": "npm:^2.3.3"
     "@napi-rs/canvas": "npm:^1.0.0"
     "@sentry/esbuild-plugin": "npm:^5.3.0"
     "@sentry/node": "npm:^10.58.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4755,9 +4755,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-win32-arm64-msvc@npm:1.0.0":
+"@napi-rs/canvas-win32-arm64-msvc@npm:@julusian/canvas-win32-arm64-msvc@1.0.0":
   version: 1.0.0
-  resolution: "@napi-rs/canvas-win32-arm64-msvc@npm:1.0.0"
+  resolution: "@julusian/canvas-win32-arm64-msvc@npm:1.0.0"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Windows ARM64 build job to produce an ARM64 installer artifact and publish it to the usual distribution targets.
* **Build & Release**
  * Improved Windows ARM64 architecture detection to ensure correct build targeting.
  * Updated installer artifact naming so ARM64 outputs the ARM64-specific executable.
  * Adjusted Node.js runtime downloading for Windows ARM64 on older Node versions to use a compatible artifact.
* **Dependencies**
  * Bumped `@julusian/segfault-raub` to `2.3.3`.
  * Added a `resolutions` mapping for `@napi-rs/canvas-win32-arm64-msvc` to `@julusian/canvas-win32-arm64-msvc@1.0.0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->