### PR TITLE
refactor: entity list pool modularity

### DIFF
--- a/companion/lib/Controls/ActionSetsTrpcRouter.ts
+++ b/companion/lib/Controls/ActionSetsTrpcRouter.ts
@@ -1,6 +1,17 @@
 import z from 'zod'
 import { publicProcedure, router } from '../UI/TRPC.js'
+import type { ControlActionSetAndStepsEditor } from './Entities/ControlActionSetAndStepsManager.js'
 import type { SomeControl } from './IControlFragments.js'
+
+/**
+ * Resolve a control to its editable step/action-set surface, or throw. Narrows the step union on its
+ * `isEditable` discriminant - read-only controls (e.g. a preset reference) keep the runtime-only surface and
+ * lack the mutators, so this is where the structural step/action-set edits are gated.
+ */
+function getEditableActionSets(control: SomeControl<any>): ControlActionSetAndStepsEditor {
+	if (control.supportsActionSets && control.actionSets.isEditable) return control.actionSets
+	throw new Error(`Control "${control.controlId}" does not support this operation`)
+}
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function createActionSetsTrpcRouter(controlsMap: Map<string, SomeControl<any>>) {
@@ -16,11 +27,7 @@ export function createActionSetsTrpcRouter(controlsMap: Map<string, SomeControl<
 				const control = controlsMap.get(input.controlId)
 				if (!control) return false
 
-				if (control.supportsActionSets) {
-					return control.actionSets.actionSetAdd(input.stepId)
-				} else {
-					throw new Error(`Control "${input.controlId}" does not support this operation`)
-				}
+				return getEditableActionSets(control).actionSetAdd(input.stepId)
 			}),
 
 		remove: publicProcedure
@@ -35,11 +42,7 @@ export function createActionSetsTrpcRouter(controlsMap: Map<string, SomeControl<
 				const control = controlsMap.get(input.controlId)
 				if (!control) return false
 
-				if (control.supportsActionSets) {
-					return control.actionSets.actionSetRemove(input.stepId, input.setId)
-				} else {
-					throw new Error(`Control "${input.controlId}" does not support this operation`)
-				}
+				return getEditableActionSets(control).actionSetRemove(input.stepId, input.setId)
 			}),
 
 		rename: publicProcedure
@@ -55,11 +58,7 @@ export function createActionSetsTrpcRouter(controlsMap: Map<string, SomeControl<
 				const control = controlsMap.get(input.controlId)
 				if (!control) return false
 
-				if (control.supportsActionSets) {
-					return control.actionSets.actionSetRename(input.stepId, input.oldSetId, input.newSetId)
-				} else {
-					throw new Error(`Control "${input.controlId}" does not support this operation`)
-				}
+				return getEditableActionSets(control).actionSetRename(input.stepId, input.oldSetId, input.newSetId)
 			}),
 
 		setRunWhileHeld: publicProcedure
@@ -75,11 +74,7 @@ export function createActionSetsTrpcRouter(controlsMap: Map<string, SomeControl<
 				const control = controlsMap.get(input.controlId)
 				if (!control) return false
 
-				if (control.supportsActionSets) {
-					return control.actionSets.actionSetRunWhileHeld(input.stepId, input.setId, input.runWhileHeld)
-				} else {
-					throw new Error(`Control "${input.controlId}" does not support this operation`)
-				}
+				return getEditableActionSets(control).actionSetRunWhileHeld(input.stepId, input.setId, input.runWhileHeld)
 			}),
 	})
 }

--- a/companion/lib/Controls/ControlBase.ts
+++ b/companion/lib/Controls/ControlBase.ts
@@ -1,10 +1,9 @@
 import { EventEmitter } from 'node:events'
-import debounceFn from 'debounce-fn'
 import jsonPatch from 'fast-json-patch'
 import type { UIControlUpdate } from '@companion-app/shared/Model/Controls.js'
-import type { DrawStyleModel } from '@companion-app/shared/Model/StyleModel.js'
 import LogController, { type Logger } from '../Log/Controller.js'
 import type { ControlDependencies } from './ControlDependencies.js'
+import type { LayeredButtonDrawer } from './ControlTypes/Button/LayeredButtonDrawer.js'
 
 export type ControlUpdateEvents = {
 	update: [change: UIControlUpdate]
@@ -71,7 +70,7 @@ export abstract class ControlBase<TJson> {
 		if (typeof this.checkButtonStatus === 'function' && this.checkButtonStatus(false)) redraw = true
 
 		// Trigger redraw
-		if (redraw) this.triggerRedraw()
+		if (redraw) this.triggerInvalidation()
 
 		const newJson = this.toJSON(true)
 
@@ -116,19 +115,9 @@ export abstract class ControlBase<TJson> {
 	abstract triggerLocationHasChanged(): void
 
 	/**
-	 * Get the complete style object of a button
-	 * @returns the processed style of the button
+	 * The drawing surface for controls that render to a button, or `null` for controls that don't draw.
 	 */
-	async getDrawStyle(): Promise<DrawStyleModel | null> {
-		return this.getLastDrawStyle()
-	}
-
-	/**
-	 * Get the complete style object from the last draw
-	 * Note: This may or may not be a cached value produced from `getDrawStyle`
-	 * @returns the last drawn style
-	 */
-	abstract getLastDrawStyle(): DrawStyleModel | null
+	abstract get drawing(): LayeredButtonDrawer | null
 
 	/**
 	 * Emit a change to the runtime properties of this control.
@@ -165,28 +154,11 @@ export abstract class ControlBase<TJson> {
 	}
 
 	/**
-	 * Trigger a redraw of this control, if it can be drawn
+	 * React to a change to this control - invalidate the rendered graphic, re-check a trigger condition, etc.
+	 * Abstract with no default on purpose, so a new control type must decide how it reacts rather than
+	 * silently inheriting drawing behaviour.
 	 */
-	triggerRedraw = debounceFn(
-		() => {
-			// This is a hacky way of ensuring we don't schedule two invalidations in short succession when doing lots of work
-			// Long term this should be replaced with a proper work queue inside GraphicsController
-			if (this.#pendingDraw) return
-
-			this.#pendingDraw = true
-			setImmediate(() => {
-				this.deps.events.emit('invalidateControlRender', this.controlId)
-				this.#pendingDraw = false
-			})
-		},
-		{
-			before: false,
-			after: true,
-			wait: 10,
-			maxWait: 20,
-		}
-	)
-	#pendingDraw = false
+	protected abstract triggerInvalidation(): void
 
 	/**
 	 * Rename an instance for variables used in the controls
@@ -202,10 +174,4 @@ export abstract class ControlBase<TJson> {
 	 * @param force Trigger actions even if already in the state
 	 */
 	abstract pressControl(pressed: boolean, surfaceId: string | undefined, force?: boolean): void
-
-	/**
-	 * Propagate variable changes
-	 * @param allChangedVariables - variables with changes
-	 */
-	abstract onVariablesChanged(allChangedVariables: ReadonlySet<string>): void
 }

--- a/companion/lib/Controls/ControlTypes/Button/Base.ts
+++ b/companion/lib/Controls/ControlTypes/Button/Base.ts
@@ -211,6 +211,9 @@ export abstract class ButtonControlRuntimeBase<
 	destroy(): void {
 		this.abortRunningHoldTimers(undefined)
 
+		// Buttons always host a drawer, so the base owns tearing it down
+		this.drawing.dispose()
+
 		this.entities.destroy()
 
 		super.destroy()
@@ -404,6 +407,9 @@ export abstract class ButtonControlRuntimeBase<
 
 		// Report the location variables for this control as having changed
 		this.deps.variableValues.triggerLocationVariablesChange(this.controlId)
+
+		// Clear location-dependent draw state so the move is reflected immediately
+		this.drawing.locationChanged()
 	}
 }
 

--- a/companion/lib/Controls/ControlTypes/Button/Base.ts
+++ b/companion/lib/Controls/ControlTypes/Button/Base.ts
@@ -8,8 +8,13 @@ import { ControlActionRunner } from '../../ActionRunner.js'
 import { ControlBase } from '../../ControlBase.js'
 import type { ControlDependencies } from '../../ControlDependencies.js'
 import type { ControlEntityListChangeProps } from '../../Entities/EntityListPoolBase.js'
-import { ControlEntityListPoolButton } from '../../Entities/EntityListPoolButton.js'
+import {
+	EditableControlEntityListPoolButton,
+	type ButtonEntityPoolConstructor,
+	type SomeButtonEntityPool,
+} from '../../Entities/EntityListPoolButton.js'
 import type { ControlWithEntities, ControlWithOptions, ControlWithPushed } from '../../IControlFragments.js'
+import type { LayeredButtonDrawer } from './LayeredButtonDrawer.js'
 
 /**
  * Abstract class for a editable button control.
@@ -26,13 +31,15 @@ import type { ControlWithEntities, ControlWithOptions, ControlWithPushed } from 
  * Individual Contributor License Agreement for Companion along with
  * this program.
  */
-export abstract class ButtonControlBase<TJson, TOptions extends ButtonOptionsBase>
+export abstract class ButtonControlRuntimeBase<
+	TJson,
+	TOptions extends ButtonOptionsBase,
+	TPool extends SomeButtonEntityPool,
+>
 	extends ControlBase<TJson>
-	implements ControlWithEntities, ControlWithOptions, ControlWithPushed
+	implements ControlWithEntities, ControlWithPushed
 {
 	readonly supportsEntities = true
-	readonly supportsConvert = false
-	readonly supportsOptions = true
 	readonly supportsPushed = true
 
 	/**
@@ -63,16 +70,29 @@ export abstract class ButtonControlBase<TJson, TOptions extends ButtonOptionsBas
 	 */
 	pushed = false
 
-	readonly entities: ControlEntityListPoolButton
+	readonly entities: TPool
 
 	protected readonly actionRunner: ControlActionRunner
 
-	constructor(deps: ControlDependencies, controlId: string, debugNamespace: string, isLayered: boolean) {
+	/** Buttons always host a drawer; subclasses provide it (the editor or the plain reader). */
+	abstract override get drawing(): LayeredButtonDrawer
+
+	protected triggerInvalidation = (): void => {
+		this.drawing.invalidate()
+	}
+
+	constructor(
+		deps: ControlDependencies,
+		controlId: string,
+		debugNamespace: string,
+		isLayered: boolean,
+		EntityPoolClass: ButtonEntityPoolConstructor<TPool>
+	) {
 		super(deps, controlId, debugNamespace)
 
-		this.actionRunner = new ControlActionRunner(deps.actionRunner, this.controlId, this.triggerRedraw.bind(this))
+		this.actionRunner = new ControlActionRunner(deps.actionRunner, this.controlId, this.triggerInvalidation.bind(this))
 
-		this.entities = new ControlEntityListPoolButton(
+		this.entities = new EntityPoolClass(
 			{
 				controlId,
 				reportChange: this.entityListReportChange.bind(this),
@@ -178,7 +198,7 @@ export abstract class ButtonControlBase<TJson, TOptions extends ButtonOptionsBas
 		// If the status has changed, emit the eent
 		if (status != this.button_status) {
 			this.button_status = status
-			if (redraw) this.triggerRedraw()
+			if (redraw) this.triggerInvalidation()
 			return true
 		} else {
 			return false
@@ -207,27 +227,6 @@ export abstract class ButtonControlBase<TJson, TOptions extends ButtonOptionsBas
 		}
 
 		return result
-	}
-
-	abstract onVariablesChanged(allChangedVariables: ReadonlySet<string>): void
-
-	/**
-	 * Update an option field of this control
-	 */
-	optionsSetField(key: string, value: JsonValue): boolean {
-		if (BANNED_PROPS.has(key)) throw new Error(`Setting option "${key}" is not allowed`)
-
-		// Check if rotary_actions should be added/remove
-		if (key === 'rotaryActions') {
-			this.entities.setupRotaryActionSets(!!value, true)
-		}
-
-		// @ts-expect-error mismatch in key type
-		this.options[key] = value
-
-		this.commitChange()
-
-		return true
 	}
 
 	/**
@@ -389,7 +388,7 @@ export abstract class ButtonControlBase<TJson, TOptions extends ButtonOptionsBas
 				this.deps.events.emit('updateButtonState', location, this.pushed, surfaceId)
 			}
 
-			this.triggerRedraw()
+			this.triggerInvalidation()
 
 			return true
 		} else {
@@ -405,6 +404,44 @@ export abstract class ButtonControlBase<TJson, TOptions extends ButtonOptionsBas
 
 		// Report the location variables for this control as having changed
 		this.deps.variableValues.triggerLocationVariablesChange(this.controlId)
+	}
+}
+
+/**
+ * Abstract class for an editable button control.
+ *
+ * This adds the editing surface (`optionsSetField`) on top of the runtime base. Read-only button controls
+ * (e.g. a preset reference) extend {@link ButtonControlRuntimeBase} directly so they cannot inherit this -
+ * or any future control-level mutator added here.
+ */
+export abstract class ButtonControlBase<TJson, TOptions extends ButtonOptionsBase>
+	extends ButtonControlRuntimeBase<TJson, TOptions, EditableControlEntityListPoolButton>
+	implements ControlWithOptions
+{
+	readonly supportsConvert = false
+	readonly supportsOptions = true
+
+	constructor(deps: ControlDependencies, controlId: string, debugNamespace: string, isLayered: boolean) {
+		super(deps, controlId, debugNamespace, isLayered, EditableControlEntityListPoolButton)
+	}
+
+	/**
+	 * Update an option field of this control
+	 */
+	optionsSetField(key: string, value: JsonValue): boolean {
+		if (BANNED_PROPS.has(key)) throw new Error(`Setting option "${key}" is not allowed`)
+
+		// Check if rotary_actions should be added/remove
+		if (key === 'rotaryActions') {
+			this.entities.setupRotaryActionSets(!!value, true)
+		}
+
+		// @ts-expect-error mismatch in key type
+		this.options[key] = value
+
+		this.commitChange()
+
+		return true
 	}
 }
 

--- a/companion/lib/Controls/ControlTypes/Button/Layered.ts
+++ b/companion/lib/Controls/ControlTypes/Button/Layered.ts
@@ -1,40 +1,22 @@
-import { nanoid } from 'nanoid'
 import type { JsonValue } from 'type-fest'
-import { formatLocation } from '@companion-app/shared/ControlId.js'
 import { FONTSIZE_SHRINK_DEFAULT } from '@companion-app/shared/Graphics/ElementPropertiesSchemas.js'
 import type {
 	LayeredButtonModel,
 	LayeredButtonOptions,
 	NormalButtonRuntimeProps,
 } from '@companion-app/shared/Model/ButtonModel.js'
-import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
 import type { ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
-import type {
-	ButtonGraphicsBoxElement,
-	ButtonGraphicsElementBase,
-	ButtonGraphicsGroupElement,
-	ButtonGraphicsImageElement,
-	ButtonGraphicsTextElement,
-	SomeButtonGraphicsElement,
-} from '@companion-app/shared/Model/StyleLayersModel.js'
+import type { SomeButtonGraphicsElement } from '@companion-app/shared/Model/StyleLayersModel.js'
 import {
 	ButtonGraphicsDecorationType,
 	ButtonGraphicsElementUsage,
 	ButtonGraphicsShowStatusIcons,
 	type ButtonStyleProperties,
-	type DrawStyleLayeredButtonModel,
 } from '@companion-app/shared/Model/StyleModel.js'
-import type { VariableValues } from '@companion-app/shared/Model/Variables.js'
-import { ConvertSomeButtonGraphicsElementForDrawing } from '../../../Graphics/ConvertGraphicsElements.js'
-import { ElementConversionCache } from '../../../Graphics/ElementConversionCache.js'
-import type { ImageResult } from '../../../Graphics/ImageResult.js'
-import type { CompositeElementIdString } from '../../../Instance/Definitions.js'
-import { ParseLegacyStyle } from '../../../Resources/ConvertLegacyStyleToElements.js'
-import { lazy } from '../../../Resources/Util.js'
 import { VisitorReferencesCollector } from '../../../Resources/Visitors/ReferencesCollector.js'
 import { VisitorReferencesUpdater } from '../../../Resources/Visitors/ReferencesUpdater.js'
 import type { ControlDependencies } from '../../ControlDependencies.js'
-import type { ControlActionSetAndStepsManager } from '../../Entities/ControlActionSetAndStepsManager.js'
+import type { ControlActionSetAndStepsEditor } from '../../Entities/ControlActionSetAndStepsManager.js'
 import type { ControlEntityListChangeProps } from '../../Entities/EntityListPoolBase.js'
 import type {
 	ControlWithActions,
@@ -43,11 +25,13 @@ import type {
 	ControlWithoutEvents,
 } from '../../IControlFragments.js'
 import { ButtonControlBase } from './Base.js'
-import { CreateElementOfType } from './LayerDefaults.js'
-import { cloneElementWithNewIds } from './LayerUtils.js'
+import { LayeredButtonStyleEditor } from './LayeredButtonStyleEditor.js'
 
 /**
  * Class for the button control with layer based rendering.
+ *
+ * The layered rendering (and its editing) lives in a composed {@link MutableLayeredButtonDrawer} (`drawing`);
+ * this control wires it into the runtime/entity machinery and the existing control event flows.
  *
  * @author Julian Waller <me@julusian.co.uk>
  * @since 4.0.0
@@ -127,34 +111,15 @@ export class ControlButtonLayered
 	readonly supportsLayeredStyle = true
 
 	/**
-	 * The variables referenced in the last draw. Whenever one of these changes, a redraw should be performed
+	 * The composed layered rendering + editing. Exposed (as the base `drawing`) so callers can reach the
+	 * drawing surface directly.
 	 */
-	#lastDrawVariables: ReadonlySet<string> | null = null
-	#lastDrawCompositeElements: ReadonlySet<CompositeElementIdString> | null = null
+	readonly #drawing: LayeredButtonStyleEditor
+	override get drawing(): LayeredButtonStyleEditor {
+		return this.#drawing
+	}
 
-	/**
-	 * Location strings (e.g. '1/0/0') of buttons this control references via reference elements.
-	 * When any of these locations are re-rendered, this control must be re-rendered too.
-	 */
-	#lastDrawReferencedLocations: ReadonlySet<string> | null = null
-
-	/**
-	 * Locations where a reference cycle was detected in the last draw.
-	 * Used to suppress redundant redraws when we're already showing ∞ for a location.
-	 */
-	#lastCyclicReferences: ReadonlySet<string> | null = null
-
-	/**
-	 * The base style without feedbacks applied
-	 */
-	#drawElements: SomeButtonGraphicsElement[] = structuredClone(ControlButtonLayered.DefaultElements)
-
-	/**
-	 * Cache for element conversion results (for future per-element caching optimization)
-	 */
-	readonly #elementConversionCache = new ElementConversionCache()
-
-	get actionSets(): ControlActionSetAndStepsManager {
+	get actionSets(): ControlActionSetAndStepsEditor {
 		return this.entities
 	}
 
@@ -168,64 +133,39 @@ export class ControlButtonLayered
 			notes: '',
 		}
 
+		this.#drawing = new LayeredButtonStyleEditor(deps, controlId, {
+			getButtonStateProps: () => this.getDrawStyleButtonStateProps(),
+			entities: this.entities,
+			commitChange: (redraw) => this.commitChange(redraw),
+			emitElementChanged: (id) => this.deps.events.emit('layeredStyleElementChanged', this.controlId, id),
+		})
+
 		if (!storage) {
 			// New control
+			this.drawing.loadElements(structuredClone(ControlButtonLayered.DefaultElements))
 
-			// Save the change
 			this.commitChange()
 			this.sendRuntimePropsChange()
 		} else {
 			if (storage.type !== 'button-layered')
 				throw new Error(`Invalid type given to ControlButtonLayered: "${storage.type}"`)
 
-			this.#drawElements = storage.style.layers || this.#drawElements
+			this.drawing.loadElements(storage.style.layers)
 			this.options = Object.assign(this.options, storage.options || {})
 			this.entities.setupRotaryActionSets(!!this.options.rotaryActions, true)
 			this.entities.loadStorage(storage, true, isImport)
 			this.entities.stepExpressionUpdate(this.options)
 
-			// HACK: temporary fill in new properties
-			for (const element of this.#drawElements) {
-				if (element.type !== 'canvas') {
-					try {
-						const defaults = CreateElementOfType(element.type)
-						for (const key of Object.keys(defaults)) {
-							if (key === 'id' || key === 'type' || key === 'name') continue
-							if (!(key in element)) {
-								;(element as any)[key] = (defaults as any)[key]
-							}
-						}
-					} catch (_e) {
-						// Ignore
-					}
-				}
-				switch (element.type) {
-					case 'canvas':
-						if (!element.showStatusIcons)
-							element.showStatusIcons = { value: ButtonGraphicsShowStatusIcons.FollowDefault, isExpression: false }
-						break
-					case 'image':
-						if (!element.fillMode.isExpression && (element.fillMode.value as string) === 'fit_or_shrink') {
-							element.fillMode.value = 'fit'
-						}
-						break
-				}
-			}
-
 			// Ensure control is stored before setup
 			if (isImport) setImmediate(() => this.postProcessImport())
 		}
-
-		// Listen for other controls finishing rendering (needed for reference element invalidation)
-		this.deps.graphics.on('button_drawn', this.onReferencedButtonDrawn)
 	}
 
 	/**
 	 * Prepare this control for deletion
 	 */
 	destroy(): void {
-		this.deps.graphics.off('button_drawn', this.onReferencedButtonDrawn)
-		this.#elementConversionCache.clear()
+		this.drawing.dispose()
 		super.destroy()
 	}
 
@@ -234,99 +174,35 @@ export class ControlButtonLayered
 			this.commitChange(false)
 		}
 		if (options.invalidateAllElements) {
-			this.#elementConversionCache.clear()
+			this.drawing.clearCache()
 		} else if (options.changedElementIds) {
 			for (const elementId of options.changedElementIds) {
-				this.#elementConversionCache.queueInvalidate(elementId)
+				this.drawing.invalidateElement(elementId)
 			}
 		}
 
 		if (options.redraw || options.changedElementIds || options.invalidateAllElements) {
-			this.triggerRedraw()
+			this.triggerInvalidation()
 		}
-	}
-
-	#lastDrawStyle: DrawStyleLayeredButtonModel | null = null
-	getLastDrawStyle(): DrawStyleLayeredButtonModel | null {
-		return this.#lastDrawStyle
-	}
-
-	/**
-	 * Get the complete style object of a button
-	 * @returns the processed style of the button
-	 */
-	async getDrawStyle(): Promise<DrawStyleLayeredButtonModel | null> {
-		// Block out the button text
-		const injectedVariableValues: VariableValues = {}
-		const location = this.deps.pageStore.getLocationOfControlId(this.controlId)
-		if (location) {
-			// Ensure we don't enter into an infinite loop
-			// TODO - legacy location variables?
-			// injectedVariableValues[`internal:b_text_${location.pageNumber}_${location.row}_${location.column}`] = '$RE'
-		}
-
-		const parser = this.deps.variableValues.createVariablesAndExpressionParser(
-			location,
-			this.entities.getLocalVariableEntities(),
-			injectedVariableValues
-		)
-
-		const locationStr = location ? formatLocation(location) : null
-
-		const feedbackOverrides = this.entities.getFeedbackStyleOverrides()
-
-		// Compute the new drawing, using the element conversion cache for per-element caching
-		const { elements, usedVariables, usedCompositeElements, referencedLocations, cyclicLocations } =
-			await ConvertSomeButtonGraphicsElementForDrawing(
-				this.deps.instance.definitions,
-				parser,
-				this.deps.graphics.renderPixelBuffers.bind(this.deps.graphics),
-				this.#drawElements,
-				feedbackOverrides,
-				true,
-				this.#elementConversionCache,
-				locationStr,
-				(location) => this.deps.graphics.getCachedRender(location) ?? null
-			)
-		this.#lastDrawVariables = usedVariables.size > 0 ? usedVariables : null
-		this.#lastDrawCompositeElements = usedCompositeElements.size > 0 ? usedCompositeElements : null
-		this.#lastDrawReferencedLocations = referencedLocations.size > 0 ? referencedLocations : null
-		this.#lastCyclicReferences = cyclicLocations.size > 0 ? cyclicLocations : null
-
-		const result: DrawStyleLayeredButtonModel = {
-			...this.getDrawStyleButtonStateProps(),
-
-			elements,
-			referencedLocations,
-
-			style: 'button-layered',
-			drawType: 'button',
-		}
-
-		this.#lastDrawStyle = result
-		return result
 	}
 
 	/**
 	 * Collect the instance ids, labels, and variables referenced by this control
-	 * @param foundConnectionIds - instance ids being referenced
-	 * @param foundConnectionLabels - instance labels being referenced
-	 * @param foundVariables - variables being referenced
 	 */
 	collectReferencedConnectionsAndVariables(
 		foundConnectionIds: Set<string>,
 		foundConnectionLabels: Set<string>,
 		foundVariables: Set<string>
 	): void {
-		new VisitorReferencesCollector(
+		const collector = new VisitorReferencesCollector(
 			this.deps.internalModule,
 			foundConnectionIds,
 			foundConnectionLabels,
 			foundVariables,
 			undefined
 		)
-			.visitEntities(this.entities.getAllEntities(), [])
-			.visitDrawElements(this.#drawElements)
+		collector.visitEntities(this.entities.getAllEntities(), [])
+		this.drawing.visit(collector)
 	}
 
 	/**
@@ -335,397 +211,70 @@ export class ControlButtonLayered
 	triggerLocationHasChanged(): void {
 		super.triggerLocationHasChanged()
 
-		// Ensure any dependencies on the location in the drawing are updated
-		this.#elementConversionCache.clear()
-		this.triggerRedraw()
+		this.drawing.locationChanged()
 	}
 
 	layeredStyleAddElement(type: string, index: number | null): string {
-		let newElement: SomeButtonGraphicsElement
-
-		// Check if this is a composite element (contains semicolon)
-		if (type.includes(';')) {
-			const [connectionId, elementId] = type.split(';', 2)
-			const compositeDefinition = this.deps.instance.definitions.getCompositeElementDefinition(connectionId, elementId)
-
-			if (compositeDefinition) {
-				// Create a composite element directly
-				newElement = {
-					id: nanoid(),
-					name: compositeDefinition.name,
-					usage: ButtonGraphicsElementUsage.Automatic,
-					type: 'composite',
-					connectionId,
-					elementId,
-					enabled: { value: true, isExpression: false },
-					opacity: { value: 100, isExpression: false },
-					x: { value: 0, isExpression: false },
-					y: { value: 0, isExpression: false },
-					width: { value: 100, isExpression: false },
-					height: { value: 100, isExpression: false },
-				}
-
-				// Add custom properties from schema with their default values
-				for (const field of compositeDefinition.options) {
-					newElement[`opt:${field.id}`] = {
-						value: 'default' in field ? field.default : undefined,
-						isExpression: false,
-					}
-				}
-			} else {
-				throw new Error(`Composite element not found: ${type}`)
-			}
-		} else {
-			// Standard element type
-			newElement = CreateElementOfType(type as SomeButtonGraphicsElement['type'])
-		}
-
-		if (typeof index === 'number' && index >= 0 && index < this.#drawElements.length) {
-			this.#drawElements.splice(index, 0, newElement)
-		} else {
-			this.#drawElements.push(newElement)
-		}
-
-		// Invalidate cache for the new element
-		this.#elementConversionCache.queueInvalidate(newElement.id)
-
-		// Save change and redraw
-		this.commitChange(true)
-
-		// Emit element change event
-		this.deps.events.emit('layeredStyleElementChanged', this.controlId, newElement.id)
-
-		return newElement.id
+		return this.drawing.addElement(type, index)
 	}
 
 	layeredStyleRemoveElement(id: string): boolean {
-		const currentElementLocation = this.#findElementIndexAndParent(this.#drawElements, null, id)
-		if (!currentElementLocation) return false
-
-		const { indexOfElement, element, currentParentElementArray } = currentElementLocation
-
-		// Canvas is the fixed background element and cannot be removed
-		if (element.type === 'canvas') return false
-
-		currentParentElementArray.splice(indexOfElement, 1)
-
-		// Invalidate cache for the removed element
-		this.#elementConversionCache.queueInvalidate(id)
-
-		// Save change and redraw
-		this.commitChange(true)
-
-		// Emit element change event
-		this.deps.events.emit('layeredStyleElementChanged', this.controlId, id)
-
-		return true
+		return this.drawing.removeElement(id)
 	}
 
 	layeredStyleDuplicateElement(id: string): string | false {
-		const currentElementLocation = this.#findElementIndexAndParent(this.#drawElements, null, id)
-		if (!currentElementLocation) return false
-
-		const { indexOfElement, element, currentParentElementArray } = currentElementLocation
-
-		// Canvas is the fixed background element and cannot be duplicated
-		if (element.type === 'canvas') return false
-
-		const clone = cloneElementWithNewIds(element)
-
-		currentParentElementArray.splice(indexOfElement + 1, 0, clone)
-
-		this.#elementConversionCache.queueInvalidate(clone.id)
-
-		this.commitChange(true)
-
-		this.deps.events.emit('layeredStyleElementChanged', this.controlId, clone.id)
-
-		return clone.id
+		return this.drawing.duplicateElement(id)
 	}
 
 	layeredStyleSetElementName(id: string, name: string): boolean {
-		const currentElementLocation = this.#findElementIndexAndParent(this.#drawElements, null, id)
-		if (!currentElementLocation) return false
-
-		const { element } = currentElementLocation
-
-		element.name = name
-
-		// Save change without a redraw
-		this.commitChange(false)
-
-		return true
+		return this.drawing.setElementName(id, name)
 	}
 
 	layeredStyleSetElementUsage(id: string, usage: ButtonGraphicsElementUsage): boolean {
-		const currentElementLocation = this.#findElementIndexAndParent(this.#drawElements, null, id)
-		if (!currentElementLocation) return false
-
-		const { element } = currentElementLocation
-
-		element.usage = usage
-
-		// Trigger a redraw, as this could affect listeners of the properties
-		this.commitChange(true)
-
-		return true
-	}
-
-	#findElementIndexAndParent(
-		searchInElements: SomeButtonGraphicsElement[],
-		parentId: string | null,
-		searchId: string
-	): {
-		indexOfElement: number
-		element: SomeButtonGraphicsElement
-		currentParentElementId: string | null
-		currentParentElementArray: SomeButtonGraphicsElement[]
-	} | null {
-		const indexOfElement = searchInElements.findIndex((element) => element.id === searchId)
-		if (indexOfElement !== -1)
-			return {
-				indexOfElement: indexOfElement,
-				element: searchInElements[indexOfElement],
-				currentParentElementId: parentId,
-				currentParentElementArray: searchInElements,
-			}
-
-		for (const element of searchInElements) {
-			if (element.type !== 'group') continue
-
-			const result = this.#findElementIndexAndParent(element.children, element.id, searchId)
-			if (result) return result
-		}
-
-		return null
-	}
-	#findGroupElementById(
-		searchInElements: SomeButtonGraphicsElement[],
-		searchId: string
-	): ButtonGraphicsGroupElement | null {
-		for (const element of searchInElements) {
-			if (element.type !== 'group') continue
-
-			if (element.id === searchId) return element
-			const result = this.#findGroupElementById(element.children, searchId)
-			if (result) return result
-		}
-
-		return null
+		return this.drawing.setElementUsage(id, usage)
 	}
 
 	layeredStyleGetElementById(id: string): SomeButtonGraphicsElement | undefined {
-		const result = this.#findElementIndexAndParent(this.#drawElements, null, id)
-		return result?.element
+		return this.drawing.getElementById(id)
 	}
 
 	layeredStyleSelectedElementIds(): { [usage in ButtonGraphicsElementUsage]: string | undefined } {
-		return {
-			[ButtonGraphicsElementUsage.Automatic]: undefined, // Not valid here
-			[ButtonGraphicsElementUsage.Text]: this.SelectLayerForUsage(ButtonGraphicsElementUsage.Text, 'text')?.id,
-			[ButtonGraphicsElementUsage.Image]: this.SelectLayerForUsage(ButtonGraphicsElementUsage.Image, 'image')?.id,
-			[ButtonGraphicsElementUsage.Color]: this.SelectLayerForUsage(ButtonGraphicsElementUsage.Color, 'box')?.id,
-		}
+		return this.drawing.selectedElementIds()
 	}
 
 	layeredStyleMoveElement(id: string, parentElementId: string | null, newIndex: number): boolean {
-		const currentElementLocation = this.#findElementIndexAndParent(this.#drawElements, null, id)
-		if (!currentElementLocation) return false
-		const { indexOfElement, currentParentElementId, currentParentElementArray } = currentElementLocation
-
-		// Can't move to or from the first element
-		if ((indexOfElement === 0 && currentParentElementId === null) || (newIndex === 0 && parentElementId === null))
-			return false
-
-		// Cycle detection: prevent moving an element into itself or one of its own descendants
-		if (parentElementId !== null) {
-			if (parentElementId === id) return false
-			const { element } = currentElementLocation
-			if (element.type === 'group' && this.#findGroupElementById(element.children, parentElementId) !== null)
-				return false
-		}
-
-		const targetElementArray = parentElementId
-			? this.#findGroupElementById(this.#drawElements, parentElementId)?.children
-			: this.#drawElements
-
-		// Make sure the target parent exists
-		if (!targetElementArray) return false
-
-		if (newIndex < 0 || newIndex > targetElementArray.length) return false
-
-		const element = currentParentElementArray.splice(indexOfElement, 1)[0]
-		targetElementArray.splice(newIndex, 0, element)
-
-		// Save change and redraw
-		this.commitChange(true)
-
-		return true
+		return this.drawing.moveElement(id, parentElementId, newIndex)
 	}
 
 	layeredStyleUpdateOption(id: string, key: string, newVal: ExpressionOrValue<JsonValue | undefined>): boolean {
-		// Ignore some fixed properties
-		if (key === 'id' || key === 'type' || key === 'name') return false
-
-		// Find the element
-		const currentElementLocation = this.#findElementIndexAndParent(this.#drawElements, null, id)
-		if (!currentElementLocation) return false
-
-		const { element } = currentElementLocation
-
-		const entry = element as any
-		if (!entry[key]) return false
-
-		// Replace the entire ExpressionOrValue with the provided value
-		entry[key] = newVal
-
-		// Invalidate cache for this element
-		this.#elementConversionCache.queueInvalidate(id)
-
-		// Save change and redraw
-		this.commitChange(true)
-
-		// Emit element change event
-		this.deps.events.emit('layeredStyleElementChanged', this.controlId, id)
-
-		return true
+		return this.drawing.updateOption(id, key, newVal)
 	}
 
 	layeredStyleUpdateFromLegacyProperties(diff: Partial<ButtonStyleProperties>): boolean {
-		if (!this.options.canModifyStyleInApis) return false
-
-		const changedElements = new Set<string>()
-
-		const lazyTextElement = lazy(() => {
-			const elm = this.SelectLayerForUsage<ButtonGraphicsTextElement>(ButtonGraphicsElementUsage.Text, 'text')
-			if (elm) changedElements.add(elm.id)
-			return elm
-		})
-		const lazyBoxElement = lazy(() => {
-			const elm = this.SelectLayerForUsage<ButtonGraphicsBoxElement>(ButtonGraphicsElementUsage.Color, 'box')
-			if (elm) changedElements.add(elm.id)
-			return elm
-		})
-		const lazyImageElement = lazy(() => {
-			const elm = this.SelectLayerForUsage<ButtonGraphicsImageElement>(ButtonGraphicsElementUsage.Image, 'image')
-			if (elm) changedElements.add(elm.id)
-			return elm
-		})
-		const canvasElement = this.#drawElements.find((e) => e.type === 'canvas')
-
-		const parsedStyle = ParseLegacyStyle(diff)
-
-		if (parsedStyle.text.text !== undefined) {
-			const textElement = lazyTextElement()
-			if (textElement) textElement.text = parsedStyle.text.text
-		}
-
-		if (parsedStyle.text.size !== undefined) {
-			const textElement = lazyTextElement()
-			if (textElement) {
-				textElement.fontsize = { isExpression: false, value: parsedStyle.text.size }
-				textElement.fontsizeAllowShrink = { isExpression: false, value: parsedStyle.text.sizeAllowShrink ?? false }
-			}
-		}
-
-		if (parsedStyle.text.color !== undefined) {
-			const textElement = lazyTextElement()
-			if (textElement) textElement.color = { isExpression: false, value: parsedStyle.text.color }
-		}
-
-		if (parsedStyle.text.halign !== undefined) {
-			const textElement = lazyTextElement()
-			if (textElement) textElement.halign = { isExpression: false, value: parsedStyle.text.halign }
-		}
-		if (parsedStyle.text.valign !== undefined) {
-			const textElement = lazyTextElement()
-			if (textElement) textElement.valign = { isExpression: false, value: parsedStyle.text.valign }
-		}
-
-		if (parsedStyle.image.halign !== undefined) {
-			const imageElement = lazyImageElement()
-			if (imageElement) imageElement.halign = { isExpression: false, value: parsedStyle.image.halign }
-		}
-		if (parsedStyle.image.valign !== undefined) {
-			const imageElement = lazyImageElement()
-			if (imageElement) imageElement.valign = { isExpression: false, value: parsedStyle.image.valign }
-		}
-
-		if (parsedStyle.image.image !== undefined) {
-			const imageElement = lazyImageElement()
-			if (imageElement) imageElement.base64Image = { isExpression: false, value: parsedStyle.image.image }
-		}
-
-		if (parsedStyle.background.color !== undefined) {
-			const boxElement = lazyBoxElement()
-			if (boxElement) boxElement.color = { isExpression: false, value: parsedStyle.background.color }
-		}
-
-		if (parsedStyle.canvas.decoration !== undefined && canvasElement) {
-			canvasElement.decoration = { isExpression: false, value: parsedStyle.canvas.decoration }
-			changedElements.add(canvasElement.id)
-		}
-
-		if (changedElements.size === 0) return false
-
-		// Invalidate changed elements
-		for (const elementId of changedElements) {
-			this.#elementConversionCache.delete(elementId)
-		}
-
-		// Save changes and redraw
-		this.commitChange(true)
-
-		// Emit element change event
-		for (const elementId of changedElements) {
-			this.deps.events.emit('layeredStyleElementChanged', this.controlId, elementId)
-		}
-
-		return true
+		return this.drawing.updateFromLegacyProperties(diff, this.options.canModifyStyleInApis)
 	}
 
 	/**
 	 * Rename a connection for variables used in this control
-	 * @param labelFrom - the old connection short name
-	 * @param labelTo - the new connection short name
 	 */
 	renameVariables(labelFrom: string, labelTo: string): void {
-		const allEntities = this.entities.getAllEntities()
-
-		// Fix up references
-		const changed = new VisitorReferencesUpdater(
+		const updater = new VisitorReferencesUpdater(
 			this.deps.internalModule,
 			{ [labelFrom]: labelTo },
 			undefined,
 			undefined
 		)
-			.visitEntities(allEntities, [])
-			.visitDrawElements(this.#drawElements)
-			.recheckChangedFeedbacks()
-			.hasChanges()
+		updater.visitEntities(this.entities.getAllEntities(), [])
+		this.drawing.visit(updater)
+		const changed = updater.recheckChangedFeedbacks().hasChanges()
 
 		if (changed) {
 			// Purge all cache, as we don't know what could have changed
-			this.#elementConversionCache.clear()
+			this.drawing.clearCache()
 		}
 
 		// redraw if needed and save changes
 		this.commitChange(changed)
-	}
-
-	/**
-	 * Propagate variable changes
-	 * @param allChangedVariables - variables with changes
-	 */
-	onVariablesChanged(allChangedVariables: ReadonlySet<string>): void {
-		if (!this.#lastDrawVariables) return
-		if (this.#lastDrawVariables.isDisjointFrom(allChangedVariables)) return
-
-		// Queue invalidation for cached elements that use any of the changed variables
-		this.#elementConversionCache.queueInvalidateVariables(allChangedVariables)
-
-		this.logger.silly('variable changed in button ' + this.controlId)
-		this.triggerRedraw()
 	}
 
 	/**
@@ -742,49 +291,13 @@ export class ControlButtonLayered
 	}
 
 	/**
-	 * Propagate composite element changes
-	 * @param allChangedElementIds - composite element ids with changes
-	 */
-	onCompositeElementsChanged(allChangedElementIds: ReadonlySet<CompositeElementIdString>): void {
-		if (!this.#lastDrawCompositeElements) return
-		if (this.#lastDrawCompositeElements.isDisjointFrom(allChangedElementIds)) return
-
-		// Queue invalidation for any cached elements that use these composite types
-		this.#elementConversionCache.queueInvalidateCompositeType(allChangedElementIds)
-
-		this.logger.silly('composite element changed in button ' + this.controlId)
-		this.triggerRedraw()
-	}
-
-	/**
-	 * Called after any located control has finished rendering. If this control references the changed
-	 * location, invalidate the relevant cache entries and trigger a redraw.
-	 */
-	onReferencedButtonDrawn = (location: ControlLocation, render: ImageResult): void => {
-		const locStr = formatLocation(location)
-		if (!this.#lastDrawReferencedLocations?.has(locStr)) return
-
-		// Suppress ping-pong when we're already rendering a cycle: if we're already showing ∞ for this
-		// location AND the target still references us back, no visible output would change.
-		if (this.#lastCyclicReferences?.has(locStr)) {
-			const myLocation = this.deps.pageStore.getLocationOfControlId(this.controlId)
-			if (myLocation && render.referencedLocations.has(formatLocation(myLocation))) return
-		}
-
-		this.#elementConversionCache.queueInvalidateReferencedLocation(locStr)
-		this.logger.silly('referenced control rendered in button ' + this.controlId)
-		this.triggerRedraw()
-	}
-
-	/**
 	 * Convert this control to JSON
 	 * To be sent to the client and written to the db
-	 * @param clone - Whether to return a cloned object
 	 */
 	override toJSON(clone = true): LayeredButtonModel {
 		const obj: LayeredButtonModel = {
 			type: this.type,
-			style: { layers: this.#drawElements },
+			style: { layers: this.drawing.drawElements },
 			options: this.options,
 			feedbacks: this.entities.getFeedbackEntities(),
 			steps: this.entities.asNormalButtonSteps(),
@@ -801,50 +314,5 @@ export class ControlButtonLayered
 		return {
 			current_step_id: this.entities.currentStepId,
 		}
-	}
-
-	private SelectLayerForUsage<TElement extends ButtonGraphicsElementBase & { type: string }>(
-		usage: ButtonGraphicsElementUsage,
-		layerType: TElement['type']
-	): TElement | undefined {
-		return (
-			ControlButtonLayered.SelectFirstLayerWithUsage<TElement>(this.#drawElements, usage, layerType) ||
-			ControlButtonLayered.SelectFirstLayerOfType<TElement>(this.#drawElements, layerType)
-		)
-	}
-
-	private static SelectFirstLayerWithUsage<TElement extends ButtonGraphicsElementBase & { type: string }>(
-		elements: SomeButtonGraphicsElement[],
-		usage: ButtonGraphicsElementUsage,
-		layerType: TElement['type']
-	): TElement | undefined {
-		for (const element of elements) {
-			if (element.type === 'group') {
-				const match = ControlButtonLayered.SelectFirstLayerWithUsage<TElement>(element.children, usage, layerType)
-				if (match) return match
-			} else if (element.type === layerType && element.usage === usage) {
-				// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-				return element as unknown as TElement
-			}
-		}
-
-		return undefined
-	}
-
-	private static SelectFirstLayerOfType<TElement extends ButtonGraphicsElementBase & { type: string }>(
-		elements: SomeButtonGraphicsElement[],
-		layerType: TElement['type']
-	): TElement | undefined {
-		for (const element of elements) {
-			if (element.type === 'group') {
-				const match = ControlButtonLayered.SelectFirstLayerOfType<TElement>(element.children, layerType)
-				if (match) return match
-			} else if (element.type === layerType && element.usage === ButtonGraphicsElementUsage.Automatic) {
-				// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-				return element as unknown as TElement
-			}
-		}
-
-		return undefined
 	}
 }

--- a/companion/lib/Controls/ControlTypes/Button/Layered.ts
+++ b/companion/lib/Controls/ControlTypes/Button/Layered.ts
@@ -161,14 +161,6 @@ export class ControlButtonLayered
 		}
 	}
 
-	/**
-	 * Prepare this control for deletion
-	 */
-	destroy(): void {
-		this.drawing.dispose()
-		super.destroy()
-	}
-
 	protected override entityListReportChange(options: ControlEntityListChangeProps): void {
 		if (!options.noSave) {
 			this.commitChange(false)
@@ -203,15 +195,6 @@ export class ControlButtonLayered
 		)
 		collector.visitEntities(this.entities.getAllEntities(), [])
 		this.drawing.visit(collector)
-	}
-
-	/**
-	 * Inform the control that it has been moved, and anything relying on its location must be invalidated
-	 */
-	triggerLocationHasChanged(): void {
-		super.triggerLocationHasChanged()
-
-		this.drawing.locationChanged()
 	}
 
 	layeredStyleAddElement(type: string, index: number | null): string {
@@ -297,7 +280,7 @@ export class ControlButtonLayered
 	override toJSON(clone = true): LayeredButtonModel {
 		const obj: LayeredButtonModel = {
 			type: this.type,
-			style: { layers: this.drawing.drawElements },
+			style: { layers: [...this.drawing.drawElements] },
 			options: this.options,
 			feedbacks: this.entities.getFeedbackEntities(),
 			steps: this.entities.asNormalButtonSteps(),

--- a/companion/lib/Controls/ControlTypes/Button/LayeredButtonDrawer.ts
+++ b/companion/lib/Controls/ControlTypes/Button/LayeredButtonDrawer.ts
@@ -122,8 +122,10 @@ export class LayeredButtonDrawer {
 	)
 	#pendingDraw = false
 
-	/** The draw elements. Mutation lives on the editor subclass; this is for read/serialize. */
-	get drawElements(): SomeButtonGraphicsElement[] {
+	/**
+	 * The draw elements, as a read-only view.
+	 */
+	get drawElements(): readonly SomeButtonGraphicsElement[] {
 		return this.drawElementsList
 	}
 
@@ -138,35 +140,48 @@ export class LayeredButtonDrawer {
 	loadElements(elements: SomeButtonGraphicsElement[] | undefined): void {
 		this.drawElementsList = elements || []
 
-		// HACK: temporary fill in new properties on loaded elements
+		// Ensure all properties are defined on elements as they are loaded
 		for (const element of this.drawElementsList) {
-			if (element.type !== 'canvas') {
-				try {
-					const defaults = CreateElementOfType(element.type)
-					for (const key of Object.keys(defaults)) {
-						if (key === 'id' || key === 'type' || key === 'name') continue
-						if (!(key in element)) {
-							;(element as any)[key] = (defaults as any)[key]
-						}
-					}
-				} catch (_e) {
-					// Ignore
-				}
-			}
-			switch (element.type) {
-				case 'canvas':
-					if (!element.showStatusIcons)
-						element.showStatusIcons = { value: ButtonGraphicsShowStatusIcons.FollowDefault, isExpression: false }
-					break
-				case 'image':
-					if (!element.fillMode.isExpression && (element.fillMode.value as string) === 'fit_or_shrink') {
-						element.fillMode.value = 'fit'
-					}
-					break
-			}
+			this.#normalizeLoadedElement(element)
 		}
 
 		this.elementConversionCache.clear()
+	}
+
+	/**
+	 * Backfill missing properties and migrate legacy values on a loaded element, recursing into group children
+	 * so that nested layers stay consistent with top-level ones.
+	 */
+	#normalizeLoadedElement(element: SomeButtonGraphicsElement): void {
+		if (element.type !== 'canvas') {
+			try {
+				const defaults = CreateElementOfType(element.type)
+				for (const key of Object.keys(defaults)) {
+					if (key === 'id' || key === 'type' || key === 'name') continue
+					if (!(key in element)) {
+						;(element as any)[key] = (defaults as any)[key]
+					}
+				}
+			} catch (_e) {
+				// Ignore
+			}
+		}
+		switch (element.type) {
+			case 'canvas':
+				if (!element.showStatusIcons)
+					element.showStatusIcons = { value: ButtonGraphicsShowStatusIcons.FollowDefault, isExpression: false }
+				break
+			case 'image':
+				if (!element.fillMode.isExpression && (element.fillMode.value as string) === 'fit_or_shrink') {
+					element.fillMode.value = 'fit'
+				}
+				break
+			case 'group':
+				for (const child of element.children) {
+					this.#normalizeLoadedElement(child)
+				}
+				break
+		}
 	}
 
 	/** Compute the draw style of the button. */

--- a/companion/lib/Controls/ControlTypes/Button/LayeredButtonDrawer.ts
+++ b/companion/lib/Controls/ControlTypes/Button/LayeredButtonDrawer.ts
@@ -1,0 +1,278 @@
+import debounceFn from 'debounce-fn'
+import type { JsonValue } from 'type-fest'
+import { formatLocation } from '@companion-app/shared/ControlId.js'
+import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
+import type { ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
+import type { SomeButtonGraphicsElement } from '@companion-app/shared/Model/StyleLayersModel.js'
+import {
+	ButtonGraphicsShowStatusIcons,
+	type DrawStyleButtonStateProps,
+	type DrawStyleLayeredButtonModel,
+} from '@companion-app/shared/Model/StyleModel.js'
+import type { VariableValues } from '@companion-app/shared/Model/Variables.js'
+import { ConvertSomeButtonGraphicsElementForDrawing } from '../../../Graphics/ConvertGraphicsElements.js'
+import { ElementConversionCache } from '../../../Graphics/ElementConversionCache.js'
+import type { ImageResult } from '../../../Graphics/ImageResult.js'
+import type { CompositeElementIdString } from '../../../Instance/Definitions.js'
+import LogController, { type Logger } from '../../../Log/Controller.js'
+import type { ControlDependencies } from '../../ControlDependencies.js'
+import type { ControlEntityInstance } from '../../Entities/EntityInstance.js'
+import { CreateElementOfType } from './LayerDefaults.js'
+
+/** Anything that can visit the draw elements (e.g. the reference collector/updater visitors). */
+export interface DrawElementsVisitor {
+	visitDrawElements(elements: SomeButtonGraphicsElement[]): void
+}
+
+/**
+ * The slice of an entity pool the drawer reads when rendering (local variables + feedback style overrides).
+ * `ControlEntityListPoolButton` satisfies this; controls without entities (e.g. page buttons) pass `null`.
+ */
+export interface LayeredButtonDrawerEntitySource {
+	getLocalVariableEntities(): ControlEntityInstance[]
+	getFeedbackStyleOverrides(): ReadonlyMap<string, ReadonlyMap<string, ExpressionOrValue<JsonValue | undefined>>>
+}
+
+/**
+ * The small surface the drawer needs back from the owning control to render. Kept deliberately minimal.
+ */
+export interface LayeredButtonDrawerHost {
+	getButtonStateProps(): DrawStyleButtonStateProps
+	/** The control's entity pool (for local variables + feedback overrides), or null if it has none. */
+	readonly entities: LayeredButtonDrawerEntitySource | null
+}
+
+const emptyFeedbackOverrides: ReadonlyMap<string, never> = new Map<string, never>()
+
+/**
+ * Owns the layered-button **rendering** (and nothing that mutates style): the draw elements, the per-element
+ * conversion cache, the "what did the last draw depend on" tracking, the conversion to a draw style, and the
+ * invalidation that follows from variable / composite-element / referenced-button changes.
+ *
+ * It is held by a control as `readonly drawing` (composition). Because this class has no style-editing methods
+ * at all, a control that composes it is **read-only by construction** - there is no mutator to forget to
+ * guard. The editable button composes `LayeredButtonStyleEditor` (a subclass that adds the editing ops).
+ *
+ * The `protected` element/cache/deps members are the surface that subclass exposes its editing operations on.
+ */
+export class LayeredButtonDrawer {
+	protected readonly logger: Logger
+	protected readonly deps: ControlDependencies
+	protected readonly controlId: string
+	readonly #host: LayeredButtonDrawerHost
+
+	protected drawElementsList: SomeButtonGraphicsElement[] = []
+
+	protected readonly elementConversionCache = new ElementConversionCache()
+
+	/** The variables referenced in the last draw. When one changes, a redraw is needed. */
+	#lastDrawVariables: ReadonlySet<string> | null = null
+	#lastDrawCompositeElements: ReadonlySet<CompositeElementIdString> | null = null
+	/** Location strings (e.g. '1/0/0') of buttons referenced via reference elements in the last draw. */
+	#lastDrawReferencedLocations: ReadonlySet<string> | null = null
+	/** Locations where a reference cycle was detected, to suppress redundant ∞ redraws. */
+	#lastCyclicReferences: ReadonlySet<string> | null = null
+
+	#lastDrawStyle: DrawStyleLayeredButtonModel | null = null
+
+	/** The draw type to report (most buttons are 'button'; page buttons use 'pageup'/'pagedown'/'pagenum'). */
+	readonly #drawType: DrawStyleLayeredButtonModel['drawType']
+
+	constructor(
+		deps: ControlDependencies,
+		controlId: string,
+		host: LayeredButtonDrawerHost,
+		drawType: DrawStyleLayeredButtonModel['drawType'] = 'button'
+	) {
+		this.logger = LogController.createLogger(`Controls/Button/Drawer/${controlId}`)
+		this.deps = deps
+		this.controlId = controlId
+		this.#host = host
+		this.#drawType = drawType
+
+		// Own the 'other control finished rendering' invalidation source, needed for reference elements
+		this.deps.graphics.on('button_drawn', this.#onReferencedButtonDrawn)
+	}
+
+	dispose(): void {
+		this.deps.graphics.off('button_drawn', this.#onReferencedButtonDrawn)
+		this.elementConversionCache.clear()
+	}
+
+	/**
+	 * Request a re-render of this control's graphic. Debounced so rapid bursts of work coalesce into a single
+	 * invalidation.
+	 */
+	invalidate = debounceFn(
+		() => {
+			if (this.#pendingDraw) return
+
+			this.#pendingDraw = true
+			setImmediate(() => {
+				this.deps.events.emit('invalidateControlRender', this.controlId)
+				this.#pendingDraw = false
+			})
+		},
+		{
+			before: false,
+			after: true,
+			wait: 10,
+			maxWait: 20,
+		}
+	)
+	#pendingDraw = false
+
+	/** The draw elements. Mutation lives on the editor subclass; this is for read/serialize. */
+	get drawElements(): SomeButtonGraphicsElement[] {
+		return this.drawElementsList
+	}
+
+	getLastDrawStyle(): DrawStyleLayeredButtonModel | null {
+		return this.#lastDrawStyle
+	}
+
+	/**
+	 * Replace the draw elements (on load or on a preset refresh), normalising any missing/legacy properties,
+	 * and clear the conversion cache.
+	 */
+	loadElements(elements: SomeButtonGraphicsElement[] | undefined): void {
+		this.drawElementsList = elements || []
+
+		// HACK: temporary fill in new properties on loaded elements
+		for (const element of this.drawElementsList) {
+			if (element.type !== 'canvas') {
+				try {
+					const defaults = CreateElementOfType(element.type)
+					for (const key of Object.keys(defaults)) {
+						if (key === 'id' || key === 'type' || key === 'name') continue
+						if (!(key in element)) {
+							;(element as any)[key] = (defaults as any)[key]
+						}
+					}
+				} catch (_e) {
+					// Ignore
+				}
+			}
+			switch (element.type) {
+				case 'canvas':
+					if (!element.showStatusIcons)
+						element.showStatusIcons = { value: ButtonGraphicsShowStatusIcons.FollowDefault, isExpression: false }
+					break
+				case 'image':
+					if (!element.fillMode.isExpression && (element.fillMode.value as string) === 'fit_or_shrink') {
+						element.fillMode.value = 'fit'
+					}
+					break
+			}
+		}
+
+		this.elementConversionCache.clear()
+	}
+
+	/** Compute the draw style of the button. */
+	async getDrawStyle(): Promise<DrawStyleLayeredButtonModel> {
+		const injectedVariableValues: VariableValues = {}
+		const location = this.deps.pageStore.getLocationOfControlId(this.controlId)
+
+		const parser = this.deps.variableValues.createVariablesAndExpressionParser(
+			location,
+			this.#host.entities?.getLocalVariableEntities() ?? null,
+			injectedVariableValues
+		)
+
+		const locationStr = location ? formatLocation(location) : null
+
+		const feedbackOverrides = this.#host.entities?.getFeedbackStyleOverrides() ?? emptyFeedbackOverrides
+
+		const { elements, usedVariables, usedCompositeElements, referencedLocations, cyclicLocations } =
+			await ConvertSomeButtonGraphicsElementForDrawing(
+				this.deps.instance.definitions,
+				parser,
+				this.deps.graphics.renderPixelBuffers.bind(this.deps.graphics),
+				this.drawElementsList,
+				feedbackOverrides,
+				true,
+				this.elementConversionCache,
+				locationStr,
+				(location) => this.deps.graphics.getCachedRender(location) ?? null
+			)
+		this.#lastDrawVariables = usedVariables.size > 0 ? usedVariables : null
+		this.#lastDrawCompositeElements = usedCompositeElements.size > 0 ? usedCompositeElements : null
+		this.#lastDrawReferencedLocations = referencedLocations.size > 0 ? referencedLocations : null
+		this.#lastCyclicReferences = cyclicLocations.size > 0 ? cyclicLocations : null
+
+		const result: DrawStyleLayeredButtonModel = {
+			...this.#host.getButtonStateProps(),
+
+			elements,
+			referencedLocations,
+
+			style: 'button-layered',
+			drawType: this.#drawType,
+		}
+
+		this.#lastDrawStyle = result
+		return result
+	}
+
+	/** Propagate a variable change: invalidate affected cached elements and redraw if relevant. */
+	onVariablesChanged(allChangedVariables: ReadonlySet<string>): void {
+		if (!this.#lastDrawVariables) return
+		if (this.#lastDrawVariables.isDisjointFrom(allChangedVariables)) return
+
+		this.elementConversionCache.queueInvalidateVariables(allChangedVariables)
+
+		this.logger.silly('variable changed in button ' + this.controlId)
+		this.invalidate()
+	}
+
+	/** The control was moved: any location-dependent drawing must be recomputed. */
+	locationChanged(): void {
+		this.elementConversionCache.clear()
+		this.invalidate()
+	}
+
+	/** Run a references visitor (collector or updater) over the draw elements. */
+	visit(visitor: DrawElementsVisitor): void {
+		visitor.visitDrawElements(this.drawElementsList)
+	}
+
+	// ── Cache-invalidation hooks for the owning control's entity/runtime change path ──
+	invalidateElement(id: string): void {
+		this.elementConversionCache.queueInvalidate(id)
+	}
+	clearCache(): void {
+		this.elementConversionCache.clear()
+	}
+
+	/**
+	 * A composite element definition used by our cached style changed - invalidate and redraw if relevant.
+	 * Called by the owning control from its existing `onCompositeElementsChanged` entry point.
+	 */
+	onCompositeElementsChanged(allChangedElementIds: ReadonlySet<CompositeElementIdString>): void {
+		if (!this.#lastDrawCompositeElements) return
+		if (this.#lastDrawCompositeElements.isDisjointFrom(allChangedElementIds)) return
+
+		this.elementConversionCache.queueInvalidateCompositeType(allChangedElementIds)
+
+		this.logger.silly('composite element changed in button ' + this.controlId)
+		this.invalidate()
+	}
+
+	/** Another located control finished rendering; if we reference it, invalidate and redraw. */
+	#onReferencedButtonDrawn = (location: ControlLocation, render: ImageResult): void => {
+		const locStr = formatLocation(location)
+		if (!this.#lastDrawReferencedLocations?.has(locStr)) return
+
+		// Suppress ping-pong when we're already rendering a cycle: if we're already showing ∞ for this
+		// location AND the target still references us back, no visible output would change.
+		if (this.#lastCyclicReferences?.has(locStr)) {
+			const myLocation = this.deps.pageStore.getLocationOfControlId(this.controlId)
+			if (myLocation && render.referencedLocations.has(formatLocation(myLocation))) return
+		}
+
+		this.elementConversionCache.queueInvalidateReferencedLocation(locStr)
+		this.logger.silly('referenced control rendered in button ' + this.controlId)
+		this.invalidate()
+	}
+}

--- a/companion/lib/Controls/ControlTypes/Button/LayeredButtonStyleEditor.ts
+++ b/companion/lib/Controls/ControlTypes/Button/LayeredButtonStyleEditor.ts
@@ -199,14 +199,22 @@ export class LayeredButtonStyleEditor extends LayeredButtonDrawer {
 	}
 
 	updateOption(id: string, key: string, newVal: ExpressionOrValue<JsonValue | undefined>): boolean {
-		// Ignore some fixed properties
-		if (key === 'id' || key === 'type' || key === 'name') return false
+		// Ignore fixed/structural properties, to avoid corrupting the layer model
+		if (
+			key === 'id' ||
+			key === 'type' ||
+			key === 'name' ||
+			key === 'usage' ||
+			key === 'children' ||
+			key === 'connectionId' ||
+			key === 'elementId'
+		)
+			return false
 
 		const currentElementLocation = this.#findElementIndexAndParent(this.drawElementsList, null, id)
 		if (!currentElementLocation) return false
 
 		const entry = currentElementLocation.element as any
-		if (!entry[key]) return false
 
 		entry[key] = newVal
 

--- a/companion/lib/Controls/ControlTypes/Button/LayeredButtonStyleEditor.ts
+++ b/companion/lib/Controls/ControlTypes/Button/LayeredButtonStyleEditor.ts
@@ -1,0 +1,396 @@
+import { nanoid } from 'nanoid'
+import type { JsonValue } from 'type-fest'
+import type { ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
+import type {
+	ButtonGraphicsBoxElement,
+	ButtonGraphicsElementBase,
+	ButtonGraphicsGroupElement,
+	ButtonGraphicsImageElement,
+	ButtonGraphicsTextElement,
+	SomeButtonGraphicsElement,
+} from '@companion-app/shared/Model/StyleLayersModel.js'
+import { ButtonGraphicsElementUsage, type ButtonStyleProperties } from '@companion-app/shared/Model/StyleModel.js'
+import { ParseLegacyStyle } from '../../../Resources/ConvertLegacyStyleToElements.js'
+import { lazy } from '../../../Resources/Util.js'
+import type { ControlDependencies } from '../../ControlDependencies.js'
+import { CreateElementOfType } from './LayerDefaults.js'
+import { LayeredButtonDrawer, type LayeredButtonDrawerHost } from './LayeredButtonDrawer.js'
+import { cloneElementWithNewIds } from './LayerUtils.js'
+
+/**
+ * The drawer host extended with the persistence callbacks the editing operations need.
+ */
+export interface LayeredButtonStyleEditorHost extends LayeredButtonDrawerHost {
+	commitChange(redraw?: boolean): void
+	emitElementChanged(elementId: string): void
+}
+
+/**
+ * A {@link LayeredButtonDrawer} that additionally owns the layered-style **editing** operations (add / remove
+ * / duplicate / move / rename / reusage / option / legacy-style). Composed only by the editable layered
+ * button; read-only controls (e.g. the preset reference) compose the plain {@link LayeredButtonDrawer}, so
+ * they have no way to mutate their style.
+ *
+ * Each mutator updates the elements and conversion cache owned by the base drawer, then `commitChange`s and
+ * emits the element-changed event via the host.
+ */
+export class LayeredButtonStyleEditor extends LayeredButtonDrawer {
+	readonly #host: LayeredButtonStyleEditorHost
+
+	constructor(deps: ControlDependencies, controlId: string, host: LayeredButtonStyleEditorHost) {
+		super(deps, controlId, host)
+		this.#host = host
+	}
+
+	addElement(type: string, index: number | null): string {
+		let newElement: SomeButtonGraphicsElement
+
+		// Check if this is a composite element (contains semicolon)
+		if (type.includes(';')) {
+			const [connectionId, elementId] = type.split(';', 2)
+			const compositeDefinition = this.deps.instance.definitions.getCompositeElementDefinition(connectionId, elementId)
+
+			if (compositeDefinition) {
+				newElement = {
+					id: nanoid(),
+					name: compositeDefinition.name,
+					usage: ButtonGraphicsElementUsage.Automatic,
+					type: 'composite',
+					connectionId,
+					elementId,
+					enabled: { value: true, isExpression: false },
+					opacity: { value: 100, isExpression: false },
+					x: { value: 0, isExpression: false },
+					y: { value: 0, isExpression: false },
+					width: { value: 100, isExpression: false },
+					height: { value: 100, isExpression: false },
+				}
+
+				for (const field of compositeDefinition.options) {
+					newElement[`opt:${field.id}`] = {
+						value: 'default' in field ? field.default : undefined,
+						isExpression: false,
+					}
+				}
+			} else {
+				throw new Error(`Composite element not found: ${type}`)
+			}
+		} else {
+			newElement = CreateElementOfType(type as SomeButtonGraphicsElement['type'])
+		}
+
+		if (typeof index === 'number' && index >= 0 && index < this.drawElementsList.length) {
+			this.drawElementsList.splice(index, 0, newElement)
+		} else {
+			this.drawElementsList.push(newElement)
+		}
+
+		this.elementConversionCache.queueInvalidate(newElement.id)
+		this.#host.commitChange(true)
+		this.#host.emitElementChanged(newElement.id)
+
+		return newElement.id
+	}
+
+	removeElement(id: string): boolean {
+		const currentElementLocation = this.#findElementIndexAndParent(this.drawElementsList, null, id)
+		if (!currentElementLocation) return false
+
+		const { indexOfElement, element, currentParentElementArray } = currentElementLocation
+
+		// Canvas is the fixed background element and cannot be removed
+		if (element.type === 'canvas') return false
+
+		currentParentElementArray.splice(indexOfElement, 1)
+
+		this.elementConversionCache.queueInvalidate(id)
+		this.#host.commitChange(true)
+		this.#host.emitElementChanged(id)
+
+		return true
+	}
+
+	duplicateElement(id: string): string | false {
+		const currentElementLocation = this.#findElementIndexAndParent(this.drawElementsList, null, id)
+		if (!currentElementLocation) return false
+
+		const { indexOfElement, element, currentParentElementArray } = currentElementLocation
+
+		// Canvas is the fixed background element and cannot be duplicated
+		if (element.type === 'canvas') return false
+
+		const clone = cloneElementWithNewIds(element)
+
+		currentParentElementArray.splice(indexOfElement + 1, 0, clone)
+
+		this.elementConversionCache.queueInvalidate(clone.id)
+		this.#host.commitChange(true)
+		this.#host.emitElementChanged(clone.id)
+
+		return clone.id
+	}
+
+	setElementName(id: string, name: string): boolean {
+		const currentElementLocation = this.#findElementIndexAndParent(this.drawElementsList, null, id)
+		if (!currentElementLocation) return false
+
+		currentElementLocation.element.name = name
+
+		this.#host.commitChange(false)
+
+		return true
+	}
+
+	setElementUsage(id: string, usage: ButtonGraphicsElementUsage): boolean {
+		const currentElementLocation = this.#findElementIndexAndParent(this.drawElementsList, null, id)
+		if (!currentElementLocation) return false
+
+		currentElementLocation.element.usage = usage
+
+		// Trigger a redraw, as this could affect listeners of the properties
+		this.#host.commitChange(true)
+
+		return true
+	}
+
+	getElementById(id: string): SomeButtonGraphicsElement | undefined {
+		return this.#findElementIndexAndParent(this.drawElementsList, null, id)?.element
+	}
+
+	selectedElementIds(): { [usage in ButtonGraphicsElementUsage]: string | undefined } {
+		return {
+			[ButtonGraphicsElementUsage.Automatic]: undefined, // Not valid here
+			[ButtonGraphicsElementUsage.Text]: this.#selectLayerForUsage(ButtonGraphicsElementUsage.Text, 'text')?.id,
+			[ButtonGraphicsElementUsage.Image]: this.#selectLayerForUsage(ButtonGraphicsElementUsage.Image, 'image')?.id,
+			[ButtonGraphicsElementUsage.Color]: this.#selectLayerForUsage(ButtonGraphicsElementUsage.Color, 'box')?.id,
+		}
+	}
+
+	moveElement(id: string, parentElementId: string | null, newIndex: number): boolean {
+		const currentElementLocation = this.#findElementIndexAndParent(this.drawElementsList, null, id)
+		if (!currentElementLocation) return false
+		const { indexOfElement, currentParentElementId, currentParentElementArray } = currentElementLocation
+
+		// Can't move to or from the first element
+		if ((indexOfElement === 0 && currentParentElementId === null) || (newIndex === 0 && parentElementId === null))
+			return false
+
+		// Cycle detection: prevent moving an element into itself or one of its own descendants
+		if (parentElementId !== null) {
+			if (parentElementId === id) return false
+			const { element } = currentElementLocation
+			if (element.type === 'group' && this.#findGroupElementById(element.children, parentElementId) !== null)
+				return false
+		}
+
+		const targetElementArray = parentElementId
+			? this.#findGroupElementById(this.drawElementsList, parentElementId)?.children
+			: this.drawElementsList
+
+		if (!targetElementArray) return false
+		if (newIndex < 0 || newIndex > targetElementArray.length) return false
+
+		const element = currentParentElementArray.splice(indexOfElement, 1)[0]
+		targetElementArray.splice(newIndex, 0, element)
+
+		this.#host.commitChange(true)
+
+		return true
+	}
+
+	updateOption(id: string, key: string, newVal: ExpressionOrValue<JsonValue | undefined>): boolean {
+		// Ignore some fixed properties
+		if (key === 'id' || key === 'type' || key === 'name') return false
+
+		const currentElementLocation = this.#findElementIndexAndParent(this.drawElementsList, null, id)
+		if (!currentElementLocation) return false
+
+		const entry = currentElementLocation.element as any
+		if (!entry[key]) return false
+
+		entry[key] = newVal
+
+		this.elementConversionCache.queueInvalidate(id)
+		this.#host.commitChange(true)
+		this.#host.emitElementChanged(id)
+
+		return true
+	}
+
+	updateFromLegacyProperties(diff: Partial<ButtonStyleProperties>, canModifyStyleInApis: boolean): boolean {
+		if (!canModifyStyleInApis) return false
+
+		const changedElements = new Set<string>()
+
+		const lazyTextElement = lazy(() => {
+			const elm = this.#selectLayerForUsage<ButtonGraphicsTextElement>(ButtonGraphicsElementUsage.Text, 'text')
+			if (elm) changedElements.add(elm.id)
+			return elm
+		})
+		const lazyBoxElement = lazy(() => {
+			const elm = this.#selectLayerForUsage<ButtonGraphicsBoxElement>(ButtonGraphicsElementUsage.Color, 'box')
+			if (elm) changedElements.add(elm.id)
+			return elm
+		})
+		const lazyImageElement = lazy(() => {
+			const elm = this.#selectLayerForUsage<ButtonGraphicsImageElement>(ButtonGraphicsElementUsage.Image, 'image')
+			if (elm) changedElements.add(elm.id)
+			return elm
+		})
+		const canvasElement = this.drawElementsList.find((e) => e.type === 'canvas')
+
+		const parsedStyle = ParseLegacyStyle(diff)
+
+		if (parsedStyle.text.text !== undefined) {
+			const textElement = lazyTextElement()
+			if (textElement) textElement.text = parsedStyle.text.text
+		}
+
+		if (parsedStyle.text.size !== undefined) {
+			const textElement = lazyTextElement()
+			if (textElement) {
+				textElement.fontsize = { isExpression: false, value: parsedStyle.text.size }
+				textElement.fontsizeAllowShrink = { isExpression: false, value: parsedStyle.text.sizeAllowShrink ?? false }
+			}
+		}
+
+		if (parsedStyle.text.color !== undefined) {
+			const textElement = lazyTextElement()
+			if (textElement) textElement.color = { isExpression: false, value: parsedStyle.text.color }
+		}
+
+		if (parsedStyle.text.halign !== undefined) {
+			const textElement = lazyTextElement()
+			if (textElement) textElement.halign = { isExpression: false, value: parsedStyle.text.halign }
+		}
+		if (parsedStyle.text.valign !== undefined) {
+			const textElement = lazyTextElement()
+			if (textElement) textElement.valign = { isExpression: false, value: parsedStyle.text.valign }
+		}
+
+		if (parsedStyle.image.halign !== undefined) {
+			const imageElement = lazyImageElement()
+			if (imageElement) imageElement.halign = { isExpression: false, value: parsedStyle.image.halign }
+		}
+		if (parsedStyle.image.valign !== undefined) {
+			const imageElement = lazyImageElement()
+			if (imageElement) imageElement.valign = { isExpression: false, value: parsedStyle.image.valign }
+		}
+
+		if (parsedStyle.image.image !== undefined) {
+			const imageElement = lazyImageElement()
+			if (imageElement) imageElement.base64Image = { isExpression: false, value: parsedStyle.image.image }
+		}
+
+		if (parsedStyle.background.color !== undefined) {
+			const boxElement = lazyBoxElement()
+			if (boxElement) boxElement.color = { isExpression: false, value: parsedStyle.background.color }
+		}
+
+		if (parsedStyle.canvas.decoration !== undefined && canvasElement) {
+			canvasElement.decoration = { isExpression: false, value: parsedStyle.canvas.decoration }
+			changedElements.add(canvasElement.id)
+		}
+
+		if (changedElements.size === 0) return false
+
+		for (const elementId of changedElements) {
+			this.elementConversionCache.delete(elementId)
+		}
+
+		this.#host.commitChange(true)
+
+		for (const elementId of changedElements) {
+			this.#host.emitElementChanged(elementId)
+		}
+
+		return true
+	}
+
+	#findElementIndexAndParent(
+		searchInElements: SomeButtonGraphicsElement[],
+		parentId: string | null,
+		searchId: string
+	): {
+		indexOfElement: number
+		element: SomeButtonGraphicsElement
+		currentParentElementId: string | null
+		currentParentElementArray: SomeButtonGraphicsElement[]
+	} | null {
+		const indexOfElement = searchInElements.findIndex((element) => element.id === searchId)
+		if (indexOfElement !== -1)
+			return {
+				indexOfElement: indexOfElement,
+				element: searchInElements[indexOfElement],
+				currentParentElementId: parentId,
+				currentParentElementArray: searchInElements,
+			}
+
+		for (const element of searchInElements) {
+			if (element.type !== 'group') continue
+
+			const result = this.#findElementIndexAndParent(element.children, element.id, searchId)
+			if (result) return result
+		}
+
+		return null
+	}
+
+	#findGroupElementById(
+		searchInElements: SomeButtonGraphicsElement[],
+		searchId: string
+	): ButtonGraphicsGroupElement | null {
+		for (const element of searchInElements) {
+			if (element.type !== 'group') continue
+
+			if (element.id === searchId) return element
+			const result = this.#findGroupElementById(element.children, searchId)
+			if (result) return result
+		}
+
+		return null
+	}
+
+	#selectLayerForUsage<TElement extends ButtonGraphicsElementBase & { type: string }>(
+		usage: ButtonGraphicsElementUsage,
+		layerType: TElement['type']
+	): TElement | undefined {
+		return (
+			LayeredButtonStyleEditor.#selectFirstLayerWithUsage<TElement>(this.drawElementsList, usage, layerType) ||
+			LayeredButtonStyleEditor.#selectFirstLayerOfType<TElement>(this.drawElementsList, layerType)
+		)
+	}
+
+	static #selectFirstLayerWithUsage<TElement extends ButtonGraphicsElementBase & { type: string }>(
+		elements: SomeButtonGraphicsElement[],
+		usage: ButtonGraphicsElementUsage,
+		layerType: TElement['type']
+	): TElement | undefined {
+		for (const element of elements) {
+			if (element.type === 'group') {
+				const match = LayeredButtonStyleEditor.#selectFirstLayerWithUsage<TElement>(element.children, usage, layerType)
+				if (match) return match
+			} else if (element.type === layerType && element.usage === usage) {
+				return element as unknown as TElement
+			}
+		}
+
+		return undefined
+	}
+
+	static #selectFirstLayerOfType<TElement extends ButtonGraphicsElementBase & { type: string }>(
+		elements: SomeButtonGraphicsElement[],
+		layerType: TElement['type']
+	): TElement | undefined {
+		for (const element of elements) {
+			if (element.type === 'group') {
+				const match = LayeredButtonStyleEditor.#selectFirstLayerOfType<TElement>(element.children, layerType)
+				if (match) return match
+			} else if (element.type === layerType && element.usage === ButtonGraphicsElementUsage.Automatic) {
+				return element as unknown as TElement
+			}
+		}
+
+		return undefined
+	}
+}

--- a/companion/lib/Controls/ControlTypes/Button/Preset.ts
+++ b/companion/lib/Controls/ControlTypes/Button/Preset.ts
@@ -256,6 +256,11 @@ export class ControlButtonPreset
 		this.#drawing.visit(updater)
 		const changed = updater.visitEntities(this.entities.getAllEntities(), []).recheckChangedFeedbacks().hasChanges()
 
+		if (changed) {
+			// Purge all cache, as we don't know what could have changed
+			this.#drawing.clearCache()
+		}
+
 		// redraw if needed and save changes
 		this.commitChange(changed)
 	}
@@ -339,7 +344,7 @@ export class ControlButtonPreset
 		const obj: PresetButtonModel = {
 			type: this.type,
 			style: {
-				layers: this.#drawing.drawElements,
+				layers: [...this.#drawing.drawElements],
 			},
 			options: this.options,
 			feedbacks: this.entities.getFeedbackEntities(),

--- a/companion/lib/Controls/ControlTypes/Button/Preset.ts
+++ b/companion/lib/Controls/ControlTypes/Button/Preset.ts
@@ -8,15 +8,8 @@ import type {
 } from '@companion-app/shared/Model/ButtonModel.js'
 import type { ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
 import type { SomeButtonGraphicsElement } from '@companion-app/shared/Model/StyleLayersModel.js'
-import {
-	ButtonGraphicsElementUsage,
-	type ButtonStyleProperties,
-	type DrawStyleLayeredButtonModel,
-} from '@companion-app/shared/Model/StyleModel.js'
-import { ConvertSomeButtonGraphicsElementForDrawing } from '../../../Graphics/ConvertGraphicsElements.js'
-import { ElementConversionCache } from '../../../Graphics/ElementConversionCache.js'
+import { ButtonGraphicsElementUsage, type ButtonStyleProperties } from '@companion-app/shared/Model/StyleModel.js'
 import type { ImageResult } from '../../../Graphics/ImageResult.js'
-import type { CompositeElementIdString } from '../../../Instance/Definitions.js'
 import { VisitorReferencesCollector } from '../../../Resources/Visitors/ReferencesCollector.js'
 import { VisitorReferencesUpdater } from '../../../Resources/Visitors/ReferencesUpdater.js'
 import { ControlBase } from '../../ControlBase.js'
@@ -34,6 +27,7 @@ import type {
 	ControlWithoutPushed,
 } from '../../IControlFragments.js'
 import { ButtonControlBase } from './Base.js'
+import { LayeredButtonDrawer } from './LayeredButtonDrawer.js'
 
 /**
  * Class for the preset button control.
@@ -72,6 +66,15 @@ export class ControlButtonPreset
 
 	readonly entities: ControlEntityListPoolButton
 
+	readonly #drawing: LayeredButtonDrawer
+	override get drawing(): LayeredButtonDrawer {
+		return this.#drawing
+	}
+
+	protected triggerInvalidation = (): void => {
+		this.#drawing.invalidate()
+	}
+
 	/**
 	 * The current status of this button
 	 */
@@ -81,22 +84,6 @@ export class ControlButtonPreset
 	 * The config of this button
 	 */
 	options!: LayeredButtonOptions
-
-	/**
-	 * The variables referenced in the last draw. Whenever one of these changes, a redraw should be performed
-	 */
-	#lastDrawVariables: ReadonlySet<string> | null = null
-	#lastDrawCompositeElements: ReadonlySet<CompositeElementIdString> | null = null
-
-	/**
-	 * The base style without feedbacks applied
-	 */
-	#drawElements: SomeButtonGraphicsElement[] = []
-
-	/**
-	 * Cache for element conversion results (for future per-element caching optimization)
-	 */
-	readonly #elementConversionCache = new ElementConversionCache()
 
 	readonly #connectionId: string
 	readonly #presetId: string
@@ -149,6 +136,17 @@ export class ControlButtonPreset
 			canModifyStyleInApis: false,
 		}
 
+		this.#drawing = new LayeredButtonDrawer(deps, controlId, {
+			getButtonStateProps: () => ({
+				pushed: false,
+				stepCurrent: this.entities.getActiveStepIndex() + 1,
+				stepCount: this.entities.getStepIds().length,
+				action_running: false,
+				button_status: this.button_status,
+			}),
+			entities: this.entities,
+		})
+
 		if (storage.type !== 'preset:button')
 			throw new Error(`Invalid type given to ControlButtonPreset: "${storage.type}"`)
 
@@ -162,7 +160,7 @@ export class ControlButtonPreset
 	 * Prepare this control for deletion
 	 */
 	destroy(): void {
-		this.#elementConversionCache.clear()
+		this.#drawing.dispose()
 		this.entities.destroy()
 
 		super.destroy()
@@ -177,15 +175,15 @@ export class ControlButtonPreset
 		}
 
 		if (options.invalidateAllElements) {
-			this.#elementConversionCache.clear()
+			this.#drawing.clearCache()
 		} else if (options.changedElementIds) {
 			for (const elementId of options.changedElementIds) {
-				this.#elementConversionCache.queueInvalidate(elementId)
+				this.#drawing.invalidateElement(elementId)
 			}
 		}
 
 		if (options.redraw || options.changedElementIds || options.invalidateAllElements) {
-			this.triggerRedraw()
+			this.triggerInvalidation()
 		}
 	}
 
@@ -206,8 +204,7 @@ export class ControlButtonPreset
 	}
 
 	#applyPresetModel(storage: PresetButtonModel): void {
-		this.#drawElements = storage.style.layers || []
-		this.#elementConversionCache.clear()
+		this.#drawing.loadElements(storage.style.layers)
 
 		this.options = Object.assign(this.options, storage.options || {})
 		this.entities.loadStorage(storage, true, true)
@@ -227,137 +224,44 @@ export class ControlButtonPreset
 		this.sendRuntimePropsChange()
 	}
 
-	#lastDrawStyle: DrawStyleLayeredButtonModel | null = null
-	getLastDrawStyle(): DrawStyleLayeredButtonModel | null {
-		return this.#lastDrawStyle
-	}
-
-	/**
-	 * Get the complete style object of a button
-	 * @returns the processed style of the button
-	 */
-	async getDrawStyle(): Promise<DrawStyleLayeredButtonModel | null> {
-		const parser = this.deps.variableValues.createVariablesAndExpressionParser(
-			null,
-			this.entities.getLocalVariableEntities(),
-			null
-		)
-
-		const feedbackOverrides = this.entities.getFeedbackStyleOverrides()
-
-		// Compute the new drawing
-		const { elements, usedVariables, usedCompositeElements } = await ConvertSomeButtonGraphicsElementForDrawing(
-			this.deps.instance.definitions,
-			parser,
-			this.deps.graphics.renderPixelBuffers.bind(this.deps.graphics),
-			this.#drawElements,
-			feedbackOverrides,
-			true,
-			this.#elementConversionCache,
-			null,
-			null
-		)
-		this.#lastDrawVariables = usedVariables.size > 0 ? usedVariables : null
-		this.#lastDrawCompositeElements = usedCompositeElements.size > 0 ? usedCompositeElements : null
-
-		const result: DrawStyleLayeredButtonModel = {
-			elements,
-
-			stepCurrent: this.entities.getActiveStepIndex() + 1,
-			stepCount: this.entities.getStepIds().length,
-
-			pushed: false,
-			action_running: false,
-			button_status: this.button_status,
-
-			style: 'button-layered',
-			drawType: 'button',
-		}
-
-		this.#lastDrawStyle = result
-		return result
-	}
-
 	/**
 	 * Collect the instance ids, labels, and variables referenced by this control
-	 * @param foundConnectionIds - instance ids being referenced
-	 * @param foundConnectionLabels - instance labels being referenced
-	 * @param foundVariables - variables being referenced
 	 */
 	collectReferencedConnectionsAndVariables(
 		foundConnectionIds: Set<string>,
 		foundConnectionLabels: Set<string>,
 		foundVariables: Set<string>
 	): void {
-		new VisitorReferencesCollector(
+		const collector = new VisitorReferencesCollector(
 			this.deps.internalModule,
 			foundConnectionIds,
 			foundConnectionLabels,
 			foundVariables,
 			undefined
 		)
-			.visitDrawElements(this.#drawElements)
-			.visitEntities(this.entities.getAllEntities(), [])
+		this.#drawing.visit(collector)
+		collector.visitEntities(this.entities.getAllEntities(), [])
 	}
 
 	/**
 	 * Rename a connection for variables used in this control
-	 * @param labelFrom - the old connection short name
-	 * @param labelTo - the new connection short name
 	 */
 	renameVariables(labelFrom: string, labelTo: string): void {
-		const allEntities = this.entities.getAllEntities()
-
-		// Fix up references
-		const changed = new VisitorReferencesUpdater(
+		const updater = new VisitorReferencesUpdater(
 			this.deps.internalModule,
 			{ [labelFrom]: labelTo },
 			undefined,
 			undefined
 		)
-			.visitDrawElements(this.#drawElements)
-			.visitEntities(allEntities, [])
-			.recheckChangedFeedbacks()
-			.hasChanges()
+		this.#drawing.visit(updater)
+		const changed = updater.visitEntities(this.entities.getAllEntities(), []).recheckChangedFeedbacks().hasChanges()
 
 		// redraw if needed and save changes
 		this.commitChange(changed)
 	}
 
 	/**
-	 * Propagate variable changes
-	 * @param allChangedVariables - variables with changes
-	 */
-	onVariablesChanged(allChangedVariables: ReadonlySet<string>): void {
-		if (!this.#lastDrawVariables) return
-		if (this.#lastDrawVariables.isDisjointFrom(allChangedVariables)) return
-
-		// Queue invalidation for cached elements that use any of the changed variables
-		this.#elementConversionCache.queueInvalidateVariables(allChangedVariables)
-
-		this.logger.silly('variable changed in button ' + this.controlId)
-		this.triggerRedraw()
-	}
-
-	/**
-	 * Propagate composite element changes
-	 * @param allChangedElementIds - composite element ids with changes
-	 */
-	onCompositeElementsChanged(allChangedElementIds: ReadonlySet<CompositeElementIdString>): void {
-		if (!this.#lastDrawCompositeElements) return
-		if (this.#lastDrawCompositeElements.isDisjointFrom(allChangedElementIds)) return
-
-		// Queue invalidation for any cached elements that use these composite types
-		this.#elementConversionCache.queueInvalidateCompositeType(allChangedElementIds)
-
-		this.logger.silly('composite element changed in button ' + this.controlId)
-		this.triggerRedraw()
-	}
-
-	/**
 	 * Add an element to the layered style
-	 * @param _type Element type to add
-	 * @param _index Index to insert the element at, or null to append
 	 */
 	layeredStyleAddElement(_type: string, _index: number | null): string {
 		throw new Error('ControlButtonPreset does not support mutations')
@@ -365,8 +269,6 @@ export class ControlButtonPreset
 
 	/**
 	 * Remove an element from the layered style
-	 * @param _id Element id to remove
-	 * @returns true if the element was removed
 	 */
 	layeredStyleRemoveElement(_id: string): boolean {
 		throw new Error('ControlButtonPreset does not support mutations')
@@ -378,10 +280,6 @@ export class ControlButtonPreset
 
 	/**
 	 * Move an element in the layered style
-	 * @param _id Element id to move
-	 * @param _parentElementId Parent element id to move the element to
-	 * @param _newIndex New index of the element
-	 * @returns true if the element was moved
 	 */
 	layeredStyleMoveElement(_id: string, _parentElementId: string | null, _newIndex: number): boolean {
 		throw new Error('ControlButtonPreset does not support mutations')
@@ -389,9 +287,6 @@ export class ControlButtonPreset
 
 	/**
 	 * Update the name of an element in the layered style
-	 * @param _id Element id to update
-	 * @param _name New name for the element
-	 * @returns true if the element was updated
 	 */
 	layeredStyleSetElementName(_id: string, _name: string): boolean {
 		throw new Error('ControlButtonPreset does not support mutations')
@@ -399,9 +294,6 @@ export class ControlButtonPreset
 
 	/**
 	 * Update the usage of an element in the layered style
-	 * @param _id Element id to update
-	 * @param usage New usage for the element
-	 * @returns true if the element was updated
 	 */
 	layeredStyleSetElementUsage(_id: string, _name: ButtonGraphicsElementUsage): boolean {
 		throw new Error('ControlButtonPreset does not support mutations')
@@ -409,10 +301,6 @@ export class ControlButtonPreset
 
 	/**
 	 * Update an option on an element from the layered style
-	 * @param _id Element id to update
-	 * @param _key Option key to update
-	 * @param _value New value for the option
-	 * @returns true if any changes were made
 	 */
 	layeredStyleUpdateOption(_id: string, _key: string, _value: ExpressionOrValue<JsonValue | undefined>): boolean {
 		throw new Error('ControlButtonPreset does not support mutations')
@@ -420,9 +308,6 @@ export class ControlButtonPreset
 
 	/**
 	 * Update the style from legacy properties
-	 * Future: Once the old button style is removed, this should be reworked to utilise the new style system better
-	 * @param _diff The properties to update
-	 * @returns true if any changes were made
 	 */
 	layeredStyleUpdateFromLegacyProperties(_diff: Partial<ButtonStyleProperties>): boolean {
 		throw new Error('ControlButtonPreset does not support mutations')
@@ -430,8 +315,6 @@ export class ControlButtonPreset
 
 	/**
 	 * Get an element from the layered style by ID
-	 * @param _id Element ID to find
-	 * @returns The element if found, undefined otherwise
 	 */
 	layeredStyleGetElementById(_id: string): SomeButtonGraphicsElement | undefined {
 		// Streaming elements is not supported
@@ -456,7 +339,7 @@ export class ControlButtonPreset
 		const obj: PresetButtonModel = {
 			type: this.type,
 			style: {
-				layers: this.#drawElements,
+				layers: this.#drawing.drawElements,
 			},
 			options: this.options,
 			feedbacks: this.entities.getFeedbackEntities(),

--- a/companion/lib/Controls/ControlTypes/ExpressionVariable.ts
+++ b/companion/lib/Controls/ControlTypes/ExpressionVariable.ts
@@ -9,7 +9,6 @@ import type {
 	ExpressionVariableModel,
 	ExpressionVariableOptions,
 } from '@companion-app/shared/Model/ExpressionVariableModel.js'
-import type { DrawStyleModel } from '@companion-app/shared/Model/StyleModel.js'
 import { VisitorReferencesCollector } from '../../Resources/Visitors/ReferencesCollector.js'
 import { VisitorReferencesUpdater } from '../../Resources/Visitors/ReferencesUpdater.js'
 import { ControlBase } from '../ControlBase.js'
@@ -142,7 +141,7 @@ export class ControlExpressionVariable
 		// Elements are not relevant for expression variables
 
 		if (options.redraw) {
-			this.triggerRedraw()
+			this.triggerInvalidation()
 		}
 	}
 
@@ -329,9 +328,8 @@ export class ControlExpressionVariable
 
 	/**
 	 * Trigger a recheck of the condition, as something has changed and it might be the 'condition'
-	 * @access protected
 	 */
-	triggerRedraw = debounceFn(
+	triggerInvalidation = debounceFn(
 		() => {
 			const name = this.options.variableName
 			if (!name) return
@@ -351,17 +349,14 @@ export class ControlExpressionVariable
 		}
 	)
 
-	getLastDrawStyle(): DrawStyleModel | null {
-		return null
+	get drawing(): null {
+		return null // Expression variables don't draw
 	}
 
 	/**
 	 * Execute a press of this control
 	 */
 	pressControl(_pressed: boolean, _surfaceId: string | undefined): void {
-		// Nothing to do
-	}
-	onVariablesChanged(_allChangedVariables: ReadonlySet<string>): void {
 		// Nothing to do
 	}
 }

--- a/companion/lib/Controls/ControlTypes/PageButton.ts
+++ b/companion/lib/Controls/ControlTypes/PageButton.ts
@@ -4,9 +4,8 @@ import { EntityModelType } from '@companion-app/shared/Model/EntityModel.js'
 import type { ExpressionableOptionsObject } from '@companion-app/shared/Model/Options.js'
 import type { SomeButtonGraphicsElement } from '@companion-app/shared/Model/StyleLayersModel.js'
 import { type DrawStyleLayeredButtonModel } from '@companion-app/shared/Model/StyleModel.js'
-import { ConvertSomeButtonGraphicsElementForDrawing } from '../../Graphics/ConvertGraphicsElements.js'
-import { ElementConversionCache } from '../../Graphics/ElementConversionCache.js'
 import { ControlBase } from '../ControlBase.js'
+import type { ControlDependencies } from '../ControlDependencies.js'
 import type {
 	ControlWithConvert,
 	ControlWithoutActions,
@@ -16,8 +15,7 @@ import type {
 	ControlWithoutOptions,
 	ControlWithoutPushed,
 } from '../IControlFragments.js'
-
-const emptyMap: ReadonlyMap<string, never> = new Map<string, never>()
+import { LayeredButtonDrawer } from './Button/LayeredButtonDrawer.js'
 
 /**
  * Class for some page button control.
@@ -54,31 +52,43 @@ export abstract class ControlButtonPage<TJson>
 	readonly supportsOptions = false
 	readonly supportsPushed = false
 
-	/**
-	 * The variables referenced in the last draw. Whenever one of these changes, a redraw should be performed
-	 */
-	#lastDrawVariables: ReadonlySet<string> | null = null
+	readonly #drawing: LayeredButtonDrawer
+	override get drawing(): LayeredButtonDrawer {
+		return this.#drawing
+	}
 
-	/**
-	 * Cache for element conversion results (for future per-element caching optimization)
-	 */
-	readonly #elementConversionCache = new ElementConversionCache()
+	protected triggerInvalidation = (): void => {
+		this.#drawing.invalidate()
+	}
+
+	constructor(deps: ControlDependencies, controlId: string, debugNamespace: string) {
+		super(deps, controlId, debugNamespace)
+
+		const { drawType, elements } = this.getDrawElements()
+		this.#drawing = new LayeredButtonDrawer(
+			deps,
+			controlId,
+			{
+				getButtonStateProps: () => ({
+					pushed: false,
+					stepCurrent: 0,
+					stepCount: 0,
+					button_status: undefined,
+					action_running: undefined,
+				}),
+				entities: null,
+			},
+			drawType
+		)
+		this.#drawing.loadElements(structuredClone(elements))
+	}
 
 	/**
 	 * Prepare this control for deletion
 	 */
 	destroy(): void {
-		this.#elementConversionCache.clear()
+		this.#drawing.dispose()
 		super.destroy()
-	}
-
-	/**
-	 * Get the complete style object of a button
-	 * @returns the processed style of the button
-	 */
-	#lastDrawStyle: DrawStyleLayeredButtonModel | null = null
-	getLastDrawStyle(): DrawStyleLayeredButtonModel | null {
-		return this.#lastDrawStyle
 	}
 
 	protected abstract getDrawElements(): {
@@ -87,51 +97,7 @@ export abstract class ControlButtonPage<TJson>
 	}
 
 	/**
-	 * Get the complete style object of a button
-	 * @returns the processed style of the button
-	 */
-	async getDrawStyle(): Promise<DrawStyleLayeredButtonModel | null> {
-		const location = this.deps.pageStore.getLocationOfControlId(this.controlId)
-		const parser = this.deps.variableValues.createVariablesAndExpressionParser(location, null, null)
-
-		const { drawType, elements: rawElements } = this.getDrawElements()
-
-		// Compute the new drawing, using the element conversion cache for per-element caching
-		const { elements, usedVariables } = await ConvertSomeButtonGraphicsElementForDrawing(
-			this.deps.instance.definitions,
-			parser,
-			this.deps.graphics.renderPixelBuffers.bind(this.deps.graphics),
-			rawElements,
-			emptyMap,
-			true,
-			this.#elementConversionCache,
-			null,
-			null
-		)
-		this.#lastDrawVariables = usedVariables.size > 0 ? usedVariables : null
-
-		const result: DrawStyleLayeredButtonModel = {
-			pushed: false,
-			stepCurrent: 0,
-			stepCount: 0,
-			button_status: undefined,
-			action_running: undefined,
-
-			elements,
-
-			style: 'button-layered',
-			drawType: drawType,
-		}
-
-		this.#lastDrawStyle = result
-		return result
-	}
-
-	/**
 	 * Collect the connection ids, labels, and variables referenced by this control
-	 * @param foundConnectionIds - connection ids being referenced
-	 * @param foundConnectionLabels - connection labels being referenced
-	 * @param foundVariables - variables being referenced
 	 */
 	collectReferencedConnectionsAndVariables(
 		_foundConnectionIds: Set<string>,
@@ -145,28 +111,11 @@ export abstract class ControlButtonPage<TJson>
 	 * Inform the control that it has been moved, and anything relying on its location must be invalidated
 	 */
 	triggerLocationHasChanged(): void {
-		// Ensure any dependencies on the location in the drawing are updated
-		this.#elementConversionCache.clear()
-		this.triggerRedraw()
+		this.#drawing.locationChanged()
 	}
 
 	renameVariables(_labelFrom: string, _labelTo: string): void {
 		// Nothing to do
-	}
-
-	/**
-	 * Propagate variable changes
-	 * @param allChangedVariables - variables with changes
-	 */
-	onVariablesChanged(allChangedVariables: ReadonlySet<string>): void {
-		if (!this.#lastDrawVariables) return
-		if (this.#lastDrawVariables.isDisjointFrom(allChangedVariables)) return
-
-		// Queue invalidation for cached elements that use any of the changed variables
-		this.#elementConversionCache.queueInvalidateVariables(allChangedVariables)
-
-		this.logger.silly('variable changed in button ' + this.controlId)
-		this.triggerRedraw()
 	}
 
 	abstract convertControl(): SomeButtonModel

--- a/companion/lib/Controls/ControlTypes/Triggers/Trigger.ts
+++ b/companion/lib/Controls/ControlTypes/Triggers/Trigger.ts
@@ -5,7 +5,6 @@ import type { JsonValue } from 'type-fest'
 import { BANNED_PROPS } from '@companion-app/shared/Expression/ExpressionResolve.js'
 import { EntityModelType } from '@companion-app/shared/Model/EntityModel.js'
 import type { EventInstance } from '@companion-app/shared/Model/EventModel.js'
-import type { DrawStyleModel } from '@companion-app/shared/Model/StyleModel.js'
 import type { ClientTriggerData, TriggerModel, TriggerOptions } from '@companion-app/shared/Model/TriggerModel.js'
 import { stringifyVariableValue } from '@companion-app/shared/Model/Variables.js'
 import { clamp } from '../../../Resources/Util.js'
@@ -133,6 +132,10 @@ export class ControlTrigger
 
 	readonly entities: ControlEntityListPoolTrigger
 
+	get drawing(): null {
+		return null // Triggers don't draw
+	}
+
 	/**
 	 * Whether this trigger and its parent collection is enabled or not
 	 */
@@ -160,7 +163,7 @@ export class ControlTrigger
 	) {
 		super(deps, controlId, `Controls/ControlTypes/Triggers/${controlId}`)
 
-		this.#actionRunner = new ControlActionRunner(deps.actionRunner, this.controlId, this.triggerRedraw.bind(this))
+		this.#actionRunner = new ControlActionRunner(deps.actionRunner, this.controlId, this.triggerInvalidation.bind(this))
 
 		this.entities = new ControlEntityListPoolTrigger({
 			controlId,
@@ -214,7 +217,7 @@ export class ControlTrigger
 		// Elements are not relevant for triggers
 
 		if (options.redraw) {
-			this.triggerRedraw()
+			this.triggerInvalidation()
 		}
 	}
 
@@ -474,12 +477,12 @@ export class ControlTrigger
 				case 'condition_true':
 					this.#conditionCheckLastValue = this.entities.checkConditionValue()
 					this.#conditionCheckEvents.add(event.id)
-					this.triggerRedraw() // Recheck the condition
+					this.triggerInvalidation() // Recheck the condition
 					break
 				case 'condition_false':
 					this.#conditionCheckLastValue = this.entities.checkConditionValue()
 					this.#conditionCheckEvents.add(event.id)
-					this.triggerRedraw() // Recheck the condition
+					this.triggerInvalidation() // Recheck the condition
 					break
 				case 'variable_changed':
 					this.#variablesEvents.setVariableChanged(event.id, stringifyVariableValue(event.options.variableId) ?? '')
@@ -610,7 +613,7 @@ export class ControlTrigger
 		if (this.#enabled !== newEnabled) {
 			this.#enabled = newEnabled
 			if (newEnabled && this.#conditionCheckEvents.size > 0) {
-				// Refresh the last-known condition value so the first triggerRedraw
+				// Refresh the last-known condition value so the first triggerInvalidation
 				// after re-enabling does not mistake a stale transition for a new edge.
 				this.#conditionCheckLastValue = this.entities.checkConditionValue()
 			}
@@ -648,10 +651,9 @@ export class ControlTrigger
 	}
 
 	/**
-	 * Trigger a recheck of the condition, as something has changed and it might be the 'condition'
-	 * @access protected
+	 * Trigger a recheck of the condition, as something has changed and it might be the 'condition'.
 	 */
-	triggerRedraw = debounceFn(
+	triggerInvalidation = debounceFn(
 		() => {
 			if (!this.#enabled || this.#conditionCheckEvents.size === 0) {
 				// the condition, above, implies !(this.options.enabled && this.#collectionEnabled)
@@ -819,17 +821,10 @@ export class ControlTrigger
 		return false
 	}
 
-	getLastDrawStyle(): DrawStyleModel | null {
-		return null
-	}
-
 	/**
 	 * Execute a press of this control
 	 */
 	pressControl(_pressed: boolean, _surfaceId: string | undefined): void {
-		// Nothing to do
-	}
-	onVariablesChanged(_allChangedVariables: ReadonlySet<string>): void {
 		// Nothing to do
 	}
 }

--- a/companion/lib/Controls/Controller.ts
+++ b/companion/lib/Controls/Controller.ts
@@ -411,10 +411,8 @@ export class ControlsController {
 
 			this.#controlEvents.emit('controlPlacedAt', location, newControlId)
 
-			newControl.triggerRedraw()
-
 			// Ensure it is stored to the db
-			newControl.commitChange()
+			newControl.commitChange(true)
 
 			return newControlId
 		}
@@ -512,7 +510,7 @@ export class ControlsController {
 				if (fromControlId && fromControlId !== control.controlId) continue
 
 				if (control.supportsEntities) control.entities.onVariablesChanged(allChangedVariablesSet)
-				control.onVariablesChanged(allChangedVariablesSet)
+				control.drawing?.onVariablesChanged(allChangedVariablesSet)
 			}
 		}
 	}
@@ -525,9 +523,7 @@ export class ControlsController {
 		if (allChangedElementIds.size === 0) return
 
 		for (const control of this.#store.controls.values()) {
-			if (control.supportsLayeredStyle) {
-				control.onCompositeElementsChanged(allChangedElementIds)
-			}
+			control.drawing?.onCompositeElementsChanged(allChangedElementIds)
 		}
 	}
 

--- a/companion/lib/Controls/ControlsTrpcRouter.ts
+++ b/companion/lib/Controls/ControlsTrpcRouter.ts
@@ -168,7 +168,8 @@ export function createControlsTrpcRouter(
 
 					controlEvents.emit('controlPlacedAt', toLocation, newControlId)
 
-					newControl.triggerRedraw()
+					// Ensure it is redrawn
+					newControl.commitChange(true)
 
 					return true
 				}

--- a/companion/lib/Controls/Entities/ControlActionSetAndStepsManager.ts
+++ b/companion/lib/Controls/Entities/ControlActionSetAndStepsManager.ts
@@ -1,6 +1,46 @@
 import type { ActionSetId } from '@companion-app/shared/Model/ActionModel.js'
 
-export interface ControlActionSetAndStepsManager {
+/**
+ * The runtime step/action-set surface. These are runtime navigation/read operations that are safe on a
+ * read-only control (e.g. a preset reference), so they live on the read-only button pool. The `isEditable`
+ * discriminant is `false`; the editing operations are in {@link ControlActionSetAndStepsEditor}.
+ */
+export interface ControlStepsRuntimeManager {
+	readonly isEditable: false
+
+	/**
+	 * Get the index of the current (next to execute) step
+	 * @returns The index of current step
+	 */
+	getActiveStepIndex(): number
+
+	/**
+	 * Progress through the action-sets
+	 * @param amount Number of steps to progress
+	 */
+	stepAdvanceDelta(amount: number): boolean
+
+	/**
+	 * Set the current (next to execute) action-set by index
+	 * @param index The step index to make the next
+	 */
+	stepMakeCurrent(index: number): boolean
+
+	/**
+	 * Set the current (next to execute) action-set by id
+	 * @param stepId The step id to make the next
+	 */
+	stepSelectCurrent(stepId: string): boolean
+}
+
+/**
+ * The editable step/action-set surface: the runtime navigation methods plus the structural editing mutators
+ * (added by the step-editing mixin), with the `isEditable` discriminant pinned to `true`. A read-only control
+ * structurally lacks the mutators - editing code narrows {@link SomeStepManager} on `isEditable`.
+ */
+export interface ControlActionSetAndStepsEditor extends Omit<ControlStepsRuntimeManager, 'isEditable'> {
+	readonly isEditable: true
+
 	/**
 	 * Add an action set to this control
 	 */
@@ -22,22 +62,10 @@ export interface ControlActionSetAndStepsManager {
 	actionSetRunWhileHeld(stepId: string, setId: ActionSetId, runWhileHeld: boolean): boolean
 
 	/**
-	 * Get the index of the current (next to execute) step
-	 * @returns The index of current step
-	 */
-	getActiveStepIndex(): number
-
-	/**
 	 * Add a step to this control
 	 * @returns Id of new step
 	 */
 	stepAdd(): string
-
-	/**
-	 * Progress through the action-sets
-	 * @param amount Number of steps to progress
-	 */
-	stepAdvanceDelta(amount: number): boolean
 
 	/**
 	 * Duplicate a step on this control
@@ -46,22 +74,10 @@ export interface ControlActionSetAndStepsManager {
 	stepDuplicate(stepId: string): boolean
 
 	/**
-	 * Set the current (next to execute) action-set by index
-	 * @param index The step index to make the next
-	 */
-	stepMakeCurrent(index: number): boolean
-
-	/**
 	 * Remove an action-set from this control
 	 * @param stepId the id of the action-set
 	 */
 	stepRemove(stepId: string): boolean
-
-	/**
-	 * Set the current (next to execute) action-set by id
-	 * @param stepId The step id to make the next
-	 */
-	stepSelectCurrent(stepId: string): boolean
 
 	/**
 	 * Swap two action-sets
@@ -77,3 +93,9 @@ export interface ControlActionSetAndStepsManager {
 	 */
 	stepRename(stepId: string, newName: string): boolean
 }
+
+/**
+ * The step/action-set surface as seen by a control: a runtime-only-or-editable discriminated union. Narrow on
+ * `isEditable` to reach the structural edit mutators.
+ */
+export type SomeStepManager = ControlStepsRuntimeManager | ControlActionSetAndStepsEditor

--- a/companion/lib/Controls/Entities/EntityListPoolBase.ts
+++ b/companion/lib/Controls/Entities/EntityListPoolBase.ts
@@ -49,7 +49,7 @@ export interface ControlEntityListPoolProps {
  * read-only control (e.g. a preset reference) is therefore read-only by construction, with no runtime flag
  * to check and no guard to forget.
  *
- * `entityReplace` is intentionally here (not in the mixin): it is an upgrade/runtime path used when a
+ * `entityReplaceForUpgrade` is intentionally here (not in the mixin): it is an upgrade/runtime path used when a
  * connection upgrades its entities, and must work on every control regardless of editability.
  */
 export abstract class ControlEntityListPoolBase {

--- a/companion/lib/Controls/Entities/EntityListPoolBase.ts
+++ b/companion/lib/Controls/Entities/EntityListPoolBase.ts
@@ -1,13 +1,8 @@
 import debounceFn from 'debounce-fn'
-import isEqual from 'fast-deep-equal'
 import type { JsonValue } from 'type-fest'
-import { isLabelValid } from '@companion-app/shared/Label.js'
 import {
 	EntityModelType,
-	type EntityOwner,
 	type FeedbackEntityStyleOverride,
-	type RawStoreResult,
-	type SomeEntityModel,
 	type SomeReplaceableEntityModel,
 	type SomeSocketEntityLocation,
 } from '@companion-app/shared/Model/EntityModel.js'
@@ -20,7 +15,7 @@ import type { IPageStore } from '../../Page/Store.js'
 import { GetLegacyStyleProperty, ParseLegacyStyle } from '../../Resources/ConvertLegacyStyleToElements.js'
 import type { VariablesValues } from '../../Variables/Values.js'
 import type { VariablesAndExpressionParser } from '../../Variables/VariablesAndExpressionParser.js'
-import { isInternalUserValueFeedback, type ControlEntityInstance } from './EntityInstance.js'
+import type { ControlEntityInstance } from './EntityInstance.js'
 import { ControlEntityList, type ControlEntityListDefinition } from './EntityList.js'
 import { EntityPoolSpecialExpressionManager } from './EntitySpecialExpressionManager.js'
 import type { NewSpecialExpressionValue } from './SpecialExpressions.js'
@@ -46,7 +41,26 @@ export interface ControlEntityListPoolProps {
 	reportChange: (options: ControlEntityListChangeProps) => void
 }
 
+/**
+ * The read-only entity pool. It owns the entity lists and all runtime/read behaviour (loading, feedback
+ * evaluation, variable propagation, serialization). It deliberately has NO user-facing structural edit
+ * mutators (entityAdd/Remove/etc) - those are added by the entity-editing mixin (see
+ * {@link ../EntityListPoolEditingMixin.js WithEntityEditing}) and so exist only on editable pools. A
+ * read-only control (e.g. a preset reference) is therefore read-only by construction, with no runtime flag
+ * to check and no guard to forget.
+ *
+ * `entityReplace` is intentionally here (not in the mixin): it is an upgrade/runtime path used when a
+ * connection upgrades its entities, and must work on every control regardless of editability.
+ */
 export abstract class ControlEntityListPoolBase {
+	/**
+	 * Discriminant for the read-only vs editable pool union. `false` on the read-only base (this class and the
+	 * read-only concrete pools); the editing mixin ({@link ../EntityListPoolEditingMixin.js WithEntityEditing})
+	 * sets it `true`. Code narrows on this (`if (pool.isEditable)`) to reach the structural edit mutators -
+	 * there is no per-control capability flag, the editability lives on the pool itself.
+	 */
+	abstract readonly isEditable: boolean
+
 	/**
 	 * The logger
 	 */
@@ -67,7 +81,9 @@ export abstract class ControlEntityListPoolBase {
 	 */
 	protected readonly reportChange: (options: ControlEntityListChangeProps) => void
 
-	protected constructor(props: ControlEntityListPoolProps, isLayeredDrawing: boolean) {
+	// Public (not protected) so the editing mixins can extend this base via a generic constructor constraint.
+	// The class is abstract, so it still cannot be instantiated directly.
+	constructor(props: ControlEntityListPoolProps, isLayeredDrawing: boolean) {
 		this.logger = LogController.createLogger(`Controls/Fragments/EntityPool/${props.controlId}`)
 
 		this.controlId = props.controlId
@@ -274,226 +290,18 @@ export abstract class ControlEntityListPoolBase {
 	}
 
 	/**
-	 * Add an entity to this control
-	 * @param entityModel the item to add
-	 * @param ownerId the ids of parent entity that this entity should be added as a child of
+	 * Replace an entity's stored props with a module-upgraded version.
+	 *
+	 * This is SOLELY the connection/module upgrade path (see {@link ../../Instance/Connection/EntityManager.js}
+	 * and the legacy child handler) - it is invoked when a connection upgrades the definition of one of its
+	 * entities, never as a result of a user edit. That is why it lives on the read-only base (it must work on
+	 * every control, including read-only ones like a preset reference) and is not part of the editable mutator
+	 * surface. Do not call it for user-facing edits.
 	 */
-	entityAdd(
-		listId: SomeSocketEntityLocation,
-		ownerId: EntityOwner | null,
-		...entityModels: SomeEntityModel[]
-	): boolean {
-		if (entityModels.length === 0) return false
-
-		const entityList = this.getEntityList(listId)
-		if (!entityList) return false
-
-		let newEntities: ControlEntityInstance[]
-		if (ownerId) {
-			const parent = entityList.findById(ownerId.parentId)
-			if (!parent) throw new Error(`Failed to find parent entity ${ownerId.parentId} when adding child entity`)
-
-			newEntities = entityModels.map((entity) => parent.addChild(ownerId.childGroup, entity))
-		} else {
-			newEntities = entityModels.map((entity) => entityList.addEntity(entity))
-		}
-
-		// Inform relevant module
-		for (const entity of newEntities) {
-			entity.subscribe(true)
-		}
-
-		this.tryTriggerLocalVariablesChanged(...newEntities)
-
-		this.reportChange({
-			// Ensure new feedbacks clear caches
-			redraw: true, // Need to recheck status icon
-			invalidateAllElements: listId === 'feedbacks',
-		})
-
-		return true
-	}
-
-	/**
-	 * Duplicate an entity on this control
-	 */
-	entityDuplicate(listId: SomeSocketEntityLocation, id: string): boolean {
-		const entityList = this.getEntityList(listId)
-		if (!entityList) return false
-
-		const entity = entityList.duplicateEntity(id)
-		if (!entity) return false
-
-		this.tryTriggerLocalVariablesChanged(entity)
-
-		this.reportChange({
-			// Ensure new feedbacks clear caches
-			redraw: listId === 'feedbacks',
-			changedElementIds: listId === 'feedbacks' ? entity.styleOverrideAffectedElementIds : undefined,
-		})
-
-		return true
-	}
-
-	/**
-	 * Enable or disable an entity
-	 */
-	entityEnabled(listId: SomeSocketEntityLocation, id: string, enabled: boolean): boolean {
-		const entityList = this.getEntityList(listId)
-		if (!entityList) return false
-
-		const entity = entityList.findById(id)
-		if (!entity) return false
-
-		// Collect element IDs referenced by style overrides
-		const affectedElementIds = listId === 'feedbacks' ? entity.styleOverrideAffectedElementIds : undefined
-
-		entity.setEnabled(enabled)
-
-		this.tryTriggerLocalVariablesChanged(entity)
-
-		this.reportChange({
-			redraw: true,
-			changedElementIds: affectedElementIds,
-		})
-
-		return true
-	}
-
-	/**
-	 * Set headline for the entity
-	 */
-	entityHeadline(listId: SomeSocketEntityLocation, id: string, headline: string): boolean {
-		const entityList = this.getEntityList(listId)
-		if (!entityList) return false
-
-		const entity = entityList.findById(id)
-		if (!entity) return false
-
-		entity.setHeadline(headline)
-
-		this.reportChange({
-			redraw: false,
-		})
-
-		return true
-	}
-
-	/**
-	 * Learn the options for an entity, by asking the connection for the current values
-	 */
-	async entityLearn(listId: SomeSocketEntityLocation, id: string): Promise<boolean> {
-		const entityList = this.getEntityList(listId)
-		if (!entityList) return false
-
-		const entity = entityList.findById(id)
-		if (!entity) return false
-
-		const changed = await entity.learnOptions()
-		if (!changed) return false
-
-		// Time has passed due to the `await`
-		// So the entity may not still exist, meaning we should find it again to be sure
-		const entityAfter = entityList.findById(id)
-		if (!entityAfter) return false
-
-		this.tryTriggerLocalVariablesChanged(entityAfter)
-
-		this.reportChange({
-			redraw: listId === 'feedbacks',
-		})
-
-		return true
-	}
-
-	/**
-	 * Remove an entity from this control
-	 */
-	entityRemove(listId: SomeSocketEntityLocation, id: string): boolean {
-		const entityList = this.getEntityList(listId)
-		if (!entityList) return false
-
-		const removedEntity = entityList.removeEntity(id)
-		if (removedEntity) {
-			this.reportChange({
-				redraw: true, // Need to recheck status icon
-				changedElementIds: listId === 'feedbacks' ? removedEntity.styleOverrideAffectedElementIds : undefined,
-			})
-
-			this.tryTriggerLocalVariablesChanged(removedEntity.localVariableName)
-
-			return true
-		} else {
-			return false
-		}
-	}
-
-	/**
-	 * Move an entity within the hierarchy
-	 * @param moveListId the id of the list to move the entity from
-	 * @param moveEntityId the id of the entity to move
-	 * @param newOwnerId the target new owner of the entity
-	 * @param newListId the id of the list to move the entity to
-	 * @param newIndex the target index of the entity
-	 */
-	entityMoveTo(
-		moveListId: SomeSocketEntityLocation,
-		moveEntityId: string,
-		newOwnerId: EntityOwner | null,
-		newListId: SomeSocketEntityLocation,
-		newIndex: number
-	): boolean {
-		if (newOwnerId && moveEntityId === newOwnerId.parentId) return false
-
-		const oldInfo = this.getEntityList(moveListId)?.findParentAndIndex(moveEntityId)
-		if (!oldInfo) return false
-
-		let movedEntity: ControlEntityInstance | undefined
-
-		if (
-			isEqual(moveListId, newListId) &&
-			oldInfo.parent.ownerId?.parentId === newOwnerId?.parentId &&
-			oldInfo.parent.ownerId?.childGroup === newOwnerId?.childGroup
-		) {
-			movedEntity = oldInfo.parent.moveEntity(oldInfo.index, newIndex)
-			if (!movedEntity) return false
-		} else {
-			const newEntityList = this.getEntityList(newListId)
-			if (!newEntityList) return false
-
-			const newParent = newOwnerId ? newEntityList.findById(newOwnerId.parentId) : null
-			if (newOwnerId && !newParent) return false
-
-			// Ensure the new parent is not a child of the entity being moved
-			if (newOwnerId && oldInfo.item.findChildById(newOwnerId.parentId)) return false
-
-			// Check if the new parent can hold the entity being moved
-			if (newParent && !newParent.canAcceptChild(newOwnerId!.childGroup, oldInfo.item)) return false
-			if (!newParent && !newEntityList.canAcceptEntity(oldInfo.item)) return false
-
-			movedEntity = oldInfo.parent.popEntity(oldInfo.index)
-			if (!movedEntity) return false
-
-			if (newParent) {
-				newParent.pushChild(movedEntity, newOwnerId!.childGroup, newIndex)
-			} else {
-				newEntityList.pushEntity(movedEntity, newIndex)
-			}
-		}
-
-		this.reportChange({
-			redraw: true,
-			// If it moved at all, that could invalidate the overrides. Play it safe
-			changedElementIds: movedEntity?.styleOverrideAffectedElementIds,
-		})
-
-		return true
-	}
-
-	/**
-	 * Replace an entity with an updated version
-	 */
-	entityReplace(newProps: SomeReplaceableEntityModel, skipNotifyModule = false): ControlEntityInstance | undefined {
+	entityReplaceForUpgrade(
+		newProps: SomeReplaceableEntityModel,
+		skipNotifyModule = false
+	): ControlEntityInstance | undefined {
 		for (const entityList of this.getAllEntityLists()) {
 			const entity = entityList.findById(newProps.id)
 			if (!entity) continue
@@ -554,219 +362,6 @@ export abstract class ControlEntityListPoolBase {
 		}
 
 		return undefined
-	}
-
-	/**
-	 * Replace all the entities in a list
-	 * @param listId the list to update
-	 * @param newEntities entities to populate
-	 */
-	entityReplaceAll(listId: SomeSocketEntityLocation, entities: SomeEntityModel[]): boolean {
-		const entityList = this.getEntityList(listId)
-		if (!entityList) return false
-
-		entityList.loadStorage(entities, false, false)
-
-		this.reportChange({
-			redraw: true,
-			invalidateAllElements: listId === 'feedbacks',
-		})
-
-		return true
-	}
-
-	/**
-	 * Update an option for an entity
-	 * @param id the id of the entity
-	 * @param key the key/name of the property
-	 * @param value the new value
-	 */
-	entitySetOption(
-		listId: SomeSocketEntityLocation,
-		id: string,
-		key: string,
-		value: ExpressionOrValue<JsonValue | undefined>
-	): boolean {
-		const entityList = this.getEntityList(listId)
-		if (!entityList) return false
-
-		const entity = entityList.findById(id)
-		if (!entity) return false
-
-		entity.setOption(key, value)
-
-		this.tryTriggerLocalVariablesChanged(entity)
-
-		this.reportChange({ redraw: false })
-
-		return true
-	}
-
-	/**
-	 * Set a new connection instance for an entity
-	 * @param id the id of the entity
-	 * @param connectionId the id of the new connection
-	 */
-	entitySetConnection(listId: SomeSocketEntityLocation, id: string, connectionId: string | number): boolean {
-		const entityList = this.getEntityList(listId)
-		if (!entityList) return false
-
-		const entity = entityList.findById(id)
-		if (!entity) return false
-
-		entity.setConnectionId(connectionId)
-
-		this.tryTriggerLocalVariablesChanged(entity)
-
-		this.reportChange({
-			redraw: true,
-			// No need to invalidate caches, feedback values havent changed
-		})
-
-		return true
-	}
-
-	/**
-	 * Set whether a boolean feedback should be inverted
-	 * @param id the id of the entity
-	 * @param isInverted the new value
-	 */
-	entitySetInverted(listId: SomeSocketEntityLocation, id: string, isInverted: ExpressionOrValue<boolean>): boolean {
-		const entityList = this.getEntityList(listId)
-		if (!entityList) return false
-
-		const entity = entityList.findById(id)
-		if (!entity) return false
-
-		entity.setInverted(isInverted)
-
-		this.tryTriggerLocalVariablesChanged(entity)
-
-		this.reportChange({
-			redraw: true,
-			changedElementIds: listId === 'feedbacks' ? entity.styleOverrideAffectedElementIds : undefined,
-		})
-
-		return true
-	}
-
-	/** Set where this action's result will be stored (if at all). */
-	entitySetRawStoreResult(listId: SomeSocketEntityLocation, id: string, target: RawStoreResult | undefined): boolean {
-		const entity = this.getEntityList(listId)?.findById(id)
-		if (!entity) return false
-
-		entity.setRawStoreResult(target)
-
-		this.reportChange({ redraw: false })
-
-		return true
-	}
-
-	/**
-	 * Set the local variable name for an entity
-	 * @param listId The list the entity is in
-	 * @param id The id of the entity
-	 * @param name The new name for the variable
-	 */
-	entitySetVariableName(listId: SomeSocketEntityLocation, id: string, name: string): boolean {
-		const entityList = this.getEntityList(listId)
-		if (!entityList) return false
-
-		const entity = entityList.findById(id)
-		if (!entity) return false
-
-		// Make sure the new name is valid
-		if (name !== '' && !isLabelValid(name)) {
-			// throw new Error(`Invalid local variable name "${name}"`)
-			return false
-		}
-
-		const oldLocalVariableName = entity.localVariableName
-
-		entity.setVariableName(name)
-
-		this.tryTriggerLocalVariablesChanged(entity, oldLocalVariableName)
-
-		this.reportChange({ redraw: false })
-
-		return true
-	}
-
-	/**
-	 * Set the variable value for an entity, if this is a user local variable
-	 * @param listId The list the entity is in
-	 * @param id The id of the entity
-	 * @param value The new value for the variable
-	 */
-	entitySetVariableValue(listId: SomeSocketEntityLocation, id: string, value: JsonValue | undefined): boolean {
-		const entityList = this.getEntityList(listId)
-		if (!entityList) return false
-
-		const entity = entityList.findById(id)
-		if (!entity) return false
-
-		if (!isInternalUserValueFeedback(entity)) return false
-
-		const needsPersistence = entity.setUserValue(value)
-
-		// Persist value if needed
-		if (needsPersistence) {
-			this.reportChange({ redraw: false })
-		}
-
-		this.tryTriggerLocalVariablesChanged(entity)
-
-		return true
-	}
-
-	entityReplaceStyleOverride(
-		listId: SomeSocketEntityLocation,
-		entityId: string,
-		override: FeedbackEntityStyleOverride
-	): boolean {
-		const entityList = this.getEntityList(listId)
-		if (!entityList) return false
-
-		const entity = entityList.findById(entityId)
-		if (!entity) return false
-
-		// if (this.#booleanOnly) throw new Error('FragmentFeedbacks not setup to use styles')
-
-		const result = entity.replaceStyleOverride(override)
-		if (result) {
-			// Invalidate the specific element if the feedback is enabled
-			this.reportChange({
-				redraw: !entity.disabled,
-				changedElementIds: !entity.disabled ? new Set([result.elementId]) : undefined,
-			})
-
-			return true
-		}
-
-		return false
-	}
-
-	entityRemoveStyleOverride(listId: SomeSocketEntityLocation, entityId: string, overrideId: string): boolean {
-		const entityList = this.getEntityList(listId)
-		if (!entityList) return false
-
-		const entity = entityList.findById(entityId)
-		if (!entity) return false
-
-		// if (this.#booleanOnly) throw new Error('FragmentFeedbacks not setup to use styles')
-
-		const removed = entity.removeStyleOverride(overrideId)
-		if (removed) {
-			// Invalidate the specific element if the feedback is enabled
-			this.reportChange({
-				redraw: !entity.disabled,
-				changedElementIds: !entity.disabled ? new Set([removed.elementId]) : undefined,
-			})
-
-			return true
-		}
-
-		return false
 	}
 
 	/**

--- a/companion/lib/Controls/Entities/EntityListPoolButton.ts
+++ b/companion/lib/Controls/Entities/EntityListPoolButton.ts
@@ -13,10 +13,11 @@ import type { ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
 import { stringifyVariableValue } from '@companion-app/shared/Model/Variables.js'
 import { assertNever } from '@companion-app/shared/Util.js'
 import { GetLegacyStyleProperty, ParseLegacyStyle } from '../../Resources/ConvertLegacyStyleToElements.js'
-import type { ControlActionSetAndStepsManager } from './ControlActionSetAndStepsManager.js'
+import type { ControlStepsRuntimeManager } from './ControlActionSetAndStepsManager.js'
 import type { ControlEntityInstance } from './EntityInstance.js'
 import type { ControlEntityList } from './EntityList.js'
 import { ControlEntityListPoolBase, type ControlEntityListPoolProps } from './EntityListPoolBase.js'
+import { WithEntityEditing, WithStepEditing } from './EntityListPoolEditingMixin.js'
 import type { NewSpecialExpressionValue } from './SpecialExpressions.js'
 import type { NewFeedbackValue } from './Types.js'
 
@@ -34,7 +35,19 @@ interface CurrentStepFromId {
 	id: string
 }
 
-export class ControlEntityListPoolButton extends ControlEntityListPoolBase implements ControlActionSetAndStepsManager {
+export interface ControlEntityListActionStep {
+	readonly sets: Map<ActionSetId, ControlEntityList>
+	options: ActionStepOptions
+}
+
+/**
+ * The shared button entity-pool base. Owns the steps/action-sets and all runtime/read behaviour (loading,
+ * step navigation, evaluation, serialization). It is abstract and does not pin the `isEditable` discriminant -
+ * the read-only {@link ControlEntityListPoolButton} and the editable {@link EditableControlEntityListPoolButton}
+ * extend it as siblings, each setting `isEditable`. (Sibling, not parent/child, so each can pin the literal
+ * discriminant without an override conflict.)
+ */
+export abstract class ButtonEntityListPoolBase extends ControlEntityListPoolBase {
 	/**
 	 * The defaults options for a step
 	 */
@@ -45,26 +58,26 @@ export class ControlEntityListPoolButton extends ControlEntityListPoolBase imple
 	readonly #feedbacks: ControlEntityList
 	readonly #localVariables: ControlEntityList
 
-	readonly #steps = new Map<string, ControlEntityListActionStep>()
+	protected readonly steps = new Map<string, ControlEntityListActionStep>()
 
 	readonly #executeExpressionInControl: (expression: string, requiredType?: string) => ExecuteExpressionResult
-	readonly #sendRuntimePropsChange: () => void
+	protected readonly sendRuntimePropsChange: () => void
 
 	/**
 	 * The current step
 	 */
-	#currentStep: CurrentStepFromExpression | CurrentStepFromId = { type: 'id', id: '0' }
+	protected currentStep: CurrentStepFromExpression | CurrentStepFromId = { type: 'id', id: '0' }
 
 	#hasRotaryActions = false
 
 	get currentStepId(): string {
-		switch (this.#currentStep.type) {
+		switch (this.currentStep.type) {
 			case 'id':
-				return this.#currentStep.id
+				return this.currentStep.id
 			case 'expression':
-				return this.#currentStep.lastStepId
+				return this.currentStep.lastStepId
 			default:
-				assertNever(this.#currentStep)
+				assertNever(this.currentStep)
 				throw new Error('Unsupported step mode')
 		}
 	}
@@ -78,7 +91,7 @@ export class ControlEntityListPoolButton extends ControlEntityListPoolBase imple
 		super(props, isLayeredButton)
 
 		this.#executeExpressionInControl = executeExpressionInControl
-		this.#sendRuntimePropsChange = sendRuntimePropsChange
+		this.sendRuntimePropsChange = sendRuntimePropsChange
 
 		this.#feedbacks = this.createEntityList({
 			type: EntityModelType.Feedback,
@@ -89,9 +102,9 @@ export class ControlEntityListPoolButton extends ControlEntityListPoolBase imple
 			feedbackListType: FeedbackEntitySubType.Value,
 		})
 
-		this.#currentStep = { type: 'id', id: '0' }
+		this.currentStep = { type: 'id', id: '0' }
 
-		this.#steps.set('0', this.#getNewStepValue(null, null))
+		this.steps.set('0', this.getNewStepValue(null, null))
 	}
 
 	loadStorage(storage: ButtonModelBase, skipSubscribe: boolean, isImport: boolean): void {
@@ -99,13 +112,13 @@ export class ControlEntityListPoolButton extends ControlEntityListPoolBase imple
 		this.#localVariables.loadStorage(storage.localVariables || [], skipSubscribe, isImport)
 
 		// Future:	cleanup the steps/sets
-		this.#steps.clear()
+		this.steps.clear()
 
 		for (const [id, stepObj] of Object.entries(storage.steps ?? {})) {
-			this.#steps.set(id, this.#getNewStepValue(stepObj.action_sets, stepObj.options))
+			this.steps.set(id, this.getNewStepValue(stepObj.action_sets, stepObj.options))
 		}
 
-		this.#currentStep = { type: 'id', id: this.getStepIds()[0] } // TODO - other modes?
+		this.currentStep = { type: 'id', id: this.getStepIds()[0] } // TODO - other modes?
 	}
 
 	/**
@@ -124,9 +137,9 @@ export class ControlEntityListPoolButton extends ControlEntityListPoolBase imple
 
 	asNormalButtonSteps(): NormalButtonSteps {
 		const stepsJson: NormalButtonSteps = {}
-		for (const [id, step] of this.#steps) {
+		for (const [id, step] of this.steps) {
 			stepsJson[id] = {
-				action_sets: this.#stepAsActionSetsModel(step),
+				action_sets: this.stepAsActionSetsModel(step),
 				options: step.options,
 			}
 		}
@@ -134,7 +147,7 @@ export class ControlEntityListPoolButton extends ControlEntityListPoolBase imple
 		return stepsJson
 	}
 
-	#stepAsActionSetsModel(step: ControlEntityListActionStep): ActionSetsModel {
+	protected stepAsActionSetsModel(step: ControlEntityListActionStep): ActionSetsModel {
 		const actionSets: ActionSetsModel = {
 			down: [],
 			up: [],
@@ -153,7 +166,7 @@ export class ControlEntityListPoolButton extends ControlEntityListPoolBase imple
 		if (listId === 'local-variables') return this.#localVariables
 
 		if (typeof listId === 'object' && 'setId' in listId && 'stepId' in listId) {
-			return this.#steps.get(listId.stepId)?.sets.get(listId.setId)
+			return this.steps.get(listId.stepId)?.sets.get(listId.setId)
 		}
 
 		return undefined
@@ -162,7 +175,7 @@ export class ControlEntityListPoolButton extends ControlEntityListPoolBase imple
 	protected getAllEntityLists(): ControlEntityList[] {
 		const entityLists: ControlEntityList[] = [this.#feedbacks, this.#localVariables]
 
-		for (const step of this.#steps.values()) {
+		for (const step of this.steps.values()) {
 			entityLists.push(...step.sets.values())
 		}
 
@@ -276,134 +289,21 @@ export class ControlEntityListPoolButton extends ControlEntityListPoolBase imple
 	}
 
 	getStepIds(): string[] {
-		return this.#steps
+		return this.steps
 			.keys()
 			.toArray()
 			.sort((a, b) => Number(a) - Number(b))
-	}
-
-	actionSetAdd(stepId: string): boolean {
-		const step = this.#steps.get(stepId)
-		if (!step) return false
-
-		const existingKeys = step.sets
-			.keys()
-			.map((k) => Number(k))
-			.filter((k) => !isNaN(k))
-			.toArray()
-		if (existingKeys.length === 0) {
-			// add the default '1000' set
-			step.sets.set(1000, this.#createActionEntityList([], false, false))
-
-			this.reportChange({ redraw: true })
-
-			return true
-			// return 1000
-		} else {
-			// add one after the last
-			const max = Math.max(...existingKeys)
-			const newIndex = Math.floor(max / 1000) * 1000 + 1000
-
-			step.sets.set(newIndex, this.#createActionEntityList([], false, false))
-
-			this.reportChange({ redraw: false })
-
-			return true
-			// return newIndex
-		}
-	}
-
-	actionSetRemove(stepId: string, setId: ActionSetId): boolean {
-		const step = this.#steps.get(stepId)
-		if (!step) return false
-
-		// Ensure is a valid number
-		const setIdNumber = Number(setId)
-		if (isNaN(setIdNumber)) return false
-
-		const setToRemove = step.sets.get(setIdNumber)
-		if (!setToRemove) return false
-
-		// Inform modules of the change
-		setToRemove.cleanup()
-
-		// Forget the step from the options
-		step.options.runWhileHeld = step.options.runWhileHeld.filter((id) => id !== setIdNumber)
-
-		// Assume it exists
-		step.sets.delete(setIdNumber)
-
-		// Save the change, and perform a draw
-		this.reportChange({ redraw: true })
-
-		return true
-	}
-
-	actionSetRename(stepId: string, oldSetId: ActionSetId, newSetId: ActionSetId): boolean {
-		const step = this.#steps.get(stepId)
-		if (!step) return false
-
-		const newSetIdNumber = Number(newSetId)
-		const oldSetIdNumber = Number(oldSetId)
-
-		// Only valid when both are numbers
-		if (isNaN(newSetIdNumber) || isNaN(oldSetIdNumber)) return false
-
-		// Ensure old set exists
-		const oldSet = step.sets.get(oldSetIdNumber)
-		if (!oldSet) return false
-
-		// Ensure new set doesnt already exist
-		if (step.sets.has(newSetIdNumber)) return false
-
-		// Rename the set
-		step.sets.set(newSetIdNumber, oldSet)
-		step.sets.delete(oldSetIdNumber)
-
-		// Update the runWhileHeld options
-		const runWhileHeldIndex = step.options.runWhileHeld.indexOf(oldSetIdNumber)
-		if (runWhileHeldIndex !== -1) step.options.runWhileHeld[runWhileHeldIndex] = newSetIdNumber
-
-		this.reportChange({ redraw: false })
-
-		return true
-	}
-
-	actionSetRunWhileHeld(stepId: string, setId: ActionSetId, runWhileHeld: boolean): boolean {
-		const step = this.#steps.get(stepId)
-		if (!step) return false
-
-		// Ensure it is a number
-		const setIdNumber = Number(setId)
-
-		// Only valid when step is a number
-		if (isNaN(setIdNumber)) return false
-
-		// Ensure set exists
-		if (!step.sets.get(setIdNumber)) return false
-
-		const runWhileHeldIndex = step.options.runWhileHeld.indexOf(setIdNumber)
-		if (runWhileHeld && runWhileHeldIndex === -1) {
-			step.options.runWhileHeld.push(setIdNumber)
-		} else if (!runWhileHeld && runWhileHeldIndex !== -1) {
-			step.options.runWhileHeld.splice(runWhileHeldIndex, 1)
-		}
-
-		this.reportChange({ redraw: false })
-
-		return true
 	}
 
 	setupRotaryActionSets(ensureCreated: boolean, skipCommit?: boolean): void {
 		// Cache the value
 		this.#hasRotaryActions = ensureCreated
 
-		for (const step of this.#steps.values()) {
+		for (const step of this.steps.values()) {
 			if (ensureCreated) {
 				// ensure they exist
-				if (!step.sets.has('rotate_left')) step.sets.set('rotate_left', this.#createActionEntityList([], false, false))
-				if (!step.sets.has('rotate_right'))
-					step.sets.set('rotate_right', this.#createActionEntityList([], false, false))
+				if (!step.sets.has('rotate_left')) step.sets.set('rotate_left', this.createActionEntityList([], false, false))
+				if (!step.sets.has('rotate_right')) step.sets.set('rotate_right', this.createActionEntityList([], false, false))
 			} else {
 				// remove the sets
 				const rotateLeftSet = step.sets.get('rotate_left')
@@ -423,33 +323,34 @@ export class ControlEntityListPoolButton extends ControlEntityListPoolBase imple
 		if (!skipCommit) this.reportChange({ redraw: true })
 	}
 
-	#createActionEntityList(entities: SomeEntityModel[], skipSubscribe: boolean, isCloned: boolean): ControlEntityList {
+	protected createActionEntityList(
+		entities: SomeEntityModel[],
+		skipSubscribe: boolean,
+		isCloned: boolean
+	): ControlEntityList {
 		const list = this.createEntityList({ type: EntityModelType.Action })
 		list.loadStorage(entities, skipSubscribe, isCloned)
 		return list
 	}
 
-	#getNewStepValue(
+	protected getNewStepValue(
 		existingActions: ActionSetsModel | null,
 		existingOptions: ActionStepOptions | null
 	): ControlEntityListActionStep {
-		const options = existingOptions || structuredClone(ControlEntityListPoolButton.DefaultStepOptions)
+		const options = existingOptions || structuredClone(ButtonEntityListPoolBase.DefaultStepOptions)
 
-		const downList = this.#createActionEntityList(existingActions?.down || [], false, !!existingActions)
-		const upList = this.#createActionEntityList(existingActions?.up || [], false, !!existingActions)
+		const downList = this.createActionEntityList(existingActions?.down || [], false, !!existingActions)
+		const upList = this.createActionEntityList(existingActions?.up || [], false, !!existingActions)
 
 		const sets = new Map<ActionSetId, ControlEntityList>()
 		sets.set('down', downList)
 		sets.set('up', upList)
 
 		if (this.#hasRotaryActions) {
-			sets.set(
-				'rotate_left',
-				this.#createActionEntityList(existingActions?.rotate_left || [], false, !!existingActions)
-			)
+			sets.set('rotate_left', this.createActionEntityList(existingActions?.rotate_left || [], false, !!existingActions))
 			sets.set(
 				'rotate_right',
-				this.#createActionEntityList(existingActions?.rotate_right || [], false, !!existingActions)
+				this.createActionEntityList(existingActions?.rotate_right || [], false, !!existingActions)
 			)
 		}
 
@@ -458,7 +359,7 @@ export class ControlEntityListPoolButton extends ControlEntityListPoolBase imple
 			if (typeof setIdNumber === 'number') {
 				sets.set(
 					setIdNumber,
-					this.#createActionEntityList(existingActions?.[setIdNumber] || [], false, !!existingActions)
+					this.createActionEntityList(existingActions?.[setIdNumber] || [], false, !!existingActions)
 				)
 			}
 		}
@@ -484,7 +385,7 @@ export class ControlEntityListPoolButton extends ControlEntityListPoolBase imple
 	 * @param newValues The new storeResult values
 	 */
 	override updateStoreResultValues(newValues: ReadonlyMap<string, NewSpecialExpressionValue<'storeResult'>>): void {
-		for (const step of this.#steps.values()) {
+		for (const step of this.steps.values()) {
 			for (const set of step.sets.values()) {
 				set.updateStoreResultValues(newValues)
 			}
@@ -497,11 +398,11 @@ export class ControlEntityListPoolButton extends ControlEntityListPoolBase imple
 	onVariablesChanged(changedVariables: ReadonlySet<string>): void {
 		super.onVariablesChanged(changedVariables)
 
-		if (this.#currentStep.type !== 'expression') return
+		if (this.currentStep.type !== 'expression') return
 
-		if (this.#currentStep.lastVariables.isDisjointFrom(changedVariables)) return
+		if (this.currentStep.lastVariables.isDisjointFrom(changedVariables)) return
 
-		if (this.#stepCheckExpression(true)) {
+		if (this.stepCheckExpression(true)) {
 			// Something changed, so redraw
 			this.reportChange({ redraw: true })
 		}
@@ -512,14 +413,14 @@ export class ControlEntityListPoolButton extends ControlEntityListPoolBase imple
 	 * @param updateClient Whether to inform the client if the step changed
 	 * @returns Whether a change was made
 	 */
-	#stepCheckExpression(updateClient: boolean): boolean {
-		if (this.#currentStep.type !== 'expression') return false
+	protected stepCheckExpression(updateClient: boolean): boolean {
+		if (this.currentStep.type !== 'expression') return false
 
 		let changed = false
 
 		const stepIds = this.getStepIds()
 
-		const latestValue = this.#executeExpressionInControl(this.#currentStep.expression, 'number')
+		const latestValue = this.#executeExpressionInControl(this.currentStep.expression, 'number')
 		if (latestValue.ok) {
 			let latestIndex = Math.max(Math.min(Number(latestValue.value) - 1, stepIds.length - 1), 0)
 			if (isNaN(latestIndex)) latestIndex = 0
@@ -527,11 +428,11 @@ export class ControlEntityListPoolButton extends ControlEntityListPoolBase imple
 			const newStepId = stepIds[latestIndex]
 
 			// Check if this will change the expected state
-			changed = this.#currentStep.lastStepId !== newStepId
+			changed = this.currentStep.lastStepId !== newStepId
 
 			// Update the state
-			this.#currentStep.lastStepId = newStepId
-			this.#currentStep.lastVariables = latestValue.variableIds
+			this.currentStep.lastStepId = newStepId
+			this.currentStep.lastVariables = latestValue.variableIds
 		} else {
 			// Lets always go to the first step, to ensure we have a sane and predictable value
 
@@ -540,15 +441,15 @@ export class ControlEntityListPoolButton extends ControlEntityListPoolBase imple
 			const firstStepId = stepIds[0]
 
 			// Check if this will change the expected state
-			changed = this.#currentStep.lastStepId !== firstStepId
+			changed = this.currentStep.lastStepId !== firstStepId
 
 			// Update the state
-			this.#currentStep.lastStepId = firstStepId
-			this.#currentStep.lastVariables = latestValue.variableIds
+			this.currentStep.lastStepId = firstStepId
+			this.currentStep.lastVariables = latestValue.variableIds
 		}
 
 		// Inform clients of the change
-		if (changed && updateClient) this.#sendRuntimePropsChange()
+		if (changed && updateClient) this.sendRuntimePropsChange()
 
 		return changed
 	}
@@ -560,45 +461,24 @@ export class ControlEntityListPoolButton extends ControlEntityListPoolBase imple
 	stepExpressionUpdate(options: ButtonOptionsBase): void {
 		if (options.stepProgression === 'expression') {
 			// It may have changed, assume it has and purge the existing state
-			if (this.#currentStep.type !== 'expression') {
-				this.#currentStep = {
+			if (this.currentStep.type !== 'expression') {
+				this.currentStep = {
 					type: 'expression',
 					expression: options.stepExpression || '',
 					lastStepId: this.getStepIds()[0],
 					lastVariables: new Set(),
 				}
 			} else {
-				this.#currentStep.expression = options.stepExpression || ''
+				this.currentStep.expression = options.stepExpression || ''
 			}
 
-			this.#stepCheckExpression(true)
+			this.stepCheckExpression(true)
 		} else {
-			if (this.#currentStep.type === 'expression') {
+			if (this.currentStep.type === 'expression') {
 				// Stick to whatever is currently selected
-				this.#currentStep = { type: 'id', id: this.currentStepId }
+				this.currentStep = { type: 'id', id: this.currentStepId }
 			}
 		}
-	}
-
-	/**
-	 * Add a step to this control
-	 * @returns Id of new step
-	 */
-	stepAdd(): string {
-		const existingKeys = this.getStepIds()
-			.map((k) => Number(k))
-			.filter((k) => !isNaN(k))
-
-		const stepId = existingKeys.length === 0 ? '0' : `${Math.max(...existingKeys) + 1}`
-
-		this.#steps.set(stepId, this.#getNewStepValue(null, null))
-
-		// Ensure current step is valid
-		this.#stepCheckExpression(true)
-
-		this.reportChange({ redraw: true })
-
-		return stepId
 	}
 
 	/**
@@ -607,12 +487,12 @@ export class ControlEntityListPoolButton extends ControlEntityListPoolBase imple
 	 */
 	stepAdvanceDelta(amount: number): boolean {
 		// If using an expression, don't allow manual progression
-		if (this.#currentStep.type !== 'id') return false
+		if (this.currentStep.type !== 'id') return false
 
 		if (amount && typeof amount === 'number') {
 			const all_steps = this.getStepIds()
 			if (all_steps.length > 0) {
-				const current = all_steps.indexOf(this.#currentStep.id)
+				const current = all_steps.indexOf(this.currentStep.id)
 
 				let newIndex = (current === -1 ? 0 : current) + amount
 				while (newIndex < 0) newIndex += all_steps.length
@@ -627,47 +507,12 @@ export class ControlEntityListPoolButton extends ControlEntityListPoolBase imple
 	}
 
 	/**
-	 * Duplicate a step on this control
-	 * @param stepId the id of the step to duplicate
-	 */
-	stepDuplicate(stepId: string): boolean {
-		const existingKeys = this.getStepIds()
-			.map((k) => Number(k))
-			.filter((k) => !isNaN(k))
-
-		const stepToCopy = this.#steps.get(stepId)
-		if (!stepToCopy) return false
-
-		const newStep = this.#getNewStepValue(
-			structuredClone(this.#stepAsActionSetsModel(stepToCopy)),
-			structuredClone(stepToCopy.options)
-		)
-
-		// add one after the last
-		const max = Math.max(...existingKeys)
-
-		const newStepId = `${max + 1}`
-		this.#steps.set(newStepId, newStep)
-
-		// Ensure current step is valid
-		this.#stepCheckExpression(false)
-
-		// Ensure the ui knows which step is current
-		this.#sendRuntimePropsChange()
-
-		// Save the change, and perform a draw
-		this.reportChange({ redraw: true })
-
-		return true
-	}
-
-	/**
 	 * Set the current (next to execute) action-set by index
 	 * @param index The step index to make the next
 	 */
 	stepMakeCurrent(index: number): boolean {
 		// If using an expression, don't allow manual progression
-		if (this.#currentStep.type !== 'id') return false
+		if (this.currentStep.type !== 'id') return false
 
 		if (typeof index === 'number') {
 			const stepId = this.getStepIds()[index - 1]
@@ -680,63 +525,22 @@ export class ControlEntityListPoolButton extends ControlEntityListPoolBase imple
 	}
 
 	/**
-	 * Remove an action-set from this control
-	 * @param stepId the id of the action-set
-	 */
-	stepRemove(stepId: string): boolean {
-		const oldKeys = this.getStepIds()
-
-		// Ensure there is at least one step
-		if (oldKeys.length === 1) return false
-
-		const step = this.#steps.get(stepId)
-		if (!step) return false
-
-		for (const set of step.sets.values()) {
-			set.cleanup()
-		}
-		this.#steps.delete(stepId)
-
-		// Update the current step
-		if (this.#currentStep.type === 'id') {
-			const oldIndex = oldKeys.indexOf(stepId)
-			let newIndex = oldIndex + 1
-			if (newIndex >= oldKeys.length) {
-				newIndex = 0
-			}
-			if (newIndex !== oldIndex) {
-				this.#currentStep.id = oldKeys[newIndex]
-
-				this.#sendRuntimePropsChange()
-			}
-		} else {
-			// Ensure current step is valid
-			this.#stepCheckExpression(true)
-		}
-
-		// Save the change, and perform a draw
-		this.reportChange({ redraw: true })
-
-		return true
-	}
-
-	/**
 	 * Set the current (next to execute) action-set by id
 	 * @param stepId The step id to make the next
 	 */
 	stepSelectCurrent(stepId: string): boolean {
 		// If using an expression, don't allow manual progression
-		if (this.#currentStep.type !== 'id') return false
+		if (this.currentStep.type !== 'id') return false
 
-		const step = this.#steps.get(stepId)
+		const step = this.steps.get(stepId)
 		if (!step) return false
 
 		// Ensure it isn't currently pressed
 		// this.setPushed(false)
 
-		this.#currentStep.id = stepId
+		this.currentStep.id = stepId
 
-		this.#sendRuntimePropsChange()
+		this.sendRuntimePropsChange()
 
 		this.reportChange({
 			redraw: true,
@@ -746,49 +550,11 @@ export class ControlEntityListPoolButton extends ControlEntityListPoolBase imple
 		return true
 	}
 
-	/**
-	 * Swap two action-sets
-	 * @param stepId1 One of the action-sets
-	 * @param stepId2 The other action-set
-	 */
-	stepSwap(stepId1: string, stepId2: string): boolean {
-		const step1 = this.#steps.get(stepId1)
-		const step2 = this.#steps.get(stepId2)
-
-		if (!step1 || !step2) return false
-
-		this.#steps.set(stepId1, step2)
-		this.#steps.set(stepId2, step1)
-
-		// Ensure current step is valid
-		this.#stepCheckExpression(true)
-
-		this.reportChange({ redraw: false })
-
-		return true
-	}
-
-	/**
-	 * Rename step
-	 * @param stepId the id of the action-set
-	 * @param newName the new name of the step
-	 */
-	stepRename(stepId: string, newName: string): boolean {
-		const step = this.#steps.get(stepId)
-		if (!step) return false
-
-		step.options.name = newName
-
-		this.reportChange({ redraw: false })
-
-		return true
-	}
-
 	validateCurrentStepIdAndGetNextProgression(): [string | null, string | null] {
-		if (this.#currentStep.type === 'expression') {
+		if (this.currentStep.type === 'expression') {
 			// When in the expression mode, the next step is unknown, but we can produce a sane current step id
 
-			if (this.#stepCheckExpression(true)) {
+			if (this.stepCheckExpression(true)) {
 				// Something changed, so redraw
 				this.reportChange({
 					redraw: true,
@@ -796,13 +562,13 @@ export class ControlEntityListPoolButton extends ControlEntityListPoolBase imple
 				})
 			}
 
-			return [this.#currentStep.lastStepId, null]
+			return [this.currentStep.lastStepId, null]
 		}
 
 		const stepIds = this.getStepIds()
 
 		// For the automatic/manual progression
-		const this_step_raw = this.#currentStep.id
+		const this_step_raw = this.currentStep.id
 		if (stepIds.length > 0) {
 			// verify 'this_step_raw' is valid, falling back to the first step if it is not
 			// (findIndex returns -1 when not found, and -1 is truthy, so `|| 0` would not catch it)
@@ -824,7 +590,7 @@ export class ControlEntityListPoolButton extends ControlEntityListPoolBase imple
 		const [this_step_id] = this.validateCurrentStepIdAndGetNextProgression()
 		if (!this_step_id) return []
 
-		const step = this.#steps.get(this_step_id)
+		const step = this.steps.get(this_step_id)
 		if (!step) return []
 
 		const set = step.sets.get(setId)
@@ -839,7 +605,7 @@ export class ControlEntityListPoolButton extends ControlEntityListPoolBase imple
 				options: Readonly<ActionStepOptions>
 		  }
 		| undefined {
-		const step = this.#steps.get(stepId)
+		const step = this.steps.get(stepId)
 		if (!step) return undefined
 
 		const sets: Map<ActionSetId, ControlEntityInstance[]> = new Map()
@@ -859,7 +625,7 @@ export class ControlEntityListPoolButton extends ControlEntityListPoolBase imple
 	 * @param newValues The new feedback values
 	 */
 	updateFeedbackValues(connectionId: string, newValues: ReadonlyMap<string, NewFeedbackValue>): void {
-		for (const step of this.#steps.values()) {
+		for (const step of this.steps.values()) {
 			for (const set of step.sets.values()) {
 				set.updateFeedbackValues(connectionId, newValues)
 			}
@@ -878,7 +644,7 @@ export class ControlEntityListPoolButton extends ControlEntityListPoolBase imple
 	 * @param newValues The new isInverted values
 	 */
 	override updateIsInvertedValues(newValues: ReadonlyMap<string, NewSpecialExpressionValue<'isInverted'>>): void {
-		for (const step of this.#steps.values()) {
+		for (const step of this.steps.values()) {
 			for (const set of step.sets.values()) {
 				set.updateIsInvertedValues(newValues)
 			}
@@ -914,7 +680,36 @@ export class ControlEntityListPoolButton extends ControlEntityListPoolBase imple
 	}
 }
 
-interface ControlEntityListActionStep {
-	readonly sets: Map<ActionSetId, ControlEntityList>
-	options: ActionStepOptions
+/**
+ * The read-only button entity pool. Has the runtime step navigation surface ({@link ControlStepsRuntimeManager})
+ * but none of the structural edit mutators - a preset reference constructs this, so it is read-only by
+ * construction.
+ */
+export class ControlEntityListPoolButton extends ButtonEntityListPoolBase implements ControlStepsRuntimeManager {
+	readonly isEditable = false
 }
+
+/**
+ * The editable button entity pool: the shared {@link ButtonEntityListPoolBase} plus the structural entity-edit
+ * and step/action-set-edit mutators (added by the editing mixins, which also set `isEditable = true`). Normal
+ * layered buttons construct this.
+ */
+export class EditableControlEntityListPoolButton extends WithStepEditing(WithEntityEditing(ButtonEntityListPoolBase)) {}
+
+/**
+ * A button's entity pool: read-only or editable. Buttons hold this union so the button runtime can use the
+ * shared step machinery while callers narrow on `isEditable` to reach the structural mutators.
+ */
+export type SomeButtonEntityPool = ControlEntityListPoolButton | EditableControlEntityListPoolButton
+
+/**
+ * Constructor for a button entity pool. A button control passes the read-only or editable class to its base
+ * constructor, which decides (by construction) whether the control can be structurally edited. `TPool` is
+ * carried through so the control's `entities` is typed as exactly the pool it constructs.
+ */
+export type ButtonEntityPoolConstructor<TPool extends SomeButtonEntityPool> = new (
+	props: ControlEntityListPoolProps,
+	sendRuntimePropsChange: () => void,
+	executeExpressionInControl: (expression: string, requiredType?: string) => ExecuteExpressionResult,
+	isLayeredButton: boolean
+) => TPool

--- a/companion/lib/Controls/Entities/EntityListPoolEditingMixin.ts
+++ b/companion/lib/Controls/Entities/EntityListPoolEditingMixin.ts
@@ -714,12 +714,9 @@ export function WithStepEditing<TBase extends AbstractConstructor<ButtonEntityLi
 
 			// Update the current step
 			if (this.currentStep.type === 'id') {
-				const oldIndex = oldKeys.indexOf(stepId)
-				let newIndex = oldIndex + 1
-				if (newIndex >= oldKeys.length) {
-					newIndex = 0
-				}
-				if (newIndex !== oldIndex) {
+				if (this.currentStep.id === stepId) {
+					const oldIndex = oldKeys.indexOf(stepId)
+					const newIndex = oldIndex + 1 >= oldKeys.length ? 0 : oldIndex + 1
 					this.currentStep.id = oldKeys[newIndex]
 
 					this.sendRuntimePropsChange()

--- a/companion/lib/Controls/Entities/EntityListPoolEditingMixin.ts
+++ b/companion/lib/Controls/Entities/EntityListPoolEditingMixin.ts
@@ -1,0 +1,778 @@
+import isEqual from 'fast-deep-equal'
+import type { JsonValue } from 'type-fest'
+import { isLabelValid } from '@companion-app/shared/Label.js'
+import type { ActionSetId } from '@companion-app/shared/Model/ActionModel.js'
+import {
+	type EntityOwner,
+	type FeedbackEntityStyleOverride,
+	type RawStoreResult,
+	type SomeEntityModel,
+	type SomeSocketEntityLocation,
+} from '@companion-app/shared/Model/EntityModel.js'
+import type { ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
+import type { ControlActionSetAndStepsEditor } from './ControlActionSetAndStepsManager.js'
+import { isInternalUserValueFeedback, type ControlEntityInstance } from './EntityInstance.js'
+import type { ControlEntityListPoolBase } from './EntityListPoolBase.js'
+import type { ButtonEntityListPoolBase } from './EntityListPoolButton.js'
+
+type Constructor<T = object> = new (...args: any[]) => T
+type AbstractConstructor<T = object> = abstract new (...args: any[]) => T
+
+/**
+ * The read-only side of the entity-pool discriminated union. Same as the base pool, with the `isEditable`
+ * discriminant pinned to `false` so it can be distinguished from {@link EditableEntityListPool}.
+ */
+export interface ReadonlyEntityPool extends ControlEntityListPoolBase {
+	readonly isEditable: false
+}
+
+/**
+ * The editable entity-pool surface: the read-only pool plus the structural entity-edit mutators added by
+ * {@link WithEntityEditing}, with the `isEditable` discriminant pinned to `true`. Used (via
+ * {@link SomeEntityPool}) to type `control.entities`; editing code narrows the union on `isEditable`.
+ */
+export interface EditableEntityListPool extends ControlEntityListPoolBase {
+	readonly isEditable: true
+
+	/**
+	 * Add one or more entities to this control
+	 * @param entityModels the items to add
+	 * @param ownerId the ids of parent entity that these entities should be added as a child of
+	 */
+	entityAdd(listId: SomeSocketEntityLocation, ownerId: EntityOwner | null, ...entityModels: SomeEntityModel[]): boolean
+
+	/** Duplicate an entity on this control */
+	entityDuplicate(listId: SomeSocketEntityLocation, id: string): boolean
+
+	/** Enable or disable an entity */
+	entityEnabled(listId: SomeSocketEntityLocation, id: string, enabled: boolean): boolean
+
+	/** Set the headline for an entity */
+	entityHeadline(listId: SomeSocketEntityLocation, id: string, headline: string): boolean
+
+	/** Learn the options for an entity, by asking the connection for the current values */
+	entityLearn(listId: SomeSocketEntityLocation, id: string): Promise<boolean>
+
+	/** Remove an entity from this control */
+	entityRemove(listId: SomeSocketEntityLocation, id: string): boolean
+
+	/**
+	 * Move an entity within the hierarchy
+	 * @param moveListId the id of the list to move the entity from
+	 * @param moveEntityId the id of the entity to move
+	 * @param newOwnerId the target new owner of the entity
+	 * @param newListId the id of the list to move the entity to
+	 * @param newIndex the target index of the entity
+	 */
+	entityMoveTo(
+		moveListId: SomeSocketEntityLocation,
+		moveEntityId: string,
+		newOwnerId: EntityOwner | null,
+		newListId: SomeSocketEntityLocation,
+		newIndex: number
+	): boolean
+
+	/**
+	 * Replace all the entities in a list
+	 * @param listId the list to update
+	 * @param entities entities to populate
+	 */
+	entityReplaceAll(listId: SomeSocketEntityLocation, entities: SomeEntityModel[]): boolean
+
+	/**
+	 * Update an option for an entity
+	 * @param id the id of the entity
+	 * @param key the key/name of the property
+	 * @param value the new value
+	 */
+	entitySetOption(
+		listId: SomeSocketEntityLocation,
+		id: string,
+		key: string,
+		value: ExpressionOrValue<JsonValue | undefined>
+	): boolean
+
+	/**
+	 * Set a new connection instance for an entity
+	 * @param id the id of the entity
+	 * @param connectionId the id of the new connection
+	 */
+	entitySetConnection(listId: SomeSocketEntityLocation, id: string, connectionId: string | number): boolean
+
+	/**
+	 * Set whether a boolean feedback should be inverted
+	 * @param id the id of the entity
+	 * @param isInverted the new value
+	 */
+	entitySetInverted(listId: SomeSocketEntityLocation, id: string, isInverted: ExpressionOrValue<boolean>): boolean
+
+	/** Set where this action's result will be stored (if at all) */
+	entitySetRawStoreResult(listId: SomeSocketEntityLocation, id: string, target: RawStoreResult | undefined): boolean
+
+	/**
+	 * Set the local variable name for an entity
+	 * @param id the id of the entity
+	 * @param name the new name for the variable
+	 */
+	entitySetVariableName(listId: SomeSocketEntityLocation, id: string, name: string): boolean
+
+	/**
+	 * Set the variable value for an entity, if this is a user local variable
+	 * @param id the id of the entity
+	 * @param value the new value for the variable
+	 */
+	entitySetVariableValue(listId: SomeSocketEntityLocation, id: string, value: JsonValue | undefined): boolean
+
+	/** Replace a feedback's style override */
+	entityReplaceStyleOverride(
+		listId: SomeSocketEntityLocation,
+		entityId: string,
+		override: FeedbackEntityStyleOverride
+	): boolean
+
+	/** Remove a style override from a feedback */
+	entityRemoveStyleOverride(listId: SomeSocketEntityLocation, entityId: string, overrideId: string): boolean
+}
+
+/**
+ * The entity pool as seen by a control: a read-only-or-editable discriminated union. Narrow on `isEditable`
+ * to reach the structural edit mutators.
+ */
+export type SomeEntityPool = ReadonlyEntityPool | EditableEntityListPool
+
+/**
+ * Mixin that adds the structural entity-edit mutators to a read-only {@link ControlEntityListPoolBase}.
+ * These methods exist only on editable pools, so a read-only control (e.g. a preset reference) is read-only
+ * by construction - it never inherits these, and there is no runtime flag to forget.
+ */
+export function WithEntityEditing<TBase extends AbstractConstructor<ControlEntityListPoolBase>>(
+	Base: TBase
+): Constructor<InstanceType<TBase> & EditableEntityListPool> {
+	abstract class EntityEditingPool extends Base implements EditableEntityListPool {
+		readonly isEditable = true
+
+		entityAdd(
+			listId: SomeSocketEntityLocation,
+			ownerId: EntityOwner | null,
+			...entityModels: SomeEntityModel[]
+		): boolean {
+			if (entityModels.length === 0) return false
+
+			const entityList = this.getEntityList(listId)
+			if (!entityList) return false
+
+			let newEntities: ControlEntityInstance[]
+			if (ownerId) {
+				const parent = entityList.findById(ownerId.parentId)
+				if (!parent) throw new Error(`Failed to find parent entity ${ownerId.parentId} when adding child entity`)
+
+				newEntities = entityModels.map((entity) => parent.addChild(ownerId.childGroup, entity))
+			} else {
+				newEntities = entityModels.map((entity) => entityList.addEntity(entity))
+			}
+
+			// Inform relevant module
+			for (const entity of newEntities) {
+				entity.subscribe(true)
+			}
+
+			this.tryTriggerLocalVariablesChanged(...newEntities)
+
+			this.reportChange({
+				// Ensure new feedbacks clear caches
+				redraw: true, // Need to recheck status icon
+				invalidateAllElements: listId === 'feedbacks',
+			})
+
+			return true
+		}
+
+		entityDuplicate(listId: SomeSocketEntityLocation, id: string): boolean {
+			const entityList = this.getEntityList(listId)
+			if (!entityList) return false
+
+			const entity = entityList.duplicateEntity(id)
+			if (!entity) return false
+
+			this.tryTriggerLocalVariablesChanged(entity)
+
+			this.reportChange({
+				// Ensure new feedbacks clear caches
+				redraw: listId === 'feedbacks',
+				changedElementIds: listId === 'feedbacks' ? entity.styleOverrideAffectedElementIds : undefined,
+			})
+
+			return true
+		}
+
+		entityEnabled(listId: SomeSocketEntityLocation, id: string, enabled: boolean): boolean {
+			const entityList = this.getEntityList(listId)
+			if (!entityList) return false
+
+			const entity = entityList.findById(id)
+			if (!entity) return false
+
+			// Collect element IDs referenced by style overrides
+			const affectedElementIds = listId === 'feedbacks' ? entity.styleOverrideAffectedElementIds : undefined
+
+			entity.setEnabled(enabled)
+
+			this.tryTriggerLocalVariablesChanged(entity)
+
+			this.reportChange({
+				redraw: true,
+				changedElementIds: affectedElementIds,
+			})
+
+			return true
+		}
+
+		entityHeadline(listId: SomeSocketEntityLocation, id: string, headline: string): boolean {
+			const entityList = this.getEntityList(listId)
+			if (!entityList) return false
+
+			const entity = entityList.findById(id)
+			if (!entity) return false
+
+			entity.setHeadline(headline)
+
+			this.reportChange({
+				redraw: false,
+			})
+
+			return true
+		}
+
+		async entityLearn(listId: SomeSocketEntityLocation, id: string): Promise<boolean> {
+			const entityList = this.getEntityList(listId)
+			if (!entityList) return false
+
+			const entity = entityList.findById(id)
+			if (!entity) return false
+
+			const changed = await entity.learnOptions()
+			if (!changed) return false
+
+			// Time has passed due to the `await`
+			// So the entity may not still exist, meaning we should find it again to be sure
+			const entityAfter = entityList.findById(id)
+			if (!entityAfter) return false
+
+			this.tryTriggerLocalVariablesChanged(entityAfter)
+
+			this.reportChange({
+				redraw: listId === 'feedbacks',
+			})
+
+			return true
+		}
+
+		entityRemove(listId: SomeSocketEntityLocation, id: string): boolean {
+			const entityList = this.getEntityList(listId)
+			if (!entityList) return false
+
+			const removedEntity = entityList.removeEntity(id)
+			if (removedEntity) {
+				this.reportChange({
+					redraw: true, // Need to recheck status icon
+					changedElementIds: listId === 'feedbacks' ? removedEntity.styleOverrideAffectedElementIds : undefined,
+				})
+
+				this.tryTriggerLocalVariablesChanged(removedEntity.localVariableName)
+
+				return true
+			} else {
+				return false
+			}
+		}
+
+		entityMoveTo(
+			moveListId: SomeSocketEntityLocation,
+			moveEntityId: string,
+			newOwnerId: EntityOwner | null,
+			newListId: SomeSocketEntityLocation,
+			newIndex: number
+		): boolean {
+			if (newOwnerId && moveEntityId === newOwnerId.parentId) return false
+
+			const oldInfo = this.getEntityList(moveListId)?.findParentAndIndex(moveEntityId)
+			if (!oldInfo) return false
+
+			let movedEntity: ControlEntityInstance | undefined
+
+			if (
+				isEqual(moveListId, newListId) &&
+				oldInfo.parent.ownerId?.parentId === newOwnerId?.parentId &&
+				oldInfo.parent.ownerId?.childGroup === newOwnerId?.childGroup
+			) {
+				movedEntity = oldInfo.parent.moveEntity(oldInfo.index, newIndex)
+				if (!movedEntity) return false
+			} else {
+				const newEntityList = this.getEntityList(newListId)
+				if (!newEntityList) return false
+
+				const newParent = newOwnerId ? newEntityList.findById(newOwnerId.parentId) : null
+				if (newOwnerId && !newParent) return false
+
+				// Ensure the new parent is not a child of the entity being moved
+				if (newOwnerId && oldInfo.item.findChildById(newOwnerId.parentId)) return false
+
+				// Check if the new parent can hold the entity being moved
+				if (newParent && !newParent.canAcceptChild(newOwnerId!.childGroup, oldInfo.item)) return false
+				if (!newParent && !newEntityList.canAcceptEntity(oldInfo.item)) return false
+
+				movedEntity = oldInfo.parent.popEntity(oldInfo.index)
+				if (!movedEntity) return false
+
+				if (newParent) {
+					newParent.pushChild(movedEntity, newOwnerId!.childGroup, newIndex)
+				} else {
+					newEntityList.pushEntity(movedEntity, newIndex)
+				}
+			}
+
+			this.reportChange({
+				redraw: true,
+				// If it moved at all, that could invalidate the overrides. Play it safe
+				changedElementIds: movedEntity?.styleOverrideAffectedElementIds,
+			})
+
+			return true
+		}
+
+		entityReplaceAll(listId: SomeSocketEntityLocation, entities: SomeEntityModel[]): boolean {
+			const entityList = this.getEntityList(listId)
+			if (!entityList) return false
+
+			entityList.loadStorage(entities, false, false)
+
+			this.reportChange({
+				redraw: true,
+				invalidateAllElements: listId === 'feedbacks',
+			})
+
+			return true
+		}
+
+		entitySetOption(
+			listId: SomeSocketEntityLocation,
+			id: string,
+			key: string,
+			value: ExpressionOrValue<JsonValue | undefined>
+		): boolean {
+			const entityList = this.getEntityList(listId)
+			if (!entityList) return false
+
+			const entity = entityList.findById(id)
+			if (!entity) return false
+
+			entity.setOption(key, value)
+
+			this.tryTriggerLocalVariablesChanged(entity)
+
+			this.reportChange({ redraw: false })
+
+			return true
+		}
+
+		entitySetConnection(listId: SomeSocketEntityLocation, id: string, connectionId: string | number): boolean {
+			const entityList = this.getEntityList(listId)
+			if (!entityList) return false
+
+			const entity = entityList.findById(id)
+			if (!entity) return false
+
+			entity.setConnectionId(connectionId)
+
+			this.tryTriggerLocalVariablesChanged(entity)
+
+			this.reportChange({
+				redraw: true,
+				// No need to invalidate caches, feedback values havent changed
+			})
+
+			return true
+		}
+
+		entitySetInverted(listId: SomeSocketEntityLocation, id: string, isInverted: ExpressionOrValue<boolean>): boolean {
+			const entityList = this.getEntityList(listId)
+			if (!entityList) return false
+
+			const entity = entityList.findById(id)
+			if (!entity) return false
+
+			entity.setInverted(isInverted)
+
+			this.tryTriggerLocalVariablesChanged(entity)
+
+			this.reportChange({
+				redraw: true,
+				changedElementIds: listId === 'feedbacks' ? entity.styleOverrideAffectedElementIds : undefined,
+			})
+
+			return true
+		}
+
+		entitySetRawStoreResult(listId: SomeSocketEntityLocation, id: string, target: RawStoreResult | undefined): boolean {
+			const entity = this.getEntityList(listId)?.findById(id)
+			if (!entity) return false
+
+			entity.setRawStoreResult(target)
+
+			this.reportChange({ redraw: false })
+
+			return true
+		}
+
+		entitySetVariableName(listId: SomeSocketEntityLocation, id: string, name: string): boolean {
+			const entityList = this.getEntityList(listId)
+			if (!entityList) return false
+
+			const entity = entityList.findById(id)
+			if (!entity) return false
+
+			// Make sure the new name is valid
+			if (name !== '' && !isLabelValid(name)) {
+				// throw new Error(`Invalid local variable name "${name}"`)
+				return false
+			}
+
+			const oldLocalVariableName = entity.localVariableName
+
+			entity.setVariableName(name)
+
+			this.tryTriggerLocalVariablesChanged(entity, oldLocalVariableName)
+
+			this.reportChange({ redraw: false })
+
+			return true
+		}
+
+		entitySetVariableValue(listId: SomeSocketEntityLocation, id: string, value: JsonValue | undefined): boolean {
+			const entityList = this.getEntityList(listId)
+			if (!entityList) return false
+
+			const entity = entityList.findById(id)
+			if (!entity) return false
+
+			if (!isInternalUserValueFeedback(entity)) return false
+
+			const needsPersistence = entity.setUserValue(value)
+
+			// Persist value if needed
+			if (needsPersistence) {
+				this.reportChange({ redraw: false })
+			}
+
+			this.tryTriggerLocalVariablesChanged(entity)
+
+			return true
+		}
+
+		entityReplaceStyleOverride(
+			listId: SomeSocketEntityLocation,
+			entityId: string,
+			override: FeedbackEntityStyleOverride
+		): boolean {
+			const entityList = this.getEntityList(listId)
+			if (!entityList) return false
+
+			const entity = entityList.findById(entityId)
+			if (!entity) return false
+
+			const result = entity.replaceStyleOverride(override)
+			if (result) {
+				// Invalidate the specific element if the feedback is enabled
+				this.reportChange({
+					redraw: !entity.disabled,
+					changedElementIds: !entity.disabled ? new Set([result.elementId]) : undefined,
+				})
+
+				return true
+			}
+
+			return false
+		}
+
+		entityRemoveStyleOverride(listId: SomeSocketEntityLocation, entityId: string, overrideId: string): boolean {
+			const entityList = this.getEntityList(listId)
+			if (!entityList) return false
+
+			const entity = entityList.findById(entityId)
+			if (!entity) return false
+
+			const removed = entity.removeStyleOverride(overrideId)
+			if (removed) {
+				// Invalidate the specific element if the feedback is enabled
+				this.reportChange({
+					redraw: !entity.disabled,
+					changedElementIds: !entity.disabled ? new Set([removed.elementId]) : undefined,
+				})
+
+				return true
+			}
+
+			return false
+		}
+	}
+
+	return EntityEditingPool as unknown as Constructor<InstanceType<TBase> & EditableEntityListPool>
+}
+
+/**
+ * Mixin that adds the structural step/action-set edit mutators to the shared {@link ButtonEntityListPoolBase}.
+ * Applied on top of {@link WithEntityEditing} (which provides the `isEditable: true` discriminant), so the
+ * resulting class is a {@link ControlActionSetAndStepsEditor}.
+ */
+export function WithStepEditing<TBase extends AbstractConstructor<ButtonEntityListPoolBase>>(
+	Base: TBase
+): Constructor<InstanceType<TBase> & ControlActionSetAndStepsEditor> {
+	abstract class StepEditingPool extends Base {
+		actionSetAdd(stepId: string): boolean {
+			const step = this.steps.get(stepId)
+			if (!step) return false
+
+			const existingKeys = step.sets
+				.keys()
+				.map((k) => Number(k))
+				.filter((k) => !isNaN(k))
+				.toArray()
+			if (existingKeys.length === 0) {
+				// add the default '1000' set
+				step.sets.set(1000, this.createActionEntityList([], false, false))
+
+				this.reportChange({ redraw: true })
+
+				return true
+			} else {
+				// add one after the last
+				const max = Math.max(...existingKeys)
+				const newIndex = Math.floor(max / 1000) * 1000 + 1000
+
+				step.sets.set(newIndex, this.createActionEntityList([], false, false))
+
+				this.reportChange({ redraw: false })
+
+				return true
+			}
+		}
+
+		actionSetRemove(stepId: string, setId: ActionSetId): boolean {
+			const step = this.steps.get(stepId)
+			if (!step) return false
+
+			// Ensure is a valid number
+			const setIdNumber = Number(setId)
+			if (isNaN(setIdNumber)) return false
+
+			const setToRemove = step.sets.get(setIdNumber)
+			if (!setToRemove) return false
+
+			// Inform modules of the change
+			setToRemove.cleanup()
+
+			// Forget the step from the options
+			step.options.runWhileHeld = step.options.runWhileHeld.filter((id) => id !== setIdNumber)
+
+			// Assume it exists
+			step.sets.delete(setIdNumber)
+
+			// Save the change, and perform a draw
+			this.reportChange({ redraw: true })
+
+			return true
+		}
+
+		actionSetRename(stepId: string, oldSetId: ActionSetId, newSetId: ActionSetId): boolean {
+			const step = this.steps.get(stepId)
+			if (!step) return false
+
+			const newSetIdNumber = Number(newSetId)
+			const oldSetIdNumber = Number(oldSetId)
+
+			// Only valid when both are numbers
+			if (isNaN(newSetIdNumber) || isNaN(oldSetIdNumber)) return false
+
+			// Ensure old set exists
+			const oldSet = step.sets.get(oldSetIdNumber)
+			if (!oldSet) return false
+
+			// Ensure new set doesnt already exist
+			if (step.sets.has(newSetIdNumber)) return false
+
+			// Rename the set
+			step.sets.set(newSetIdNumber, oldSet)
+			step.sets.delete(oldSetIdNumber)
+
+			// Update the runWhileHeld options
+			const runWhileHeldIndex = step.options.runWhileHeld.indexOf(oldSetIdNumber)
+			if (runWhileHeldIndex !== -1) step.options.runWhileHeld[runWhileHeldIndex] = newSetIdNumber
+
+			this.reportChange({ redraw: false })
+
+			return true
+		}
+
+		actionSetRunWhileHeld(stepId: string, setId: ActionSetId, runWhileHeld: boolean): boolean {
+			const step = this.steps.get(stepId)
+			if (!step) return false
+
+			// Ensure it is a number
+			const setIdNumber = Number(setId)
+
+			// Only valid when step is a number
+			if (isNaN(setIdNumber)) return false
+
+			// Ensure set exists
+			if (!step.sets.get(setIdNumber)) return false
+
+			const runWhileHeldIndex = step.options.runWhileHeld.indexOf(setIdNumber)
+			if (runWhileHeld && runWhileHeldIndex === -1) {
+				step.options.runWhileHeld.push(setIdNumber)
+			} else if (!runWhileHeld && runWhileHeldIndex !== -1) {
+				step.options.runWhileHeld.splice(runWhileHeldIndex, 1)
+			}
+
+			this.reportChange({ redraw: false })
+
+			return true
+		}
+
+		/**
+		 * Add a step to this control
+		 * @returns Id of new step
+		 */
+		stepAdd(): string {
+			const existingKeys = this.getStepIds()
+				.map((k) => Number(k))
+				.filter((k) => !isNaN(k))
+
+			const stepId = existingKeys.length === 0 ? '0' : `${Math.max(...existingKeys) + 1}`
+
+			this.steps.set(stepId, this.getNewStepValue(null, null))
+
+			// Ensure current step is valid
+			this.stepCheckExpression(true)
+
+			this.reportChange({ redraw: true })
+
+			return stepId
+		}
+
+		/**
+		 * Duplicate a step on this control
+		 * @param stepId the id of the step to duplicate
+		 */
+		stepDuplicate(stepId: string): boolean {
+			const existingKeys = this.getStepIds()
+				.map((k) => Number(k))
+				.filter((k) => !isNaN(k))
+
+			const stepToCopy = this.steps.get(stepId)
+			if (!stepToCopy) return false
+
+			const newStep = this.getNewStepValue(
+				structuredClone(this.stepAsActionSetsModel(stepToCopy)),
+				structuredClone(stepToCopy.options)
+			)
+
+			// add one after the last
+			const max = Math.max(...existingKeys)
+
+			const newStepId = `${max + 1}`
+			this.steps.set(newStepId, newStep)
+
+			// Ensure current step is valid
+			this.stepCheckExpression(false)
+
+			// Ensure the ui knows which step is current
+			this.sendRuntimePropsChange()
+
+			// Save the change, and perform a draw
+			this.reportChange({ redraw: true })
+
+			return true
+		}
+
+		/**
+		 * Remove an action-set from this control
+		 * @param stepId the id of the action-set
+		 */
+		stepRemove(stepId: string): boolean {
+			const oldKeys = this.getStepIds()
+
+			// Ensure there is at least one step
+			if (oldKeys.length === 1) return false
+
+			const step = this.steps.get(stepId)
+			if (!step) return false
+
+			for (const set of step.sets.values()) {
+				set.cleanup()
+			}
+			this.steps.delete(stepId)
+
+			// Update the current step
+			if (this.currentStep.type === 'id') {
+				const oldIndex = oldKeys.indexOf(stepId)
+				let newIndex = oldIndex + 1
+				if (newIndex >= oldKeys.length) {
+					newIndex = 0
+				}
+				if (newIndex !== oldIndex) {
+					this.currentStep.id = oldKeys[newIndex]
+
+					this.sendRuntimePropsChange()
+				}
+			} else {
+				// Ensure current step is valid
+				this.stepCheckExpression(true)
+			}
+
+			// Save the change, and perform a draw
+			this.reportChange({ redraw: true })
+
+			return true
+		}
+
+		/**
+		 * Swap two action-sets
+		 * @param stepId1 One of the action-sets
+		 * @param stepId2 The other action-set
+		 */
+		stepSwap(stepId1: string, stepId2: string): boolean {
+			const step1 = this.steps.get(stepId1)
+			const step2 = this.steps.get(stepId2)
+
+			if (!step1 || !step2) return false
+
+			this.steps.set(stepId1, step2)
+			this.steps.set(stepId2, step1)
+
+			// Ensure current step is valid
+			this.stepCheckExpression(true)
+
+			this.reportChange({ redraw: false })
+
+			return true
+		}
+
+		/**
+		 * Rename step
+		 * @param stepId the id of the action-set
+		 * @param newName the new name of the step
+		 */
+		stepRename(stepId: string, newName: string): boolean {
+			const step = this.steps.get(stepId)
+			if (!step) return false
+
+			step.options.name = newName
+
+			this.reportChange({ redraw: false })
+
+			return true
+		}
+	}
+
+	return StepEditingPool as unknown as Constructor<InstanceType<TBase> & ControlActionSetAndStepsEditor>
+}

--- a/companion/lib/Controls/Entities/EntityListPoolExpressionVariable.ts
+++ b/companion/lib/Controls/Entities/EntityListPoolExpressionVariable.ts
@@ -9,10 +9,16 @@ import type { ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
 import type { ControlEntityInstance } from './EntityInstance.js'
 import type { ControlEntityList } from './EntityList.js'
 import { ControlEntityListPoolBase, type ControlEntityListPoolProps } from './EntityListPoolBase.js'
+import { WithEntityEditing } from './EntityListPoolEditingMixin.js'
 import type { NewSpecialExpressionValue } from './SpecialExpressions.js'
 import type { NewFeedbackValue } from './Types.js'
 
-export class EntityListPoolExpressionVariable extends ControlEntityListPoolBase {
+/**
+ * The expression-variable entity pool. Always editable, so this single exported class IS the editable pool
+ * (entity-edit mutators mixed in via {@link WithEntityEditing}); there is no separate read-only variant. The
+ * shared read-only machinery lives on the internal {@link ControlEntityListPoolBase}.
+ */
+export class EntityListPoolExpressionVariable extends WithEntityEditing(ControlEntityListPoolBase) {
 	#entities: ControlEntityList
 	#localVariables: ControlEntityList
 

--- a/companion/lib/Controls/Entities/EntityListPoolTrigger.ts
+++ b/companion/lib/Controls/Entities/EntityListPoolTrigger.ts
@@ -9,10 +9,16 @@ import type { TriggerModel } from '@companion-app/shared/Model/TriggerModel.js'
 import type { ControlEntityInstance } from './EntityInstance.js'
 import type { ControlEntityList } from './EntityList.js'
 import { ControlEntityListPoolBase, type ControlEntityListPoolProps } from './EntityListPoolBase.js'
+import { WithEntityEditing } from './EntityListPoolEditingMixin.js'
 import type { NewSpecialExpressionValue } from './SpecialExpressions.js'
 import type { NewFeedbackValue } from './Types.js'
 
-export class ControlEntityListPoolTrigger extends ControlEntityListPoolBase {
+/**
+ * The trigger entity pool. Triggers are always editable, so this single exported class IS the editable pool
+ * (the structural entity-edit mutators are mixed in via {@link WithEntityEditing}); there is no separate
+ * read-only variant. The shared read-only machinery lives on the internal {@link ControlEntityListPoolBase}.
+ */
+export class ControlEntityListPoolTrigger extends WithEntityEditing(ControlEntityListPoolBase) {
 	#feedbacks: ControlEntityList
 
 	#actions: ControlEntityList

--- a/companion/lib/Controls/EntitiesTrpcRouter.ts
+++ b/companion/lib/Controls/EntitiesTrpcRouter.ts
@@ -16,12 +16,23 @@ import type { InstanceDefinitions } from '../Instance/Definitions.js'
 import LogController from '../Log/Controller.js'
 import type { ActiveLearningStore } from '../Resources/ActiveLearningStore.js'
 import { publicProcedure, router } from '../UI/TRPC.js'
+import type { EditableEntityListPool } from './Entities/EntityListPoolEditingMixin.js'
 import type { SomeControl } from './IControlFragments.js'
 
 const zodEntityOwner: z.ZodSchema<EntityOwner> = z.object({
 	parentId: z.string(),
 	childGroup: z.string(),
 })
+
+/**
+ * Resolve a control to its editable entity pool, or throw if the control has no entities or is read-only.
+ * Narrows the pool union on its `isEditable` discriminant - on a read-only control (e.g. a preset reference)
+ * the pool is the read-only type and genuinely lacks the mutators, so this is where the edits are gated.
+ */
+function getEditableEntities(control: SomeControl<any>): EditableEntityListPool {
+	if (control.supportsEntities && control.entities.isEditable) return control.entities
+	throw new Error(`Control "${control.controlId}" does not support editing entities`)
+}
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function createEntitiesTrpcRouter(
@@ -49,8 +60,6 @@ export function createEntitiesTrpcRouter(
 				const control = controlsMap.get(controlId)
 				if (!control) return null
 
-				if (!control.supportsEntities) throw new Error(`Control "${controlId}" does not support entities`)
-
 				const newEntity = instanceDefinitions.createEntityItem(
 					connectionId,
 					entityType,
@@ -61,7 +70,7 @@ export function createEntitiesTrpcRouter(
 				)
 				if (!newEntity) return null
 
-				const added = control.entities.entityAdd(entityLocation, ownerId, newEntity)
+				const added = getEditableEntities(control).entityAdd(entityLocation, ownerId, newEntity)
 				if (!added) return null
 
 				return newEntity.id
@@ -81,10 +90,9 @@ export function createEntitiesTrpcRouter(
 				const control = controlsMap.get(controlId)
 				if (!control) return false
 
-				if (!control.supportsEntities) throw new Error(`Control "${controlId}" does not support entities`)
-
+				const editable = getEditableEntities(control)
 				await activeLearningStore.runLearnRequest(entityId, async () => {
-					await control.entities.entityLearn(entityLocation, entityId).catch((e) => {
+					await editable.entityLearn(entityLocation, entityId).catch((e) => {
 						logger.error(`Learn failed: ${e}`)
 						throw e
 					})
@@ -107,9 +115,7 @@ export function createEntitiesTrpcRouter(
 				const control = controlsMap.get(controlId)
 				if (!control) return false
 
-				if (!control.supportsEntities) throw new Error(`Control "${controlId}" does not support entities`)
-
-				return control.entities.entityEnabled(entityLocation, entityId, enabled)
+				return getEditableEntities(control).entityEnabled(entityLocation, entityId, enabled)
 			}),
 
 		setRawStoreResult: publicProcedure
@@ -130,9 +136,7 @@ export function createEntitiesTrpcRouter(
 				const control = controlsMap.get(controlId)
 				if (!control) return false
 
-				if (!control.supportsEntities) throw new Error(`Control "${controlId}" does not support entities`)
-
-				return control.entities.entitySetRawStoreResult(entityLocation, entityId, target)
+				return getEditableEntities(control).entitySetRawStoreResult(entityLocation, entityId, target)
 			}),
 
 		setHeadline: publicProcedure
@@ -150,9 +154,7 @@ export function createEntitiesTrpcRouter(
 				const control = controlsMap.get(controlId)
 				if (!control) return false
 
-				if (!control.supportsEntities) throw new Error(`Control "${controlId}" does not support entities`)
-
-				return control.entities.entityHeadline(entityLocation, entityId, headline)
+				return getEditableEntities(control).entityHeadline(entityLocation, entityId, headline)
 			}),
 
 		remove: publicProcedure
@@ -169,9 +171,7 @@ export function createEntitiesTrpcRouter(
 				const control = controlsMap.get(controlId)
 				if (!control) return false
 
-				if (!control.supportsEntities) throw new Error(`Control "${controlId}" does not support entities`)
-
-				return control.entities.entityRemove(entityLocation, entityId)
+				return getEditableEntities(control).entityRemove(entityLocation, entityId)
 			}),
 
 		duplicate: publicProcedure
@@ -188,9 +188,7 @@ export function createEntitiesTrpcRouter(
 				const control = controlsMap.get(controlId)
 				if (!control) return false
 
-				if (!control.supportsEntities) throw new Error(`Control "${controlId}" does not support entities`)
-
-				return control.entities.entityDuplicate(entityLocation, entityId)
+				return getEditableEntities(control).entityDuplicate(entityLocation, entityId)
 			}),
 
 		setOption: publicProcedure
@@ -209,9 +207,7 @@ export function createEntitiesTrpcRouter(
 				const control = controlsMap.get(controlId)
 				if (!control) return false
 
-				if (!control.supportsEntities) throw new Error(`Control "${controlId}" does not support entities`)
-
-				return control.entities.entitySetOption(entityLocation, entityId, key, value)
+				return getEditableEntities(control).entitySetOption(entityLocation, entityId, key, value)
 			}),
 
 		setConnection: publicProcedure
@@ -229,9 +225,7 @@ export function createEntitiesTrpcRouter(
 				const control = controlsMap.get(controlId)
 				if (!control) return false
 
-				if (!control.supportsEntities) throw new Error(`Control "${controlId}" does not support entities`)
-
-				return control.entities.entitySetConnection(entityLocation, entityId, connectionId)
+				return getEditableEntities(control).entitySetConnection(entityLocation, entityId, connectionId)
 			}),
 
 		setInverted: publicProcedure
@@ -249,9 +243,7 @@ export function createEntitiesTrpcRouter(
 				const control = controlsMap.get(controlId)
 				if (!control) return false
 
-				if (!control.supportsEntities) throw new Error(`Control "${controlId}" does not support entities`)
-
-				return control.entities.entitySetInverted(entityLocation, entityId, isInverted)
+				return getEditableEntities(control).entitySetInverted(entityLocation, entityId, isInverted)
 			}),
 
 		move: publicProcedure
@@ -271,9 +263,13 @@ export function createEntitiesTrpcRouter(
 				const control = controlsMap.get(controlId)
 				if (!control) return false
 
-				if (!control.supportsEntities) throw new Error(`Control "${controlId}" does not support entities`)
-
-				return control.entities.entityMoveTo(moveEntityLocation, moveEntityId, newOwnerId, newEntityLocation, newIndex)
+				return getEditableEntities(control).entityMoveTo(
+					moveEntityLocation,
+					moveEntityId,
+					newOwnerId,
+					newEntityLocation,
+					newIndex
+				)
 			}),
 
 		replaceStyleOverride: publicProcedure
@@ -291,10 +287,9 @@ export function createEntitiesTrpcRouter(
 				const control = controlsMap.get(controlId)
 				if (!control) return false
 
-				if (!control.supportsEntities || !control.supportsLayeredStyle)
-					throw new Error(`Control "${controlId}" does not support entities or layered styles`)
+				if (!control.supportsLayeredStyle) throw new Error(`Control "${controlId}" does not support layered styles`)
 
-				return control.entities.entityReplaceStyleOverride(entityLocation, entityId, override)
+				return getEditableEntities(control).entityReplaceStyleOverride(entityLocation, entityId, override)
 			}),
 
 		removeStyleOverride: publicProcedure
@@ -312,10 +307,9 @@ export function createEntitiesTrpcRouter(
 				const control = controlsMap.get(controlId)
 				if (!control) return false
 
-				if (!control.supportsEntities || !control.supportsLayeredStyle)
-					throw new Error(`Control "${controlId}" does not support entities or layered styles`)
+				if (!control.supportsLayeredStyle) throw new Error(`Control "${controlId}" does not support layered styles`)
 
-				return control.entities.entityRemoveStyleOverride(entityLocation, entityId, overrideId)
+				return getEditableEntities(control).entityRemoveStyleOverride(entityLocation, entityId, overrideId)
 			}),
 
 		setVariableName: publicProcedure
@@ -333,9 +327,7 @@ export function createEntitiesTrpcRouter(
 				const control = controlsMap.get(controlId)
 				if (!control) return false
 
-				if (!control.supportsEntities) throw new Error(`Control "${controlId}" does not support entities`)
-
-				return control.entities.entitySetVariableName(entityLocation, entityId, name)
+				return getEditableEntities(control).entitySetVariableName(entityLocation, entityId, name)
 			}),
 
 		setVariableValue: publicProcedure
@@ -353,9 +345,7 @@ export function createEntitiesTrpcRouter(
 				const control = controlsMap.get(controlId)
 				if (!control) return false
 
-				if (!control.supportsEntities) throw new Error(`Control "${controlId}" does not support entities`)
-
-				return control.entities.entitySetVariableValue(entityLocation, entityId, value)
+				return getEditableEntities(control).entitySetVariableValue(entityLocation, entityId, value)
 			}),
 
 		localVariableValues: publicProcedure

--- a/companion/lib/Controls/ExpressionVariableNameMap.ts
+++ b/companion/lib/Controls/ExpressionVariableNameMap.ts
@@ -83,7 +83,7 @@ export class ExpressionVariableNameMap {
 				// Invalidate the newly promoted control so it updates its variable value
 				const newActiveControl = this.#controls.get(newActiveControlId) as ControlExpressionVariable | undefined
 				if (newActiveControl) {
-					newActiveControl.triggerRedraw()
+					newActiveControl.triggerInvalidation()
 				}
 			} else {
 				// No other controls, remove the entry entirely

--- a/companion/lib/Controls/IControlFragments.ts
+++ b/companion/lib/Controls/IControlFragments.ts
@@ -4,10 +4,9 @@ import type { EventInstance } from '@companion-app/shared/Model/EventModel.js'
 import type { ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
 import type { SomeButtonGraphicsElement } from '@companion-app/shared/Model/StyleLayersModel.js'
 import type { ButtonGraphicsElementUsage, ButtonStyleProperties } from '@companion-app/shared/Model/StyleModel.js'
-import type { CompositeElementIdString } from '../Instance/Definitions.js'
 import type { ControlBase } from './ControlBase.js'
-import type { ControlActionSetAndStepsManager } from './Entities/ControlActionSetAndStepsManager.js'
-import type { ControlEntityListPoolBase } from './Entities/EntityListPoolBase.js'
+import type { SomeStepManager } from './Entities/ControlActionSetAndStepsManager.js'
+import type { SomeEntityPool } from './Entities/EntityListPoolEditingMixin.js'
 
 export type SomeControl<TJson> = ControlBase<TJson> &
 	(ControlWithLayeredStyle | ControlWithoutLayeredStyle) &
@@ -90,12 +89,6 @@ export interface ControlWithLayeredStyle extends ControlBase<any> {
 	layeredStyleUpdateFromLegacyProperties(diff: Partial<ButtonStyleProperties>): boolean
 
 	/**
-	 * Propagate composite element changes
-	 * @param allChangedElementIds - composite element ids with changes
-	 */
-	onCompositeElementsChanged(allChangedElementIds: ReadonlySet<CompositeElementIdString>): void
-
-	/**
 	 * Get an element from the layered style by ID
 	 * @param id Element ID to find
 	 * @returns The element if found, undefined otherwise
@@ -111,7 +104,13 @@ export interface ControlWithLayeredStyle extends ControlBase<any> {
 export interface ControlWithEntities extends ControlBase<any> {
 	readonly supportsEntities: true
 
-	readonly entities: ControlEntityListPoolBase
+	/**
+	 * The entity pool, as a read-only-or-editable discriminated union. The structural edit mutators live only
+	 * on the editable side; editing code narrows on `entities.isEditable` to reach them. A read-only control
+	 * (e.g. a preset reference) constructs a read-only pool, so the mutators are genuinely absent - read-only
+	 * by construction, with the discriminant living on the pool rather than a per-control capability flag.
+	 */
+	readonly entities: SomeEntityPool
 }
 
 export interface ControlWithoutEntities extends ControlBase<any> {
@@ -189,7 +188,13 @@ export interface ControlWithoutEvents extends ControlBase<any> {
 export interface ControlWithActionSets extends ControlBase<any> {
 	readonly supportsActionSets: true
 
-	readonly actionSets: ControlActionSetAndStepsManager
+	/**
+	 * The step/action-set surface, as a runtime-only-or-editable discriminated union. The structural edit
+	 * mutators live only on the editable side; editing code narrows on `actionSets.isEditable` to reach them,
+	 * while runtime navigation is always available. (Same discriminant as {@link ControlWithEntities.entities};
+	 * for a button they are the same pool object.)
+	 */
+	readonly actionSets: SomeStepManager
 
 	/**
 	 * Execute a rotate of this control

--- a/companion/lib/Controls/StepsTrpcRouter.ts
+++ b/companion/lib/Controls/StepsTrpcRouter.ts
@@ -1,6 +1,16 @@
 import z from 'zod'
 import { publicProcedure, router } from '../UI/TRPC.js'
+import type { ControlActionSetAndStepsEditor } from './Entities/ControlActionSetAndStepsManager.js'
 import type { SomeControl } from './IControlFragments.js'
+
+/**
+ * Resolve a control to its editable step surface, or throw. Narrows the step union on its `isEditable`
+ * discriminant; read-only controls keep only the runtime navigation surface, gating the structural step edits.
+ */
+function getEditableSteps(control: SomeControl<any>): ControlActionSetAndStepsEditor {
+	if (control.supportsActionSets && control.actionSets.isEditable) return control.actionSets
+	throw new Error(`Control "${control.controlId}" does not support steps`)
+}
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function createStepsTrpcRouter(controlsMap: Map<string, SomeControl<any>>) {
@@ -15,11 +25,7 @@ export function createStepsTrpcRouter(controlsMap: Map<string, SomeControl<any>>
 				const control = controlsMap.get(input.controlId)
 				if (!control) return false
 
-				if (control.supportsActionSets) {
-					return control.actionSets.stepAdd()
-				} else {
-					throw new Error(`Control "${input.controlId}" does not support steps`)
-				}
+				return getEditableSteps(control).stepAdd()
 			}),
 
 		duplicate: publicProcedure
@@ -33,11 +39,7 @@ export function createStepsTrpcRouter(controlsMap: Map<string, SomeControl<any>>
 				const control = controlsMap.get(input.controlId)
 				if (!control) return false
 
-				if (control.supportsActionSets) {
-					return control.actionSets.stepDuplicate(input.stepId)
-				} else {
-					throw new Error(`Control "${input.controlId}" does not support steps`)
-				}
+				return getEditableSteps(control).stepDuplicate(input.stepId)
 			}),
 
 		remove: publicProcedure
@@ -51,11 +53,7 @@ export function createStepsTrpcRouter(controlsMap: Map<string, SomeControl<any>>
 				const control = controlsMap.get(input.controlId)
 				if (!control) return false
 
-				if (control.supportsActionSets) {
-					return control.actionSets.stepRemove(input.stepId)
-				} else {
-					throw new Error(`Control "${input.controlId}" does not support steps`)
-				}
+				return getEditableSteps(control).stepRemove(input.stepId)
 			}),
 
 		swap: publicProcedure
@@ -70,11 +68,7 @@ export function createStepsTrpcRouter(controlsMap: Map<string, SomeControl<any>>
 				const control = controlsMap.get(input.controlId)
 				if (!control) return false
 
-				if (control.supportsActionSets) {
-					return control.actionSets.stepSwap(input.stepId1, input.stepId2)
-				} else {
-					throw new Error(`Control "${input.controlId}" does not support steps`)
-				}
+				return getEditableSteps(control).stepSwap(input.stepId1, input.stepId2)
 			}),
 
 		setCurrent: publicProcedure
@@ -88,6 +82,7 @@ export function createStepsTrpcRouter(controlsMap: Map<string, SomeControl<any>>
 				const control = controlsMap.get(input.controlId)
 				if (!control) return false
 
+				// Runtime navigation - allowed on read-only controls too, so it uses the runtime actionSets surface
 				if (control.supportsActionSets) {
 					return control.actionSets.stepSelectCurrent(input.stepId)
 				} else {
@@ -107,11 +102,7 @@ export function createStepsTrpcRouter(controlsMap: Map<string, SomeControl<any>>
 				const control = controlsMap.get(input.controlId)
 				if (!control) return false
 
-				if (control.supportsActionSets) {
-					return control.actionSets.stepRename(input.stepId, input.newName)
-				} else {
-					throw new Error(`Control "${input.controlId}" does not support steps`)
-				}
+				return getEditableSteps(control).stepRename(input.stepId, input.newName)
 			}),
 	})
 }

--- a/companion/lib/Graphics/Controller.ts
+++ b/companion/lib/Graphics/Controller.ts
@@ -235,7 +235,7 @@ export class GraphicsController extends EventEmitter<GraphicsControllerEvents> {
 				try {
 					if (args.type === 'preset') {
 						const control = this.controlsStore.getControl(args.controlId)
-						const buttonStyle = (await control?.getDrawStyle()) ?? undefined
+						const buttonStyle = (await control?.drawing?.getDrawStyle()) ?? undefined
 
 						let render: ImageResult | undefined
 						if (buttonStyle && buttonStyle.style === 'button-layered') {
@@ -280,7 +280,7 @@ export class GraphicsController extends EventEmitter<GraphicsControllerEvents> {
 
 					const controlId = this.#pageStore.getControlIdAt(location)
 					const control = controlId ? this.controlsStore.getControl(controlId) : undefined
-					const buttonStyle = (await control?.getDrawStyle()) ?? undefined
+					const buttonStyle = (await control?.drawing?.getDrawStyle()) ?? undefined
 
 					let render: ImageResult | undefined
 					if (location && locationIsInBounds && buttonStyle && buttonStyle.style) {

--- a/companion/lib/Instance/ActionRecorder.ts
+++ b/companion/lib/Instance/ActionRecorder.ts
@@ -487,20 +487,15 @@ export class ActionRecorder extends EventEmitter<ActionRecorderEvents> {
 		const control = this.#controlStore.getControl(controlId)
 		if (!control) throw new Error(`Unknown control: ${controlId}`)
 
+		const editableEntities = control.supportsEntities && control.entities.isEditable ? control.entities : null
+		if (!editableEntities) throw new Error('Not supported by control')
+
 		if (mode === 'append') {
-			if (control.supportsEntities) {
-				if (!control.entities.entityAdd({ stepId, setId }, null, ...this.#currentSession.actions))
-					throw new Error('Unknown set')
-			} else {
-				throw new Error('Not supported by control')
-			}
+			if (!editableEntities.entityAdd({ stepId, setId }, null, ...this.#currentSession.actions))
+				throw new Error('Unknown set')
 		} else {
-			if (control.supportsEntities) {
-				const listId: SomeSocketEntityLocation = { stepId, setId }
-				if (!control.entities.entityReplaceAll(listId, this.#currentSession.actions)) throw new Error('Unknown set')
-			} else {
-				throw new Error('Not supported by control')
-			}
+			const listId: SomeSocketEntityLocation = { stepId, setId }
+			if (!editableEntities.entityReplaceAll(listId, this.#currentSession.actions)) throw new Error('Unknown set')
 		}
 
 		this.destroySession(true)

--- a/companion/lib/Instance/Connection/ChildHandlerLegacy.ts
+++ b/companion/lib/Instance/Connection/ChildHandlerLegacy.ts
@@ -1004,7 +1004,7 @@ export class ConnectionChildHandlerLegacy implements ChildProcessHandlerBase, Co
 					const control = this.#deps.controls.getControl(feedback.controlId)
 					const found =
 						control?.supportsEntities &&
-						control.entities.entityReplace(
+						control.entities.entityReplaceForUpgrade(
 							{
 								type: EntityModelType.Feedback,
 								id: feedback.id,
@@ -1027,7 +1027,7 @@ export class ConnectionChildHandlerLegacy implements ChildProcessHandlerBase, Co
 					const control = this.#deps.controls.getControl(action.controlId)
 					const found =
 						control?.supportsEntities &&
-						control.entities.entityReplace(
+						control.entities.entityReplaceForUpgrade(
 							{
 								type: EntityModelType.Action,
 								id: action.id,

--- a/companion/lib/Instance/Connection/EntityManager.ts
+++ b/companion/lib/Instance/Connection/EntityManager.ts
@@ -386,7 +386,7 @@ export class ConnectionEntityManager {
 					}
 
 					try {
-						control.entities.entityReplace(upgradedEntity)
+						control.entities.entityReplaceForUpgrade(upgradedEntity)
 					} catch (e) {
 						// If we fail to replace the entity, we can just ignore it
 						this.#logger.error(`Error replacing entity ${entity.id} in control ${wrapper.controlId}`, e)

--- a/companion/lib/Variables/LocalVariablesController.ts
+++ b/companion/lib/Variables/LocalVariablesController.ts
@@ -13,7 +13,7 @@ import type { SomeSocketEntityLocation } from '@companion-app/shared/Model/Entit
 import { stringifyVariableValue, type VariableValues } from '@companion-app/shared/Model/Variables.js'
 import type { JsonValue } from '@companion-module/host'
 import { isInternalUserValueFeedback, type ControlEntityInstance } from '../Controls/Entities/EntityInstance.js'
-import type { ControlWithEntities } from '../Controls/IControlFragments.js'
+import type { EditableEntityListPool, SomeEntityPool } from '../Controls/Entities/EntityListPoolEditingMixin.js'
 import type { IControlStore } from '../Controls/IControlStore.js'
 import type { RunActionExtras } from '../Instance/Connection/ChildHandlerApi.js'
 import { ParseLocationString } from '../Internal/Util.js'
@@ -38,7 +38,7 @@ export class LocalVariablesController {
 	#getControlAndVariable({
 		controlId,
 		name,
-	}: LocalVariable): { control: ControlWithEntities; variableEntity: ControlEntityInstance } | null {
+	}: LocalVariable): { entities: SomeEntityPool; variableEntity: ControlEntityInstance } | null {
 		const control = this.#controlsStore.getControl(controlId)
 		if (!control || !control.supportsEntities) return null
 
@@ -52,7 +52,21 @@ export class LocalVariablesController {
 
 		if (!isInternalUserValueFeedback(variableEntity)) return null
 
-		return { control, variableEntity }
+		return { entities: control.entities, variableEntity }
+	}
+
+	/**
+	 * As {@link #getControlAndVariable}, but only for controls whose entity pool is editable (narrowing on the
+	 * pool's `isEditable` discriminant). Returns `null` for read-only controls (e.g. a preset reference), so the
+	 * mutating callers below don't each repeat the editability check.
+	 */
+	#getEditableControlAndVariable(
+		localVariable: LocalVariable
+	): { entities: EditableEntityListPool; variableEntity: ControlEntityInstance } | null {
+		const found = this.#getControlAndVariable(localVariable)
+		if (!found || !found.entities.isEditable) return null
+
+		return { entities: found.entities, variableEntity: found.variableEntity }
 	}
 
 	/**
@@ -97,10 +111,10 @@ export class LocalVariablesController {
 		const controlAndVariable = this.#getControlAndVariable(localVariable)
 		if (!controlAndVariable) return null
 
-		const { control, variableEntity } = controlAndVariable
+		const { entities, variableEntity } = controlAndVariable
 		const result: VariableValues = { 'this:current': variableEntity.feedbackValue }
 
-		for (const entity of control.entities.getAllEntitiesInList('local-variables')) {
+		for (const entity of entities.getAllEntitiesInList('local-variables')) {
 			const rawName = entity.rawLocalVariableName
 			if (!rawName) continue
 			result[`target:${rawName}`] = entity.feedbackValue
@@ -114,11 +128,11 @@ export class LocalVariablesController {
 	 * value.
 	 */
 	setLocalVariable(localVariable: LocalVariable, value: JsonValue | undefined): void {
-		const controlAndVariable = this.#getControlAndVariable(localVariable)
+		const controlAndVariable = this.#getEditableControlAndVariable(localVariable)
 		if (!controlAndVariable) return
 
-		const { control, variableEntity } = controlAndVariable
-		control.entities.entitySetVariableValue(LocalVariablesList, variableEntity.id, value)
+		const { entities, variableEntity } = controlAndVariable
+		entities.entitySetVariableValue(LocalVariablesList, variableEntity.id, value)
 	}
 
 	/**
@@ -126,14 +140,14 @@ export class LocalVariablesController {
 	 * value.
 	 */
 	resetLocalVariable(localVariable: LocalVariable): void {
-		const controlAndVariable = this.#getControlAndVariable(localVariable)
+		const controlAndVariable = this.#getEditableControlAndVariable(localVariable)
 		if (!controlAndVariable) return
 
-		const { control, variableEntity } = controlAndVariable
+		const { entities, variableEntity } = controlAndVariable
 
 		// This isn't allowed to be an expression
 		const startupValue = variableEntity.rawOptions.startup_value?.value
-		control.entities.entitySetVariableValue(LocalVariablesList, variableEntity.id, startupValue)
+		entities.entitySetVariableValue(LocalVariablesList, variableEntity.id, startupValue)
 	}
 
 	/**
@@ -141,16 +155,11 @@ export class LocalVariablesController {
 	 * from its current value.
 	 */
 	writeLocalVariableStartupValue(localVariable: LocalVariable): void {
-		const controlAndVariable = this.#getControlAndVariable(localVariable)
+		const controlAndVariable = this.#getEditableControlAndVariable(localVariable)
 		if (!controlAndVariable) return
 
-		const { control, variableEntity } = controlAndVariable
+		const { entities, variableEntity } = controlAndVariable
 
-		control.entities.entitySetOption(
-			LocalVariablesList,
-			variableEntity.id,
-			'startup_value',
-			variableEntity.feedbackValue
-		)
+		entities.entitySetOption(LocalVariablesList, variableEntity.id, 'startup_value', variableEntity.feedbackValue)
 	}
 }

--- a/companion/lib/Variables/LocalVariablesController.ts
+++ b/companion/lib/Variables/LocalVariablesController.ts
@@ -160,6 +160,9 @@ export class LocalVariablesController {
 
 		const { entities, variableEntity } = controlAndVariable
 
-		entities.entitySetOption(LocalVariablesList, variableEntity.id, 'startup_value', variableEntity.feedbackValue)
+		entities.entitySetOption(LocalVariablesList, variableEntity.id, 'startup_value', {
+			isExpression: false,
+			value: variableEntity.feedbackValue,
+		})
 	}
 }

--- a/companion/test/Controls/Entities/EntityListPool.entities.test.ts
+++ b/companion/test/Controls/Entities/EntityListPool.entities.test.ts
@@ -268,7 +268,7 @@ describe('EntityListPool - entityMoveTo', () => {
 	})
 })
 
-describe('EntityListPool - entityReplace', () => {
+describe('EntityListPool - entityReplaceForUpgrade', () => {
 	test('replaces props on an existing entity of the same type', () => {
 		const { pool } = createPool()
 		const action = actionModel({ definitionId: 'def-old' })
@@ -281,7 +281,7 @@ describe('EntityListPool - entityReplace', () => {
 			options: { x: { isExpression: false, value: 1 } },
 			upgradeIndex: undefined,
 		}
-		const result = pool.entityReplace(replacement)
+		const result = pool.entityReplaceForUpgrade(replacement)
 
 		expect(result?.id).toBe(action.id)
 		expect(pool.findEntityById(action.id)?.definitionId).toBe('def-new')
@@ -292,7 +292,7 @@ describe('EntityListPool - entityReplace', () => {
 		const action = actionModel()
 		pool.entityAdd(downSet(), null, action)
 
-		const result = pool.entityReplace({
+		const result = pool.entityReplaceForUpgrade({
 			id: action.id,
 			type: EntityModelType.Feedback,
 			definitionId: 'def-new',
@@ -306,7 +306,7 @@ describe('EntityListPool - entityReplace', () => {
 	test('returns undefined for an unknown entity', () => {
 		const { pool } = createPool()
 
-		const result = pool.entityReplace({
+		const result = pool.entityReplaceForUpgrade({
 			id: 'nope',
 			type: EntityModelType.Action,
 			definitionId: 'def-new',

--- a/companion/test/Controls/Entities/EntityListPool.test.ts
+++ b/companion/test/Controls/Entities/EntityListPool.test.ts
@@ -1,7 +1,18 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import type { ButtonModelBase } from '@companion-app/shared/Model/ButtonModel.js'
 import type { ControlEntityListChangeProps } from '../../../lib/Controls/Entities/EntityListPoolBase.js'
-import { actionModel, createPool, downSet, feedbackModel, feedbackValues } from './EntityListPoolTestHelpers.js'
+import {
+	ControlEntityListPoolButton,
+	EditableControlEntityListPoolButton,
+} from '../../../lib/Controls/Entities/EntityListPoolButton.js'
+import {
+	actionModel,
+	createPool,
+	createPoolDeps,
+	downSet,
+	feedbackModel,
+	feedbackValues,
+} from './EntityListPoolTestHelpers.js'
 
 /** A style override carrying the layered-drawing fields the pool reads. */
 function styleOverride(overrides: Record<string, unknown> = {}) {
@@ -183,6 +194,64 @@ describe('EntityListPool - destroy', () => {
 		pool.entityAdd('feedbacks', null, feedbackModel())
 
 		expect(() => pool.destroy()).not.toThrow()
+	})
+})
+
+describe('EntityListPool - read-only by construction', () => {
+	test('the isEditable discriminant distinguishes the two pools', () => {
+		const readonly = new ControlEntityListPoolButton(
+			createPoolDeps({ controlId: 'disc0' }).deps,
+			vi.fn(),
+			vi.fn(),
+			true
+		)
+		const editable = new EditableControlEntityListPoolButton(
+			createPoolDeps({ controlId: 'disc1' }).deps,
+			vi.fn(),
+			vi.fn(),
+			true
+		)
+
+		expect(readonly.isEditable).toBe(false)
+		expect(editable.isEditable).toBe(true)
+	})
+
+	test('the read-only pool structurally lacks the edit mutators', () => {
+		const pool = new ControlEntityListPoolButton(createPoolDeps({ controlId: 'ro00' }).deps, vi.fn(), vi.fn(), true)
+
+		// Compile-time: these properties do not exist on the read-only pool type.
+		// Runtime: confirm they are genuinely absent (not merely guarded).
+		// @ts-expect-error stepAdd is only on the editable pool
+		expect(typeof pool.stepAdd).toBe('undefined')
+		// @ts-expect-error entityAdd is only on the editable pool
+		expect(typeof pool.entityAdd).toBe('undefined')
+		// @ts-expect-error actionSetAdd is only on the editable pool
+		expect(typeof pool.actionSetAdd).toBe('undefined')
+		// @ts-expect-error stepRename is only on the editable pool
+		expect(typeof pool.stepRename).toBe('undefined')
+	})
+
+	test('the editable pool has working edit mutators', () => {
+		const pool = new EditableControlEntityListPoolButton(
+			createPoolDeps({ controlId: 'rw00' }).deps,
+			vi.fn(),
+			vi.fn(),
+			true
+		)
+
+		expect(typeof pool.stepAdd).toBe('function')
+		pool.stepAdd()
+		expect(pool.getStepIds()).toEqual(['0', '1'])
+	})
+
+	test('loading and runtime step navigation work on the read-only pool', () => {
+		const pool = new ControlEntityListPoolButton(createPoolDeps({ controlId: 'ro01' }).deps, vi.fn(), vi.fn(), true)
+
+		// Loading the cached data must work on a read-only pool
+		expect(() => pool.loadStorage({ feedbacks: [], steps: {}, localVariables: [] }, true, false)).not.toThrow()
+
+		// Runtime step navigation (used by pressControl) must work
+		expect(() => pool.stepSelectCurrent('0')).not.toThrow()
 	})
 })
 

--- a/companion/test/Controls/Entities/EntityListPoolTestHelpers.ts
+++ b/companion/test/Controls/Entities/EntityListPoolTestHelpers.ts
@@ -11,7 +11,7 @@ import type {
 	ControlEntityListChangeProps,
 	ControlEntityListPoolProps,
 } from '../../../lib/Controls/Entities/EntityListPoolBase.js'
-import { ControlEntityListPoolButton } from '../../../lib/Controls/Entities/EntityListPoolButton.js'
+import { EditableControlEntityListPoolButton } from '../../../lib/Controls/Entities/EntityListPoolButton.js'
 import { EntityListPoolExpressionVariable } from '../../../lib/Controls/Entities/EntityListPoolExpressionVariable.js'
 import { ControlEntityListPoolTrigger } from '../../../lib/Controls/Entities/EntityListPoolTrigger.js'
 import type { NewFeedbackValue } from '../../../lib/Controls/Entities/Types.js'
@@ -111,7 +111,14 @@ export function createPool(options: CreatePoolOptions = {}) {
 
 	const base = createPoolDeps(options)
 
-	const pool = new ControlEntityListPoolButton(base.deps, sendRuntimeProps, executeExpressionInControl, isLayered)
+	// The functional helper builds the editable pool so tests can exercise the entity/step mutators. The
+	// read-only `ControlEntityListPoolButton` is constructed directly by the read-only-by-construction tests.
+	const pool = new EditableControlEntityListPoolButton(
+		base.deps,
+		sendRuntimeProps,
+		executeExpressionInControl,
+		isLayered
+	)
 
 	return {
 		...base,

--- a/companion/test/Controls/ExpressionVariableNameMap.test.ts
+++ b/companion/test/Controls/ExpressionVariableNameMap.test.ts
@@ -11,12 +11,12 @@ vi.mock('../../lib/Controls/ControlTypes/ExpressionVariable.js', () => {
 	class ControlExpressionVariable {
 		controlId: string
 		options: { variableName: string }
-		triggerRedraw: ReturnType<typeof vi.fn>
+		triggerInvalidation: ReturnType<typeof vi.fn>
 
 		constructor(controlId: string, variableName: string) {
 			this.controlId = controlId
 			this.options = { variableName }
-			this.triggerRedraw = vi.fn()
+			this.triggerInvalidation = vi.fn()
 		}
 	}
 	return { ControlExpressionVariable }
@@ -82,7 +82,7 @@ describe('removeExpressionVariable', () => {
 		])
 	})
 
-	test('removing active control promotes the first conflict and calls triggerRedraw', () => {
+	test('removing active control promotes the first conflict and calls triggerInvalidation', () => {
 		const { map, controls } = makeMap()
 
 		const ctrl2 = makeCveControl('ctrl-2', 'myVar')
@@ -94,7 +94,7 @@ describe('removeExpressionVariable', () => {
 		map.removeExpressionVariable('ctrl-1', 'myVar')
 
 		expect(map.getControlIdByName('myVar')).toBe('ctrl-2')
-		expect(ctrl2.triggerRedraw).toHaveBeenCalledOnce()
+		expect(ctrl2.triggerInvalidation).toHaveBeenCalledOnce()
 	})
 
 	test('removing a non-active conflict just removes it from the queue', () => {

--- a/companion/test/Controls/Triggers/Trigger.test.ts
+++ b/companion/test/Controls/Triggers/Trigger.test.ts
@@ -394,24 +394,24 @@ describe('ControlTrigger', () => {
 			runMultipleActions.mockClear()
 
 			condition.mockReturnValue(true)
-			trigger.triggerRedraw()
+			trigger.triggerInvalidation()
 			vi.runAllTimers()
 			expect(runMultipleActions).toHaveBeenCalledTimes(1)
 
 			// Staying true does not re-fire
-			trigger.triggerRedraw()
+			trigger.triggerInvalidation()
 			vi.runAllTimers()
 			expect(runMultipleActions).toHaveBeenCalledTimes(1)
 
 			// Falling does not fire a condition_true event
 			condition.mockReturnValue(false)
-			trigger.triggerRedraw()
+			trigger.triggerInvalidation()
 			vi.runAllTimers()
 			expect(runMultipleActions).toHaveBeenCalledTimes(1)
 
 			// But the next rise fires again
 			condition.mockReturnValue(true)
-			trigger.triggerRedraw()
+			trigger.triggerInvalidation()
 			vi.runAllTimers()
 			expect(runMultipleActions).toHaveBeenCalledTimes(2)
 		})
@@ -425,7 +425,7 @@ describe('ControlTrigger', () => {
 			runMultipleActions.mockClear()
 
 			condition.mockReturnValue(false)
-			trigger.triggerRedraw()
+			trigger.triggerInvalidation()
 			vi.runAllTimers()
 			expect(runMultipleActions).toHaveBeenCalledTimes(1)
 		})
@@ -440,9 +440,9 @@ describe('ControlTrigger', () => {
 
 			// Many redraw requests in quick succession produce a single recheck
 			condition.mockReturnValue(true)
-			trigger.triggerRedraw()
-			trigger.triggerRedraw()
-			trigger.triggerRedraw()
+			trigger.triggerInvalidation()
+			trigger.triggerInvalidation()
+			trigger.triggerInvalidation()
 			vi.runAllTimers()
 			expect(runMultipleActions).toHaveBeenCalledTimes(1)
 		})
@@ -465,10 +465,10 @@ describe('ControlTrigger', () => {
 
 			// While a real falling and rising edge afterwards still fires
 			condition.mockReturnValue(false)
-			trigger.triggerRedraw()
+			trigger.triggerInvalidation()
 			vi.runAllTimers()
 			condition.mockReturnValue(true)
-			trigger.triggerRedraw()
+			trigger.triggerInvalidation()
 			vi.runAllTimers()
 			expect(runMultipleActions).toHaveBeenCalledTimes(1)
 		})
@@ -485,7 +485,7 @@ describe('ControlTrigger', () => {
 			vi.runAllTimers()
 
 			condition.mockReturnValue(true)
-			trigger.triggerRedraw()
+			trigger.triggerInvalidation()
 			vi.runAllTimers()
 			expect(runMultipleActions).not.toHaveBeenCalled()
 		})

--- a/companion/test/Instance/ActionRecorder.test.ts
+++ b/companion/test/Instance/ActionRecorder.test.ts
@@ -44,6 +44,7 @@ function makeEntityControl() {
 	return {
 		supportsEntities: true,
 		entities: {
+			isEditable: true,
 			entityAdd: vi.fn(() => true),
 			entityReplaceAll: vi.fn(() => true),
 		},

--- a/companion/test/Instance/EntityManager.test.ts
+++ b/companion/test/Instance/EntityManager.test.ts
@@ -29,7 +29,7 @@ describe('InstanceEntityManager', () => {
 
 	const mockControl = {
 		entities: {
-			entityReplace: vi.fn(),
+			entityReplaceForUpgrade: vi.fn(),
 		},
 		supportsEntities: true,
 	}
@@ -773,7 +773,7 @@ describe('InstanceEntityManager', () => {
 			// Mock the control
 			const mockControl = {
 				entities: {
-					entityReplace: vi.fn(),
+					entityReplaceForUpgrade: vi.fn(),
 				},
 				supportsEntities: true,
 			}
@@ -801,8 +801,8 @@ describe('InstanceEntityManager', () => {
 			// Wait for the Promise microtasks to resolve
 			await vi.runAllTimersAsync()
 
-			// Verify that the entityReplace was called with the upgraded entity
-			expect(mockControl.entities.entityReplace).toHaveBeenCalledWith(
+			// Verify that the entityReplaceForUpgrade was called with the upgraded entity
+			expect(mockControl.entities.entityReplaceForUpgrade).toHaveBeenCalledWith(
 				expect.objectContaining({
 					id: 'entity-1',
 					type: EntityModelType.Action,
@@ -1290,7 +1290,7 @@ describe('InstanceEntityManager', () => {
 			await vi.runAllTimersAsync()
 
 			// The entity should not get updated in the control since it was deleted
-			expect(mockControl.entities.entityReplace).not.toHaveBeenCalled()
+			expect(mockControl.entities.entityReplaceForUpgrade).not.toHaveBeenCalled()
 		})
 	})
 

--- a/companion/test/Variables/LocalVariablesController.test.ts
+++ b/companion/test/Variables/LocalVariablesController.test.ts
@@ -183,12 +183,10 @@ describe('LocalVariablesController', () => {
 
 			controller.writeLocalVariableStartupValue({ controlId: 'control-a1', name: 'my_var' })
 
-			expect(control.entities.entitySetOption).toHaveBeenCalledWith(
-				'local-variables',
-				entity.id,
-				'startup_value',
-				'current'
-			)
+			expect(control.entities.entitySetOption).toHaveBeenCalledWith('local-variables', entity.id, 'startup_value', {
+				isExpression: false,
+				value: 'current',
+			})
 		})
 	})
 })

--- a/companion/test/Variables/LocalVariablesController.test.ts
+++ b/companion/test/Variables/LocalVariablesController.test.ts
@@ -30,6 +30,7 @@ function makeControl(entities: any[]) {
 	return {
 		supportsEntities: true,
 		entities: {
+			isEditable: true,
 			getAllEntitiesInList: (listId: string) => (listId === 'local-variables' ? entities : []),
 			entitySetVariableValue: vi.fn(),
 			entitySetOption: vi.fn(),


### PR DESCRIPTION
preparing for a new control type that needs a readonly version of `ControlEntityListPoolButton`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Layered button rendering is now driven by a dedicated drawer/editor, enabling richer layered style editing.
  * Clearer editable vs. read-only behavior for control action sets and entity pools.
* **Bug Fixes**
  * Editing operations are now stricter: mutations succeed only when the underlying action sets/entities are explicitly editable.
  * UI refresh now consistently uses invalidation/redraw updates after relevant changes.
* **Refactor**
  * Rendering and drawer updates were reworked around invalidation.
  * Step/action-set and entity editing surfaces were reorganized, including upgrade-safe entity replacement.
* **Tests**
  * Updated and added coverage for the new editability and redraw/invalidation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->