### PR TITLE
feat: mdns announce satellite ports

### DIFF
--- a/companion/lib/Data/UserConfig.ts
+++ b/companion/lib/Data/UserConfig.ts
@@ -106,6 +106,7 @@ export class DataUserConfig extends EventEmitter<DataUserConfigEvents> {
 		gridSizePromptGrow: true,
 
 		installName: '',
+		mdns_announcements_enabled: true,
 		default_export_filename: '$(internal:hostname)_$(internal:date_iso)-$(internal:time_h)$(internal:time_m)',
 
 		timezone: '',

--- a/companion/lib/Registry.ts
+++ b/companion/lib/Registry.ts
@@ -303,6 +303,7 @@ export class Registry {
 		)
 
 		this.services = new ServiceController(
+			this.#appInfo,
 			serviceApi,
 			this.userconfig,
 			oscSender,

--- a/companion/lib/Service/Controller.ts
+++ b/companion/lib/Service/Controller.ts
@@ -3,6 +3,7 @@ import type { DataUserConfig } from '../Data/UserConfig.js'
 import type { ImageResult } from '../Graphics/ImageResult.js'
 import type { InstanceController } from '../Instance/Controller.js'
 import type { IPageStore } from '../Page/Store.js'
+import type { AppInfo } from '../Registry.js'
 import type { SurfaceController } from '../Surface/Controller.js'
 import type { UIExpress } from '../UI/Express.js'
 import type { UIHandler } from '../UI/Handler.js'
@@ -11,6 +12,7 @@ import { ServiceBonjourDiscovery } from './BonjourDiscovery.js'
 import { ServiceEmberPlus } from './EmberPlus.js'
 import { ServiceHttpApi } from './HttpApi.js'
 import { ServiceHttps } from './Https.js'
+import { ServiceMdnsAdvertise } from './MdnsAdvertise.js'
 import { ServiceOscListener } from './OscListener.js'
 import type { ServiceOscSender } from './OscSender.js'
 import { ServiceRosstalk } from './Rosstalk.js'
@@ -50,8 +52,10 @@ export class ServiceController {
 	readonly satelliteTcp: ServiceSatelliteTcp
 	readonly satelliteWebsocket: ServiceSatelliteWebsocket
 	readonly bonjourDiscovery: ServiceBonjourDiscovery
+	readonly mdnsAdvertise: ServiceMdnsAdvertise
 
 	constructor(
+		appInfo: AppInfo,
 		serviceApi: ServiceApi,
 		userconfig: DataUserConfig,
 		oscSender: ServiceOscSender,
@@ -74,6 +78,7 @@ export class ServiceController {
 		this.satelliteTcp = new ServiceSatelliteTcp(this.satelliteApi, userconfig)
 		this.satelliteWebsocket = new ServiceSatelliteWebsocket(this.satelliteApi, userconfig)
 		this.bonjourDiscovery = new ServiceBonjourDiscovery(userconfig, instanceController)
+		this.mdnsAdvertise = new ServiceMdnsAdvertise(userconfig, appInfo)
 	}
 
 	onButtonDrawn(location: ControlLocation, render: ImageResult): void {
@@ -92,6 +97,7 @@ export class ServiceController {
 		this.bonjourDiscovery.updateUserConfig(key, value)
 		this.emberplus.updateUserConfig(key, value)
 		this.https.updateUserConfig(key, value)
+		this.mdnsAdvertise.updateUserConfig(key, value)
 		this.oscListener.updateUserConfig(key, value)
 		this.oscSender.updateUserConfig(key, value)
 		this.rosstalk.updateUserConfig(key, value)

--- a/companion/lib/Service/MdnsAdvertise.ts
+++ b/companion/lib/Service/MdnsAdvertise.ts
@@ -48,7 +48,7 @@ export class ServiceMdnsAdvertise extends ServiceBase {
 		try {
 			this.#bonjour = new Bonjour()
 
-			const name = String(this.userconfig.getKey('installName') || '').trim() || os.hostname() || 'Companion'
+			const name = String(this.userconfig.getKey('installName') || '').trim() || `Companion (${os.hostname()})`
 			const txt = {
 				id: this.#appInfo.machineId,
 				version: this.#appInfo.appVersion,

--- a/companion/lib/Service/MdnsAdvertise.ts
+++ b/companion/lib/Service/MdnsAdvertise.ts
@@ -1,0 +1,107 @@
+import os from 'node:os'
+import { Bonjour } from '@julusian/bonjour-service'
+import { stringifyError } from '@companion-app/shared/Stringify.js'
+import type { DataUserConfig } from '../Data/UserConfig.js'
+import type { AppInfo } from '../Registry.js'
+import { DISABLE_IPv6 } from '../Resources/Constants.js'
+import { ServiceBase } from './Base.js'
+import { API_VERSION as SATELLITE_API_VERSION } from './Satellite/SatelliteApi.js'
+
+/**
+ * Class providing mDNS/Bonjour advertisement of Companion's satellite ports,
+ * so that the Companion Satellite app can auto-discover this Companion.
+ *
+ * This is the reverse direction of {@link ServiceBonjourDiscovery}: here Companion
+ * advertises itself, mirroring the conventions used by the satellite app's own announcer.
+ *
+ * @author Julian Waller <me@julusian.co.uk>
+ * @since 5.0.0
+ * @copyright 2026 Bitfocus AS
+ * @license
+ * This program is free software.
+ * You should have received a copy of the MIT licence as well as the Bitfocus
+ * Individual Contributor License Agreement for Companion along with
+ * this program.
+ */
+export class ServiceMdnsAdvertise extends ServiceBase {
+	readonly #appInfo: AppInfo
+
+	#bonjour: Bonjour | undefined = undefined
+
+	/**
+	 * Debounce timer used to coalesce rapid config changes (e.g. typing the install name)
+	 * into a single republish.
+	 */
+	#restartTimeout: NodeJS.Timeout | undefined = undefined
+
+	constructor(userconfig: DataUserConfig, appInfo: AppInfo) {
+		super(userconfig, 'Service/MdnsAdvertise', 'mdns_announcements_enabled', null)
+
+		this.#appInfo = appInfo
+
+		this.init()
+	}
+
+	listen(): void {
+		if (this.#bonjour !== undefined) return
+
+		try {
+			this.#bonjour = new Bonjour()
+
+			const name = String(this.userconfig.getKey('installName') || '').trim() || os.hostname() || 'Companion'
+			const txt = {
+				id: this.#appInfo.machineId,
+				version: this.#appInfo.appVersion,
+				protocolVersion: SATELLITE_API_VERSION,
+			}
+
+			// Advertise a separate service per satellite port, so each SRV record points
+			// straight at the port the satellite app should connect to.
+			this.#publish(name, txt, 'companion-satellite-tcp', 16622)
+			this.#publish(name, txt, 'companion-satellite-ws', 16623)
+
+			this.currentState = true
+
+			this.logger.info('Advertising Companion satellite ports via mDNS')
+		} catch (e) {
+			this.logger.error(`Could not launch: ${stringifyError(e)}`)
+		}
+	}
+
+	#publish(name: string, txt: Record<string, string>, type: string, port: number): void {
+		this.#bonjour?.publish(
+			{
+				name,
+				type,
+				protocol: 'tcp',
+				port,
+				txt,
+				ttl: 150,
+				disableIPv6: DISABLE_IPv6,
+			},
+			{ announceOnInterval: 60 * 1000 }
+		)
+	}
+
+	close(): void {
+		if (this.#bonjour) {
+			this.#bonjour.unpublishAll()
+			this.#bonjour.destroy()
+			this.#bonjour = undefined
+		}
+	}
+
+	override updateUserConfig(key: string, value: boolean | number | string): void {
+		// Let the base class handle enable/disable via the mdns_announcements_enabled key
+		super.updateUserConfig(key, value)
+
+		// The advertised service name is derived from the install name, so republish when it changes
+		if (key === 'installName' && this.currentState) {
+			if (this.#restartTimeout) clearTimeout(this.#restartTimeout)
+			this.#restartTimeout = setTimeout(() => {
+				this.#restartTimeout = undefined
+				this.restartModule()
+			}, 50)
+		}
+	}
+}

--- a/companion/lib/Service/MdnsAdvertise.ts
+++ b/companion/lib/Service/MdnsAdvertise.ts
@@ -65,6 +65,10 @@ export class ServiceMdnsAdvertise extends ServiceBase {
 			this.logger.info('Advertising Companion satellite ports via mDNS')
 		} catch (e) {
 			this.logger.error(`Could not launch: ${stringifyError(e)}`)
+
+			// Tear down the partially-initialized instance so a later enable cycle can retry,
+			// rather than leaving #bonjour populated with currentState still false.
+			this.close()
 		}
 	}
 

--- a/shared-lib/lib/Model/UserConfigModel.ts
+++ b/shared-lib/lib/Model/UserConfigModel.ts
@@ -63,6 +63,7 @@ export type UserConfigModel = {
 	gridSizePromptGrow: boolean
 
 	installName: string
+	mdns_announcements_enabled: boolean
 	default_export_filename: string
 
 	/** IANA timezone name (e.g. 'America/New_York') used for internal time variables and time-based triggers. Empty = system timezone. */

--- a/webui/src/UserConfig/Sections/CompanionConfig.tsx
+++ b/webui/src/UserConfig/Sections/CompanionConfig.tsx
@@ -3,6 +3,7 @@ import { TIMEZONE_CHOICES } from '~/Resources/timezones.js'
 import type { UserConfigProps } from '../Components/Common.js'
 import { UserConfigDropdownRow } from '../Components/UserConfigDropdownRow.js'
 import { UserConfigHeadingRow } from '../Components/UserConfigHeadingRow.js'
+import { UserConfigSwitchRow } from '../Components/UserConfigSwitchRow.js'
 import { UserConfigTextInputRow } from '../Components/UserConfigTextInputRow.js'
 
 export const CompanionConfig = observer(function CompanionConfig(props: UserConfigProps) {
@@ -10,6 +11,11 @@ export const CompanionConfig = observer(function CompanionConfig(props: UserConf
 		<>
 			<UserConfigHeadingRow label="Installation Settings" helpAction="/user-guide/config/settings#general" />
 			<UserConfigTextInputRow userConfig={props} label="Installation Name" field="installName" />
+			<UserConfigSwitchRow
+				userConfig={props}
+				label="Announce Companion on the network (mDNS/Bonjour)"
+				field="mdns_announcements_enabled"
+			/>
 			<UserConfigTextInputRow
 				userConfig={props}
 				useVariables={true}


### PR DESCRIPTION
To allow for auto-discovery/suggestions from clients

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new setting to control whether Companion advertises itself on the local network via mDNS/Bonjour.
  * Companion’s network announcements are enabled by default.
  * When enabled, Companion publishes discovery information for its satellite connectivity services; changes to the install name take effect with a brief refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->