### PR TITLE
fix: surfaces confusing never lock property

### DIFF
--- a/companion/lib/Data/Upgrade.ts
+++ b/companion/lib/Data/Upgrade.ts
@@ -16,6 +16,7 @@ import v10tov11 from './Upgrades/v10tov11.js'
 import v11tov12 from './Upgrades/v11tov12.js'
 import v12tov13 from './Upgrades/v12tov13.js'
 import v13tov14 from './Upgrades/v13tov14.js'
+import v14tov15 from './Upgrades/v14tov15.js'
 
 const logger = LogController.createLogger('Data/Upgrade')
 
@@ -33,6 +34,7 @@ const allUpgrades = [
 	v11tov12, // v4.3 - surface plugin config field renames
 	v12tov13, // v5.0 - graphics overhaul
 	v13tov14, // v5.0 - split fontsize into size + allowShrink
+	v14tov15, // v5.0 - move surface never_lock to the surface group
 ]
 const targetVersion = allUpgrades.length + 1
 
@@ -67,7 +69,7 @@ export function upgradeStartup(db: DataDatabase): void {
 	}
 
 	// Debug: uncomment to force the upgrade to run again
-	db.defaultTableView.set('page_config_version', targetVersion - 1)
+	// db.defaultTableView.set('page_config_version', targetVersion - 1)
 }
 
 /**

--- a/companion/lib/Data/Upgrades/v14tov15.ts
+++ b/companion/lib/Data/Upgrades/v14tov15.ts
@@ -1,0 +1,99 @@
+import type { ExportFullv6, SomeExportv6 } from '@companion-app/shared/Model/ExportModel.js'
+import type { Logger } from '../../Log/Controller.js'
+import type { DataStoreBase } from '../StoreBase.js'
+
+/**
+ * Move the `never_lock` property from the per-surface panel config to the surface group config.
+ *
+ * Lock state is tracked at the group level, so the lock-eligibility flag belongs there too.
+ * For auto-groups (a surface that is its own group) the flag is stored on the surface's own
+ * `groupConfig`. For explicit groups the flag is merged onto the shared group config, with a
+ * surface that opted out of locking winning (OR merge).
+ */
+function migrateSurfaces(
+	getSurfaces: () => Record<string, any>,
+	setSurface: (id: string, config: any) => void,
+	getGroup: (id: string) => any,
+	setGroup: (id: string, config: any) => void
+): void {
+	// never_lock values collected from members of explicit groups
+	const explicitGroupNeverLock = new Map<string, boolean>()
+
+	for (const [surfaceId, surfaceConfig] of Object.entries(getSurfaces())) {
+		if (!surfaceConfig || typeof surfaceConfig !== 'object') continue
+
+		const config = surfaceConfig.config
+		if (!config || typeof config !== 'object' || !('never_lock' in config)) continue
+
+		const neverLock = !!config.never_lock
+		delete config.never_lock
+
+		if (surfaceConfig.groupId) {
+			// Explicit group: merge onto the shared group config later
+			explicitGroupNeverLock.set(
+				surfaceConfig.groupId,
+				(explicitGroupNeverLock.get(surfaceConfig.groupId) ?? false) || neverLock
+			)
+		} else {
+			// Auto-group: store on the surface's own group config
+			surfaceConfig.groupConfig = surfaceConfig.groupConfig ?? {}
+			surfaceConfig.groupConfig.never_lock = neverLock
+		}
+
+		setSurface(surfaceId, surfaceConfig)
+	}
+
+	for (const [groupId, neverLock] of explicitGroupNeverLock) {
+		const groupConfig = getGroup(groupId)
+		if (!groupConfig || typeof groupConfig !== 'object') continue
+
+		groupConfig.never_lock = neverLock
+		setGroup(groupId, groupConfig)
+	}
+}
+
+function convertDatabaseToV15(db: DataStoreBase<any>, _logger: Logger): void {
+	if (!db.store) return
+
+	const surfaces = db.getTableView('surfaces')
+	const groups = db.getTableView('surface_groups')
+
+	migrateSurfaces(
+		() => surfaces.all(),
+		(id, config) => surfaces.set(id, config),
+		(id) => groups.get(id),
+		(id, config) => groups.set(id, config)
+	)
+}
+
+function convertImportToV15(obj: SomeExportv6, _logger: Logger): SomeExportv6 {
+	if (obj.type === 'full') {
+		const newObj: ExportFullv6 = { ...structuredClone(obj), version: 15 }
+
+		const surfaces = (newObj.surfaces ?? {}) as Record<string, any>
+		const groups = (newObj.surfaceGroups ?? {}) as Record<string, any>
+
+		migrateSurfaces(
+			() => surfaces,
+			(id, config) => {
+				surfaces[id] = config
+			},
+			(id) => groups[id],
+			(id, config) => {
+				groups[id] = config
+			}
+		)
+
+		newObj.surfaces = surfaces
+		newObj.surfaceGroups = groups
+
+		return newObj
+	} else {
+		return { ...structuredClone(obj), version: 15 }
+	}
+}
+
+export default {
+	upgradeStartup: convertDatabaseToV15,
+	upgradeImport: convertImportToV15,
+}

--- a/companion/lib/Surface/CommonConfigFields.ts
+++ b/companion/lib/Surface/CommonConfigFields.ts
@@ -42,12 +42,3 @@ export const RotationConfigField: CompanionSurfaceConfigField = {
 		{ id: 'surface180', label: '180' },
 	],
 }
-
-export const LockConfigFields: CompanionSurfaceConfigField[] = [
-	{
-		id: 'never_lock',
-		type: 'checkbox',
-		label: 'Never pin code lock',
-		default: false,
-	},
-]

--- a/companion/lib/Surface/Config.ts
+++ b/companion/lib/Surface/Config.ts
@@ -8,7 +8,6 @@ export const PanelDefaults: SurfacePanelConfig = {
 	rotation: 0,
 
 	// companion owned defaults
-	never_lock: false,
 	xOffset: 0,
 	yOffset: 0,
 	groupId: null,

--- a/companion/lib/Surface/Controller.ts
+++ b/companion/lib/Surface/Controller.ts
@@ -858,13 +858,6 @@ export class SurfaceController extends EventEmitter<SurfaceControllerEvents> {
 								[input.key]: input.value,
 							})
 
-							// Ensure the surface has the correct locked state
-							const groupId = surface.getGroupId()
-							const group = groupId ? this.#surfaceGroups.get(groupId) : null
-							if (group) {
-								group.syncLocked()
-							}
-
 							this.triggerUpdateDevicesList()
 						}
 					}

--- a/companion/lib/Surface/Group.ts
+++ b/companion/lib/Surface/Group.ts
@@ -31,6 +31,7 @@ export class SurfaceGroup {
 		last_page_id: '',
 		startup_page_id: '',
 		use_last_page: true,
+		never_lock: false,
 		restrict_pages: false,
 		allowed_page_ids: [],
 	}
@@ -212,7 +213,7 @@ export class SurfaceGroup {
 
 		this.surfaceHandlers.push(surfaceHandler)
 
-		surfaceHandler.setLocked(this.#isLocked, true)
+		surfaceHandler.setLocked(this.#isLocked && !this.groupConfig.never_lock, true)
 		surfaceHandler.storeNewDevicePage(this.#currentPageId, true)
 	}
 
@@ -428,6 +429,11 @@ export class SurfaceGroup {
 			;(this.groupConfig as any)[key] = newValue
 			this.#saveConfig()
 
+			// Changing never_lock changes whether the lock is suppressed for the member surfaces
+			if (key === 'never_lock') {
+				this.#applyLockedToSurfaces()
+			}
+
 			return
 		}
 	}
@@ -437,37 +443,28 @@ export class SurfaceGroup {
 	 * @returns whether the locked state changed
 	 */
 	setLocked(locked: boolean): boolean {
-		// If an auto-group, just pass to the sole surface
-		if (this.isAutoGroup) {
-			return this.surfaceHandlers[0].setLocked(locked)
-		}
-
-		// // skip if surface can't be locked
-		// if (this.#surfaceConfig.config.never_lock) return
-
 		if (this.#isLocked === !!locked) {
 			return false
 		}
 
-		// Track the locked status
+		// Track the intended locked status. `never_lock` is applied when pushing to the surfaces,
+		// so the intent is still remembered while suppressed and can be restored if it is toggled off.
 		this.#isLocked = !!locked
 
-		// If it changed, redraw
-		for (const surface of this.surfaceHandlers) {
-			surface.setLocked(locked)
-		}
+		this.#applyLockedToSurfaces()
 
 		return true
 	}
 
 	/**
-	 * Ensure all surfaces in this group have the correct locked state
+	 * Push the effective locked state to all surfaces in this group.
+	 * A group configured to never lock is always pushed as unlocked.
 	 */
-	syncLocked(): void {
-		if (this.isAutoGroup) return
+	#applyLockedToSurfaces(): void {
+		const locked = this.#isLocked && !this.groupConfig.never_lock
 
 		for (const surface of this.surfaceHandlers) {
-			surface.setLocked(this.#isLocked)
+			surface.setLocked(locked)
 		}
 	}
 
@@ -517,6 +514,9 @@ export function validateGroupConfigValue(pageStore: IPageStore, key: string, val
 
 			return value
 		}
+		case 'never_lock':
+			return Boolean(value)
+
 		case 'restrict_pages':
 			return Boolean(value)
 

--- a/companion/lib/Surface/Handler.ts
+++ b/companion/lib/Surface/Handler.ts
@@ -156,11 +156,6 @@ export class SurfaceHandler extends EventEmitter<SurfaceHandlerEvents> {
 		// Setup logger to use the name
 		this.#recreateLogger()
 
-		if (this.#surfaceConfig.config.never_lock) {
-			// if device can't be locked, then make sure it isnt already locked
-			this.#isSurfaceLocked = false
-		}
-
 		this.#graphics.on('button_drawn', this.#onButtonDrawn)
 
 		this.panel.on('click', this.#onDeviceClick.bind(this))
@@ -304,9 +299,6 @@ export class SurfaceHandler extends EventEmitter<SurfaceHandlerEvents> {
 	 * Set the surface as locked
 	 */
 	setLocked(locked: boolean, skipDraw = false): boolean {
-		// skip if surface can't be locked
-		if (this.#surfaceConfig.config.never_lock && locked) return false
-
 		if (this.#isSurfaceLocked === !!locked) return false
 
 		this.#isSurfaceLocked = !!locked
@@ -623,11 +615,6 @@ export class SurfaceHandler extends EventEmitter<SurfaceHandlerEvents> {
 		)
 			redraw = true
 		if (newconfig.rotation != this.#surfaceConfig.config.rotation) redraw = true
-
-		if (newconfig.never_lock && newconfig.never_lock != this.#surfaceConfig.config.never_lock) {
-			this.setLocked(false, true)
-			redraw = true
-		}
 
 		// if this is an import, the config file may have been missing fields:
 		//  (note: import does not call `createOrSanitizeSurfaceHandlerConfig`, which might be a better option?)

--- a/companion/lib/Surface/IP/ElgatoEmulator.ts
+++ b/companion/lib/Surface/IP/ElgatoEmulator.ts
@@ -18,7 +18,7 @@ import type { CompanionSurfaceConfigField, GridSize } from '@companion-app/share
 import type { ImageResult } from '../../Graphics/ImageResult.js'
 import LogController from '../../Log/Controller.js'
 import { ImageWriteQueue } from '../../Resources/ImageWriteQueue.js'
-import { LockConfigFields, OffsetConfigFields, RotationConfigField } from '../CommonConfigFields.js'
+import { OffsetConfigFields, RotationConfigField } from '../CommonConfigFields.js'
 import type { DrawButtonItem, SurfacePanel, SurfacePanelEvents, SurfacePanelInfo } from '../Types.js'
 
 export function EmulatorRoom(id: string): string {
@@ -66,7 +66,6 @@ const configFields: CompanionSurfaceConfigField[] = [
 		label: 'Prompt to enter fullscreen',
 		default: DefaultConfig.emulator_prompt_fullscreen,
 	},
-	...LockConfigFields,
 ]
 
 export type EmulatorUpdateEvents = {

--- a/companion/lib/Surface/IP/Satellite.ts
+++ b/companion/lib/Surface/IP/Satellite.ts
@@ -26,12 +26,7 @@ import type {
 	SatelliteControlStylePreset,
 	SatelliteSurfaceLayout,
 } from '../../Service/Satellite/SatelliteSurfaceManifestSchema.js'
-import {
-	BrightnessConfigField,
-	LockConfigFields,
-	OffsetConfigFields,
-	RotationConfigField,
-} from '../CommonConfigFields.js'
+import { BrightnessConfigField, OffsetConfigFields, RotationConfigField } from '../CommonConfigFields.js'
 import { createSurfaceConfigPayload } from '../PluginConfigFields.js'
 import type {
 	DrawButtonItem,
@@ -87,7 +82,7 @@ function generateConfigFields(
 	if (deviceInfo.supportsBrightness) {
 		fields.push(BrightnessConfigField)
 	}
-	fields.push(RotationConfigField, ...LockConfigFields)
+	fields.push(RotationConfigField)
 
 	if (deviceInfo.canChangePage) {
 		fields.push({

--- a/companion/lib/Surface/PluginPanel.ts
+++ b/companion/lib/Surface/PluginPanel.ts
@@ -21,12 +21,7 @@ import type {
 import LogController, { type Logger } from '../Log/Controller.js'
 import { ImageWriteQueue } from '../Resources/ImageWriteQueue.js'
 import { parseColorToNumber } from '../Resources/Util.js'
-import {
-	BrightnessConfigField,
-	LockConfigFields,
-	OffsetConfigFields,
-	RotationConfigField,
-} from './CommonConfigFields.js'
+import { BrightnessConfigField, OffsetConfigFields, RotationConfigField } from './CommonConfigFields.js'
 import type {
 	DrawButtonItem,
 	SurfaceExecuteExpressionFn,
@@ -59,7 +54,7 @@ function generateConfigFields(
 
 	// If there are any controls, add rotation and lock config
 	if (gridSize.columns > 0 && gridSize.rows > 0) {
-		fields.push(RotationConfigField, ...LockConfigFields)
+		fields.push(RotationConfigField)
 	}
 
 	if (surfaceInfo.canChangePage) {

--- a/companion/test/Surface/Group-locking.test.ts
+++ b/companion/test/Surface/Group-locking.test.ts
@@ -1,0 +1,170 @@
+import EventEmitter from 'node:events'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { SurfaceGroup } from '../../lib/Surface/Group.js'
+import { SuppressLogging } from '../Util.js'
+
+/**
+ * These tests exercise the `never_lock` masking behaviour of `SurfaceGroup`:
+ * `#isLocked` tracks the intended lock state, and `never_lock` suppresses it
+ * only when pushing to the member surfaces.
+ */
+
+interface FakeSurface {
+	surfaceId: string
+	displayName: string
+	lockLog: boolean[]
+	readonly lastLocked: boolean | undefined
+	setLocked: (locked: boolean, skipDraw?: boolean) => boolean
+	storeNewDevicePage: () => void
+	getGroupConfig: () => any
+	saveGroupConfig: (config: any) => void
+}
+
+function makeSurface(id: string, autoGroupConfig: any = {}): FakeSurface {
+	return {
+		surfaceId: id,
+		displayName: id,
+		lockLog: [],
+		get lastLocked() {
+			return this.lockLog[this.lockLog.length - 1]
+		},
+		setLocked(locked: boolean) {
+			this.lockLog.push(locked)
+			return true
+		},
+		storeNewDevicePage() {},
+		getGroupConfig: () => autoGroupConfig,
+		saveGroupConfig(config: any) {
+			autoGroupConfig = config
+		},
+	}
+}
+
+function makeDeps(storedGroupConfig: Record<string, any> = {}) {
+	const store = new Map<string, any>(Object.entries(storedGroupConfig))
+	const dbTable = {
+		getOrDefault: (id: string, def: any) => (store.has(id) ? store.get(id) : structuredClone(def)),
+		set: (id: string, val: any) => store.set(id, val),
+		delete: (id: string) => store.delete(id),
+		get: (id: string) => store.get(id),
+	}
+	const pageStore = {
+		getFirstPageId: () => 'page-1',
+		isPageIdValid: (id: string) => id === 'page-1',
+		getPageInfo: () => undefined,
+		on: () => {},
+		off: () => {},
+	}
+	const userconfig = { getKey: () => undefined }
+	const surfaceController = { emit: () => {} }
+	const updateEvents = new EventEmitter()
+
+	return { dbTable, pageStore, userconfig, surfaceController, updateEvents }
+}
+
+function makeGroup(opts: {
+	groupId: string
+	soleHandler?: FakeSurface | null
+	isLocked?: boolean
+	storedConfig?: Record<string, any>
+}): SurfaceGroup {
+	const deps = makeDeps(opts.storedConfig ?? {})
+	return new SurfaceGroup(
+		deps.surfaceController as any,
+		deps.dbTable as any,
+		deps.pageStore as any,
+		deps.userconfig as any,
+		deps.updateEvents,
+		opts.groupId,
+		(opts.soleHandler ?? null) as any,
+		opts.isLocked ?? false
+	)
+}
+
+describe('SurfaceGroup never_lock masking', () => {
+	SuppressLogging()
+
+	describe('explicit (multi-surface) group', () => {
+		let group: SurfaceGroup
+		let s1: FakeSurface
+		let s2: FakeSurface
+
+		beforeEach(() => {
+			group = makeGroup({ groupId: 'explicit-1', soleHandler: null, isLocked: false })
+			s1 = makeSurface('s1')
+			s2 = makeSurface('s2')
+			group.attachSurface(s1 as any)
+			group.attachSurface(s2 as any)
+		})
+
+		it('locks all member surfaces when the group locks', () => {
+			group.setLocked(true)
+			expect(s1.lastLocked).toBe(true)
+			expect(s2.lastLocked).toBe(true)
+		})
+
+		it('suppresses the lock on the surfaces while never_lock is on, but restores it when turned off', () => {
+			group.setLocked(true)
+			expect(s1.lastLocked).toBe(true)
+
+			// Turning never_lock on must push the surfaces unlocked...
+			group.setGroupConfigValue('never_lock', true)
+			expect(s1.lastLocked).toBe(false)
+			expect(s2.lastLocked).toBe(false)
+
+			// ...without losing the intended locked state - turning it back off re-locks them
+			group.setGroupConfigValue('never_lock', false)
+			expect(s1.lastLocked).toBe(true)
+			expect(s2.lastLocked).toBe(true)
+		})
+
+		it('never pushes a locked state while never_lock is on', () => {
+			group.setGroupConfigValue('never_lock', true)
+			group.setLocked(true)
+			expect(s1.lastLocked).toBe(false)
+			expect(s2.lastLocked).toBe(false)
+		})
+
+		it('keeps a surface unlocked when it joins a never_lock group that intends to be locked', () => {
+			group.setLocked(true)
+			group.setGroupConfigValue('never_lock', true)
+
+			const s3 = makeSurface('s3')
+			group.attachSurface(s3 as any)
+
+			expect(s3.lastLocked).toBe(false)
+		})
+	})
+
+	describe('group configured to never_lock from the start', () => {
+		it('does not lock its surfaces', () => {
+			const group = makeGroup({
+				groupId: 'explicit-2',
+				soleHandler: null,
+				isLocked: false,
+				storedConfig: { 'explicit-2': { name: 'g', use_last_page: true, never_lock: true } },
+			})
+			const s1 = makeSurface('s1')
+			group.attachSurface(s1 as any)
+
+			group.setLocked(true)
+
+			expect(s1.lastLocked).toBe(false)
+		})
+	})
+
+	describe('auto-group', () => {
+		it('masks and restores the lock for its sole surface', () => {
+			const surface = makeSurface('auto-1', { never_lock: true })
+			const group = makeGroup({ groupId: 'auto-1', soleHandler: surface, isLocked: false })
+
+			// Intends to lock, but never_lock suppresses it
+			group.setLocked(true)
+			expect(surface.lastLocked).toBe(false)
+
+			// Turning never_lock off restores the intended lock
+			group.setGroupConfigValue('never_lock', false)
+			expect(surface.lastLocked).toBe(true)
+		})
+	})
+})

--- a/companion/test/Upgrade/v14tov15-upgradeStartup.test.ts
+++ b/companion/test/Upgrade/v14tov15-upgradeStartup.test.ts
@@ -1,0 +1,108 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+import { createTables } from '../../lib/Data/Schema/v1.js'
+import { DataStoreBase } from '../../lib/Data/StoreBase.js'
+import v14tov15 from '../../lib/Data/Upgrades/v14tov15.js'
+import LogController from '../../lib/Log/Controller.js'
+import { SuppressLogging } from '../Util.js'
+
+class DataDatabase extends DataStoreBase<any> {
+	constructor() {
+		super(':memory:', '', 'main', 'Data/Database')
+		this.startSQLite()
+	}
+	protected create(): void {
+		createTables(this.store, this.defaultTable, this.logger)
+	}
+	protected loadDefaults(): void {}
+	protected migrateFileToSqlite(): void {}
+}
+
+function makeSurface(groupId: string | null, neverLock: boolean | undefined) {
+	const config: Record<string, any> = { brightness: 100 }
+	if (neverLock !== undefined) config.never_lock = neverLock
+
+	return {
+		config,
+		groupConfig: { name: 'Auto group' },
+		groupId,
+	}
+}
+
+describe('v14tov15 upgradeStartup', () => {
+	SuppressLogging()
+
+	const db = new DataDatabase()
+	const logger = LogController.createLogger('test-logger')
+
+	beforeAll(() => {
+		const surfaces = db.getTableView('surfaces')
+		const groups = db.getTableView('surface_groups')
+
+		// Auto-group surfaces (not part of an explicit group)
+		surfaces.set('auto-locked', makeSurface(null, true))
+		surfaces.set('auto-unlocked', makeSurface(null, false))
+
+		// Members of an explicit group with mixed never_lock - the group should end up locked-exempt
+		surfaces.set('member-a', makeSurface('explicit-1', false))
+		surfaces.set('member-b', makeSurface('explicit-1', true))
+
+		// Members of a second explicit group, none exempt
+		surfaces.set('member-c', makeSurface('explicit-2', false))
+
+		// A surface from before the field existed - must be left alone
+		surfaces.set('legacy', makeSurface(null, undefined))
+
+		groups.set('explicit-1', { name: 'Group One', use_last_page: true })
+		groups.set('explicit-2', { name: 'Group Two', use_last_page: true })
+
+		v14tov15.upgradeStartup(db, logger)
+	})
+
+	it('moves never_lock onto an auto-group surface own group config', () => {
+		const surface = db.getTableView('surfaces').get('auto-locked')
+		expect(surface.config.never_lock).toBeUndefined()
+		expect(surface.groupConfig.never_lock).toBe(true)
+	})
+
+	it('preserves a false never_lock on an auto-group surface', () => {
+		const surface = db.getTableView('surfaces').get('auto-unlocked')
+		expect(surface.config.never_lock).toBeUndefined()
+		expect(surface.groupConfig.never_lock).toBe(false)
+	})
+
+	it('removes never_lock from explicit group members but does not store it on the surface', () => {
+		const surfaces = db.getTableView('surfaces')
+		expect(surfaces.get('member-a').config.never_lock).toBeUndefined()
+		expect(surfaces.get('member-b').config.never_lock).toBeUndefined()
+		// The auto group config is not the source of truth for explicit-group members
+		expect(surfaces.get('member-a').groupConfig.never_lock).toBeUndefined()
+		expect(surfaces.get('member-b').groupConfig.never_lock).toBeUndefined()
+	})
+
+	it('OR-merges never_lock from members onto the explicit group', () => {
+		expect(db.getTableView('surface_groups').get('explicit-1').never_lock).toBe(true)
+	})
+
+	it('sets never_lock false on an explicit group where no member was exempt', () => {
+		expect(db.getTableView('surface_groups').get('explicit-2').never_lock).toBe(false)
+	})
+
+	it('leaves a surface without the field untouched', () => {
+		const surface = db.getTableView('surfaces').get('legacy')
+		expect('never_lock' in surface.config).toBe(false)
+		expect('never_lock' in surface.groupConfig).toBe(false)
+	})
+
+	it('is idempotent when run again', () => {
+		// Snapshot the migrated state
+		const before = {
+			surfaces: db.getTableView('surfaces').all(),
+			groups: db.getTableView('surface_groups').all(),
+		}
+
+		v14tov15.upgradeStartup(db, logger)
+
+		expect(db.getTableView('surfaces').all()).toEqual(before.surfaces)
+		expect(db.getTableView('surface_groups').all()).toEqual(before.groups)
+	})
+})

--- a/shared-lib/lib/Model/ExportModel.ts
+++ b/shared-lib/lib/Model/ExportModel.ts
@@ -11,7 +11,7 @@ import type { UserConfigGridSize } from './UserConfigModel.js'
 export type SomeExportv6 = ExportFullv6 | ExportPageModelv6 | ExportTriggersListv6
 
 export interface ExportBase<Type extends string> {
-	readonly version: 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14
+	readonly version: 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15
 	readonly type: Type
 	readonly companionBuild: string | undefined // The build of the companion that exported this
 }

--- a/shared-lib/lib/Model/Surfaces.ts
+++ b/shared-lib/lib/Model/Surfaces.ts
@@ -88,6 +88,7 @@ export interface SurfaceGroupConfig {
 	last_page_id: string
 	startup_page_id: string
 	use_last_page: boolean
+	never_lock: boolean
 	restrict_pages?: boolean
 	allowed_page_ids?: string[]
 
@@ -105,7 +106,6 @@ export interface SurfacePanelConfig {
 	rotation: SurfaceRotation
 
 	// companion owned defaults
-	never_lock: boolean
 	xOffset: number
 	yOffset: number
 	groupId: string | null

--- a/webui/src/Surfaces/EditPanel.tsx
+++ b/webui/src/Surfaces/EditPanel.tsx
@@ -328,6 +328,7 @@ const SurfaceEditPanelContent = observer<SurfaceEditPanelContentProps>(function 
 	const currentPageFieldId = useId()
 	const restrictPagesFieldId = useId()
 	const allowedPagesFieldId = useId()
+	const neverLockFieldId = useId()
 
 	// Show loading or error state
 	const dataReady = (!surfaceId || !!surfaceConfig.config) && (!groupId || groupConfig.config !== null)
@@ -479,6 +480,19 @@ const SurfaceEditPanelContent = observer<SurfaceEditPanelContentProps>(function 
 								</Grid.Col>
 							</>
 						)}
+
+						<FormLabel htmlFor={neverLockFieldId} className="col-sm-4 col-form-label col-form-label-sm">
+							Never pin code lock
+						</FormLabel>
+						<Grid.Col sm={8}>
+							<div className="mx-2">
+								<SwitchInputField
+									id={neverLockFieldId}
+									value={!!groupConfig.config.never_lock}
+									setValue={(value) => setGroupConfigValue('never_lock', !!value)}
+								/>
+							</div>
+						</Grid.Col>
 					</>
 				)}
 


### PR DESCRIPTION
Closes https://github.com/bitfocus/companion/issues/3827

Move it to the groups, as whole groups are locked and unlocked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **“Never pin code lock”** setting for surface groups.

* **Bug Fixes**
  * Existing surface configurations are now upgraded so lock-related settings are stored at the group level.
  * Group lock behavior now respects the new setting consistently, including shared and auto-grouped surfaces.
  * Import and startup upgrades now preserve the latest configuration version more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->