### PR TITLE
Fix: deep cloning of preset to prevent erroneous changes

### DIFF
--- a/companion/lib/Instance/Definitions.ts
+++ b/companion/lib/Instance/Definitions.ts
@@ -404,10 +404,7 @@ export class InstanceDefinitions extends EventEmitter<InstanceDefinitionsEvents>
 
 		if (!variableValues) return structuredClone(definition.model)
 
-		const model: LayeredButtonModel = {
-			...structuredClone(definition.model),
-			localVariables: structuredClone(definition.model.localVariables),
-		}
+		const model: LayeredButtonModel = structuredClone(definition.model)
 
 		injectOverriddenLocalVariableValues(model.localVariables, variableValues)
 

--- a/companion/lib/Instance/Definitions.ts
+++ b/companion/lib/Instance/Definitions.ts
@@ -402,10 +402,10 @@ export class InstanceDefinitions extends EventEmitter<InstanceDefinitionsEvents>
 		const definition = this.#presetDefinitions[connectionId]?.get(presetId)
 		if (!definition || definition.type !== 'button') return null
 
-		if (!variableValues) return definition.model
+		if (!variableValues) return structuredClone(definition.model)
 
 		const model: LayeredButtonModel = {
-			...definition.model,
+			...structuredClone(definition.model),
 			localVariables: structuredClone(definition.model.localVariables),
 		}
 


### PR DESCRIPTION
Resolves #4306 

Simply wraps the `definition.model` in a `structuredClone` to prevent any modification of the button after a preset gets dragged on to it from impacting the original preset object that's being referenced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preset handling by returning and generating preset-derived control models as independent deep copies.
  * Prevented overridden variable/local values from unintentionally mutating the original preset-backed model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->