### PR TITLE
fix: standalone pipe for child ipc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           node-version-file: ".node-version"
       - name: yarn install
         run: |
-          corepack enable
+          npm install -g corepack --force
 
           # try and avoid timeout errors
           yarn config set httpTimeout 100000

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [
+            ubuntu-latest,
+            # windows-latest, macos-latest
+          ]
     timeout-minutes: 20
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,12 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v7

--- a/companion/lib/Instance/Common/DataChannelClient.ts
+++ b/companion/lib/Instance/Common/DataChannelClient.ts
@@ -1,0 +1,48 @@
+/*
+ * Child side of the module data channel transport (see DataChannelServer.ts for why this is a socket rather
+ * than an inherited stdio fd). Kept apart from the server so a child never pulls the host code into its bundle.
+ */
+
+import net from 'node:net'
+
+const CONNECT_ATTEMPTS = 10
+const CONNECT_RETRY_INTERVAL = 100
+
+/**
+ * Connect to the host's data channel. The host listens before spawning us, so the first attempt should
+ * always succeed; the retries are only a guard against a slow or contended socket at startup.
+ *
+ * This covers the initial connect only. Once connected, losing the socket is terminal - the host will not
+ * accept a replacement without respawning the process.
+ */
+export async function connectDataChannel(socketPath: string): Promise<net.Socket> {
+	let lastError: unknown = null
+
+	for (let attempt = 0; attempt < CONNECT_ATTEMPTS; attempt++) {
+		if (attempt > 0) await new Promise((resolve) => setTimeout(resolve, CONNECT_RETRY_INTERVAL))
+
+		try {
+			return await connectOnce(socketPath)
+		} catch (e) {
+			lastError = e
+		}
+	}
+
+	throw new Error(`Failed to connect to host data channel "${socketPath}": ${lastError}`)
+}
+
+async function connectOnce(socketPath: string): Promise<net.Socket> {
+	return new Promise<net.Socket>((resolve, reject) => {
+		const socket = net.connect(socketPath)
+
+		const onError = (err: Error) => {
+			socket.destroy()
+			reject(err)
+		}
+		socket.once('error', onError)
+		socket.once('connect', () => {
+			socket.off('error', onError)
+			resolve(socket)
+		})
+	})
+}

--- a/companion/lib/Instance/Common/DataChannelServer.ts
+++ b/companion/lib/Instance/Common/DataChannelServer.ts
@@ -1,0 +1,163 @@
+/*
+ * Host side of the module data channel transport.
+ *
+ * The framed message transport (see FramedMessageChannel.ts) used to ride on an extra stdio fd, but that
+ * cannot work on Windows: libuv implements stdio fd 3+ as named pipes rather than inheritable fds, so the
+ * child has no fd to attach a net.Socket to. Instead the host listens on a socket (a named pipe on Windows,
+ * a unix domain socket elsewhere), passes the path to the child via env, and the child connects back.
+ *
+ * Holding the path is the capability - it carries a random component and lives in a directory only the
+ * current user can write to - so no separate handshake is needed to authenticate the child.
+ */
+
+import crypto from 'node:crypto'
+import { EventEmitter } from 'node:events'
+import fs from 'node:fs/promises'
+import net from 'node:net'
+import os from 'node:os'
+import path from 'node:path'
+import LogController, { type Logger } from '../../Log/Controller.js'
+
+/**
+ * Generate a unique path for a child's data channel. Kept short, as unix domain socket paths are limited to
+ * ~104 characters on macOS and ~108 on Linux.
+ */
+export function makeDataChannelPath(pid: number = process.pid): string {
+	const id = `${pid}-${crypto.randomBytes(6).toString('hex')}`
+	return process.platform === 'win32'
+		? `\\\\.\\pipe\\companion-ipc-${id}`
+		: path.join(os.tmpdir(), `companion-ipc-${id}.sock`)
+}
+
+export interface DataChannelServerEvents {
+	/** A child has connected and its socket is ready to carry framed messages */
+	connect: [socket: net.Socket]
+	/** The connected child's socket has gone away. A later `connect` may follow, once the child is respawned */
+	disconnect: []
+}
+
+/**
+ * A listening socket for exactly one child process at a time.
+ *
+ * The child is respawned repeatedly by RespawnMonitor and each incarnation connects afresh, so the server
+ * outlives any single connection. It only accepts a connection when one is expected - that is, when a spawn
+ * has happened since the last one connected. Anything else is a client that should not know the path at all,
+ * so it is dropped and logged rather than trusted.
+ */
+export class DataChannelServer extends EventEmitter<DataChannelServerEvents> {
+	readonly #logger: Logger
+	readonly #server: net.Server
+	readonly socketPath: string
+
+	#socket: net.Socket | null = null
+	#expectingConnection = false
+	#closed = false
+
+	private constructor(socketPath: string, instanceId: string) {
+		super()
+
+		this.#logger = LogController.createLogger(`Instance/DataChannel/${instanceId}`)
+		this.socketPath = socketPath
+		this.#server = net.createServer((socket) => this.#handleConnection(socket))
+		this.#server.on('error', (err) => {
+			// Nothing to recover here - a child that cannot reach us fails to register and is restarted.
+			if (!this.#closed) this.#logger.error(`Data channel server error: ${err}`)
+		})
+	}
+
+	/**
+	 * Create a server and wait for it to be listening. Must complete before the child is spawned, so the
+	 * child never races against a socket that does not exist yet.
+	 */
+	static async create(instanceId: string): Promise<DataChannelServer> {
+		const server = new DataChannelServer(makeDataChannelPath(), instanceId)
+		await server.#listen()
+		return server
+	}
+
+	async #listen(): Promise<void> {
+		try {
+			await this.#listenOnce()
+		} catch (e: any) {
+			// A leftover socket file from an unclean exit. The path carries a random component so this should
+			// not be reachable, but recovering costs one unlink and it would otherwise be unstartable forever.
+			if (e?.code !== 'EADDRINUSE' || process.platform === 'win32') throw e
+
+			this.#logger.warn(`Removing stale data channel socket "${this.socketPath}"`)
+			await fs.rm(this.socketPath, { force: true })
+			await this.#listenOnce()
+		}
+	}
+
+	async #listenOnce(): Promise<void> {
+		return new Promise<void>((resolve, reject) => {
+			const onError = (err: Error) => {
+				this.#server.off('listening', onListening)
+				reject(err)
+			}
+			const onListening = () => {
+				this.#server.off('error', onError)
+				resolve()
+			}
+
+			this.#server.once('error', onError)
+			this.#server.once('listening', onListening)
+			this.#server.listen(this.socketPath)
+		})
+	}
+
+	/**
+	 * Tell the server a child is about to start, so the next connection is a legitimate one.
+	 * Any socket from a previous incarnation of the child is dropped.
+	 */
+	expectConnection(): void {
+		if (this.#closed) return
+
+		this.#dropSocket()
+		this.#expectingConnection = true
+	}
+
+	#handleConnection(socket: net.Socket): void {
+		if (!this.#expectingConnection) {
+			// Each child builds its data socket once, in its entrypoint, and cannot rebuild it without being
+			// respawned - which would have armed expectConnection() first. So this is either a second socket
+			// from a child that should not have opened one, or a client that is not our child at all.
+			this.#logger.warn(`Rejected unexpected connection to data channel "${this.socketPath}"`)
+			socket.destroy()
+			return
+		}
+
+		this.#expectingConnection = false
+		this.#socket = socket
+
+		socket.on('close', () => {
+			// A child that has lost its socket cannot get another; treat it as gone until it is respawned.
+			if (this.#socket !== socket) return
+			this.#socket = null
+			this.emit('disconnect')
+		})
+
+		this.emit('connect', socket)
+	}
+
+	#dropSocket(): void {
+		const socket = this.#socket
+		if (!socket) return
+
+		this.#socket = null
+		socket.destroy()
+		this.emit('disconnect')
+	}
+
+	/**
+	 * Stop listening and tear down any live connection. On posix this unlinks the socket file, so nothing is
+	 * left behind once the child is gone; windows reclaims named pipes itself.
+	 */
+	close(): void {
+		if (this.#closed) return
+		this.#closed = true
+
+		this.#dropSocket()
+		this.#server.close()
+	}
+}

--- a/companion/lib/Instance/Common/FramedMessageChannel.ts
+++ b/companion/lib/Instance/Common/FramedMessageChannel.ts
@@ -1,14 +1,15 @@
 /*
  * The stateful side of the framed module IPC transport (see MessageFraming.ts for the wire format).
  *
- * FramedChannel wraps a single duplex stream (a raw 'pipe' stdio fd): it frames outbound messages with
+ * FramedChannel wraps a single duplex stream (the data channel socket): it frames outbound messages with
  * backpressure handling and decodes inbound frames. HostFramedTransport adds the host-side respawn
- * lifecycle - the child (and its fd streams) is replaced on every restart, so it rebinds a fresh
- * FramedChannel on each RespawnMonitor 'spawn'.
+ * lifecycle - the child is replaced on every restart, and each incarnation opens its own socket, so it
+ * rebinds a fresh FramedChannel on each DataChannelServer 'connect'.
  */
 
+import type { Socket } from 'node:net'
 import type { Duplex } from 'node:stream'
-import type { RespawnChild, RespawnMonitor } from '@companion-app/shared/Respawn.js'
+import type { DataChannelServer } from './DataChannelServer.js'
 import { encodeFrame, FrameDecoder } from './MessageFraming.js'
 
 /** Called for each decoded inbound message, with the exact wire byte count of its body. */
@@ -24,11 +25,14 @@ export class FramedChannel {
 	readonly #decoder = new FrameDecoder()
 	readonly #writeQueue: Buffer[] = []
 	#blocked = false
+	#destroyed = false
 
 	constructor(stream: Duplex, onMessage: FramedMessageHandler) {
 		this.#stream = stream
 
 		stream.on('data', (chunk: Buffer) => {
+			if (this.#destroyed) return
+
 			let frames
 			try {
 				frames = this.#decoder.push(chunk)
@@ -39,6 +43,7 @@ export class FramedChannel {
 				return
 			}
 			for (const frame of frames) {
+				if (this.#destroyed) return
 				onMessage(frame.message, frame.bodyBytes)
 			}
 		})
@@ -51,13 +56,27 @@ export class FramedChannel {
 	}
 
 	/**
-	 * Queue a message for sending. Returns the exact body byte count put on the wire (for metrics).
+	 * Queue a message for sending. Returns the exact body byte count put on the wire (for metrics), or 0 once
+	 * the channel has been destroyed.
 	 */
 	send(message: unknown): number {
+		if (this.#destroyed) return 0
+
 		const { frame, bodyBytes } = encodeFrame(message)
 		this.#writeQueue.push(frame)
 		this.#flush()
 		return bodyBytes
+	}
+
+	/**
+	 * Stop carrying messages in either direction. Anything still in flight on the stream is discarded rather
+	 * than delivered, so a late message cannot land on an owner that has already torn itself down.
+	 *
+	 * The stream itself is left alone - it belongs to the child's lifecycle, not to this channel.
+	 */
+	destroy(): void {
+		this.#destroyed = true
+		this.#writeQueue.length = 0
 	}
 
 	#flush(): void {
@@ -70,28 +89,48 @@ export class FramedChannel {
 }
 
 /**
- * Host-side transport over a child's extra stdio fd. Rebinds a fresh FramedChannel whenever the child is
- * (re)spawned, so partial-frame state from a dead child can never bleed into the next one.
+ * Host-side transport over the child's data channel socket. Binds a fresh FramedChannel each time a child
+ * connects, so partial-frame state from a dead child can never bleed into the next one, and drops it again
+ * when that child goes away so messages are not written into a dead socket.
  */
 export class HostFramedTransport {
+	readonly #dataChannel: DataChannelServer
+	readonly #onConnect: (socket: Socket) => void
+	readonly #onDisconnect: () => void
+
 	#channel: FramedChannel | null = null
 
-	constructor(monitor: RespawnMonitor, fd: number, onMessage: FramedMessageHandler) {
-		const bind = (child: RespawnChild) => {
-			const stream = child.stdio[fd] as Duplex | undefined
-			if (!stream) return
-			this.#channel = new FramedChannel(stream, onMessage)
+	constructor(dataChannel: DataChannelServer, onMessage: FramedMessageHandler) {
+		this.#dataChannel = dataChannel
+
+		this.#onConnect = (socket) => {
+			this.#channel = new FramedChannel(socket, onMessage)
+		}
+		this.#onDisconnect = () => {
+			this.#channel?.destroy()
+			this.#channel = null
 		}
 
-		monitor.on('spawn', bind)
-		if (monitor.child) bind(monitor.child)
+		dataChannel.on('connect', this.#onConnect)
+		dataChannel.on('disconnect', this.#onDisconnect)
 	}
 
 	/**
-	 * Send a message to the current child. Returns the body byte count, or 0 if no child is running.
+	 * Send a message to the current child. Returns the body byte count, or 0 if no child is connected.
 	 */
 	send(message: unknown): number {
 		if (!this.#channel) return 0
 		return this.#channel.send(message)
+	}
+
+	/**
+	 * Permanently stop carrying messages, in either direction, for an owner that is being torn down. A child
+	 * that is still alive (or one that connects later) can no longer deliver a message into stale state.
+	 */
+	destroy(): void {
+		this.#dataChannel.off('connect', this.#onConnect)
+		this.#dataChannel.off('disconnect', this.#onDisconnect)
+
+		this.#onDisconnect()
 	}
 }

--- a/companion/lib/Instance/Connection/ChildHandlerNew.ts
+++ b/companion/lib/Instance/Connection/ChildHandlerNew.ts
@@ -16,7 +16,6 @@ import {
 	type ExpressionableOptionsObject,
 	type SomeCompanionInputField,
 } from '@companion-app/shared/Model/Options.js'
-import type { RespawnMonitor } from '@companion-app/shared/Respawn.js'
 import { stringifyError } from '@companion-app/shared/Stringify.js'
 import { assertNever, type CompanionHTTPRequest, type LogLevel, type OSCMetaArgument } from '@companion-module/base'
 import type { SharedUdpSocketMessageJoin, SharedUdpSocketMessageLeave } from '@companion-module/base/host-api'
@@ -24,6 +23,7 @@ import type { JsonValue } from '@companion-module/host'
 import type { ControlEntityInstance } from '../../Controls/Entities/EntityInstance.js'
 import type { IControlStore } from '../../Controls/IControlStore.js'
 import LogController, { type Logger } from '../../Log/Controller.js'
+import type { DataChannelServer } from '../Common/DataChannelServer.js'
 import { HostFramedTransport } from '../Common/FramedMessageChannel.js'
 import { IpcWrapper, type IpcEventHandlers, type IpcMessagePacket } from '../Common/IpcWrapper.js'
 import type { ChildProcessHandlerBase } from '../ProcessManager.js'
@@ -89,7 +89,7 @@ export class ConnectionChildHandlerNew implements ChildProcessHandlerBase, Conne
 
 	constructor(
 		deps: ConnectionChildHandlerDependencies,
-		monitor: RespawnMonitor,
+		dataChannel: DataChannelServer,
 		connectionId: string,
 		apiVersion0: string,
 		onRegister: (verificationToken: string) => Promise<void>
@@ -132,12 +132,11 @@ export class ConnectionChildHandlerNew implements ChildProcessHandlerBase, Conne
 			sharedUdpSocketSend: this.#handleSharedUdpSocketSend.bind(this),
 		}
 
-		// Framed message transport over the dedicated 'pipe' fd (fd 4). Owning the serialization means one
+		// Framed message transport over the child's data channel socket. Owning the serialization means one
 		// JSON.stringify per message and an exact wire byte count for metrics - no object-mode double-encode.
-		// Created before the IpcWrapper: its onMessage uses #ipcWrapper lazily (no message arrives until
-		// monitor.start(), after this constructor), and the monitor isn't started yet so it only arms its
-		// 'spawn' listener now.
-		const transport = new HostFramedTransport(monitor, 4, (msg, bytes) => {
+		// Created before the IpcWrapper: its onMessage uses #ipcWrapper lazily (no message arrives until the
+		// child connects, after this constructor), so it only arms its listeners now.
+		const transport = new HostFramedTransport(dataChannel, (msg, bytes) => {
 			this.#deps.trackIpcMessage(this.connectionId, 'received', bytes)
 			this.#ipcWrapper.receivedMessage(msg as IpcMessagePacket)
 		})
@@ -157,8 +156,7 @@ export class ConnectionChildHandlerNew implements ChildProcessHandlerBase, Conne
 			this.connectionId
 		)
 
-		// The transport binds to the monitor, which is discarded on restart; nothing persistent to unbind.
-		this.#unsubListeners = () => undefined
+		this.#unsubListeners = () => transport.destroy()
 	}
 
 	/**

--- a/companion/lib/Instance/Connection/Thread/Entrypoint.ts
+++ b/companion/lib/Instance/Connection/Thread/Entrypoint.ts
@@ -1,8 +1,8 @@
 /* eslint-disable n/no-process-exit */
 import fs from 'node:fs/promises'
-import net from 'node:net'
 import type { ModuleManifest } from '@companion-module/base/manifest'
 import { createModuleLogger, InstanceWrapper, registerLoggingSink } from '@companion-module/host'
+import { connectDataChannel } from '../../Common/DataChannelClient.js'
 import { FramedChannel } from '../../Common/FramedMessageChannel.js'
 import { IpcWrapper } from '../../Common/IpcWrapper.js'
 import { importModuleFromPath } from '../../Common/ThreadUtil.js'
@@ -41,7 +41,23 @@ const verificationToken = process.env.VERIFICATION_TOKEN
 if (typeof verificationToken !== 'string' || !verificationToken)
 	throw new Error('Module initialise is missing VERIFICATION_TOKEN')
 
+const dataChannelPath = process.env.MODULE_DATA_CHANNEL
+if (!dataChannelPath) throw new Error('Module initialise is missing MODULE_DATA_CHANNEL')
+
+// Everything the host passed us has now been captured, so take it back out of the environment. Module code
+// runs in this process and has no business reading these.
+delete process.env.MODULE_ENTRYPOINT
+delete process.env.MODULE_MANIFEST
+delete process.env.VERIFICATION_TOKEN
+delete process.env.MODULE_DATA_CHANNEL
+
 const logger = createModuleLogger('Entrypoint')
+
+// The host is listening before it spawns us, so this connects immediately. It is the only socket this
+// process will ever have: if it is lost the host will not accept a replacement, so we exit and let the
+// host respawn us.
+const dataSocket = await connectDataChannel(dataChannelPath)
+dataSocket.on('close', () => process.exit())
 
 let instance: InstanceWrapper<any> | null = null
 let hostContext: HostContext<any, any> | null = null
@@ -175,11 +191,9 @@ const ipcWrapper = new IpcWrapper<ModuleToHostEventsNew, HostToModuleEventsNew>(
 	},
 	5000
 )
-// Framed message transport over the dedicated 'pipe' fd (fd 4), paired with the host side. The 'ipc'
-// channel (process.send) is retained only for the disconnect lifecycle signal below.
-const channel = new FramedChannel(new net.Socket({ fd: 4, readable: true, writable: true }), (msg) =>
-	ipcWrapper.receivedMessage(msg as any)
-)
+// Framed message transport over the data channel socket, paired with the host side.
+// The 'ipc' channel is retained only for the disconnect signal below.
+const channel = new FramedChannel(dataSocket, (msg) => ipcWrapper.receivedMessage(msg as any))
 
 process.on('disconnect', () => process.exit())
 

--- a/companion/lib/Instance/Connection/Thread/Entrypoint.ts
+++ b/companion/lib/Instance/Connection/Thread/Entrypoint.ts
@@ -63,10 +63,17 @@ let instance: InstanceWrapper<any> | null = null
 let hostContext: HostContext<any, any> | null = null
 let instanceInitialized = false
 
+// The connection id needed to build the instance only arrives in the response to 'register', so the module
+// cannot be imported until after we have registered. The host sends 'init' as soon as it has answered that
+// registration, which can easily beat the import - so 'init' waits for the instance rather than rejecting.
+const { promise: instanceReady, resolve: resolveInstanceReady } = Promise.withResolvers<void>()
+
 // Setup the ipc wrapper, the plugin may not yet exist, but this is better so that we can send log lines out
 const ipcWrapper = new IpcWrapper<ModuleToHostEventsNew, HostToModuleEventsNew>(
 	{
 		init: async (msg): Promise<InitResponseMessage> => {
+			// May arrive before the module import has finished; the host allows time for this
+			await instanceReady
 			if (!instance) throw new Error('Not ready for init')
 
 			const res = await instance.init(msg)
@@ -232,6 +239,9 @@ ipcWrapper
 			moduleUpgradeScripts,
 			msg.moduleApiVersion
 		)
+
+		// Release any 'init' that beat the import here
+		resolveInstanceReady()
 	})
 	.catch((err) => {
 		logger.error(`Module registration failed: ${err}`)

--- a/companion/lib/Instance/ProcessManager.ts
+++ b/companion/lib/Instance/ProcessManager.ts
@@ -18,6 +18,7 @@ import type { SurfaceModuleManifest } from '@companion-surface/host'
 import type { ControlEntityInstance } from '../Controls/Entities/EntityInstance.js'
 import LogController, { type Logger } from '../Log/Controller.js'
 import { isPackaged } from '../Resources/Util.js'
+import { DataChannelServer } from './Common/DataChannelServer.js'
 import type { InstanceConfigStore } from './ConfigStore.js'
 import { doesModuleUseNewChildHandler } from './Connection/ApiVersions.js'
 import type { ConnectionChildHandlerApi, ConnectionChildHandlerDependencies } from './Connection/ChildHandlerApi.js'
@@ -60,6 +61,8 @@ interface ModuleChild {
 	forget?: boolean
 
 	monitor?: RespawnMonitor
+	/** Listening socket carrying the framed message transport. Not used by legacy children. */
+	dataChannel?: DataChannelServer
 	handler?: ChildProcessHandlerBase
 	lifeCycleQueue: PQueue
 	authToken?: string
@@ -310,6 +313,12 @@ export class InstanceProcessManager extends EventEmitter<InstanceProcessManagerE
 				delete child.monitor
 			}
 
+			if (child.dataChannel) {
+				// Stop listening once the child that would connect to it is gone
+				child.dataChannel.close()
+				delete child.dataChannel
+			}
+
 			if (allowDeleteIfEmpty && child.lifeCycleQueue.size === 0) {
 				// Delete the queue now that it is empty
 				this.#children.delete(instanceId)
@@ -528,22 +537,40 @@ export class InstanceProcessManager extends EventEmitter<InstanceProcessManagerE
 				`** API version: ${runtimeInfo.apiVersion} **`
 			)
 
+			// New connections + surfaces carry their messages over a data channel socket (see DataChannelServer);
+			// legacy children only have the 'ipc' channel. The socket must be listening before the child is
+			// spawned, and its path baked into the env the child is spawned with.
+			let dataChannel: DataChannelServer | undefined
+			if (runtimeInfo.usesDataChannel) {
+				try {
+					dataChannel = await DataChannelServer.create(instanceId)
+				} catch (e) {
+					this.#logger.error(`Failed to open data channel for instance "${baseChild.lastLabel}": ${e}`)
+					this.#connectionDeps.instanceStatus.updateInstanceStatus(instanceId, 'system', 'Failed to start')
+					this.emit('childStateChange', instanceId)
+					return
+				}
+				child.dataChannel = dataChannel
+			}
+
 			const monitor = new RespawnMonitor(cmd, {
 				env: {
 					...PreserveEnvVars(),
 					VERIFICATION_TOKEN: child.authToken,
 					MODULE_MANIFEST: 'companion/manifest.json',
+					...(dataChannel ? { MODULE_DATA_CHANNEL: dataChannel.socketPath } : {}),
 					...runtimeInfo.env,
 				},
 				maxRestarts: -1,
 				kill: 5000,
 				cwd: moduleInfo.basePath,
 				fork: false,
-				// fd 3 = 'ipc' (legacy modules + registration/disconnect lifecycle); fd 4 = raw 'pipe' carrying
-				// the framed message transport for new connections + surfaces (see FramedMessageChannel). Legacy
-				// children simply never open fd 4.
-				stdio: ['pipe', 'pipe', 'pipe', 'ipc', 'pipe'],
+				stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
 			})
+
+			// Arm the data channel for each incarnation of the child, so that the one connection it makes is
+			// accepted and anything else is rejected.
+			monitor.on('spawn', () => dataChannel?.expectConnection())
 
 			monitor.on('start', () => {
 				child.isReady = false
@@ -593,7 +620,7 @@ export class InstanceProcessManager extends EventEmitter<InstanceProcessManagerE
 
 			// Create handler and wait for registration + initialization
 			try {
-				await this.#createHandlerAndWaitForInit(child, monitor, runtimeInfo, moduleInfo)
+				await this.#createHandlerAndWaitForInit(child, monitor, dataChannel, runtimeInfo, moduleInfo)
 			} catch (error) {
 				this.#logger.error(`Failed to initialize instance "${child.lastLabel}": ${error}`)
 				throw error
@@ -607,6 +634,7 @@ export class InstanceProcessManager extends EventEmitter<InstanceProcessManagerE
 	async #createHandlerAndWaitForInit(
 		child: ModuleChild,
 		monitor: RespawnMonitor,
+		dataChannel: DataChannelServer | undefined,
 		runtimeInfo: RuntimeInfo,
 		moduleInfo: SomeModuleVersionInfo
 	): Promise<void> {
@@ -737,9 +765,11 @@ export class InstanceProcessManager extends EventEmitter<InstanceProcessManagerE
 		switch (child.targetState.moduleType) {
 			case ModuleInstanceType.Connection:
 				if (doesModuleUseNewChildHandler(runtimeInfo.apiVersion)) {
+					if (!dataChannel) throw new Error('Missing data channel for connection')
+
 					child.handler = new ConnectionChildHandlerNew(
 						this.#connectionDeps,
-						monitor,
+						dataChannel,
 						child.instanceId,
 						runtimeInfo.apiVersion,
 						onRegisterReceived
@@ -755,9 +785,11 @@ export class InstanceProcessManager extends EventEmitter<InstanceProcessManagerE
 				}
 				break
 			case ModuleInstanceType.Surface:
+				if (!dataChannel) throw new Error('Missing data channel for surface')
+
 				child.handler = new SurfaceChildHandler(
 					this.#surfaceDeps,
-					monitor,
+					dataChannel,
 					child.targetState.moduleId,
 					child.instanceId,
 					moduleInfo.manifest as SurfaceModuleManifest,
@@ -791,6 +823,7 @@ export class InstanceProcessManager extends EventEmitter<InstanceProcessManagerE
 				moduleEntrypoint: string
 				apiVersion: string
 				env: Record<string, string>
+				usesDataChannel: boolean
 		  }
 		| { error: string }
 	> {
@@ -850,6 +883,7 @@ export class InstanceProcessManager extends EventEmitter<InstanceProcessManagerE
 						env: {
 							MODULE_ENTRYPOINT: jsFullPath,
 						},
+						usesDataChannel: true,
 					}
 				} else {
 					return {
@@ -860,6 +894,8 @@ export class InstanceProcessManager extends EventEmitter<InstanceProcessManagerE
 						env: {
 							CONNECTION_ID: instanceId,
 						},
+						// Legacy modules talk over the 'ipc' channel instead
+						usesDataChannel: false,
 					}
 				}
 			}
@@ -898,6 +934,7 @@ export class InstanceProcessManager extends EventEmitter<InstanceProcessManagerE
 					env: {
 						MODULE_ENTRYPOINT: jsFullPath,
 					},
+					usesDataChannel: true,
 				}
 			}
 			default:
@@ -938,6 +975,8 @@ interface RuntimeInfo {
 	entrypoint: string
 	apiVersion: string
 	env: Record<string, string>
+	/** Whether the child talks over a data channel socket, rather than the legacy 'ipc' channel */
+	usesDataChannel: boolean
 }
 
 function isConnectionChild(handler: ChildProcessHandlerBase): handler is ConnectionChildHandlerApi {

--- a/companion/lib/Instance/Surface/ChildHandler.ts
+++ b/companion/lib/Instance/Surface/ChildHandler.ts
@@ -1,11 +1,11 @@
 import type { CompanionSurfaceConfigField, OutboundSurfaceInfo } from '@companion-app/shared/Model/Surfaces.js'
-import type { RespawnMonitor } from '@companion-app/shared/Respawn.js'
 import { stringifyError } from '@companion-app/shared/Stringify.js'
 import type { HIDDevice, RemoteSurfaceConnectionInfo, SurfaceModuleManifest } from '@companion-surface/base'
 import LogController, { type Logger } from '../../Log/Controller.js'
 import type { SurfaceController, SurfaceScanHandler } from '../../Surface/Controller.js'
 import { createSurfaceConfigPayload, sanitizePluginConfigFields } from '../../Surface/PluginConfigFields.js'
 import { SurfacePluginPanel } from '../../Surface/PluginPanel.js'
+import type { DataChannelServer } from '../Common/DataChannelServer.js'
 import { HostFramedTransport } from '../Common/FramedMessageChannel.js'
 import { IpcWrapper, type IpcEventHandlers, type IpcMessagePacket } from '../Common/IpcWrapper.js'
 import type { ChildProcessHandlerBase } from '../ProcessManager.js'
@@ -90,7 +90,7 @@ export class SurfaceChildHandler implements ChildProcessHandlerBase, SurfaceScan
 
 	constructor(
 		deps: SurfaceChildHandlerDependencies,
-		monitor: RespawnMonitor,
+		dataChannel: DataChannelServer,
 		moduleId: string,
 		instanceId: string,
 		manifest: SurfaceModuleManifest,
@@ -143,10 +143,10 @@ export class SurfaceChildHandler implements ChildProcessHandlerBase, SurfaceScan
 			'firmware-update-info': this.#handleFirmwareUpdateInfo.bind(this),
 		}
 
-		// Framed message transport over the dedicated 'pipe' fd (fd 4) - one JSON.stringify per message and an
+		// Framed message transport over the child's data channel socket - one JSON.stringify per message and an
 		// exact wire byte count for metrics, no object-mode double-encode. Created before the IpcWrapper (its
-		// onMessage uses #ipcWrapper lazily; no message arrives until monitor.start() after this constructor).
-		const transport = new HostFramedTransport(monitor, 4, (msg, bytes) => {
+		// onMessage uses #ipcWrapper lazily; no message arrives until the child connects, after this constructor).
+		const transport = new HostFramedTransport(dataChannel, (msg, bytes) => {
 			this.#deps.trackIpcMessage(this.instanceId, 'received', bytes)
 			this.#ipcWrapper.receivedMessage(msg as IpcMessagePacket)
 		})
@@ -160,8 +160,7 @@ export class SurfaceChildHandler implements ChildProcessHandlerBase, SurfaceScan
 			5000
 		)
 
-		// The transport binds to the monitor, which is discarded on restart; nothing persistent to unbind.
-		this.#unsubListeners = () => undefined
+		this.#unsubListeners = () => transport.destroy()
 
 		// Build relevant HID devices map for quick lookup
 		for (const usbIds of manifest.usbIds || []) {

--- a/companion/lib/Instance/Surface/Thread/Entrypoint.ts
+++ b/companion/lib/Instance/Surface/Thread/Entrypoint.ts
@@ -1,12 +1,12 @@
 /* eslint-disable n/no-process-exit */
 import fs from 'node:fs/promises'
-import net from 'node:net'
 import {
 	createModuleLogger,
 	PluginWrapper,
 	registerLoggingSink,
 	type SurfaceModuleManifest,
 } from '@companion-surface/host'
+import { connectDataChannel } from '../../Common/DataChannelClient.js'
 import { FramedChannel } from '../../Common/FramedMessageChannel.js'
 import { IpcWrapper } from '../../Common/IpcWrapper.js'
 import { importModuleFromPath } from '../../Common/ThreadUtil.js'
@@ -33,7 +33,23 @@ const verificationToken = process.env.VERIFICATION_TOKEN
 if (typeof verificationToken !== 'string' || !verificationToken)
 	throw new Error('Module initialise is missing VERIFICATION_TOKEN')
 
+const dataChannelPath = process.env.MODULE_DATA_CHANNEL
+if (!dataChannelPath) throw new Error('Module initialise is missing MODULE_DATA_CHANNEL')
+
+// Everything the host passed us has now been captured, so take it back out of the environment. Module code
+// runs in this process and has no business reading these.
+delete process.env.MODULE_ENTRYPOINT
+delete process.env.MODULE_MANIFEST
+delete process.env.VERIFICATION_TOKEN
+delete process.env.MODULE_DATA_CHANNEL
+
 const logger = createModuleLogger('Entrypoint')
+
+// The host is listening before it spawns us, so this connects immediately. It is the only socket this
+// process will ever have: if it is lost the host will not accept a replacement, so we exit and let the
+// host respawn us.
+const dataSocket = await connectDataChannel(dataChannelPath)
+dataSocket.on('close', () => process.exit())
 
 let plugin: PluginWrapper | null = null
 let pluginInitialized = false
@@ -178,11 +194,9 @@ const ipcWrapper = new IpcWrapper<SurfaceModuleToHostEvents, HostToSurfaceModule
 	},
 	5000
 )
-// Framed message transport over the dedicated 'pipe' fd (fd 4), paired with the host side. The 'ipc'
-// channel (process.send) is retained only for the disconnect lifecycle signal below.
-const channel = new FramedChannel(new net.Socket({ fd: 4, readable: true, writable: true }), (msg) =>
-	ipcWrapper.receivedMessage(msg as any)
-)
+// Framed message transport over the data channel socket, paired with the host side.
+// The 'ipc' channel is retained only for the disconnect signal below.
+const channel = new FramedChannel(dataSocket, (msg) => ipcWrapper.receivedMessage(msg as any))
 
 process.on('disconnect', () => process.exit())
 

--- a/companion/test/Instance/DataChannel.test.ts
+++ b/companion/test/Instance/DataChannel.test.ts
@@ -1,0 +1,335 @@
+import { spawn, type ChildProcess } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import net from 'node:net'
+import path from 'node:path'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { connectDataChannel } from '../../lib/Instance/Common/DataChannelClient.js'
+import { DataChannelServer, makeDataChannelPath } from '../../lib/Instance/Common/DataChannelServer.js'
+import { FramedChannel, HostFramedTransport } from '../../lib/Instance/Common/FramedMessageChannel.js'
+
+const isWindows = process.platform === 'win32'
+
+/** Servers opened by a test, torn down afterwards so no test leaves a listening socket behind */
+const openServers: DataChannelServer[] = []
+
+async function createServer(): Promise<DataChannelServer> {
+	const server = await DataChannelServer.create('test-instance')
+	openServers.push(server)
+	return server
+}
+
+/** Wait for a condition driven by socket io, which needs real event loop turns to settle */
+async function waitFor(check: () => boolean, timeout = 2000): Promise<void> {
+	const expiry = Date.now() + timeout
+	while (!check()) {
+		if (Date.now() > expiry) throw new Error('Timed out waiting for condition')
+		await new Promise((resolve) => setTimeout(resolve, 5))
+	}
+}
+
+afterEach(() => {
+	for (const server of openServers) server.close()
+	openServers.length = 0
+})
+
+describe('makeDataChannelPath', () => {
+	test('uses the right transport for the platform', () => {
+		const path = makeDataChannelPath(1234)
+
+		if (isWindows) {
+			expect(path).toMatch(/^\\\\\.\\pipe\\companion-ipc-1234-[0-9a-f]{12}$/)
+		} else {
+			expect(path).toMatch(/companion-ipc-1234-[0-9a-f]{12}\.sock$/)
+			// Unix domain socket paths are limited to ~104 characters
+			expect(path.length).toBeLessThan(100)
+		}
+	})
+
+	test('is unique per call', () => {
+		const paths = new Set(Array.from({ length: 100 }, () => makeDataChannelPath()))
+		expect(paths.size).toBe(100)
+	})
+})
+
+describe('DataChannelServer', () => {
+	test('round-trips messages with a connected child', async () => {
+		const server = await createServer()
+
+		const hostReceived: unknown[] = []
+		const transport = new HostFramedTransport(server, (msg) => hostReceived.push(msg))
+
+		// No child yet, so there is nothing to send to
+		expect(transport.send({ hello: 'nobody' })).toBe(0)
+
+		server.expectConnection()
+		const childSocket = await connectDataChannel(server.socketPath)
+
+		const childReceived: unknown[] = []
+		const childChannel = new FramedChannel(childSocket, (msg) => childReceived.push(msg))
+
+		await waitFor(() => transport.send({ direction: 'call', name: 'register' }) > 0)
+		childChannel.send({ direction: 'response', callbackId: 1 })
+
+		await waitFor(() => childReceived.length > 0 && hostReceived.length > 0)
+		expect(childReceived).toContainEqual({ direction: 'call', name: 'register' })
+		expect(hostReceived).toEqual([{ direction: 'response', callbackId: 1 }])
+
+		// The socket's own counters see the framed bytes, header included
+		expect(childSocket.bytesRead).toBeGreaterThan(0)
+		expect(childSocket.bytesWritten).toBeGreaterThan(0)
+
+		childSocket.destroy()
+	})
+
+	test('reports the exact body byte count of each message', async () => {
+		const server = await createServer()
+
+		const received: [unknown, number][] = []
+		const transport = new HostFramedTransport(server, (msg, bytes) => received.push([msg, bytes]))
+
+		server.expectConnection()
+		const childSocket = await connectDataChannel(server.socketPath)
+		const childChannel = new FramedChannel(childSocket, () => undefined)
+
+		const message = { direction: 'call', name: 'hello' }
+		const sentBytes = childChannel.send(message)
+
+		await waitFor(() => received.length > 0)
+		expect(received).toEqual([[message, sentBytes]])
+		expect(sentBytes).toBe(Buffer.byteLength(JSON.stringify(message), 'utf8'))
+
+		// Same count as the host measures on its way out
+		expect(transport.send(message)).toBe(sentBytes)
+
+		childSocket.destroy()
+	})
+
+	test('rejects a second connection, leaving the first healthy', async () => {
+		const server = await createServer()
+
+		const hostReceived: unknown[] = []
+		const transport = new HostFramedTransport(server, (msg) => hostReceived.push(msg))
+
+		server.expectConnection()
+		const childSocket = await connectDataChannel(server.socketPath)
+		const childChannel = new FramedChannel(childSocket, () => undefined)
+
+		// Nothing has respawned, so no further connection is legitimate
+		const intruder = await connectDataChannel(server.socketPath)
+		const intruderErrors: unknown[] = []
+		intruder.on('error', (e) => intruderErrors.push(e))
+
+		await waitFor(() => intruder.destroyed || intruder.readableEnded)
+		expect(intruder.destroyed || intruder.readableEnded).toBe(true)
+
+		// The real child is untouched
+		childChannel.send({ direction: 'call', name: 'still-here' })
+		await waitFor(() => hostReceived.length > 0)
+		expect(hostReceived).toEqual([{ direction: 'call', name: 'still-here' }])
+		expect(childSocket.destroyed).toBe(false)
+		expect(transport.send({ direction: 'response' })).toBeGreaterThan(0)
+
+		childSocket.destroy()
+		intruder.destroy()
+	})
+
+	test('rebinds to the child on respawn, dropping the dead one', async () => {
+		const server = await createServer()
+
+		const hostReceived: unknown[] = []
+		const transport = new HostFramedTransport(server, (msg) => hostReceived.push(msg))
+
+		server.expectConnection()
+		const firstSocket = await connectDataChannel(server.socketPath)
+		new FramedChannel(firstSocket, () => undefined)
+		await waitFor(() => transport.send({ to: 'first' }) > 0)
+
+		// The child died and is being respawned
+		firstSocket.destroy()
+		await waitFor(() => transport.send({ to: 'nobody' }) === 0)
+
+		server.expectConnection()
+		const secondSocket = await connectDataChannel(server.socketPath)
+		const secondReceived: unknown[] = []
+		const secondChannel = new FramedChannel(secondSocket, (msg) => secondReceived.push(msg))
+
+		await waitFor(() => transport.send({ to: 'second' }) > 0)
+		secondChannel.send({ from: 'second' })
+
+		await waitFor(() => secondReceived.length > 0 && hostReceived.length > 0)
+		expect(secondReceived).toContainEqual({ to: 'second' })
+		expect(hostReceived).toEqual([{ from: 'second' }])
+
+		secondSocket.destroy()
+	})
+
+	test('stops carrying messages once the transport is destroyed', async () => {
+		const server = await createServer()
+
+		const hostReceived: unknown[] = []
+		const transport = new HostFramedTransport(server, (msg) => hostReceived.push(msg))
+
+		server.expectConnection()
+		const childSocket = await connectDataChannel(server.socketPath)
+		const childChannel = new FramedChannel(childSocket, () => undefined)
+
+		await waitFor(() => transport.send({ direction: 'call' }) > 0)
+
+		// The handler is being torn down, while the child is still alive and talking
+		transport.destroy()
+
+		expect(transport.send({ direction: 'call' })).toBe(0)
+
+		childChannel.send({ direction: 'call', name: 'too-late' })
+		await new Promise((resolve) => setTimeout(resolve, 50))
+		expect(hostReceived).toEqual([])
+
+		// A child connecting afterwards cannot reach the destroyed handler either
+		server.expectConnection()
+		const laterSocket = await connectDataChannel(server.socketPath)
+		new FramedChannel(laterSocket, () => undefined).send({ direction: 'call', name: 'later' })
+		await new Promise((resolve) => setTimeout(resolve, 50))
+		expect(hostReceived).toEqual([])
+
+		childSocket.destroy()
+		laterSocket.destroy()
+	})
+
+	test('drops the live socket and stops listening on close', async () => {
+		const server = await createServer()
+		const transport = new HostFramedTransport(server, () => undefined)
+
+		server.expectConnection()
+		const childSocket = await connectDataChannel(server.socketPath)
+		// A child always reads its socket; an unread socket stays paused and would never see the close
+		new FramedChannel(childSocket, () => undefined)
+		await waitFor(() => transport.send({ hello: 'child' }) > 0)
+
+		server.close()
+
+		await waitFor(() => childSocket.destroyed || childSocket.readableEnded)
+		expect(transport.send({ hello: 'child' })).toBe(0)
+
+		// Nothing may connect to a closed channel
+		await expect(connectDataChannel(server.socketPath)).rejects.toThrow(/Failed to connect/)
+
+		childSocket.destroy()
+	})
+
+	test.skipIf(isWindows)('leaves no socket file behind on close', async () => {
+		const server = await createServer()
+		expect(existsSync(server.socketPath)).toBe(true)
+
+		server.close()
+
+		await waitFor(() => !existsSync(server.socketPath))
+	})
+})
+
+/*
+ * The reason this transport exists: an inherited stdio fd cannot be picked up by the child on windows, so
+ * the channel has to survive a real process boundary. Mirrors how ProcessManager spawns a child - same stdio
+ * layout, same env, and the same permission flags a real connection runs under.
+ */
+describe('a real child process', () => {
+	const fixture = path.join(import.meta.dirname, 'fixtures/dataChannelChild.mjs')
+
+	const spawnedChildren: ChildProcess[] = []
+
+	afterEach(() => {
+		for (const child of spawnedChildren) child.kill()
+		spawnedChildren.length = 0
+	})
+
+	function spawnChild(socketPath: string): ChildProcess {
+		const child = spawn(
+			process.execPath,
+			[
+				// As applied to real connections by getNodeJsPermissionArguments()
+				'--permission',
+				'--allow-net',
+				`--allow-fs-read=${fixture}`,
+				fixture,
+			],
+			{
+				// fd 3 = 'ipc', and nothing beyond it - the data channel is a socket, not an inherited fd
+				stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
+				env: { ...process.env, MODULE_DATA_CHANNEL: socketPath },
+			}
+		)
+		spawnedChildren.push(child)
+		return child
+	}
+
+	test('connects and round-trips messages under the permission model', async () => {
+		const server = await createServer()
+
+		const received: unknown[] = []
+		const transport = new HostFramedTransport(server, (msg) => received.push(msg))
+
+		server.expectConnection()
+
+		const child = spawnChild(server.socketPath)
+		const stderr: string[] = []
+		child.stderr?.on('data', (d) => stderr.push(d.toString()))
+
+		// The child connects on its own, which is what makes this work on windows
+		await waitFor(() => transport.send({ direction: 'call', name: 'register' }) > 0)
+		await waitFor(() => received.length > 0)
+
+		// Nothing was denied on the way (node also prints an ExperimentalWarning for --allow-net, which is fine)
+		expect(stderr.join('')).not.toMatch(/Error|ERR_/)
+		expect(received[0]).toEqual({
+			echo: { direction: 'call', name: 'register' },
+			hasIpcChannel: true,
+			hasPermissionModel: true,
+		})
+	}, 20_000)
+
+	test('is treated as gone once the child dies', async () => {
+		const server = await createServer()
+		const transport = new HostFramedTransport(server, () => undefined)
+
+		server.expectConnection()
+		const child = spawnChild(server.socketPath)
+
+		await waitFor(() => transport.send({ direction: 'call' }) > 0)
+
+		child.kill()
+		await waitFor(() => transport.send({ direction: 'call' }) === 0)
+	}, 20_000)
+})
+
+describe('connectDataChannel', () => {
+	test('retries a path that is not listening yet', async () => {
+		// As if the child had somehow won the race against the host's listen()
+		const socketPath = makeDataChannelPath()
+		const promise = connectDataChannel(socketPath)
+
+		const server = net.createServer()
+		await new Promise<void>((resolve) => server.listen(socketPath, resolve))
+
+		try {
+			const socket = await promise
+			expect(socket.destroyed).toBe(false)
+			socket.destroy()
+		} finally {
+			server.close()
+		}
+	})
+
+	test('gives up on a path that never accepts', async () => {
+		vi.useFakeTimers()
+		try {
+			// Assert before advancing, so the rejection is never left unhandled
+			const assertion = expect(connectDataChannel(makeDataChannelPath())).rejects.toThrow(
+				/Failed to connect to host data channel/
+			)
+			// Run out the backoff without waiting for it
+			await vi.advanceTimersByTimeAsync(10_000)
+			await assertion
+		} finally {
+			vi.useRealTimers()
+		}
+	})
+})

--- a/companion/test/Instance/fixtures/dataChannelChild.mjs
+++ b/companion/test/Instance/fixtures/dataChannelChild.mjs
@@ -1,0 +1,54 @@
+/*
+ * Stands in for a module child process, for the data channel integration test. Deliberately hand-rolls the
+ * framing (see MessageFraming.ts, which is unit tested separately) rather than importing the typescript
+ * sources, so it can be run by a real node binary the way a real child is.
+ *
+ * Echoes back every message it is sent, along with what it can see of its own plumbing.
+ */
+
+import net from 'node:net'
+
+const socketPath = process.env.MODULE_DATA_CHANNEL
+if (!socketPath) {
+	console.error('MODULE_DATA_CHANNEL is missing')
+	process.exit(2)
+}
+
+const socket = net.connect(socketPath)
+
+// Losing the channel is terminal for a child, exactly as in the real entrypoints
+socket.on('close', () => process.exit(0))
+socket.on('error', (e) => {
+	console.error(`data channel error: ${e}`)
+	process.exit(3)
+})
+
+function send(message) {
+	const body = Buffer.from(JSON.stringify(message), 'utf8')
+	const header = Buffer.allocUnsafe(4)
+	header.writeUInt32BE(body.length, 0)
+	socket.write(Buffer.concat([header, body]))
+}
+
+let buffer = Buffer.alloc(0)
+socket.on('data', (chunk) => {
+	buffer = Buffer.concat([buffer, chunk])
+
+	for (;;) {
+		if (buffer.length < 4) return
+
+		const bodyLength = buffer.readUInt32BE(0)
+		if (buffer.length < 4 + bodyLength) return
+
+		const message = JSON.parse(buffer.subarray(4, 4 + bodyLength).toString('utf8'))
+		buffer = buffer.subarray(4 + bodyLength)
+
+		send({
+			echo: message,
+			// The 'ipc' channel is still there for the disconnect signal, but carries no messages
+			hasIpcChannel: typeof process.send === 'function',
+			// Whether the permission model is restricting this process, as it does for real connections
+			hasPermissionModel: !!process.permission,
+		})
+	}
+})


### PR DESCRIPTION
closes #4311 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated cross-platform data-channel transport for host-to-child framed IPC.
  * Child entrypoints and runtime handling now use the host-provided data-channel when supported.
  * Added retry behavior for child connections until the endpoint is ready.

* **Bug Fixes**
  * Prevented stale/unexpected connections from receiving framed messages.
  * Improved transport teardown so destroyed channels stop processing and sending immediately.

* **Tests**
  * Added comprehensive data-channel IPC tests, including cross-process and failure/retry scenarios.
  * Updated CI test workflow with matrix-based runner selection and longer job timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->