### PR TITLE
feat: reference/mirror control type

### DIFF
--- a/companion/lib/Controls/ControlBase.ts
+++ b/companion/lib/Controls/ControlBase.ts
@@ -3,7 +3,7 @@ import jsonPatch from 'fast-json-patch'
 import type { UIControlUpdate } from '@companion-app/shared/Model/Controls.js'
 import LogController, { type Logger } from '../Log/Controller.js'
 import type { ControlDependencies } from './ControlDependencies.js'
-import type { LayeredButtonDrawer } from './ControlTypes/Button/LayeredButtonDrawer.js'
+import type { IButtonDrawer } from './IButtonDrawer.js'
 
 export type ControlUpdateEvents = {
 	update: [change: UIControlUpdate]
@@ -117,7 +117,7 @@ export abstract class ControlBase<TJson> {
 	/**
 	 * The drawing surface for controls that render to a button, or `null` for controls that don't draw.
 	 */
-	abstract get drawing(): LayeredButtonDrawer | null
+	abstract get drawing(): IButtonDrawer | null
 
 	/**
 	 * Emit a change to the runtime properties of this control.
@@ -174,4 +174,14 @@ export abstract class ControlBase<TJson> {
 	 * @param force Trigger actions even if already in the state
 	 */
 	abstract pressControl(pressed: boolean, surfaceId: string | undefined, force?: boolean): void
+
+	/**
+	 * Execute a rotate of this control. Controls that don't support rotation (the default) do nothing and report
+	 * that they didn't handle it.
+	 * @param delta Signed rotation amount - sign is the direction, magnitude is the number of steps
+	 * @param surfaceId The surface that initiated this rotate
+	 */
+	rotateControl(_delta: number, _surfaceId: string | undefined): boolean {
+		return false
+	}
 }

--- a/companion/lib/Controls/ControlDependencies.ts
+++ b/companion/lib/Controls/ControlDependencies.ts
@@ -28,7 +28,7 @@ import type { TriggerEvents } from './TriggerEvents.js'
 export interface ControlsAccessor {
 	getControl(controlId: string): SomeControl<any> | undefined
 	pressControl(controlId: string, pressed: boolean, surfaceId: string | undefined, force?: boolean): boolean
-	rotateControl(controlId: string, rightward: boolean, surfaceId: string | undefined): boolean
+	rotateControl(controlId: string, delta: number, surfaceId: string | undefined): boolean
 }
 
 export interface ControlExternalDependencies {

--- a/companion/lib/Controls/ControlDependencies.ts
+++ b/companion/lib/Controls/ControlDependencies.ts
@@ -18,8 +18,18 @@ import type { VariablesValues } from '../Variables/Values.js'
 import type { ActionRunner } from './ActionRunner.js'
 import type { ControlEntityInstance } from './Entities/EntityInstance.js'
 import type { ExpressionVariableNameMap } from './ExpressionVariableNameMap.js'
+import type { SomeControl } from './IControlFragments.js'
 import type { RenderClock } from './RenderClock.js'
 import type { TriggerEvents } from './TriggerEvents.js'
+
+/**
+ * A narrow accessor letting one control reach other controls (to press/rotate a target, or read its model).
+ */
+export interface ControlsAccessor {
+	getControl(controlId: string): SomeControl<any> | undefined
+	pressControl(controlId: string, pressed: boolean, surfaceId: string | undefined, force?: boolean): boolean
+	rotateControl(controlId: string, rightward: boolean, surfaceId: string | undefined): boolean
+}
 
 export interface ControlExternalDependencies {
 	readonly surfaces: SurfaceController
@@ -38,6 +48,9 @@ export interface ControlExternalDependencies {
 
 export interface ControlDependencies extends ControlExternalDependencies {
 	readonly dbTable: DataStoreTableView<Record<string, SomeControlModel>>
+
+	/** Narrow access to other controls (for controls that forward to or read a target control). */
+	readonly controlsAccessor: ControlsAccessor
 
 	readonly events: EventEmitter<ControlCommonEvents>
 

--- a/companion/lib/Controls/ControlStore.ts
+++ b/companion/lib/Controls/ControlStore.ts
@@ -2,6 +2,7 @@ import type { SomeControlModel } from '@companion-app/shared/Model/Controls.js'
 import type { VariableValues } from '@companion-app/shared/Model/Variables.js'
 import type { DataDatabase } from '../Data/Database.js'
 import type { DataStoreTableView } from '../Data/StoreBase.js'
+import type { IPageStore } from '../Page/Store.js'
 import type { VariablesValues } from '../Variables/Values.js'
 import type {
 	ExpressionParserOptions,
@@ -31,10 +32,12 @@ export class ControlStore implements IControlStore {
 	readonly triggerEvents: TriggerEvents
 
 	readonly #variablesValues: VariablesValues
+	readonly #pageStore: IPageStore
 
-	constructor(db: DataDatabase, variablesValues: VariablesValues) {
+	constructor(db: DataDatabase, variablesValues: VariablesValues, pageStore: IPageStore) {
 		this.triggerEvents = new TriggerEvents()
 		this.#variablesValues = variablesValues
+		this.#pageStore = pageStore
 
 		this.dbTable = db.getTableView('controls')
 	}
@@ -176,7 +179,9 @@ export class ControlStore implements IControlStore {
 		if (control && control.supportsEntities)
 			return control.entities.createVariablesAndExpressionParser(overrideVariableValues, options)
 
-		// Otherwise create a generic one
-		return this.#variablesValues.createVariablesAndExpressionParser(null, null, overrideVariableValues, null, options)
+		// Otherwise create a generic one. It still gets the control's grid location so `$(this:page)` and the
+		// other `this:*` variables resolve for located controls without an entity pool (e.g. a button reference).
+		const location = controlId ? this.#pageStore.getLocationOfControlId(controlId) : null
+		return this.#variablesValues.createVariablesAndExpressionParser(location, null, overrideVariableValues, null, options)
 	}
 }

--- a/companion/lib/Controls/ControlStore.ts
+++ b/companion/lib/Controls/ControlStore.ts
@@ -179,8 +179,7 @@ export class ControlStore implements IControlStore {
 		if (control && control.supportsEntities)
 			return control.entities.createVariablesAndExpressionParser(overrideVariableValues, options)
 
-		// Otherwise create a generic one. It still gets the control's grid location so `$(this:page)` and the
-		// other `this:*` variables resolve for located controls without an entity pool (e.g. a button reference).
+		// Generic parser, but with the control's grid location so `$(this:page)` resolves for located non-entity controls
 		const location = controlId ? this.#pageStore.getLocationOfControlId(controlId) : null
 		return this.#variablesValues.createVariablesAndExpressionParser(
 			location,

--- a/companion/lib/Controls/ControlStore.ts
+++ b/companion/lib/Controls/ControlStore.ts
@@ -117,13 +117,7 @@ export class ControlStore implements IControlStore {
 		// accidentally run the `rotate_left` set (chosen when `delta > 0` is false) for a zero delta.
 		if (!Number.isFinite(delta) || delta === 0) return false
 
-		const control = this.getControl(controlId)
-		if (control && control.supportsActionSets) {
-			control.rotateControl(delta, surfaceId)
-			return true
-		}
-
-		return false
+		return this.getControl(controlId)?.rotateControl(delta, surfaceId) ?? false
 	}
 
 	/**

--- a/companion/lib/Controls/ControlStore.ts
+++ b/companion/lib/Controls/ControlStore.ts
@@ -182,6 +182,12 @@ export class ControlStore implements IControlStore {
 		// Otherwise create a generic one. It still gets the control's grid location so `$(this:page)` and the
 		// other `this:*` variables resolve for located controls without an entity pool (e.g. a button reference).
 		const location = controlId ? this.#pageStore.getLocationOfControlId(controlId) : null
-		return this.#variablesValues.createVariablesAndExpressionParser(location, null, overrideVariableValues, null, options)
+		return this.#variablesValues.createVariablesAndExpressionParser(
+			location,
+			null,
+			overrideVariableValues,
+			null,
+			options
+		)
 	}
 }

--- a/companion/lib/Controls/ControlTypes/Button/Base.ts
+++ b/companion/lib/Controls/ControlTypes/Button/Base.ts
@@ -352,9 +352,8 @@ export abstract class ButtonControlRuntimeBase<
 	 * @param delta Signed rotation amount - sign is the direction, magnitude is the number of steps
 	 * @param surfaceId The surface that initiated this rotate
 	 */
-	rotateControl(delta: number, surfaceId: string | undefined): void {
-		const rightward = delta > 0
-		const actions = this.entities.getActionsToExecuteForSet(rightward ? 'rotate_right' : 'rotate_left')
+	override rotateControl(delta: number, surfaceId: string | undefined): boolean {
+		const actions = this.entities.getActionsToExecuteForSet(delta > 0 ? 'rotate_right' : 'rotate_left')
 
 		const location = this.deps.pageStore.getLocationOfControlId(this.controlId)
 
@@ -368,6 +367,8 @@ export abstract class ButtonControlRuntimeBase<
 			.catch((e) => {
 				this.logger.error(`action execution failed: ${e}`)
 			})
+
+		return true
 	}
 
 	/**

--- a/companion/lib/Controls/ControlTypes/Button/LayeredButtonDrawer.ts
+++ b/companion/lib/Controls/ControlTypes/Button/LayeredButtonDrawer.ts
@@ -17,6 +17,7 @@ import type { CompositeElementIdString } from '../../../Instance/Definitions.js'
 import LogController, { type Logger } from '../../../Log/Controller.js'
 import type { ControlDependencies } from '../../ControlDependencies.js'
 import type { ControlEntityInstance } from '../../Entities/EntityInstance.js'
+import type { IButtonDrawer } from '../../IButtonDrawer.js'
 import { CreateElementOfType } from './LayerDefaults.js'
 
 /** Anything that can visit the draw elements (e.g. the reference collector/updater visitors). */
@@ -55,7 +56,7 @@ const emptyFeedbackOverrides: ReadonlyMap<string, never> = new Map<string, never
  *
  * The `protected` element/cache/deps members are the surface that subclass exposes its editing operations on.
  */
-export class LayeredButtonDrawer {
+export class LayeredButtonDrawer implements IButtonDrawer {
 	protected readonly logger: Logger
 	protected readonly deps: ControlDependencies
 	protected readonly controlId: string

--- a/companion/lib/Controls/ControlTypes/Button/LayeredButtonDrawer.ts
+++ b/companion/lib/Controls/ControlTypes/Button/LayeredButtonDrawer.ts
@@ -90,13 +90,11 @@ export class LayeredButtonDrawer implements IButtonDrawer {
 		this.controlId = controlId
 		this.#host = host
 		this.#drawType = drawType
-
-		// Own the 'other control finished rendering' invalidation source, needed for reference elements
-		this.deps.graphics.on('button_drawn', this.#onReferencedButtonDrawn)
 	}
 
 	dispose(): void {
-		this.deps.graphics.off('button_drawn', this.#onReferencedButtonDrawn)
+		// Cancel any redraw still queued so it can't fire after the owning control is gone
+		this.invalidate.cancel()
 		this.elementConversionCache.clear()
 	}
 
@@ -286,7 +284,7 @@ export class LayeredButtonDrawer implements IButtonDrawer {
 	}
 
 	/** Another located control finished rendering; if we reference it, invalidate and redraw. */
-	#onReferencedButtonDrawn = (location: ControlLocation, render: ImageResult): void => {
+	onButtonDrawn(location: ControlLocation, render: ImageResult): void {
 		const locStr = formatLocation(location)
 		if (!this.#lastDrawReferencedLocations?.has(locStr)) return
 

--- a/companion/lib/Controls/ControlTypes/Button/MirrorButtonDrawer.ts
+++ b/companion/lib/Controls/ControlTypes/Button/MirrorButtonDrawer.ts
@@ -1,0 +1,135 @@
+import debounceFn from 'debounce-fn'
+import { formatLocation } from '@companion-app/shared/ControlId.js'
+import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
+import type { DrawStyleLayeredButtonModel } from '@companion-app/shared/Model/StyleModel.js'
+import { makeReferencePlaceholder } from '../../../Graphics/ConvertGraphicsElements.js'
+import type { ImageResult } from '../../../Graphics/ImageResult.js'
+import type { CompositeElementIdString } from '../../../Instance/Definitions.js'
+import LogController, { type Logger } from '../../../Log/Controller.js'
+import type { ControlDependencies } from '../../ControlDependencies.js'
+import type { IButtonDrawer } from '../../IButtonDrawer.js'
+
+const emptyStateProps = {
+	pushed: false,
+	stepCurrent: 0,
+	stepCount: 0,
+	button_status: undefined,
+	action_running: undefined,
+} as const
+
+/**
+ * The `drawing` for a button-reference control: owns no elements, but mirrors the target button's whole draw
+ * style and redraws when the target renders. Reference cycles resolve to a placeholder.
+ */
+export class MirrorButtonDrawer implements IButtonDrawer {
+	readonly #logger: Logger
+	readonly #deps: ControlDependencies
+	readonly #controlId: string
+	readonly #getTargetLocation: () => ControlLocation | null
+
+	/** Locations the last draw depended on, so we know which `button_drawn` events must trigger a redraw. */
+	#lastReferencedLocations: ReadonlySet<string> | null = null
+
+	#lastDrawStyle: DrawStyleLayeredButtonModel | null = null
+
+	constructor(deps: ControlDependencies, controlId: string, getTargetLocation: () => ControlLocation | null) {
+		this.#logger = LogController.createLogger(`Controls/Button/MirrorDrawer/${controlId}`)
+		this.#deps = deps
+		this.#controlId = controlId
+		this.#getTargetLocation = getTargetLocation
+
+		this.#deps.graphics.on('button_drawn', this.#onReferencedButtonDrawn)
+	}
+
+	dispose(): void {
+		this.#deps.graphics.off('button_drawn', this.#onReferencedButtonDrawn)
+	}
+
+	#placeholder(text: string): DrawStyleLayeredButtonModel {
+		return {
+			...emptyStateProps,
+			elements: makeReferencePlaceholder('reference', text),
+			referencedLocations: undefined,
+			style: 'button-layered',
+			drawType: 'button',
+		}
+	}
+
+	async getDrawStyle(): Promise<DrawStyleLayeredButtonModel> {
+		const targetLocation = this.#getTargetLocation()
+		if (!targetLocation) {
+			this.#lastReferencedLocations = null
+			return this.#storeAndReturn(this.#placeholder('Unresolved\nReference'))
+		}
+
+		const targetLocationStr = formatLocation(targetLocation)
+		const myLocation = this.#deps.pageStore.getLocationOfControlId(this.#controlId)
+		const myLocationStr = myLocation ? formatLocation(myLocation) : null
+
+		// Direct self-reference
+		if (myLocationStr === targetLocationStr) {
+			this.#lastReferencedLocations = new Set([targetLocationStr])
+			return this.#storeAndReturn(this.#placeholder('∞'))
+		}
+
+		const targetControlId = this.#deps.pageStore.getControlIdAt(targetLocation)
+		const targetStyle = targetControlId
+			? this.#deps.controlsAccessor.getControl(targetControlId)?.drawing?.getLastDrawStyle()
+			: undefined
+
+		// Not rendered yet (or gone): placeholder until the target's next `button_drawn` redraws us. Reading the
+		// cached style (never getDrawStyle) keeps this sync and recursion-free.
+		if (!targetStyle) {
+			this.#lastReferencedLocations = new Set([targetLocationStr])
+			return this.#storeAndReturn(this.#placeholder('Unresolved\nReference'))
+		}
+
+		// Transitive cycle: the target's render references us back
+		if (myLocationStr && targetStyle.referencedLocations?.has(myLocationStr)) {
+			this.#lastReferencedLocations = new Set([targetLocationStr])
+			return this.#storeAndReturn(this.#placeholder('∞'))
+		}
+
+		const referencedLocations = new Set<string>([targetLocationStr, ...(targetStyle.referencedLocations ?? [])])
+		this.#lastReferencedLocations = referencedLocations
+
+		return this.#storeAndReturn({
+			...structuredClone(targetStyle),
+			referencedLocations,
+		})
+	}
+
+	#storeAndReturn(style: DrawStyleLayeredButtonModel): DrawStyleLayeredButtonModel {
+		this.#lastDrawStyle = style
+		return style
+	}
+
+	getLastDrawStyle(): DrawStyleLayeredButtonModel | null {
+		return this.#lastDrawStyle
+	}
+
+	// A mirror owns no variables/elements; it redraws off the target's render instead.
+	onVariablesChanged(_allChangedVariables: ReadonlySet<string>): void {}
+	onCompositeElementsChanged(_allChangedElementIds: ReadonlySet<CompositeElementIdString>): void {}
+
+	invalidate = debounceFn(
+		() => {
+			if (this.#pendingDraw) return
+			this.#pendingDraw = true
+			setImmediate(() => {
+				this.#deps.events.emit('invalidateControlRender', this.#controlId)
+				this.#pendingDraw = false
+			})
+		},
+		{ before: false, after: true, wait: 10, maxWait: 20 }
+	)
+	#pendingDraw = false
+
+	/** Redraw when a location our last draw referenced finishes rendering. */
+	#onReferencedButtonDrawn = (location: ControlLocation, _render: ImageResult): void => {
+		if (!this.#lastReferencedLocations?.has(formatLocation(location))) return
+
+		this.#logger.silly('referenced control rendered')
+		this.invalidate()
+	}
+}

--- a/companion/lib/Controls/ControlTypes/Button/MirrorButtonDrawer.ts
+++ b/companion/lib/Controls/ControlTypes/Button/MirrorButtonDrawer.ts
@@ -37,12 +37,11 @@ export class MirrorButtonDrawer implements IButtonDrawer {
 		this.#deps = deps
 		this.#controlId = controlId
 		this.#getTargetLocation = getTargetLocation
-
-		this.#deps.graphics.on('button_drawn', this.#onReferencedButtonDrawn)
 	}
 
 	dispose(): void {
-		this.#deps.graphics.off('button_drawn', this.#onReferencedButtonDrawn)
+		// Cancel any redraw still queued so it can't fire after the owning control is gone
+		this.invalidate.cancel()
 	}
 
 	#placeholder(text: string): DrawStyleLayeredButtonModel {
@@ -126,7 +125,7 @@ export class MirrorButtonDrawer implements IButtonDrawer {
 	#pendingDraw = false
 
 	/** Redraw when a location our last draw referenced finishes rendering. */
-	#onReferencedButtonDrawn = (location: ControlLocation, _render: ImageResult): void => {
+	onButtonDrawn(location: ControlLocation, _render: ImageResult): void {
 		if (!this.#lastReferencedLocations?.has(formatLocation(location))) return
 
 		this.#logger.silly('referenced control rendered')

--- a/companion/lib/Controls/ControlTypes/Button/Reference.ts
+++ b/companion/lib/Controls/ControlTypes/Button/Reference.ts
@@ -1,0 +1,262 @@
+import type { JsonValue } from 'type-fest'
+import type {
+	ButtonReferenceButtonModel,
+	LayeredButtonModel,
+	SomeButtonModel,
+} from '@companion-app/shared/Model/ButtonModel.js'
+import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
+import { exprVal, isExpressionOrValue } from '@companion-app/shared/Model/Options.js'
+import type { ButtonGraphicsReferenceElement } from '@companion-app/shared/Model/StyleLayersModel.js'
+import { stringifyVariableValue } from '@companion-app/shared/Model/Variables.js'
+import { ParseLocationString } from '../../../Internal/Util.js'
+import { VisitorReferencesCollector } from '../../../Resources/Visitors/ReferencesCollector.js'
+import { VisitorReferencesUpdater } from '../../../Resources/Visitors/ReferencesUpdater.js'
+import {
+	mangleReferenceSurfaceId,
+	MAX_REFERENCE_DEPTH,
+	referenceSurfaceIdDepth,
+} from '../../../Surface/ReferenceSurfaceId.js'
+import { ControlBase } from '../../ControlBase.js'
+import type { ControlDependencies } from '../../ControlDependencies.js'
+import type {
+	ControlWithConvert,
+	ControlWithOptions,
+	ControlWithoutActions,
+	ControlWithoutActionSets,
+	ControlWithoutEntities,
+	ControlWithoutEvents,
+	ControlWithoutLayeredStyle,
+	ControlWithoutPushed,
+} from '../../IControlFragments.js'
+import { CreateElementOfType } from './LayerDefaults.js'
+import { ControlButtonLayered } from './Layered.js'
+import { MirrorButtonDrawer } from './MirrorButtonDrawer.js'
+
+/**
+ * A button that mirrors another button at a grid location: it renders the target's full draw output (via
+ * {@link MirrorButtonDrawer}) and forwards presses/rotation to it. The only editable field is the `location`.
+ * Presses forward with a mangled surfaceId (see {@link mangleReferenceSurfaceId}); 'Edit' snapshots the target
+ * into a normal `button-layered` control via {@link convertControl}.
+ *
+ * @author Julian Waller <me@julusian.co.uk>
+ * @since 5.1.0
+ * @copyright 2026 Bitfocus AS
+ * @license
+ * This program is free software.
+ * You should have received a copy of the MIT licence as well as the Bitfocus
+ * Individual Contributor License Agreement for Companion along with
+ * this program.
+ */
+export class ControlButtonReference
+	extends ControlBase<ButtonReferenceButtonModel>
+	implements
+		ControlWithoutLayeredStyle,
+		ControlWithoutEntities,
+		ControlWithoutActions,
+		ControlWithoutEvents,
+		ControlWithoutActionSets,
+		ControlWithOptions,
+		ControlWithoutPushed,
+		ControlWithConvert
+{
+	readonly type = 'button-reference'
+
+	readonly supportsActions = false
+	readonly supportsActionSets = false
+	readonly supportsConvert = true
+	readonly supportsEntities = false
+	readonly supportsEvents = false
+	readonly supportsLayeredStyle = false
+	readonly supportsOptions = true
+	readonly supportsPushed = false
+
+	options: ButtonReferenceButtonModel['options']
+
+	readonly #drawing: MirrorButtonDrawer
+	override get drawing(): MirrorButtonDrawer {
+		return this.#drawing
+	}
+
+	protected triggerInvalidation = (): void => {
+		this.#drawing.invalidate()
+	}
+
+	constructor(
+		deps: ControlDependencies,
+		controlId: string,
+		storage: ButtonReferenceButtonModel | null,
+		isImport: boolean
+	) {
+		super(deps, controlId, 'Controls/Button/Reference')
+
+		this.options = { location: exprVal('') }
+
+		this.#drawing = new MirrorButtonDrawer(deps, controlId, () => this.#resolveTargetLocation())
+
+		if (!storage) {
+			// New control
+			this.commitChange()
+		} else {
+			if (storage.type !== 'button-reference')
+				throw new Error(`Invalid type given to ControlButtonReference: "${storage.type}"`)
+
+			this.options = { location: storage.options.location, notes: storage.options.notes }
+
+			if (isImport) this.commitChange()
+		}
+	}
+
+	destroy(): void {
+		this.#drawing.dispose()
+		super.destroy()
+	}
+
+	/** Resolve the mirrored location, evaluating the expression/variables in the `location` field. */
+	#resolveTargetLocation(): ControlLocation | null {
+		const myLocation = this.deps.pageStore.getLocationOfControlId(this.controlId)
+		const parser = this.deps.variableValues.createVariablesAndExpressionParser(myLocation, null, null)
+
+		const location = this.options.location
+		let raw: string
+		if (location.isExpression) {
+			const res = parser.executeExpression(location.value, 'string')
+			raw = res.ok ? (stringifyVariableValue(res.value) ?? '') : ''
+		} else {
+			raw = parser.parseVariables(location.value).text
+		}
+
+		return ParseLocationString(raw, myLocation ?? undefined)
+	}
+
+	#resolveTargetControlId(): string | undefined {
+		const location = this.#resolveTargetLocation()
+		return (location ? this.deps.pageStore.getControlIdAt(location) : undefined) ?? undefined
+	}
+
+	pressControl(pressed: boolean, surfaceId: string | undefined, force?: boolean): void {
+		// Loop guard: stop forwarding once a press has hopped through too many references
+		if (surfaceId && referenceSurfaceIdDepth(surfaceId) >= MAX_REFERENCE_DEPTH) return
+
+		const targetControlId = this.#resolveTargetControlId()
+		if (!targetControlId || targetControlId === this.controlId) return
+
+		this.deps.controlsAccessor.pressControl(
+			targetControlId,
+			pressed,
+			mangleReferenceSurfaceId(surfaceId, this.controlId),
+			force
+		)
+	}
+
+	override rotateControl(rightward: boolean, surfaceId: string | undefined): boolean {
+		if (surfaceId && referenceSurfaceIdDepth(surfaceId) >= MAX_REFERENCE_DEPTH) return false
+
+		const targetControlId = this.#resolveTargetControlId()
+		if (!targetControlId || targetControlId === this.controlId) return false
+
+		return this.deps.controlsAccessor.rotateControl(
+			targetControlId,
+			rightward,
+			mangleReferenceSurfaceId(surfaceId, this.controlId)
+		)
+	}
+
+	/**
+	 * Update an option field. Only `location` (the mirrored target) and `notes` are editable.
+	 */
+	optionsSetField(key: string, value: JsonValue | undefined): boolean {
+		if (key === 'notes') {
+			if (typeof value !== 'string') return false
+			this.options.notes = value
+			this.commitChange(false)
+			return true
+		}
+
+		if (key === 'location') {
+			if (!isExpressionOrValue(value)) return false
+			this.options.location = value
+			this.commitChange(true)
+			this.#drawing.invalidate()
+			return true
+		}
+
+		return false
+	}
+
+	/**
+	 * Snapshot the mirrored target into a normal editable layered button, breaking the link. If the target can't
+	 * be resolved, produce a blank layered button.
+	 */
+	convertControl(): SomeButtonModel {
+		const targetControlId = this.#resolveTargetControlId()
+		const target = targetControlId ? this.deps.controlsAccessor.getControl(targetControlId) : undefined
+		if (target) {
+			return structuredClone(target.toJSON(true)) as SomeButtonModel
+		}
+
+		const blank: LayeredButtonModel = {
+			type: 'button-layered',
+			options: { stepProgression: 'auto', rotaryActions: false, canModifyStyleInApis: false },
+			style: { layers: structuredClone(ControlButtonLayered.DefaultElements) },
+			feedbacks: [],
+			steps: {
+				'0': {
+					action_sets: { down: [], up: undefined, rotate_left: undefined, rotate_right: undefined },
+					options: { runWhileHeld: [] },
+				},
+			},
+			localVariables: [],
+		}
+		return blank
+	}
+
+	collectReferencedConnectionsAndVariables(
+		foundConnectionIds: Set<string>,
+		foundConnectionLabels: Set<string>,
+		foundVariables: Set<string>
+	): void {
+		const collector = new VisitorReferencesCollector(
+			this.deps.internalModule,
+			foundConnectionIds,
+			foundConnectionLabels,
+			foundVariables,
+			undefined
+		)
+		collector.visitDrawElements([this.#locationAsElement()])
+	}
+
+	renameVariables(labelFrom: string, labelTo: string): void {
+		const element = this.#locationAsElement()
+
+		const updater = new VisitorReferencesUpdater(
+			this.deps.internalModule,
+			{ [labelFrom]: labelTo },
+			undefined,
+			undefined
+		)
+		updater.visitDrawElements([element])
+
+		// The visitor mutates the element's location in-place; mirror it back and persist it
+		this.options.location = element.location
+		this.commitChange(true)
+	}
+
+	/** Build a throwaway reference element carrying the `location` expression, for the references visitors. */
+	#locationAsElement(): ButtonGraphicsReferenceElement {
+		const element = CreateElementOfType('reference') as ButtonGraphicsReferenceElement
+		element.location = this.options.location
+		return element
+	}
+
+	triggerLocationHasChanged(): void {
+		this.#drawing.invalidate()
+	}
+
+	toJSON(clone = true): ButtonReferenceButtonModel {
+		const obj: ButtonReferenceButtonModel = {
+			type: this.type,
+			options: this.options,
+		}
+		return clone ? structuredClone(obj) : obj
+	}
+}

--- a/companion/lib/Controls/ControlTypes/Button/Reference.ts
+++ b/companion/lib/Controls/ControlTypes/Button/Reference.ts
@@ -6,7 +6,6 @@ import type {
 } from '@companion-app/shared/Model/ButtonModel.js'
 import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
 import { exprVal, isExpressionOrValue } from '@companion-app/shared/Model/Options.js'
-import type { ButtonGraphicsReferenceElement } from '@companion-app/shared/Model/StyleLayersModel.js'
 import { stringifyVariableValue } from '@companion-app/shared/Model/Variables.js'
 import { ParseLocationString } from '../../../Internal/Util.js'
 import { VisitorReferencesCollector } from '../../../Resources/Visitors/ReferencesCollector.js'
@@ -28,7 +27,6 @@ import type {
 	ControlWithoutLayeredStyle,
 	ControlWithoutPushed,
 } from '../../IControlFragments.js'
-import { CreateElementOfType } from './LayerDefaults.js'
 import { ControlButtonLayered } from './Layered.js'
 import { MirrorButtonDrawer } from './MirrorButtonDrawer.js'
 
@@ -114,7 +112,12 @@ export class ControlButtonReference
 	/** Resolve the mirrored location, evaluating the expression/variables in the `location` field. */
 	#resolveTargetLocation(): ControlLocation | null {
 		const myLocation = this.deps.pageStore.getLocationOfControlId(this.controlId)
-		const parser = this.deps.variableValues.createVariablesAndExpressionParser(myLocation, null, null)
+		const parser = this.deps.variableValues.createVariablesAndExpressionParser(
+			myLocation,
+			null,
+			null,
+			myLocation ? this.deps.getPageVariableEntities(myLocation.pageNumber) : null
+		)
 
 		const location = this.options.location
 		let raw: string
@@ -135,7 +138,7 @@ export class ControlButtonReference
 
 	pressControl(pressed: boolean, surfaceId: string | undefined, force?: boolean): void {
 		// Loop guard: stop forwarding once a press has hopped through too many references
-		if (surfaceId && referenceSurfaceIdDepth(surfaceId) >= MAX_REFERENCE_DEPTH) return
+		if (referenceSurfaceIdDepth(surfaceId) >= MAX_REFERENCE_DEPTH) return
 
 		const targetControlId = this.#resolveTargetControlId()
 		if (!targetControlId || targetControlId === this.controlId) return
@@ -149,7 +152,7 @@ export class ControlButtonReference
 	}
 
 	override rotateControl(rightward: boolean, surfaceId: string | undefined): boolean {
-		if (surfaceId && referenceSurfaceIdDepth(surfaceId) >= MAX_REFERENCE_DEPTH) return false
+		if (referenceSurfaceIdDepth(surfaceId) >= MAX_REFERENCE_DEPTH) return false
 
 		const targetControlId = this.#resolveTargetControlId()
 		if (!targetControlId || targetControlId === this.controlId) return false
@@ -176,7 +179,6 @@ export class ControlButtonReference
 			if (!isExpressionOrValue(value)) return false
 			this.options.location = value
 			this.commitChange(true)
-			this.#drawing.invalidate()
 			return true
 		}
 
@@ -222,30 +224,20 @@ export class ControlButtonReference
 			foundVariables,
 			undefined
 		)
-		collector.visitDrawElements([this.#locationAsElement()])
+		collector.visitExpressionOrValue(this.options.location, true)
 	}
 
 	renameVariables(labelFrom: string, labelTo: string): void {
-		const element = this.#locationAsElement()
-
 		const updater = new VisitorReferencesUpdater(
 			this.deps.internalModule,
 			{ [labelFrom]: labelTo },
 			undefined,
 			undefined
 		)
-		updater.visitDrawElements([element])
+		// Renames the label in-place within the location expression/variable-string
+		updater.visitExpressionOrValue(this.options.location, true)
 
-		// The visitor mutates the element's location in-place; mirror it back and persist it
-		this.options.location = element.location
-		this.commitChange(true)
-	}
-
-	/** Build a throwaway reference element carrying the `location` expression, for the references visitors. */
-	#locationAsElement(): ButtonGraphicsReferenceElement {
-		const element = CreateElementOfType('reference') as ButtonGraphicsReferenceElement
-		element.location = this.options.location
-		return element
+		if (updater.hasChanges()) this.commitChange(true)
 	}
 
 	triggerLocationHasChanged(): void {

--- a/companion/lib/Controls/ControlTypes/Button/Reference.ts
+++ b/companion/lib/Controls/ControlTypes/Button/Reference.ts
@@ -151,7 +151,7 @@ export class ControlButtonReference
 		)
 	}
 
-	override rotateControl(rightward: boolean, surfaceId: string | undefined): boolean {
+	override rotateControl(delta: number, surfaceId: string | undefined): boolean {
 		if (referenceSurfaceIdDepth(surfaceId) >= MAX_REFERENCE_DEPTH) return false
 
 		const targetControlId = this.#resolveTargetControlId()
@@ -159,7 +159,7 @@ export class ControlButtonReference
 
 		return this.deps.controlsAccessor.rotateControl(
 			targetControlId,
-			rightward,
+			delta,
 			mangleReferenceSurfaceId(surfaceId, this.controlId)
 		)
 	}

--- a/companion/lib/Controls/Controller.ts
+++ b/companion/lib/Controls/Controller.ts
@@ -138,6 +138,7 @@ export class ControlsController {
 			getPageVariableEntities: this.#getPageVariableEntities,
 			triggerEvents: this.#store.triggerEvents,
 			expressionVariableNamesMap: this.#expressionVariableNamesMap,
+			controlsAccessor: this.#store,
 		})
 
 		this.#triggerCollections = new TriggerCollections(

--- a/companion/lib/Controls/Controller.ts
+++ b/companion/lib/Controls/Controller.ts
@@ -23,6 +23,7 @@ import type { TriggerCollection, TriggerModel } from '@companion-app/shared/Mode
 import type { VariableValues } from '@companion-app/shared/Model/Variables.js'
 import { createStableObjectHash } from '@companion-app/shared/Util/Hash.js'
 import type { DataDatabase } from '../Data/Database.js'
+import type { ImageResult } from '../Graphics/ImageResult.js'
 import type { CompositeElementIdString } from '../Instance/Definitions.js'
 import LogController from '../Log/Controller.js'
 import type { ActiveLearningStore } from '../Resources/ActiveLearningStore.js'
@@ -534,6 +535,17 @@ export class ControlsController {
 
 		for (const control of this.#store.controls.values()) {
 			control.drawing?.onCompositeElementsChanged(allChangedElementIds)
+		}
+	}
+
+	/**
+	 * A control finished rendering. Notify every drawer so any that mirror or reference that location can redraw.
+	 * @param location - the grid location that was drawn
+	 * @param render - the resulting render
+	 */
+	onButtonDrawn(location: ControlLocation, render: ImageResult): void {
+		for (const control of this.#store.controls.values()) {
+			control.drawing?.onButtonDrawn(location, render)
 		}
 	}
 

--- a/companion/lib/Controls/ControlsTrpcRouter.ts
+++ b/companion/lib/Controls/ControlsTrpcRouter.ts
@@ -2,6 +2,7 @@ import type EventEmitter from 'node:events'
 import { nanoid } from 'nanoid'
 import z from 'zod'
 import { CreateBankControlId, formatLocation } from '@companion-app/shared/ControlId.js'
+import type { ButtonReferenceButtonModel } from '@companion-app/shared/Model/ButtonModel.js'
 import { JsonValueSchema } from '@companion-app/shared/Model/Options.js'
 import type { InstanceDefinitions } from '../Instance/Definitions.js'
 import type { Logger } from '../Log/Controller.js'
@@ -52,6 +53,24 @@ export function createControlsTrpcRouter(
 				if (!model) return null
 
 				return controlsController.importControl(input.location, model)
+			}),
+
+		createReferenceControl: publicProcedure
+			.input(
+				z.object({
+					fromLocation: zodLocation,
+					toLocation: zodLocation,
+				})
+			)
+			.mutation(async ({ input }) => {
+				// Place a button that mirrors `fromLocation`. Stored as a plain (non-expression) location string.
+				const model: ButtonReferenceButtonModel = {
+					type: 'button-reference',
+					options: {
+						location: { value: formatLocation(input.fromLocation), isExpression: false },
+					},
+				}
+				return controlsController.importControl(input.toLocation, model)
 			}),
 
 		setPresetReferenceVariable: publicProcedure

--- a/companion/lib/Controls/ControlsTrpcRouter.ts
+++ b/companion/lib/Controls/ControlsTrpcRouter.ts
@@ -63,11 +63,19 @@ export function createControlsTrpcRouter(
 				})
 			)
 			.mutation(async ({ input }) => {
+				const fromStr = formatLocation(input.fromLocation)
+
+				// Don't create a circular reference
+				if (fromStr === formatLocation(input.toLocation)) return null
+
+				// Don't place at an unreachable location
+				if (!pageStore.isPageValid(input.toLocation.pageNumber)) return null
+
 				// Place a button that mirrors `fromLocation`. Stored as a plain (non-expression) location string.
 				const model: ButtonReferenceButtonModel = {
 					type: 'button-reference',
 					options: {
-						location: { value: formatLocation(input.fromLocation), isExpression: false },
+						location: { value: fromStr, isExpression: false },
 					},
 				}
 				return controlsController.importControl(input.toLocation, model)

--- a/companion/lib/Controls/EntitiesTrpcRouter.ts
+++ b/companion/lib/Controls/EntitiesTrpcRouter.ts
@@ -358,7 +358,8 @@ export function createEntitiesTrpcRouter(
 				const control = controlsMap.get(input.controlId)
 				if (!control) return {}
 
-				if (!control.supportsEntities) throw new Error(`Control "${input.controlId}" does not support entities`)
+				// A control without an entity pool (e.g. a button reference) simply has no local variable values
+				if (!control.supportsEntities) return {}
 
 				return control.entities.getLocalVariableValues()
 			}),

--- a/companion/lib/Controls/Factory.ts
+++ b/companion/lib/Controls/Factory.ts
@@ -7,6 +7,7 @@ import type { ControlDependencies } from './ControlDependencies.js'
 import { ControlButtonLayered } from './ControlTypes/Button/Layered.js'
 import { ControlButtonPreset } from './ControlTypes/Button/Preset.js'
 import { ControlButtonPresetReference } from './ControlTypes/Button/PresetReference.js'
+import { ControlButtonReference } from './ControlTypes/Button/Reference.js'
 import { ControlExpressionVariable } from './ControlTypes/ExpressionVariable.js'
 import { ControlPage } from './ControlTypes/Page.js'
 import { ControlButtonPageDown } from './ControlTypes/PageDown.js'
@@ -51,6 +52,8 @@ export class ControlsFactory {
 				return new ControlButtonLayered(this.#controlDeps, controlId, controlObj2, isImport)
 			} else if (controlObj2?.type === 'preset-reference') {
 				return new ControlButtonPresetReference(this.#controlDeps, controlId, controlObj2, isImport)
+			} else if (controlObj2?.type === 'button-reference' || (controlType === 'button-reference' && !controlObj2)) {
+				return new ControlButtonReference(this.#controlDeps, controlId, controlObj2, isImport)
 			} else if (controlObj2?.type === 'pagenum' || (controlType === 'pagenum' && !controlObj2)) {
 				return new ControlButtonPageNumber(this.#controlDeps, controlId, controlObj2, isImport)
 			} else if (controlObj2?.type === 'pageup' || (controlType === 'pageup' && !controlObj2)) {

--- a/companion/lib/Controls/IButtonDrawer.ts
+++ b/companion/lib/Controls/IButtonDrawer.ts
@@ -1,0 +1,18 @@
+import type { DrawStyleLayeredButtonModel } from '@companion-app/shared/Model/StyleModel.js'
+import type { CompositeElementIdString } from '../Instance/Definitions.js'
+
+/**
+ * The minimal surface a control's `drawing` exposes to the rest of the application (the graphics controller and
+ * the controls controller). The concrete {@link LayeredButtonDrawer} implements a much richer set of methods for
+ * its owning control's internal use; only what is called externally lives here.
+ */
+export interface IButtonDrawer {
+	/** Compute the draw style of the button. */
+	getDrawStyle(): Promise<DrawStyleLayeredButtonModel>
+	/** The most recently computed draw style, if any (without recomputing). */
+	getLastDrawStyle(): DrawStyleLayeredButtonModel | null
+	/** Propagate a variable change: invalidate affected cached elements and redraw if relevant. */
+	onVariablesChanged(allChangedVariables: ReadonlySet<string>): void
+	/** A composite element definition changed: invalidate and redraw if relevant. */
+	onCompositeElementsChanged(allChangedElementIds: ReadonlySet<CompositeElementIdString>): void
+}

--- a/companion/lib/Controls/IButtonDrawer.ts
+++ b/companion/lib/Controls/IButtonDrawer.ts
@@ -1,4 +1,6 @@
+import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
 import type { DrawStyleLayeredButtonModel } from '@companion-app/shared/Model/StyleModel.js'
+import type { ImageResult } from '../Graphics/ImageResult.js'
 import type { CompositeElementIdString } from '../Instance/Definitions.js'
 
 /**
@@ -15,4 +17,9 @@ export interface IButtonDrawer {
 	onVariablesChanged(allChangedVariables: ReadonlySet<string>): void
 	/** A composite element definition changed: invalidate and redraw if relevant. */
 	onCompositeElementsChanged(allChangedElementIds: ReadonlySet<CompositeElementIdString>): void
+	/**
+	 * Another located control finished rendering: invalidate and redraw if this button mirrors or references it.
+	 * Dispatched by the controls controller rather than each drawer subscribing to `button_drawn` itself.
+	 */
+	onButtonDrawn(location: ControlLocation, render: ImageResult): void
 }

--- a/companion/lib/Controls/IButtonDrawer.ts
+++ b/companion/lib/Controls/IButtonDrawer.ts
@@ -17,9 +17,6 @@ export interface IButtonDrawer {
 	onVariablesChanged(allChangedVariables: ReadonlySet<string>): void
 	/** A composite element definition changed: invalidate and redraw if relevant. */
 	onCompositeElementsChanged(allChangedElementIds: ReadonlySet<CompositeElementIdString>): void
-	/**
-	 * Another located control finished rendering: invalidate and redraw if this button mirrors or references it.
-	 * Dispatched by the controls controller rather than each drawer subscribing to `button_drawn` itself.
-	 */
+	/** Another located control finished rendering: invalidate and redraw if this button mirrors or references it. */
 	onButtonDrawn(location: ControlLocation, render: ImageResult): void
 }

--- a/companion/lib/Controls/IControlFragments.ts
+++ b/companion/lib/Controls/IControlFragments.ts
@@ -203,13 +203,6 @@ export interface ControlWithActionSets extends ControlBase<any> {
 	 * for a button they are the same pool object.)
 	 */
 	readonly actionSets: SomeStepManager
-
-	/**
-	 * Execute a rotate of this control
-	 * @param delta Signed rotation amount - sign is the direction, magnitude is the number of steps
-	 * @param surfaceId The surface that initiated this rotate
-	 */
-	rotateControl(delta: number, surfaceId: string | undefined): void
 }
 
 export interface ControlWithoutActionSets extends ControlBase<any> {

--- a/companion/lib/Graphics/ConvertGraphicsElements.ts
+++ b/companion/lib/Graphics/ConvertGraphicsElements.ts
@@ -411,7 +411,7 @@ async function convertReferenceElementForDrawing(
 	return { drawElement, references, compositeElement: null, referencedLocation: referencedLocationStr }
 }
 
-function makeReferencePlaceholder(
+export function makeReferencePlaceholder(
 	parentId: string,
 	text: string
 ): [ButtonGraphicsBoxDrawElement, ButtonGraphicsTextDrawElement] {

--- a/companion/lib/ImportExport/Controller.ts
+++ b/companion/lib/ImportExport/Controller.ts
@@ -23,9 +23,13 @@ import {
 	type ImportOrResetType,
 } from '@companion-app/shared/Model/ImportExport.js'
 import type { RendererButtonStyle } from '@companion-app/shared/Model/Render.js'
-import type { SomeButtonGraphicsElement } from '@companion-app/shared/Model/StyleLayersModel.js'
+import type {
+	ButtonGraphicsReferenceElement,
+	SomeButtonGraphicsElement,
+} from '@companion-app/shared/Model/StyleLayersModel.js'
 import { assertNever } from '@companion-app/shared/Util.js'
 import type { ControlsController } from '../Controls/Controller.js'
+import { CreateElementOfType } from '../Controls/ControlTypes/Button/LayerDefaults.js'
 import { pageDownElements } from '../Controls/ControlTypes/PageDown.js'
 import { pageNumberElements } from '../Controls/ControlTypes/PageNumber.js'
 import { pageUpElements } from '../Controls/ControlTypes/PageUp.js'
@@ -366,6 +370,15 @@ export class ImportExportController {
 							drawType = 'button'
 							rawElements = controlObjLayered.style.layers
 							break
+						case 'button-reference': {
+							// The mirror is drawn as a single reference element. Cross-page references can't be resolved
+							// in the import preview (no render cache), so this renders the "unresolved" placeholder.
+							drawType = 'button'
+							const referenceElement = CreateElementOfType('reference') as ButtonGraphicsReferenceElement
+							referenceElement.location = controlObjLayered.options.location
+							rawElements = [referenceElement]
+							break
+						}
 						case 'pagenum':
 							drawType = 'pagenum'
 							rawElements = structuredClone(pageNumberElements)

--- a/companion/lib/ImportExport/Import.ts
+++ b/companion/lib/ImportExport/Import.ts
@@ -27,6 +27,7 @@ import { VisitorReferencesUpdater } from '../Resources/Visitors/ReferencesUpdate
 import type { SurfaceController } from '../Surface/Controller.js'
 import type { VariablesController } from '../Variables/Controller.js'
 import {
+	fixupButtonReferenceControl,
 	fixupExpressionVariableControl,
 	fixupLayeredButtonControl,
 	fixupPageVariables,
@@ -395,6 +396,9 @@ export class ImportController {
 						// Keep it a live reference: remap the referenced connection id the same way entity references
 						// are remapped during import, so it re-links to the re-created connection.
 						fixedControlObj = fixupPresetReferenceControl(this.#logger, control, referencesUpdater, instanceIdMap)
+					} else if (control.type === 'button-reference') {
+						// Keep it a live mirror: remap any connection labels used in the location expression.
+						fixedControlObj = fixupButtonReferenceControl(control, referencesUpdater)
 					} else {
 						this.#logger.warn(`Unknown control type: ${control.type}`)
 						continue

--- a/companion/lib/ImportExport/ImportFixup.ts
+++ b/companion/lib/ImportExport/ImportFixup.ts
@@ -9,9 +9,7 @@ import type {
 import type { SomeEntityModel } from '@companion-app/shared/Model/EntityModel.js'
 import type { ExportControlv6, ExportTriggerContentv6 } from '@companion-app/shared/Model/ExportModel.js'
 import type { ExpressionVariableModel } from '@companion-app/shared/Model/ExpressionVariableModel.js'
-import type { ButtonGraphicsReferenceElement } from '@companion-app/shared/Model/StyleLayersModel.js'
 import type { TriggerModel } from '@companion-app/shared/Model/TriggerModel.js'
-import { CreateElementOfType } from '../Controls/ControlTypes/Button/LayerDefaults.js'
 import type { InternalController } from '../Internal/Controller.js'
 import type { Logger } from '../Log/Controller.js'
 import { VisitorReferencesUpdater } from '../Resources/Visitors/ReferencesUpdater.js'
@@ -195,19 +193,16 @@ export function fixupButtonReferenceControl(
 	control: ExportControlv6,
 	referencesUpdater: VisitorReferencesUpdater
 ): ButtonReferenceButtonModel {
-	// Remap connection labels used in the location expression the same way other element expressions are remapped.
-	// Note: an absolute location (e.g. "3/0/0") is NOT page-remapped here, so it may point at the wrong page after a
+	const options = structuredClone(control.options)
+
+	// Remap connection labels used in the location the same way other element expressions are remapped.
+	// Note: an absolute location (e.g. "3/0/0") is NOT page-remapped, so it may point at the wrong page after a
 	// partial import that renumbers pages; expression/relative locations are offset-safe.
-	const referenceElement = CreateElementOfType('reference') as ButtonGraphicsReferenceElement
-	if (control.options?.location) referenceElement.location = structuredClone(control.options.location)
-	referencesUpdater.visitDrawElements([referenceElement])
+	if (options.location) referencesUpdater.visitExpressionOrValue(options.location, true)
 
 	return {
 		type: 'button-reference',
-		options: {
-			location: referenceElement.location,
-			notes: control.options?.notes,
-		},
+		options,
 	}
 }
 

--- a/companion/lib/ImportExport/ImportFixup.ts
+++ b/companion/lib/ImportExport/ImportFixup.ts
@@ -2,13 +2,16 @@ import { validateActionSetId } from '@companion-app/shared/ControlId.js'
 import type { ActionSetsModel } from '@companion-app/shared/Model/ActionModel.js'
 import type {
 	ButtonModelBase,
+	ButtonReferenceButtonModel,
 	LayeredButtonModel,
 	PresetReferenceButtonModel,
 } from '@companion-app/shared/Model/ButtonModel.js'
 import type { SomeEntityModel } from '@companion-app/shared/Model/EntityModel.js'
 import type { ExportControlv6, ExportTriggerContentv6 } from '@companion-app/shared/Model/ExportModel.js'
 import type { ExpressionVariableModel } from '@companion-app/shared/Model/ExpressionVariableModel.js'
+import type { ButtonGraphicsReferenceElement } from '@companion-app/shared/Model/StyleLayersModel.js'
 import type { TriggerModel } from '@companion-app/shared/Model/TriggerModel.js'
+import { CreateElementOfType } from '../Controls/ControlTypes/Button/LayerDefaults.js'
 import type { InternalController } from '../Internal/Controller.js'
 import type { Logger } from '../Log/Controller.js'
 import { VisitorReferencesUpdater } from '../Resources/Visitors/ReferencesUpdater.js'
@@ -186,6 +189,26 @@ export function fixupPresetReferenceControl(
 	referencesUpdater.visitDrawElements(result.style.layers)
 
 	return result
+}
+
+export function fixupButtonReferenceControl(
+	control: ExportControlv6,
+	referencesUpdater: VisitorReferencesUpdater
+): ButtonReferenceButtonModel {
+	// Remap connection labels used in the location expression the same way other element expressions are remapped.
+	// Note: an absolute location (e.g. "3/0/0") is NOT page-remapped here, so it may point at the wrong page after a
+	// partial import that renumbers pages; expression/relative locations are offset-safe.
+	const referenceElement = CreateElementOfType('reference') as ButtonGraphicsReferenceElement
+	if (control.options?.location) referenceElement.location = structuredClone(control.options.location)
+	referencesUpdater.visitDrawElements([referenceElement])
+
+	return {
+		type: 'button-reference',
+		options: {
+			location: referenceElement.location,
+			notes: control.options?.notes,
+		},
+	}
 }
 
 function fixupButtonControlBase(

--- a/companion/lib/ImportExport/ImportFixup.ts
+++ b/companion/lib/ImportExport/ImportFixup.ts
@@ -9,6 +9,7 @@ import type {
 import type { SomeEntityModel } from '@companion-app/shared/Model/EntityModel.js'
 import type { ExportControlv6, ExportTriggerContentv6 } from '@companion-app/shared/Model/ExportModel.js'
 import type { ExpressionVariableModel } from '@companion-app/shared/Model/ExpressionVariableModel.js'
+import { isExpressionOrValue } from '@companion-app/shared/Model/Options.js'
 import type { TriggerModel } from '@companion-app/shared/Model/TriggerModel.js'
 import type { InternalController } from '../Internal/Controller.js'
 import type { Logger } from '../Log/Controller.js'
@@ -193,12 +194,14 @@ export function fixupButtonReferenceControl(
 	control: ExportControlv6,
 	referencesUpdater: VisitorReferencesUpdater
 ): ButtonReferenceButtonModel {
-	const options = structuredClone(control.options)
+	const options = structuredClone(control.options) ?? {}
+
+	if (!isExpressionOrValue(options.location)) options.location = { value: '', isExpression: false }
 
 	// Remap connection labels used in the location the same way other element expressions are remapped.
 	// Note: an absolute location (e.g. "3/0/0") is NOT page-remapped, so it may point at the wrong page after a
 	// partial import that renumbers pages; expression/relative locations are offset-safe.
-	if (options.location) referencesUpdater.visitExpressionOrValue(options.location, true)
+	referencesUpdater.visitExpressionOrValue(options.location, true)
 
 	return {
 		type: 'button-reference',

--- a/companion/lib/Registry.ts
+++ b/companion/lib/Registry.ts
@@ -216,7 +216,7 @@ export class Registry {
 		const pageStore = new PageStore(this.db.getTableView('pages'))
 
 		this.variables = new VariablesController(this.db, this.userconfig)
-		const controlStore = new ControlStore(this.db, this.variables.values)
+		const controlStore = new ControlStore(this.db, this.variables.values, pageStore)
 
 		this.#renderClock = new RenderClock()
 

--- a/companion/lib/Registry.ts
+++ b/companion/lib/Registry.ts
@@ -419,6 +419,7 @@ export class Registry {
 		})
 
 		this.graphics.on('button_drawn', (location, render) => {
+			this.controls.onButtonDrawn(location, render)
 			this.services.onButtonDrawn(location, render)
 		})
 	}

--- a/companion/lib/Resources/Visitors/VisitorReferencesBase.ts
+++ b/companion/lib/Resources/Visitors/VisitorReferencesBase.ts
@@ -46,6 +46,18 @@ export class VisitorReferencesBase<T extends InternalVisitor> {
 		return this
 	}
 
+	/**
+	 * Visit a standalone {@link ExpressionOrValue} (e.g. a control option not held as a draw element). Expressions
+	 * are always visited; pass `visitPlainValue` to also rename variables inside a plain string value.
+	 */
+	visitExpressionOrValue(value: ExpressionOrValue<JsonValue | undefined>, visitPlainValue = false): this {
+		if (value.isExpression || (visitPlainValue && typeof value.value === 'string')) {
+			this.visitor.visitString(value, 'value')
+		}
+
+		return this
+	}
+
 	visitDrawElements(elements: SomeButtonGraphicsElement[]): this {
 		for (const element of elements) {
 			for (const key in element) {

--- a/companion/lib/Surface/Controller.ts
+++ b/companion/lib/Surface/Controller.ts
@@ -1953,6 +1953,8 @@ export class SurfaceController extends EventEmitter<SurfaceControllerEvents> {
 	 * in that group, while a surface id targets only that surface.
 	 */
 	#getSurfaceHandlersForBrightness(surfaceOrGroupId: string, looseIdMatching: boolean): SurfaceHandler[] {
+		surfaceOrGroupId = stripReferenceSurfaceId(surfaceOrGroupId)
+
 		const surfaceGroup = this.#surfaceGroups.get(surfaceOrGroupId)
 		if (surfaceGroup) return surfaceGroup.surfaceHandlers
 

--- a/companion/lib/Surface/Controller.ts
+++ b/companion/lib/Surface/Controller.ts
@@ -54,6 +54,7 @@ import { EmulatorRoom, SurfaceIPElgatoEmulator } from './IP/ElgatoEmulator.js'
 import { SurfaceIPSatellite, type SatelliteDeviceInfo } from './IP/Satellite.js'
 import { SurfaceOutboundController } from './Outbound.js'
 import type { SurfacePluginPanel } from './PluginPanel.js'
+import { stripReferenceSurfaceId } from './ReferenceSurfaceId.js'
 import type { SurfaceHandlerDependencies, SurfacePanel, UpdateEvents } from './Types.js'
 
 /**
@@ -2004,6 +2005,9 @@ export class SurfaceController extends EventEmitter<SurfaceControllerEvents> {
 	 * Get the `SurfaceGroup` for a surfaceId or groupId
 	 */
 	#getGroupForId(surfaceOrGroupId: string, looseIdMatching = false): SurfaceGroup | undefined {
+		// A button-reference forwards presses with the reference control id appended; recover the real id
+		surfaceOrGroupId = stripReferenceSurfaceId(surfaceOrGroupId)
+
 		const matchingGroup = this.#surfaceGroups.get(surfaceOrGroupId)
 		if (matchingGroup) return matchingGroup
 
@@ -2022,6 +2026,9 @@ export class SurfaceController extends EventEmitter<SurfaceControllerEvents> {
 	 * @param looseIdMatching Loosely match the id, to handle old device naming
 	 */
 	#getSurfaceHandlerForId(surfaceId: string, looseIdMatching: boolean): SurfaceHandler | undefined {
+		// A button-reference forwards presses with the reference control id appended; recover the real id
+		surfaceId = stripReferenceSurfaceId(surfaceId)
+
 		if (surfaceId === 'emulator') surfaceId = 'emulator:emulator'
 
 		const surfaces = this.#surfaceHandlers.values().toArray()

--- a/companion/lib/Surface/ReferenceSurfaceId.ts
+++ b/companion/lib/Surface/ReferenceSurfaceId.ts
@@ -1,0 +1,39 @@
+/**
+ * Mangled surfaceIds for button-reference forwarding. A reference forwards to its target with its own control id
+ * appended to the surfaceId, isolating the target's per-surface press/hold state per reference. Surface resolution
+ * strips the suffix again (see {@link stripReferenceSurfaceId}) so `self` actions hit the real originating surface.
+ */
+
+/** Separator between the real surfaceId and an appended control id. `#` appears in no surface/control id, so it
+ * can't collide, and it stays display/JSON-safe. */
+const SEP = '#ref#'
+
+/** How many reference hops a forwarded press may take before it is treated as a loop and dropped. */
+export const MAX_REFERENCE_DEPTH = 8
+
+/** Append a reference control id to a surfaceId. Returns `undefined` unchanged (a legitimate no-surface press). */
+export function mangleReferenceSurfaceId(
+	surfaceId: string | undefined,
+	referenceControlId: string
+): string | undefined {
+	if (surfaceId === undefined) return undefined
+	return `${surfaceId}${SEP}${referenceControlId}`
+}
+
+/** Recover the real surfaceId by dropping any appended reference control id(s). A no-op on unmangled ids. */
+export function stripReferenceSurfaceId(surfaceId: string): string {
+	const index = surfaceId.indexOf(SEP)
+	return index === -1 ? surfaceId : surfaceId.slice(0, index)
+}
+
+/** The number of reference hops encoded in a surfaceId (0 for an unmangled id). */
+export function referenceSurfaceIdDepth(surfaceId: string | undefined): number {
+	if (!surfaceId) return 0
+	let count = 0
+	let index = surfaceId.indexOf(SEP)
+	while (index !== -1) {
+		count++
+		index = surfaceId.indexOf(SEP, index + SEP.length)
+	}
+	return count
+}

--- a/companion/lib/Surface/ReferenceSurfaceId.ts
+++ b/companion/lib/Surface/ReferenceSurfaceId.ts
@@ -11,13 +11,12 @@ const SEP = '#ref#'
 /** How many reference hops a forwarded press may take before it is treated as a loop and dropped. */
 export const MAX_REFERENCE_DEPTH = 8
 
-/** Append a reference control id to a surfaceId. Returns `undefined` unchanged (a legitimate no-surface press). */
-export function mangleReferenceSurfaceId(
-	surfaceId: string | undefined,
-	referenceControlId: string
-): string | undefined {
-	if (surfaceId === undefined) return undefined
-	return `${surfaceId}${SEP}${referenceControlId}`
+/**
+ * Append a reference control id to a surfaceId. A missing surfaceId becomes an empty real part, so the result is
+ * still depth-countable - this is what bounds a surface-less reference cycle via {@link referenceSurfaceIdDepth}.
+ */
+export function mangleReferenceSurfaceId(surfaceId: string | undefined, referenceControlId: string): string {
+	return `${surfaceId ?? ''}${SEP}${referenceControlId}`
 }
 
 /** Recover the real surfaceId by dropping any appended reference control id(s). A no-op on unmangled ids. */

--- a/companion/test/Controls/ControlStore.test.ts
+++ b/companion/test/Controls/ControlStore.test.ts
@@ -1,0 +1,287 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ControlStore } from '../../lib/Controls/ControlStore.js'
+
+/** A mock control exposing only what ControlStore touches, with vi.fn spies for the methods it calls. */
+function makeControl(
+	opts: {
+		controlId?: string
+		supportsEntities?: boolean
+		supportsActions?: boolean
+		rotateResult?: boolean
+		entityParser?: object
+	} = {}
+) {
+	return {
+		controlId: opts.controlId ?? 'bank:x',
+		supportsEntities: opts.supportsEntities ?? false,
+		supportsActions: opts.supportsActions ?? false,
+		renameVariables: vi.fn(),
+		pressControl: vi.fn(),
+		rotateControl: vi.fn(() => opts.rotateResult ?? true),
+		abortDelayedActions: vi.fn(),
+		entities: {
+			forgetConnection: vi.fn(),
+			clearConnectionState: vi.fn(),
+			updateFeedbackValues: vi.fn(),
+			createVariablesAndExpressionParser: vi.fn(() => opts.entityParser ?? ({} as any)),
+		},
+	}
+}
+
+describe('ControlStore', () => {
+	let tableView: { delete: ReturnType<typeof vi.fn> }
+	let getTableView: ReturnType<typeof vi.fn>
+	let createParser: ReturnType<typeof vi.fn>
+	let getLocationOfControlId: ReturnType<typeof vi.fn>
+	let store: ControlStore
+
+	beforeEach(() => {
+		tableView = { delete: vi.fn() }
+		getTableView = vi.fn(() => tableView)
+		createParser = vi.fn(() => ({}) as any)
+		getLocationOfControlId = vi.fn(() => null)
+
+		const db = { getTableView } as any
+		const variablesValues = { createVariablesAndExpressionParser: createParser } as any
+		const pageStore = { getLocationOfControlId } as any
+
+		store = new ControlStore(db, variablesValues, pageStore)
+	})
+
+	function addControl(controlId: string, opts: Parameters<typeof makeControl>[0] = {}) {
+		const control = makeControl({ ...opts, controlId })
+		store.controls.set(controlId, control as any)
+		return control
+	}
+
+	describe('construction', () => {
+		it('opens the controls table view', () => {
+			expect(getTableView).toHaveBeenCalledWith('controls')
+			expect(store.dbTable).toBe(tableView)
+		})
+
+		it('creates a trigger event bus', () => {
+			expect(store.triggerEvents).toBeTruthy()
+		})
+	})
+
+	describe('getControl', () => {
+		it('returns a stored control', () => {
+			const control = addControl('bank:1')
+			expect(store.getControl('bank:1')).toBe(control)
+		})
+
+		it('returns undefined for a missing control', () => {
+			expect(store.getControl('bank:missing')).toBeUndefined()
+		})
+
+		it('returns undefined for an empty id (without hitting the map)', () => {
+			expect(store.getControl('')).toBeUndefined()
+		})
+	})
+
+	describe('getAllControls', () => {
+		it('returns every stored control', () => {
+			const a = addControl('bank:1')
+			const b = addControl('bank:2')
+			const all = store.getAllControls()
+			expect(all.size).toBe(2)
+			expect(all.get('bank:1')).toBe(a)
+			expect(all.get('bank:2')).toBe(b)
+		})
+	})
+
+	describe('deleteControl', () => {
+		it('removes the control from the map and the db table', () => {
+			addControl('bank:1')
+			store.deleteControl('bank:1')
+
+			expect(store.getControl('bank:1')).toBeUndefined()
+			expect(tableView.delete).toHaveBeenCalledWith('bank:1')
+		})
+	})
+
+	describe('renameVariables', () => {
+		it('renames across every control', () => {
+			const a = addControl('bank:1')
+			const b = addControl('bank:2')
+			store.renameVariables('old', 'new')
+
+			expect(a.renameVariables).toHaveBeenCalledWith('old', 'new')
+			expect(b.renameVariables).toHaveBeenCalledWith('old', 'new')
+		})
+	})
+
+	describe('forgetConnection', () => {
+		it('forgets the connection only on entity-backed controls', () => {
+			const withEntities = addControl('bank:1', { supportsEntities: true })
+			const withoutEntities = addControl('bank:2', { supportsEntities: false })
+
+			store.forgetConnection('conn1')
+
+			expect(withEntities.entities.forgetConnection).toHaveBeenCalledWith('conn1')
+			expect(withoutEntities.entities.forgetConnection).not.toHaveBeenCalled()
+		})
+	})
+
+	describe('clearConnectionState', () => {
+		it('clears state only on entity-backed controls', () => {
+			const withEntities = addControl('bank:1', { supportsEntities: true })
+			const withoutEntities = addControl('bank:2', { supportsEntities: false })
+
+			store.clearConnectionState('conn1')
+
+			expect(withEntities.entities.clearConnectionState).toHaveBeenCalledWith('conn1')
+			expect(withoutEntities.entities.clearConnectionState).not.toHaveBeenCalled()
+		})
+	})
+
+	describe('abortAllDelayedActions', () => {
+		it('aborts only on action-backed controls, forwarding the exempt signal', () => {
+			const withActions = addControl('bank:1', { supportsActions: true })
+			const withoutActions = addControl('bank:2', { supportsActions: false })
+			const signal = new AbortController().signal
+
+			store.abortAllDelayedActions(signal)
+
+			expect(withActions.abortDelayedActions).toHaveBeenCalledWith(false, signal)
+			expect(withoutActions.abortDelayedActions).not.toHaveBeenCalled()
+		})
+
+		it('accepts a null signal', () => {
+			const withActions = addControl('bank:1', { supportsActions: true })
+			store.abortAllDelayedActions(null)
+			expect(withActions.abortDelayedActions).toHaveBeenCalledWith(false, null)
+		})
+	})
+
+	describe('pressControl', () => {
+		it('emits control_press and forwards the press, returning true', () => {
+			const control = addControl('bank:1')
+			const pressListener = vi.fn()
+			store.triggerEvents.on('control_press', pressListener)
+
+			expect(store.pressControl('bank:1', true, 'surface1', true)).toBe(true)
+
+			expect(pressListener).toHaveBeenCalledWith('bank:1', true, 'surface1')
+			expect(control.pressControl).toHaveBeenCalledWith(true, 'surface1', true)
+		})
+
+		it('returns false and does not emit for a missing control', () => {
+			const pressListener = vi.fn()
+			store.triggerEvents.on('control_press', pressListener)
+
+			expect(store.pressControl('bank:missing', true, 'surface1')).toBe(false)
+			expect(pressListener).not.toHaveBeenCalled()
+		})
+	})
+
+	describe('rotateControl', () => {
+		it('forwards a valid rotation and returns the control result', () => {
+			const control = addControl('bank:1', { rotateResult: true })
+			expect(store.rotateControl('bank:1', 2, 'surface1')).toBe(true)
+			expect(control.rotateControl).toHaveBeenCalledWith(2, 'surface1')
+		})
+
+		it('propagates a control that reports it did not handle the rotation', () => {
+			addControl('bank:1', { rotateResult: false })
+			expect(store.rotateControl('bank:1', -1, 'surface1')).toBe(false)
+		})
+
+		it('returns false for a missing control', () => {
+			expect(store.rotateControl('bank:missing', 1, 'surface1')).toBe(false)
+		})
+
+		it.each([0, NaN, Infinity, -Infinity])('rejects a %s delta without touching the control', (delta) => {
+			const control = addControl('bank:1')
+			expect(store.rotateControl('bank:1', delta, 'surface1')).toBe(false)
+			expect(control.rotateControl).not.toHaveBeenCalled()
+		})
+	})
+
+	describe('updateFeedbackValues', () => {
+		it('is a no-op for an empty result set', () => {
+			const control = addControl('bank:1', { supportsEntities: true })
+			store.updateFeedbackValues('conn1', [])
+			expect(control.entities.updateFeedbackValues).not.toHaveBeenCalled()
+		})
+
+		it('groups values per control and dispatches to entity-backed controls', () => {
+			const control = addControl('bank:1', { supportsEntities: true })
+			const v1 = { controlId: 'bank:1', entityId: 'e1' } as any
+			const v2 = { controlId: 'bank:1', entityId: 'e2' } as any
+
+			store.updateFeedbackValues('conn1', [v1, v2])
+
+			expect(control.entities.updateFeedbackValues).toHaveBeenCalledTimes(1)
+			const [connectionId, valuesMap] = control.entities.updateFeedbackValues.mock.calls[0]
+			expect(connectionId).toBe('conn1')
+			expect(valuesMap.get('e1')).toBe(v1)
+			expect(valuesMap.get('e2')).toBe(v2)
+		})
+
+		it('skips controls that do not support entities or are missing', () => {
+			const noEntities = addControl('bank:1', { supportsEntities: false })
+
+			store.updateFeedbackValues('conn1', [
+				{ controlId: 'bank:1', entityId: 'e1' } as any,
+				{ controlId: 'bank:missing', entityId: 'e2' } as any,
+			])
+
+			expect(noEntities.entities.updateFeedbackValues).not.toHaveBeenCalled()
+		})
+	})
+
+	// The grid location sourced here feeds the `this:*` variables. A control with an entity pool uses its own
+	// parser; a located control without one (e.g. a button reference) must still have its location injected so
+	// `$(this:page)` resolves rather than yielding `$NA`.
+	describe('createVariablesAndExpressionParser', () => {
+		it('injects the grid location for a located control without an entity pool', () => {
+			const location = { pageNumber: 3, row: 1, column: 2 }
+			getLocationOfControlId.mockReturnValue(location)
+			addControl('bank:1', { supportsEntities: false })
+
+			store.createVariablesAndExpressionParser('bank:1', null)
+
+			expect(getLocationOfControlId).toHaveBeenCalledWith('bank:1')
+			expect(createParser).toHaveBeenCalledWith(location, null, null, null, undefined)
+		})
+
+		it('injects the location even when the control is not (yet) in the store', () => {
+			const location = { pageNumber: 1, row: 0, column: 0 }
+			getLocationOfControlId.mockReturnValue(location)
+
+			store.createVariablesAndExpressionParser('bank:9', null)
+
+			expect(createParser).toHaveBeenCalledWith(location, null, null, null, undefined)
+		})
+
+		it('forwards override values and parser options on the generic path', () => {
+			const overrides = { 'custom:x': 5 } as any
+			const options = { marker: true } as any
+			store.createVariablesAndExpressionParser(null, overrides, options)
+
+			expect(createParser).toHaveBeenCalledWith(null, null, overrides, null, options)
+		})
+
+		it('passes a null location when there is no control id', () => {
+			store.createVariablesAndExpressionParser(null, null)
+
+			expect(getLocationOfControlId).not.toHaveBeenCalled()
+			expect(createParser).toHaveBeenCalledWith(null, null, null, null, undefined)
+		})
+
+		it('defers to the entity pool parser when the control supports entities', () => {
+			const entityParser = {} as any
+			const control = addControl('bank:2', { supportsEntities: true, entityParser })
+			const overrides = { 'custom:y': 1 } as any
+
+			const result = store.createVariablesAndExpressionParser('bank:2', overrides)
+
+			expect(result).toBe(entityParser)
+			expect(control.entities.createVariablesAndExpressionParser).toHaveBeenCalledWith(overrides, undefined)
+			expect(createParser).not.toHaveBeenCalled()
+			expect(getLocationOfControlId).not.toHaveBeenCalled()
+		})
+	})
+})

--- a/companion/test/Controls/ControlTypes/Button/PresetReference.test.ts
+++ b/companion/test/Controls/ControlTypes/Button/PresetReference.test.ts
@@ -79,6 +79,11 @@ describe('ControlButtonPresetReference', () => {
 			events: new EventEmitter() as any,
 			changeEvents: new EventEmitter() as any,
 			renderClock: { subscribe: vi.fn(() => () => {}) } as any,
+			controlsAccessor: {
+				getControl: vi.fn(() => undefined),
+				pressControl: vi.fn(() => false),
+				rotateControl: vi.fn(() => false),
+			},
 		}
 	})
 

--- a/companion/test/Controls/ControlTypes/Button/Reference.test.ts
+++ b/companion/test/Controls/ControlTypes/Button/Reference.test.ts
@@ -1,0 +1,262 @@
+import { EventEmitter } from 'node:events'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ButtonReferenceButtonModel, LayeredButtonModel } from '@companion-app/shared/Model/ButtonModel.js'
+import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
+import type { ControlDependencies } from '../../../../lib/Controls/ControlDependencies.js'
+import { ControlButtonReference } from '../../../../lib/Controls/ControlTypes/Button/Reference.js'
+import { mangleReferenceSurfaceId, MAX_REFERENCE_DEPTH } from '../../../../lib/Surface/ReferenceSurfaceId.js'
+
+const MY_CONTROL_ID = 'bank:test01'
+const MY_LOCATION: ControlLocation = { pageNumber: 1, row: 2, column: 3 }
+
+function makeModel(location: ButtonReferenceButtonModel['options']['location']): ButtonReferenceButtonModel {
+	return { type: 'button-reference', options: { location } }
+}
+
+function plainLocation(value: string): ButtonReferenceButtonModel['options']['location'] {
+	return { value, isExpression: false }
+}
+
+describe('ControlButtonReference', () => {
+	let deps: ControlDependencies
+	let controlsAccessor: {
+		getControl: ReturnType<typeof vi.fn>
+		pressControl: ReturnType<typeof vi.fn>
+		rotateControl: ReturnType<typeof vi.fn>
+	}
+	let getControlIdAt: ReturnType<typeof vi.fn>
+
+	beforeEach(() => {
+		controlsAccessor = {
+			getControl: vi.fn(() => undefined),
+			pressControl: vi.fn(() => true),
+			rotateControl: vi.fn(() => true),
+		}
+
+		// Identity parser: a plain value passes through untouched, an expression evaluates to its raw text
+		const parser = {
+			parseVariables: vi.fn((value: string) => ({ text: String(value) })),
+			executeExpression: vi.fn((value: string) => ({ ok: true, value })),
+		}
+
+		getControlIdAt = vi.fn(() => undefined)
+
+		deps = {
+			surfaces: {} as any,
+			pageStore: {
+				getLocationOfControlId: vi.fn(() => MY_LOCATION),
+				getControlIdAt,
+			} as any,
+			getPageVariableEntities: () => null,
+			triggerEvents: null as any,
+			expressionVariableNamesMap: null as any,
+			internalModule: { entityUpgrade: vi.fn(() => undefined), visitReferences: vi.fn() } as any,
+			instance: {} as any,
+			variableValues: {
+				createVariablesAndExpressionParser: vi.fn(() => parser),
+			} as any,
+			userconfig: {} as any,
+			graphics: new EventEmitter() as any,
+			actionRunner: {} as any,
+			dbTable: { set: vi.fn(), delete: vi.fn() } as any,
+			events: new EventEmitter() as any,
+			changeEvents: new EventEmitter() as any,
+			renderClock: { subscribe: vi.fn(() => () => {}) } as any,
+			controlsAccessor: controlsAccessor as any,
+		}
+	})
+
+	function createControl(location = plainLocation('4/0/0')) {
+		return new ControlButtonReference(deps, MY_CONTROL_ID, makeModel(location), false)
+	}
+
+	it('exposes the reference metadata and capability flags', () => {
+		const control = createControl()
+		expect(control.type).toBe('button-reference')
+		expect(control.supportsConvert).toBe(true)
+		expect(control.supportsOptions).toBe(true)
+		expect(control.supportsActions).toBe(false)
+		expect(control.supportsEntities).toBe(false)
+		expect(control.supportsLayeredStyle).toBe(false)
+		expect(control.drawing).toBeTruthy()
+	})
+
+	it('round-trips the stored location and notes', () => {
+		const control = new ControlButtonReference(
+			deps,
+			MY_CONTROL_ID,
+			{ type: 'button-reference', options: { location: plainLocation('2/1/1'), notes: 'hello' } },
+			false
+		)
+		const json = control.toJSON()
+		expect(json.type).toBe('button-reference')
+		expect(json.options.location).toEqual(plainLocation('2/1/1'))
+		expect(json.options.notes).toBe('hello')
+	})
+
+	describe('optionsSetField', () => {
+		it('accepts a new location', () => {
+			const control = createControl()
+			expect(control.optionsSetField('location', plainLocation('5/0/0'))).toBe(true)
+			expect(control.toJSON().options.location).toEqual(plainLocation('5/0/0'))
+		})
+
+		it('accepts notes', () => {
+			const control = createControl()
+			expect(control.optionsSetField('notes', 'a note')).toBe(true)
+			expect(control.toJSON().options.notes).toBe('a note')
+		})
+
+		it('rejects a non-string notes value', () => {
+			const control = createControl()
+			expect(control.optionsSetField('notes', 5 as any)).toBe(false)
+		})
+
+		it('rejects a location that is not an expression-or-value', () => {
+			const control = createControl()
+			expect(control.optionsSetField('location', 'nope' as any)).toBe(false)
+		})
+
+		it('rejects any other field', () => {
+			const control = createControl()
+			expect(control.optionsSetField('rotaryActions', true)).toBe(false)
+		})
+	})
+
+	describe('pressControl', () => {
+		it('forwards to the resolved target with a mangled surfaceId', () => {
+			getControlIdAt.mockReturnValue('bank:target')
+			const control = createControl(plainLocation('4/0/0'))
+
+			control.pressControl(true, 'surface1', false)
+
+			expect(controlsAccessor.pressControl).toHaveBeenCalledWith(
+				'bank:target',
+				true,
+				mangleReferenceSurfaceId('surface1', MY_CONTROL_ID),
+				false
+			)
+		})
+
+		it('does nothing when the location does not resolve to a control', () => {
+			getControlIdAt.mockReturnValue(undefined)
+			const control = createControl(plainLocation('4/0/0'))
+
+			control.pressControl(true, 'surface1')
+			expect(controlsAccessor.pressControl).not.toHaveBeenCalled()
+		})
+
+		it('does nothing when the location is empty', () => {
+			const control = createControl(plainLocation(''))
+
+			control.pressControl(true, 'surface1')
+			expect(controlsAccessor.pressControl).not.toHaveBeenCalled()
+		})
+
+		it('does not forward to itself (self-reference)', () => {
+			getControlIdAt.mockReturnValue(MY_CONTROL_ID)
+			const control = createControl(plainLocation('1/2/3'))
+
+			control.pressControl(true, 'surface1')
+			expect(controlsAccessor.pressControl).not.toHaveBeenCalled()
+		})
+
+		it('stops forwarding once the loop guard depth is reached', () => {
+			getControlIdAt.mockReturnValue('bank:target')
+			const control = createControl(plainLocation('4/0/0'))
+
+			let deepSurfaceId = 'surface1'
+			for (let i = 0; i < MAX_REFERENCE_DEPTH; i++) {
+				deepSurfaceId = mangleReferenceSurfaceId(deepSurfaceId, 'bank:hop')
+			}
+
+			control.pressControl(true, deepSurfaceId)
+			expect(controlsAccessor.pressControl).not.toHaveBeenCalled()
+		})
+	})
+
+	describe('rotateControl', () => {
+		it('forwards and reports handled', () => {
+			getControlIdAt.mockReturnValue('bank:target')
+			const control = createControl(plainLocation('4/0/0'))
+
+			expect(control.rotateControl(1, 'surface1')).toBe(true)
+			expect(controlsAccessor.rotateControl).toHaveBeenCalledWith(
+				'bank:target',
+				1,
+				mangleReferenceSurfaceId('surface1', MY_CONTROL_ID)
+			)
+		})
+
+		it('reports not-handled when there is no target', () => {
+			getControlIdAt.mockReturnValue(undefined)
+			const control = createControl(plainLocation('4/0/0'))
+
+			expect(control.rotateControl(1, 'surface1')).toBe(false)
+			expect(controlsAccessor.rotateControl).not.toHaveBeenCalled()
+		})
+
+		it('reports not-handled once the loop guard depth is reached', () => {
+			getControlIdAt.mockReturnValue('bank:target')
+			const control = createControl(plainLocation('4/0/0'))
+
+			let deepSurfaceId = 'surface1'
+			for (let i = 0; i < MAX_REFERENCE_DEPTH; i++) {
+				deepSurfaceId = mangleReferenceSurfaceId(deepSurfaceId, 'bank:hop')
+			}
+
+			expect(control.rotateControl(1, deepSurfaceId)).toBe(false)
+			expect(controlsAccessor.rotateControl).not.toHaveBeenCalled()
+		})
+	})
+
+	describe('convertControl', () => {
+		it('snapshots the target button, breaking the link', () => {
+			const targetModel: LayeredButtonModel = {
+				type: 'button-layered',
+				options: { stepProgression: 'auto', rotaryActions: false, canModifyStyleInApis: false },
+				style: { layers: [] },
+				feedbacks: [],
+				steps: {},
+				localVariables: [],
+			}
+			getControlIdAt.mockReturnValue('bank:target')
+			controlsAccessor.getControl.mockReturnValue({ toJSON: vi.fn(() => targetModel) })
+
+			const control = createControl(plainLocation('4/0/0'))
+			const converted = control.convertControl()
+
+			expect(converted).toEqual(targetModel)
+			// A snapshot, not the same object
+			expect(converted).not.toBe(targetModel)
+		})
+
+		it('produces a blank layered button when the target cannot be resolved', () => {
+			getControlIdAt.mockReturnValue(undefined)
+			const control = createControl(plainLocation('4/0/0'))
+
+			const converted = control.convertControl()
+			expect(converted.type).toBe('button-layered')
+			expect((converted as LayeredButtonModel).style.layers.length).toBeGreaterThan(0)
+			expect(controlsAccessor.getControl).not.toHaveBeenCalled()
+		})
+	})
+
+	describe('references', () => {
+		it('collects variables referenced by an expression location', () => {
+			const control = createControl({ value: '`${$(internal:page)}/0/0`', isExpression: true })
+
+			const foundVariables = new Set<string>()
+			control.collectReferencedConnectionsAndVariables(new Set(), new Set(), foundVariables)
+
+			expect(foundVariables).toContain('internal:page')
+		})
+
+		it('renames a connection label used inside the location expression', () => {
+			const control = createControl({ value: '$(old:pos)', isExpression: true })
+
+			control.renameVariables('old', 'new')
+			expect(control.toJSON().options.location.value).toBe('$(new:pos)')
+		})
+	})
+})

--- a/companion/test/Controls/MirrorButtonDrawer.test.ts
+++ b/companion/test/Controls/MirrorButtonDrawer.test.ts
@@ -1,0 +1,183 @@
+import { EventEmitter } from 'node:events'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { formatLocation } from '@companion-app/shared/ControlId.js'
+import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
+import type { DrawStyleLayeredButtonModel } from '@companion-app/shared/Model/StyleModel.js'
+import { MirrorButtonDrawer } from '../../lib/Controls/ControlTypes/Button/MirrorButtonDrawer.js'
+
+const MY_LOCATION: ControlLocation = { pageNumber: 2, row: 0, column: 0 }
+const TARGET_LOCATION: ControlLocation = { pageNumber: 1, row: 0, column: 0 }
+
+function makeStyle(referencedLocations?: string[]): DrawStyleLayeredButtonModel {
+	return {
+		pushed: false,
+		stepCurrent: 0,
+		stepCount: 0,
+		button_status: undefined,
+		action_running: undefined,
+		elements: [{ id: 'canvas', type: 'canvas' } as any, { id: 'text0', type: 'text', text: 'hello' } as any],
+		referencedLocations: referencedLocations ? new Set(referencedLocations) : undefined,
+		style: 'button-layered',
+		drawType: 'button',
+	}
+}
+
+/** The text of the placeholder rendered for unresolved/cyclic references. */
+function placeholderText(style: DrawStyleLayeredButtonModel): string | undefined {
+	const textEl = style.elements.find((el) => el.type === 'text') as { text?: string } | undefined
+	return textEl?.text
+}
+
+describe('MirrorButtonDrawer', () => {
+	let graphics: EventEmitter
+	let events: EventEmitter
+	let getControl: ReturnType<typeof vi.fn>
+	let getControlIdAt: ReturnType<typeof vi.fn>
+	let deps: any
+
+	beforeEach(() => {
+		graphics = new EventEmitter()
+		events = new EventEmitter()
+		getControl = vi.fn(() => undefined)
+		getControlIdAt = vi.fn(() => undefined)
+
+		deps = {
+			graphics,
+			events,
+			pageStore: {
+				getLocationOfControlId: vi.fn(() => MY_LOCATION),
+				getControlIdAt,
+			},
+			controlsAccessor: { getControl },
+		}
+	})
+
+	function makeDrawer(getTargetLocation: () => ControlLocation | null): MirrorButtonDrawer {
+		return new MirrorButtonDrawer(deps, 'bank:2-0-0', getTargetLocation)
+	}
+
+	it('renders an unresolved placeholder when there is no target location', async () => {
+		const drawer = makeDrawer(() => null)
+		const style = await drawer.getDrawStyle()
+		expect(placeholderText(style)).toBe('Unresolved\nReference')
+	})
+
+	it('renders an unresolved placeholder when the target control is missing', async () => {
+		getControlIdAt.mockReturnValue(undefined)
+		const drawer = makeDrawer(() => TARGET_LOCATION)
+		const style = await drawer.getDrawStyle()
+		expect(placeholderText(style)).toBe('Unresolved\nReference')
+	})
+
+	it('renders a cycle placeholder for a direct self-reference', async () => {
+		const drawer = makeDrawer(() => MY_LOCATION)
+		const style = await drawer.getDrawStyle()
+		expect(placeholderText(style)).toBe('∞')
+	})
+
+	it('mirrors the target style and merges referenced locations', async () => {
+		getControlIdAt.mockReturnValue('bank:1-0-0')
+		const targetStyle = makeStyle(['3/0/0'])
+		getControl.mockReturnValue({
+			drawing: { getLastDrawStyle: () => targetStyle, getDrawStyle: async () => targetStyle },
+		})
+
+		const drawer = makeDrawer(() => TARGET_LOCATION)
+		const style = await drawer.getDrawStyle()
+
+		// Mirrors the target's elements
+		expect(style.elements.map((el) => el.type)).toEqual(['canvas', 'text'])
+		// Tracks the target + its transitive references, so it redraws when either changes
+		expect([...(style.referencedLocations ?? [])].sort()).toEqual([formatLocation(TARGET_LOCATION), '3/0/0'].sort())
+	})
+
+	it('shows a placeholder while the target has not drawn yet, without calling its getDrawStyle', async () => {
+		getControlIdAt.mockReturnValue('bank:1-0-0')
+		const getDrawStyle = vi.fn(async () => makeStyle())
+		getControl.mockReturnValue({ drawing: { getLastDrawStyle: () => null, getDrawStyle } })
+
+		const drawer = makeDrawer(() => TARGET_LOCATION)
+		const style = await drawer.getDrawStyle()
+
+		// It waits for the target's imminent render rather than forcing a (recursion-prone) fresh compute
+		expect(getDrawStyle).not.toHaveBeenCalled()
+		expect(placeholderText(style)).toBe('Unresolved\nReference')
+	})
+
+	it('shows a cycle placeholder when the target references us back', async () => {
+		getControlIdAt.mockReturnValue('bank:1-0-0')
+		// The target's cached style references this control's own location (an A -> B -> A cycle)
+		const targetStyle = makeStyle([formatLocation(MY_LOCATION)])
+		getControl.mockReturnValue({
+			drawing: { getLastDrawStyle: () => targetStyle, getDrawStyle: async () => targetStyle },
+		})
+
+		const drawer = makeDrawer(() => TARGET_LOCATION)
+		const style = await drawer.getDrawStyle()
+
+		expect(placeholderText(style)).toBe('∞')
+	})
+
+	it('invalidates when a referenced location is drawn', async () => {
+		getControlIdAt.mockReturnValue('bank:1-0-0')
+		const targetStyle = makeStyle()
+		getControl.mockReturnValue({
+			drawing: { getLastDrawStyle: () => targetStyle, getDrawStyle: async () => targetStyle },
+		})
+
+		const drawer = makeDrawer(() => TARGET_LOCATION)
+		await drawer.getDrawStyle()
+
+		const invalidateSpy = vi.fn()
+		events.on('invalidateControlRender', invalidateSpy)
+
+		// A draw at the mirrored location should schedule a redraw
+		graphics.emit('button_drawn', TARGET_LOCATION, {} as any)
+		await vi.waitFor(() => expect(invalidateSpy).toHaveBeenCalledWith('bank:2-0-0'))
+	})
+
+	it('does not invalidate when an unrelated location is drawn', async () => {
+		getControlIdAt.mockReturnValue('bank:1-0-0')
+		const targetStyle = makeStyle()
+		getControl.mockReturnValue({
+			drawing: { getLastDrawStyle: () => targetStyle, getDrawStyle: async () => targetStyle },
+		})
+
+		const drawer = makeDrawer(() => TARGET_LOCATION)
+		await drawer.getDrawStyle()
+
+		const invalidateSpy = vi.fn()
+		events.on('invalidateControlRender', invalidateSpy)
+
+		graphics.emit('button_drawn', { pageNumber: 9, row: 9, column: 9 }, {} as any)
+		await new Promise((resolve) => setTimeout(resolve, 30))
+		expect(invalidateSpy).not.toHaveBeenCalled()
+	})
+
+	it('stops redrawing after dispose', async () => {
+		getControlIdAt.mockReturnValue('bank:1-0-0')
+		const targetStyle = makeStyle()
+		getControl.mockReturnValue({
+			drawing: { getLastDrawStyle: () => targetStyle, getDrawStyle: async () => targetStyle },
+		})
+
+		const drawer = makeDrawer(() => TARGET_LOCATION)
+		await drawer.getDrawStyle()
+
+		const invalidateSpy = vi.fn()
+		events.on('invalidateControlRender', invalidateSpy)
+
+		drawer.dispose()
+		graphics.emit('button_drawn', TARGET_LOCATION, {} as any)
+		await new Promise((resolve) => setTimeout(resolve, 30))
+		expect(invalidateSpy).not.toHaveBeenCalled()
+	})
+
+	it('exposes the last computed style via getLastDrawStyle', async () => {
+		const drawer = makeDrawer(() => null)
+		expect(drawer.getLastDrawStyle()).toBeNull()
+
+		const style = await drawer.getDrawStyle()
+		expect(drawer.getLastDrawStyle()).toBe(style)
+	})
+})

--- a/companion/test/Controls/MirrorButtonDrawer.test.ts
+++ b/companion/test/Controls/MirrorButtonDrawer.test.ts
@@ -132,7 +132,7 @@ describe('MirrorButtonDrawer', () => {
 		events.on('invalidateControlRender', invalidateSpy)
 
 		// A draw at the mirrored location should schedule a redraw
-		graphics.emit('button_drawn', TARGET_LOCATION, {} as any)
+		drawer.onButtonDrawn(TARGET_LOCATION, {} as any)
 		await vi.waitFor(() => expect(invalidateSpy).toHaveBeenCalledWith('bank:2-0-0'))
 	})
 
@@ -149,12 +149,12 @@ describe('MirrorButtonDrawer', () => {
 		const invalidateSpy = vi.fn()
 		events.on('invalidateControlRender', invalidateSpy)
 
-		graphics.emit('button_drawn', { pageNumber: 9, row: 9, column: 9 }, {} as any)
+		drawer.onButtonDrawn({ pageNumber: 9, row: 9, column: 9 }, {} as any)
 		await new Promise((resolve) => setTimeout(resolve, 30))
 		expect(invalidateSpy).not.toHaveBeenCalled()
 	})
 
-	it('stops redrawing after dispose', async () => {
+	it('cancels a queued redraw on dispose', async () => {
 		getControlIdAt.mockReturnValue('bank:1-0-0')
 		const targetStyle = makeStyle()
 		getControl.mockReturnValue({
@@ -167,8 +167,9 @@ describe('MirrorButtonDrawer', () => {
 		const invalidateSpy = vi.fn()
 		events.on('invalidateControlRender', invalidateSpy)
 
+		// Queue a redraw, then dispose before the debounce fires - it must be cancelled
+		drawer.onButtonDrawn(TARGET_LOCATION, {} as any)
 		drawer.dispose()
-		graphics.emit('button_drawn', TARGET_LOCATION, {} as any)
 		await new Promise((resolve) => setTimeout(resolve, 30))
 		expect(invalidateSpy).not.toHaveBeenCalled()
 	})

--- a/companion/test/Controls/Triggers/Helpers.ts
+++ b/companion/test/Controls/Triggers/Helpers.ts
@@ -70,6 +70,11 @@ export function createMockControlDependencies(): MockControlDependencies {
 		events: new EventEmitter() as any,
 		changeEvents: new EventEmitter() as any,
 		renderClock: { subscribe: vi.fn(() => () => {}) } as any,
+		controlsAccessor: {
+			getControl: vi.fn(() => undefined),
+			pressControl: vi.fn(() => false),
+			rotateControl: vi.fn(() => false),
+		},
 	}
 
 	return { deps, bus, dbSet, runMultipleActions }

--- a/companion/test/ImportExport/ImportFixup.test.ts
+++ b/companion/test/ImportExport/ImportFixup.test.ts
@@ -9,6 +9,7 @@ import type { ExportControlv6, ExportTriggerContentv6 } from '@companion-app/sha
 import type { ExpressionVariableModel } from '@companion-app/shared/Model/ExpressionVariableModel.js'
 import { exprVal } from '@companion-app/shared/Model/Options.js'
 import {
+	fixupButtonReferenceControl,
 	fixupEntitiesRecursive,
 	fixupExpressionVariableControl,
 	fixupLayeredButtonControl,
@@ -680,5 +681,45 @@ describe('fixupPresetReferenceControl', () => {
 		expect(result.presetRef.connectionId).toBe('old-conn')
 		expect(result.presetRef.moduleId).toBe('mod1')
 		expect(result.presetRef.variableValues).toEqual({ channel: 3 })
+	})
+})
+
+describe('fixupButtonReferenceControl', () => {
+	function makeUpdater(labelRemap: Record<string, string> = {}): VisitorReferencesUpdater {
+		const internalModule = { visitReferences: vi.fn() } as any
+		return new VisitorReferencesUpdater(internalModule, labelRemap, {}, undefined)
+	}
+
+	function makeExport(options: any): ExportControlv6 {
+		return { type: 'button-reference', options }
+	}
+
+	test('preserves an existing plain location and clones the options', () => {
+		const control = makeExport({ location: { value: '3/0/0', isExpression: false }, notes: 'hi' })
+
+		const result = fixupButtonReferenceControl(control, makeUpdater())
+
+		expect(result.type).toBe('button-reference')
+		expect(result.options.location).toEqual({ value: '3/0/0', isExpression: false })
+		expect(result.options.notes).toBe('hi')
+		expect(result.options).not.toBe(control.options)
+	})
+
+	test('defaults a missing location to an empty reference', () => {
+		const result = fixupButtonReferenceControl(makeExport({}), makeUpdater())
+		expect(result.options.location).toEqual({ value: '', isExpression: false })
+	})
+
+	test('defaults a malformed location to an empty reference', () => {
+		const result = fixupButtonReferenceControl(makeExport({ location: 'nonsense' }), makeUpdater())
+		expect(result.options.location).toEqual({ value: '', isExpression: false })
+	})
+
+	test('renames a connection label used inside the location', () => {
+		const control = makeExport({ location: { value: '$(old:foo)/0/0', isExpression: false } })
+
+		const result = fixupButtonReferenceControl(control, makeUpdater({ old: 'new' }))
+
+		expect(result.options.location.value).toBe('$(new:foo)/0/0')
 	})
 })

--- a/companion/test/Surface/ReferenceSurfaceId.test.ts
+++ b/companion/test/Surface/ReferenceSurfaceId.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import {
+	mangleReferenceSurfaceId,
+	MAX_REFERENCE_DEPTH,
+	referenceSurfaceIdDepth,
+	stripReferenceSurfaceId,
+} from '../../lib/Surface/ReferenceSurfaceId.js'
+
+describe('ReferenceSurfaceId', () => {
+	describe('mangleReferenceSurfaceId', () => {
+		it('appends the reference control id', () => {
+			const mangled = mangleReferenceSurfaceId('streamdeck:ABC123', 'bank:1-0-0')
+			expect(mangled).toContain('streamdeck:ABC123')
+			expect(mangled).toContain('bank:1-0-0')
+			expect(mangled).not.toBe('streamdeck:ABC123')
+		})
+
+		it('passes undefined through unchanged (a no-surface press)', () => {
+			expect(mangleReferenceSurfaceId(undefined, 'bank:1-0-0')).toBeUndefined()
+		})
+
+		it('is reversible via strip regardless of hop count', () => {
+			let id: string | undefined = 'emulator:emulator'
+			id = mangleReferenceSurfaceId(id, 'bank:1-0-0')
+			id = mangleReferenceSurfaceId(id, 'bank:2-0-0')
+			expect(stripReferenceSurfaceId(id!)).toBe('emulator:emulator')
+		})
+	})
+
+	describe('stripReferenceSurfaceId', () => {
+		it.each(['streamdeck:ABC123', 'emulator:emulator', 'satellite-abc-def', 'self', 'osc', 'context-menu'])(
+			'is a no-op on the unmangled real id %s',
+			(realId) => {
+				expect(stripReferenceSurfaceId(realId)).toBe(realId)
+			}
+		)
+
+		it('recovers the real id after a single hop', () => {
+			const mangled = mangleReferenceSurfaceId('streamdeck:ABC123', 'bank:1-0-0')!
+			expect(stripReferenceSurfaceId(mangled)).toBe('streamdeck:ABC123')
+		})
+	})
+
+	describe('referenceSurfaceIdDepth', () => {
+		it('is 0 for an unmangled id and for undefined', () => {
+			expect(referenceSurfaceIdDepth('streamdeck:ABC123')).toBe(0)
+			expect(referenceSurfaceIdDepth(undefined)).toBe(0)
+		})
+
+		it('counts each reference hop', () => {
+			let id: string | undefined = 'emulator:emulator'
+			for (let i = 1; i <= 3; i++) {
+				id = mangleReferenceSurfaceId(id, `bank:${i}-0-0`)
+				expect(referenceSurfaceIdDepth(id)).toBe(i)
+			}
+		})
+
+		it('exposes a sane max depth for the loop guard', () => {
+			expect(MAX_REFERENCE_DEPTH).toBeGreaterThan(0)
+		})
+	})
+})

--- a/companion/test/Surface/ReferenceSurfaceId.test.ts
+++ b/companion/test/Surface/ReferenceSurfaceId.test.ts
@@ -15,15 +15,26 @@ describe('ReferenceSurfaceId', () => {
 			expect(mangled).not.toBe('streamdeck:ABC123')
 		})
 
-		it('passes undefined through unchanged (a no-surface press)', () => {
-			expect(mangleReferenceSurfaceId(undefined, 'bank:1-0-0')).toBeUndefined()
+		it('mangles a missing surfaceId to a depth-countable id with an empty real part', () => {
+			// This is what bounds a surface-less reference cycle: the depth still grows
+			const mangled = mangleReferenceSurfaceId(undefined, 'bank:1-0-0')
+			expect(referenceSurfaceIdDepth(mangled)).toBe(1)
+			expect(stripReferenceSurfaceId(mangled)).toBe('')
+		})
+
+		it('grows depth to the cap when forwarded through a surface-less cycle', () => {
+			let id = mangleReferenceSurfaceId(undefined, 'bank:1-0-0')
+			for (let i = 0; i < MAX_REFERENCE_DEPTH * 2; i++) {
+				if (referenceSurfaceIdDepth(id) >= MAX_REFERENCE_DEPTH) break
+				id = mangleReferenceSurfaceId(id, 'bank:1-0-0')
+			}
+			expect(referenceSurfaceIdDepth(id)).toBeGreaterThanOrEqual(MAX_REFERENCE_DEPTH)
 		})
 
 		it('is reversible via strip regardless of hop count', () => {
-			let id: string | undefined = 'emulator:emulator'
-			id = mangleReferenceSurfaceId(id, 'bank:1-0-0')
+			let id = mangleReferenceSurfaceId('emulator:emulator', 'bank:1-0-0')
 			id = mangleReferenceSurfaceId(id, 'bank:2-0-0')
-			expect(stripReferenceSurfaceId(id!)).toBe('emulator:emulator')
+			expect(stripReferenceSurfaceId(id)).toBe('emulator:emulator')
 		})
 	})
 
@@ -36,7 +47,7 @@ describe('ReferenceSurfaceId', () => {
 		)
 
 		it('recovers the real id after a single hop', () => {
-			const mangled = mangleReferenceSurfaceId('streamdeck:ABC123', 'bank:1-0-0')!
+			const mangled = mangleReferenceSurfaceId('streamdeck:ABC123', 'bank:1-0-0')
 			expect(stripReferenceSurfaceId(mangled)).toBe('streamdeck:ABC123')
 		})
 	})

--- a/shared-lib/lib/Model/ButtonModel.ts
+++ b/shared-lib/lib/Model/ButtonModel.ts
@@ -1,10 +1,16 @@
 import type { ActionSetsModel, ActionStepOptions } from './ActionModel.js'
 import type { SomeEntityModel } from './EntityModel.js'
+import type { ExpressionOrValue } from './Options.js'
 import type { SomeButtonGraphicsElement } from './StyleLayersModel.js'
 import type { VariableValues } from './Variables.js'
 
 export type SomeButtonModel =
-	PageNumberButtonModel | PageUpButtonModel | PageDownButtonModel | LayeredButtonModel | PresetReferenceButtonModel
+	| PageNumberButtonModel
+	| PageUpButtonModel
+	| PageDownButtonModel
+	| LayeredButtonModel
+	| PresetReferenceButtonModel
+	| ButtonReferenceButtonModel
 
 export interface PageNumberButtonModel {
 	readonly type: 'pagenum'
@@ -74,6 +80,22 @@ export interface PresetReferenceButtonModel extends ButtonModelBase {
 		moduleId: string
 		presetId: string
 		variableValues: VariableValues | null
+	}
+}
+
+/**
+ * A button that mirrors another button at a grid location. It has no style/entities of its own: it renders the
+ * target button's full draw output (canvas, layers and runtime state) and forwards presses/rotation to the target.
+ * The `location` is a page/row/column string, editable as plain text or an expression. Editing it in the UI
+ * snapshots the target into a normal `button-layered` control (breaking the link).
+ */
+export interface ButtonReferenceButtonModel {
+	readonly type: 'button-reference'
+
+	options: {
+		/** The grid location (page/row/column) of the button to mirror. */
+		location: ExpressionOrValue<string>
+		notes?: string
 	}
 }
 

--- a/webui/src/Buttons/EditButton/ButtonReferenceEditor.tsx
+++ b/webui/src/Buttons/EditButton/ButtonReferenceEditor.tsx
@@ -1,0 +1,171 @@
+import { faArrowUpRightFromSquare, faClone } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { useSubscription } from '@trpc/tanstack-react-query'
+import { observer } from 'mobx-react-lite'
+import { useCallback, useId } from 'react'
+import type { JsonValue } from 'type-fest'
+import { formatLocation } from '@companion-app/shared/ControlId.js'
+import type { ExpressionStreamResult } from '@companion-app/shared/ExpressionResult.js'
+import type { ButtonReferenceButtonModel } from '@companion-app/shared/Model/ButtonModel.js'
+import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
+import type { ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
+import { stringifyVariableValue } from '@companion-app/shared/Model/Variables.js'
+import { Button } from '~/Components/Button'
+import { Callout } from '~/Components/Callout.js'
+import { FieldOrExpression } from '~/Components/FieldOrExpression.js'
+import { Form, FormLabel } from '~/Components/Form.js'
+import { Grid } from '~/Components/Grid'
+import { TextInputField } from '~/Components/TextInputField.js'
+import { useLocalVariablesStore } from '~/Controls/LocalVariablesStore.js'
+import { trpc, useMutationExt } from '~/Resources/TRPC.js'
+import { PreventDefaultHandler } from '~/Resources/util.js'
+
+interface ButtonReferenceEditorProps {
+	config: ButtonReferenceButtonModel
+	controlId: string
+	navigateToControl: ((location: ControlLocation) => void) | undefined
+}
+
+/**
+ * Editor for a button-reference (mirror) control: the grid `location` to mirror (plain text or expression), with a
+ * live resolved-location preview and a shortcut to open the mirrored button's editor.
+ */
+export const ButtonReferenceEditor = observer(function ButtonReferenceEditor({
+	config,
+	controlId,
+	navigateToControl,
+}: ButtonReferenceEditorProps) {
+	const setOptionsFieldMutation = useMutationExt(trpc.controls.setOptionsField.mutationOptions())
+
+	const setLocation = useCallback(
+		(value: ExpressionOrValue<JsonValue | undefined>) => {
+			setOptionsFieldMutation
+				.mutateAsync({ controlId, key: 'location', value })
+				.catch((e) => console.error(`Failed to set reference location: ${e}`))
+		},
+		[setOptionsFieldMutation, controlId]
+	)
+
+	const localVariablesStore = useLocalVariablesStore(controlId, null)
+	const localVariables = localVariablesStore.getOptions(null, true, true)
+
+	const location = config.options.location
+	const fieldId = useId()
+
+	return (
+		<>
+			<Callout color="info" className="my-2">
+				<div className="d-flex gap-2">
+					<FontAwesomeIcon icon={faClone} className="mt-1" />
+					<div>
+						This button <strong>mirrors</strong> another button. It shows that button's appearance and forwards presses
+						to it.
+						<br />
+						Use <strong>Edit</strong> above to turn it into a normal, fully editable copy.
+					</div>
+				</div>
+			</Callout>
+
+			<Form className="row g-2" onSubmit={PreventDefaultHandler}>
+				<FormLabel htmlFor={fieldId} className="col-sm-4 col-form-label col-form-label-sm">
+					Mirrored location
+				</FormLabel>
+				<Grid.Col sm={8}>
+					<FieldOrExpression
+						inputId={fieldId}
+						localVariablesStore={localVariablesStore}
+						value={location}
+						setValue={setLocation}
+						disabled={false}
+						entityType={null}
+						isLocatedInGrid={true}
+					>
+						<TextInputField
+							id={fieldId}
+							value={String(location.value ?? '')}
+							setValue={(value) => setLocation({ isExpression: false, value })}
+							useVariables
+							localVariables={localVariables}
+							placeholder="page/row/column, e.g. 1/0/0"
+						/>
+					</FieldOrExpression>
+
+					<ResolvedLocationRow controlId={controlId} location={location} navigateToControl={navigateToControl} />
+				</Grid.Col>
+			</Form>
+		</>
+	)
+})
+
+interface ResolvedLocationRowProps {
+	controlId: string
+	location: ExpressionOrValue<string>
+	navigateToControl: ((location: ControlLocation) => void) | undefined
+}
+
+/**
+ * Shows the live resolved value of the location field (after variable/expression interpolation), with a shortcut
+ * to open that button's editor.
+ */
+function ResolvedLocationRow({ controlId, location, navigateToControl }: ResolvedLocationRowProps) {
+	const rawValue = String(location.value ?? '')
+
+	const sub = useSubscription(
+		trpc.preview.expressionStream.watchExpression.subscriptionOptions(
+			{
+				controlId,
+				expression: rawValue,
+				isVariableString: !location.isExpression,
+				contextResolution: undefined,
+			},
+			{ enabled: rawValue.trim().length > 0 }
+		)
+	)
+
+	if (!rawValue.trim()) return null
+
+	const data = sub.data as ExpressionStreamResult | undefined
+	const resolved = data?.ok ? (stringifyVariableValue(data.value) ?? '') : undefined
+	const error = data && !data.ok ? data.error : undefined
+	const targetLocation = resolved ? tryParseLocation(resolved) : null
+
+	return (
+		<div className="d-flex align-items-end gap-2 mt-2">
+			<div className="flex-grow-1">
+				<div className="form-text mb-1 mt-0">Resolves to</div>
+				<input
+					className="form-control form-control-sm"
+					readOnly
+					value={error !== undefined ? `Error: ${error}` : (resolved ?? '')}
+					title={error !== undefined ? error : undefined}
+				/>
+			</div>
+			<Button
+				color="secondary"
+				variant="outline"
+				disabled={!targetLocation || !navigateToControl}
+				onClick={() => targetLocation && navigateToControl?.(targetLocation)}
+				title={
+					targetLocation
+						? `Open the editor for ${formatLocation(targetLocation)}`
+						: 'The mirrored location is not a plain button location'
+				}
+			>
+				<FontAwesomeIcon icon={faArrowUpRightFromSquare} /> Go to source
+			</Button>
+		</div>
+	)
+}
+
+/** Parse a resolved `page/row/column` string into a location. Returns null for relative/invalid forms. */
+function tryParseLocation(str: string): ControlLocation | null {
+	const parts = str.trim().split('/')
+	if (parts.length !== 3 || parts.some((part) => part.trim() === '')) return null
+
+	const pageNumber = Number(parts[0])
+	const row = Number(parts[1])
+	const column = Number(parts[2])
+	if (![pageNumber, row, column].every((n) => Number.isInteger(n))) return null
+
+	return { pageNumber, row, column }
+}

--- a/webui/src/Buttons/EditButton/ButtonReferenceEditor.tsx
+++ b/webui/src/Buttons/EditButton/ButtonReferenceEditor.tsx
@@ -1,6 +1,7 @@
 import { faArrowUpRightFromSquare, faClone } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useSubscription } from '@trpc/tanstack-react-query'
+import classNames from 'classnames'
 import { observer } from 'mobx-react-lite'
 import { useCallback, useId } from 'react'
 import type { JsonValue } from 'type-fest'
@@ -15,6 +16,7 @@ import { Callout } from '~/Components/Callout.js'
 import { FieldOrExpression } from '~/Components/FieldOrExpression.js'
 import { Form, FormLabel } from '~/Components/Form.js'
 import { Grid } from '~/Components/Grid'
+import { InputValidityIcon, type InputValidity } from '~/Components/InputValidity.js'
 import { TextInputField } from '~/Components/TextInputField.js'
 import { EntityListActionContext, useLocalVariablesStore } from '~/Controls/LocalVariablesStore.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC.js'
@@ -94,9 +96,9 @@ export const ButtonReferenceEditor = observer(function ButtonReferenceEditor({
 							placeholder="page/row/column, e.g. 1/0/0"
 						/>
 					</FieldOrExpression>
-
-					<ResolvedLocationRow controlId={controlId} location={location} navigateToControl={navigateToControl} />
 				</Grid.Col>
+
+				<ResolvedLocationRow controlId={controlId} location={location} navigateToControl={navigateToControl} />
 			</Form>
 		</>
 	)
@@ -132,33 +134,51 @@ function ResolvedLocationRow({ controlId, location, navigateToControl }: Resolve
 	const data = sub.data as ExpressionStreamResult | undefined
 	const resolved = data?.ok ? (stringifyVariableValue(data.value) ?? '') : undefined
 	const error = data && !data.ok ? data.error : undefined
-	const targetLocation = resolved ? tryParseLocation(resolved) : null
+	const targetLocation = resolved !== undefined ? tryParseLocation(resolved) : null
+
+	// Red when the expression errored or resolves to something that isn't a `page/row/column` location;
+	// unknown (no icon) until the first result arrives.
+	const validity: InputValidity = !data ? 'unknown' : error !== undefined || !targetLocation ? 'invalid' : 'valid'
+
+	const displayValue = error !== undefined ? `Error: ${error}` : (resolved ?? '')
 
 	return (
-		<div className="d-flex align-items-end gap-2 mt-2">
-			<div className="flex-grow-1">
-				<div className="form-text mb-1 mt-0">Resolves to</div>
-				<input
-					className="form-control form-control-sm"
-					readOnly
-					value={error !== undefined ? `Error: ${error}` : (resolved ?? '')}
-					title={error !== undefined ? error : undefined}
-				/>
+		<Grid.Col sm={{ span: 8, offset: 4 }}>
+			<div className="d-flex align-items-center gap-2">
+				<span className="form-text m-0 flex-shrink-0">Resolves to</span>
+				<div className="input-validity-wrapper">
+					<input
+						className={classNames('form-input text-input-field', {
+							'invalid-value': validity === 'invalid',
+							'has-validity-icon': validity !== 'unknown',
+						})}
+						readOnly
+						value={displayValue}
+						title={error !== undefined ? error : displayValue}
+					/>
+					<InputValidityIcon validity={validity} />
+				</div>
+				<Button
+					className="flex-shrink-0 text-nowrap"
+					color="secondary"
+					variant="outline"
+					disabled={!targetLocation || !navigateToControl}
+					onClick={() => targetLocation && navigateToControl?.(targetLocation)}
+					title={
+						targetLocation
+							? `Open the editor for ${formatLocation(targetLocation)}`
+							: 'The mirrored location is not a plain button location'
+					}
+				>
+					<FontAwesomeIcon icon={faArrowUpRightFromSquare} /> Go to source
+				</Button>
 			</div>
-			<Button
-				color="secondary"
-				variant="outline"
-				disabled={!targetLocation || !navigateToControl}
-				onClick={() => targetLocation && navigateToControl?.(targetLocation)}
-				title={
-					targetLocation
-						? `Open the editor for ${formatLocation(targetLocation)}`
-						: 'The mirrored location is not a plain button location'
-				}
-			>
-				<FontAwesomeIcon icon={faArrowUpRightFromSquare} /> Go to source
-			</Button>
-		</div>
+			{validity === 'invalid' && error === undefined && (
+				<div className="text-danger mt-1" style={{ fontSize: '0.875em' }}>
+					Not a valid button location — expected <code>page/row/column</code>
+				</div>
+			)}
+		</Grid.Col>
 	)
 }
 

--- a/webui/src/Buttons/EditButton/ButtonReferenceEditor.tsx
+++ b/webui/src/Buttons/EditButton/ButtonReferenceEditor.tsx
@@ -16,7 +16,7 @@ import { FieldOrExpression } from '~/Components/FieldOrExpression.js'
 import { Form, FormLabel } from '~/Components/Form.js'
 import { Grid } from '~/Components/Grid'
 import { TextInputField } from '~/Components/TextInputField.js'
-import { useLocalVariablesStore } from '~/Controls/LocalVariablesStore.js'
+import { EntityListActionContext, useLocalVariablesStore } from '~/Controls/LocalVariablesStore.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC.js'
 import { PreventDefaultHandler } from '~/Resources/util.js'
 
@@ -47,7 +47,12 @@ export const ButtonReferenceEditor = observer(function ButtonReferenceEditor({
 	)
 
 	const localVariablesStore = useLocalVariablesStore(controlId, null)
-	const localVariables = localVariablesStore.getOptions(null, true, true)
+	const localVariables = localVariablesStore.getOptions({
+		entityType: null,
+		internalParser: true,
+		isLocatedInGrid: true,
+		actionContext: EntityListActionContext.NotActions,
+	})
 
 	const location = config.options.location
 	const fieldId = useId()

--- a/webui/src/Buttons/EditButton/ButtonReferenceEditor.tsx
+++ b/webui/src/Buttons/EditButton/ButtonReferenceEditor.tsx
@@ -136,8 +136,7 @@ function ResolvedLocationRow({ controlId, location, navigateToControl }: Resolve
 	const error = data && !data.ok ? data.error : undefined
 	const targetLocation = resolved !== undefined ? tryParseLocation(resolved) : null
 
-	// Red when the expression errored or resolves to something that isn't a `page/row/column` location;
-	// unknown (no icon) until the first result arrives.
+	// Red when the expression errored or didn't resolve to a valid location; unknown (no icon) until the first result
 	const validity: InputValidity = !data ? 'unknown' : error !== undefined || !targetLocation ? 'invalid' : 'valid'
 
 	const displayValue = error !== undefined ? `Error: ${error}` : (resolved ?? '')
@@ -185,12 +184,11 @@ function ResolvedLocationRow({ controlId, location, navigateToControl }: Resolve
 /** Parse a resolved `page/row/column` string into a location. Returns null for relative/invalid forms. */
 function tryParseLocation(str: string): ControlLocation | null {
 	const parts = str.trim().split('/')
-	if (parts.length !== 3 || parts.some((part) => part.trim() === '')) return null
+	if (parts.length !== 3) return null
+	const [page, row, column] = parts.map((part) => part.trim())
 
-	const pageNumber = Number(parts[0])
-	const row = Number(parts[1])
-	const column = Number(parts[2])
-	if (![pageNumber, row, column].every((n) => Number.isInteger(n))) return null
+	// Page is absolute; row/column may be negative. Reject relative (`+1`) and exponent (`1e2`) forms Number() accepts.
+	if (!/^\d+$/.test(page) || !/^-?\d+$/.test(row) || !/^-?\d+$/.test(column)) return null
 
-	return { pageNumber, row, column }
+	return { pageNumber: Number(page), row: Number(row), column: Number(column) }
 }

--- a/webui/src/Buttons/EditButton/CreateButtonTypeButtons.tsx
+++ b/webui/src/Buttons/EditButton/CreateButtonTypeButtons.tsx
@@ -1,4 +1,4 @@
-import { faFileArrowDown, faFileArrowUp, faFileLines, faSquarePlus } from '@fortawesome/free-solid-svg-icons'
+import { faClone, faFileArrowDown, faFileArrowUp, faFileLines, faSquarePlus } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useCallback } from 'react'
 import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
@@ -57,6 +57,15 @@ export function CreateButtonTypeButtons({ location }: { location: ControlLocatio
 				>
 					<FontAwesomeIcon icon={faFileArrowDown} />
 					<span>Page down</span>
+				</Button>
+				<Button
+					variant="outline"
+					className="empty-button-type-tile"
+					onClick={() => setButtonType('button-reference')}
+					title="Create a button that mirrors another button."
+				>
+					<FontAwesomeIcon icon={faClone} />
+					<span>Button reference</span>
 				</Button>
 			</div>
 		</div>

--- a/webui/src/Buttons/EditButton/CreateButtonTypeButtons.tsx
+++ b/webui/src/Buttons/EditButton/CreateButtonTypeButtons.tsx
@@ -33,6 +33,16 @@ export function CreateButtonTypeButtons({ location }: { location: ControlLocatio
 
 				<Button
 					variant="outline"
+					className="empty-button-type-tile empty-button-type-tile-primary"
+					onClick={() => setButtonType('button-reference')}
+					title="Create a button that mirrors another button."
+				>
+					<FontAwesomeIcon icon={faClone} />
+					<span>Button reference</span>
+				</Button>
+
+				<Button
+					variant="outline"
 					className="empty-button-type-tile"
 					onClick={() => setButtonType('pageup')}
 					title="Create a page up button."
@@ -57,15 +67,6 @@ export function CreateButtonTypeButtons({ location }: { location: ControlLocatio
 				>
 					<FontAwesomeIcon icon={faFileArrowDown} />
 					<span>Page down</span>
-				</Button>
-				<Button
-					variant="outline"
-					className="empty-button-type-tile"
-					onClick={() => setButtonType('button-reference')}
-					title="Create a button that mirrors another button."
-				>
-					<FontAwesomeIcon icon={faClone} />
-					<span>Button reference</span>
 				</Button>
 			</div>
 		</div>

--- a/webui/src/Buttons/EditButton/EditButton.tsx
+++ b/webui/src/Buttons/EditButton/EditButton.tsx
@@ -16,6 +16,7 @@ import { MyErrorBoundary } from '~/Resources/Error.js'
 import { LoadingRetryOrError } from '~/Resources/Loading.js'
 import { KeyReceiver } from '~/Resources/util.js'
 import { RootAppStoreContext } from '~/Stores/RootAppStore.js'
+import { ButtonReferenceEditor } from './ButtonReferenceEditor.js'
 import { ControlClearButton } from './ControlClearButton.js'
 import { ControlHotPressButtons } from './ControlHotPressButtons.js'
 import { ConvertToNormalButton } from './ConvertToNormalButton.js'
@@ -26,9 +27,10 @@ import { PresetReferenceEditor } from './PresetReferenceEditor.js'
 interface EditButtonProps {
 	location: ControlLocation
 	onKeyUp: (e: React.KeyboardEvent<HTMLDivElement>) => void
+	navigateToControl: ((location: ControlLocation) => void) | undefined
 }
 
-export const EditButton = observer(function EditButton({ location, onKeyUp }: EditButtonProps) {
+export const EditButton = observer(function EditButton({ location, onKeyUp, navigateToControl }: EditButtonProps) {
 	const { pages } = useContext(RootAppStoreContext)
 
 	const resetModalRef = useRef<GenericConfirmModalRef>(null)
@@ -65,6 +67,7 @@ export const EditButton = observer(function EditButton({ location, onKeyUp }: Ed
 								previewImage={previewImage}
 								config={controlConfig.config}
 								runtimeProps={controlConfig.runtime}
+								navigateToControl={navigateToControl}
 							/>
 						))}
 				</>
@@ -97,6 +100,7 @@ interface EditButtonContentProps {
 	previewImage: string | null
 	config: SomeButtonModel
 	runtimeProps: Record<string, any> | false
+	navigateToControl: ((location: ControlLocation) => void) | undefined
 }
 const EditButtonContent = observer(function EditButton({
 	resetModalRef,
@@ -105,6 +109,7 @@ const EditButtonContent = observer(function EditButton({
 	previewImage,
 	config,
 	runtimeProps,
+	navigateToControl,
 }: EditButtonContentProps) {
 	return (
 		<>
@@ -116,13 +121,21 @@ const EditButtonContent = observer(function EditButton({
 							{(config.type === 'pageup' ||
 								config.type === 'pagenum' ||
 								config.type === 'pagedown' ||
-								config.type === 'preset-reference') && <ConvertToNormalButton location={location} />}
-							{(config.type === 'button-layered' || config.type === 'preset-reference') && (
-								<ControlHotPressButtons location={location} showRotaries={config.options.rotaryActions} />
+								config.type === 'preset-reference' ||
+								config.type === 'button-reference') && <ConvertToNormalButton location={location} />}
+							{(config.type === 'button-layered' ||
+								config.type === 'preset-reference' ||
+								config.type === 'button-reference') && (
+								<ControlHotPressButtons
+									location={location}
+									showRotaries={config.type === 'button-reference' || config.options.rotaryActions}
+								/>
 							)}
 						</MyErrorBoundary>
 					</div>
-					{(config.type === 'button-layered' || config.type === 'preset-reference') && (
+					{(config.type === 'button-layered' ||
+						config.type === 'preset-reference' ||
+						config.type === 'button-reference') && (
 						<MyErrorBoundary>
 							<ControlNotesEditor controlId={controlId} notes={config.options.notes} className="w-100 mt-1" />
 						</MyErrorBoundary>
@@ -155,6 +168,12 @@ const EditButtonContent = observer(function EditButton({
 			{config.type === 'preset-reference' && (
 				<MyErrorBoundary>
 					<PresetReferenceEditor config={config} location={location} />
+				</MyErrorBoundary>
+			)}
+
+			{config.type === 'button-reference' && (
+				<MyErrorBoundary>
+					<ButtonReferenceEditor config={config} controlId={controlId} navigateToControl={navigateToControl} />
 				</MyErrorBoundary>
 			)}
 

--- a/webui/src/Buttons/index.tsx
+++ b/webui/src/Buttons/index.tsx
@@ -108,6 +108,15 @@ export const ButtonsPage = observer(function ButtonsPage() {
 		},
 		[hotPressMutation, viewControl]
 	)
+	const navigateToControl = useCallback(
+		(location: ControlLocation) => {
+			setPageNumber(location.pageNumber)
+			setActiveTab('edit')
+			setSelectedButton(location)
+			setTabResetToken(nanoid())
+		},
+		[setPageNumber]
+	)
 	const clearSelectedButton = useCallback(() => {
 		doChangeTab('pages')
 	}, [doChangeTab])
@@ -437,6 +446,7 @@ export const ButtonsPage = observer(function ButtonsPage() {
 										key={`${formatLocation(selectedButton)}-${tabResetToken}`}
 										location={selectedButton}
 										onKeyUp={handleKeyDownInButtons}
+										navigateToControl={navigateToControl}
 									/>
 								)}
 							</MyErrorBoundary>

--- a/webui/src/Buttons/useButtonContextMenu.tsx
+++ b/webui/src/Buttons/useButtonContextMenu.tsx
@@ -49,6 +49,7 @@ export function useButtonContextMenu({
 	const moveControlMutation = useMutationExt(trpc.controls.moveControl.mutationOptions())
 	const swapControlMutation = useMutationExt(trpc.controls.swapControl.mutationOptions())
 	const resetControlMutation = useMutationExt(trpc.controls.resetControl.mutationOptions())
+	const createReferenceControlMutation = useMutationExt(trpc.controls.createReferenceControl.mutationOptions())
 
 	const contextMenuItems = useMemo((): MenuItemProps[] => {
 		if (!contextMenuLocation) return []
@@ -96,7 +97,8 @@ export function useButtonContextMenu({
 		if (!copyFromButton) {
 			items.push(
 				{ label: 'Paste here', disabled: true, do: () => {} },
-				{ label: 'Swap here', disabled: true, do: () => {} }
+				{ label: 'Swap here', disabled: true, do: () => {} },
+				{ label: 'Paste as reference', disabled: true, do: () => {} }
 			)
 		} else {
 			items.push(
@@ -124,6 +126,16 @@ export function useButtonContextMenu({
 							.mutateAsync({ fromLocation: copyFromButton[0], toLocation: location })
 							.catch((e) => console.error(`Swap failed: ${e}`))
 						setCopyFromButton(null)
+						setTabResetToken(nanoid())
+					},
+				},
+				{
+					label: 'Paste as reference',
+					do: () => {
+						// Place a button that mirrors the copied button, rather than a full copy
+						createReferenceControlMutation
+							.mutateAsync({ fromLocation: copyFromButton[0], toLocation: location })
+							.catch((e) => console.error(`Paste reference failed: ${e}`))
 						setTabResetToken(nanoid())
 					},
 				}
@@ -161,6 +173,7 @@ export function useButtonContextMenu({
 		moveControlMutation,
 		swapControlMutation,
 		resetControlMutation,
+		createReferenceControlMutation,
 		setCopyFromButton,
 		setTabResetToken,
 		clearModalRef,

--- a/webui/src/Buttons/useButtonContextMenu.tsx
+++ b/webui/src/Buttons/useButtonContextMenu.tsx
@@ -136,6 +136,8 @@ export function useButtonContextMenu({
 						createReferenceControlMutation
 							.mutateAsync({ fromLocation: copyFromButton[0], toLocation: location })
 							.catch((e) => console.error(`Paste reference failed: ${e}`))
+						// A reference leaves the source in place, so clear a pending cut - it never completes otherwise
+						if (copyFromButton[1] === 'cut') setCopyFromButton(null)
 						setTabResetToken(nanoid())
 					},
 				}


### PR DESCRIPTION
Inspired by #4284, this adds a new 'reference' button type.
Replaces #3500

The idea is that it is a simple button, simply specify the location of another button and it will mirror that button. Pressess/rotates will be forwarded, drawing will be copied.  
The intention here is to simplify the workflow that many users are doing today with the reference element (or use another style feedback) and press + release actions, and make this a simple and easy to setup.

By doing this we can offer some nicer utils, like the ability to convert this reference into a full copy, one click to jump to the button being referenced, and while copying and pasting in the grid, the ability to paste a reference

This is not intended to be the only way to do a 'build once, place on many pages' flow, just a simple one that users are already familiat with.  
While other approaches may be better in some ways, this allows for a great deal of dynamics, as the location reference can be an expression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added button references that mirror another button’s appearance, behavior, and updates.
  * Create references from the button picker or context menu, with direct navigation to the source button.
  * Configure reference locations using values or expressions, with validation and error feedback.
  * Added support for importing, exporting, previewing, converting, pressing, and rotating referenced buttons.
  * Added safeguards against circular and deeply nested references.
* **Bug Fixes**
  * Controls without entities now return empty local-variable values instead of errors.
  * Surface lookups now handle referenced-button identifiers correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->