### PR TITLE
fix(actions): make Wait a barrier for concurrent action groups

### DIFF
--- a/companion/lib/Controls/ActionRunner.ts
+++ b/companion/lib/Controls/ActionRunner.ts
@@ -148,8 +148,6 @@ export class ActionRunner {
 		} else {
 			const groupedActions = this.#splitActionsAroundWaits(actions)
 
-			const ps: Promise<void>[] = []
-
 			for (const { waitAction, actions } of groupedActions) {
 				if (extras.abortDelayed.aborted) break
 
@@ -163,17 +161,20 @@ export class ActionRunner {
 				if (extras.abortDelayed.aborted) break
 
 				// Spawn all the actions in parallel
-				for (const action of actions) {
-					ps.push(
-						this.#runAction(action, extras).catch((e) => {
-							this.#logger.silly(`Error executing action for ${action.connectionId}: ${e.message ?? e}`)
-						})
-					)
-				}
-			}
+				const ps = actions.map(async (action) => {
+					try {
+						await this.#runAction(action, extras)
+					} catch (e) {
+						this.#logger.silly(
+							`Error executing action for ${action.connectionId}: ${e instanceof Error ? e.message : e}`
+						)
+					}
+				})
 
-			// Await all the actions, so that the abort signal is respected and the promise is pending until all actions are done
-			await Promise.all(ps)
+				// Wait is a barrier: all actions before the next wait must finish
+				// before the following group is allowed to start.
+				await Promise.all(ps)
+			}
 		}
 	}
 

--- a/companion/test/Controls/ActionRunner.test.ts
+++ b/companion/test/Controls/ActionRunner.test.ts
@@ -209,7 +209,9 @@ describe('ActionRunner', () => {
 		test('a wait action acts as a barrier for the actions after it', async () => {
 			const { runner, internalModule, actionRun } = createRunner()
 			const { extras } = makeExtras()
+			const beforePromise = deferred()
 			const waitPromise = deferred<undefined>()
+			actionRun.mockReturnValueOnce(beforePromise.promise).mockResolvedValueOnce(undefined)
 			internalModule.executeAction.mockReturnValue(waitPromise.promise)
 
 			const before = fakeEntity()
@@ -219,15 +221,18 @@ describe('ActionRunner', () => {
 			const p = runner.runMultipleActions([before, wait, after], extras)
 			await flush()
 
-			// The action before the wait and the wait itself start immediately, the one after does not
+			// The action before the wait starts first; the wait itself is held behind it.
 			expect(actionRun).toHaveBeenCalledTimes(1)
+			expect(internalModule.executeAction).toHaveBeenCalledTimes(0)
+
+			beforePromise.resolve()
+			await flush()
 			expect(internalModule.executeAction).toHaveBeenCalledTimes(1)
+			expect(actionRun).toHaveBeenCalledTimes(1)
 
 			waitPromise.resolve(undefined)
-			await flush()
-			expect(actionRun).toHaveBeenCalledTimes(2)
-
 			await p
+			expect(actionRun).toHaveBeenCalledTimes(2)
 		})
 
 		test('waits are only detected for the internal wait action', async () => {


### PR DESCRIPTION
## Summary

In concurrent action execution, `ActionRunner` started the actions after a Wait as soon as the Wait completed, without awaiting the concurrent group before it. This change awaits each group after launching its actions in parallel, so Wait remains a true barrier while preserving concurrency within each group.

## Verification

- `corepack yarn vitest run companion/test/Controls/ActionRunner.test.ts` — 40 tests passed
- `corepack yarn build:ts` — passed
- `corepack yarn eslint companion/lib/Controls/ActionRunner.ts companion/test/Controls/ActionRunner.test.ts` — passed
- Pre-commit lint-staged ran ESLint and TypeScript checks successfully

The change is limited to first-party action sequencing and has no schema, protocol, or user-data migration.