### PR TITLE
feat: add connection duplication

### DIFF
--- a/companion/lib/Instance/Connection/TrpcRouter.ts
+++ b/companion/lib/Instance/Connection/TrpcRouter.ts
@@ -68,6 +68,19 @@ export function createConnectionsTrpcRouter(
 				return connectionInfo[0]
 			}),
 
+		duplicate: publicProcedure
+			.input(
+				z.object({
+					connectionId: z.string(),
+				})
+			)
+			.mutation(({ input }) => {
+				const connectionId = instanceController.duplicateConnection(input.connectionId)
+				if (!connectionId) throw new Error('Connection not found')
+
+				return connectionId
+			}),
+
 		delete: publicProcedure
 			.input(
 				z.object({

--- a/companion/lib/Instance/Controller.ts
+++ b/companion/lib/Instance/Controller.ts
@@ -861,7 +861,7 @@ export class InstanceController extends EventEmitter<InstanceControllerEvents> {
 			sourceIndex + 1
 		)
 
-		if (sourceConfig.enabled) this.enableDisableConnection(newId, true)
+		if (sourceConfig.enabled !== false) this.enableDisableConnection(newId, true)
 
 		return newId
 	}

--- a/companion/lib/Instance/Controller.ts
+++ b/companion/lib/Instance/Controller.ts
@@ -821,6 +821,51 @@ export class InstanceController extends EventEmitter<InstanceControllerEvents> {
 		return [id, config]
 	}
 
+	duplicateConnection(sourceId: string): string | undefined {
+		const sourceConfig = this.#configStore.getConfigOfTypeForId(sourceId, ModuleInstanceType.Connection)
+		if (!sourceConfig) return undefined
+
+		const sourceIndex = this.#configStore
+			.getAllInstanceConfigs()
+			.entries()
+			.filter(
+				([, config]) =>
+					config.moduleInstanceType === ModuleInstanceType.Connection &&
+					config.collectionId === sourceConfig.collectionId
+			)
+			.toArray()
+			.sort(([, a], [, b]) => a.sortOrder - b.sortOrder)
+			.findIndex(([id]) => id === sourceId)
+
+		const [newId] = this.addConnectionWithLabel({ type: sourceConfig.moduleId }, sourceConfig.label, {
+			versionId: sourceConfig.moduleVersionId,
+			updatePolicy: sourceConfig.updatePolicy,
+			disabled: true,
+			collectionId: sourceConfig.collectionId,
+		})
+
+		const updateResult = this.setConnectionLabelAndConfig(newId, {
+			label: null,
+			enabled: null,
+			config: structuredClone(sourceConfig.config),
+			secrets: structuredClone(sourceConfig.secrets ?? {}),
+			updatePolicy: null,
+			upgradeIndex: sourceConfig.lastUpgradeIndex,
+		})
+		if (!updateResult.ok) throw new Error(updateResult.message)
+
+		this.#configStore.moveInstance(
+			sourceConfig.collectionId ?? null,
+			ModuleInstanceType.Connection,
+			newId,
+			sourceIndex + 1
+		)
+
+		if (sourceConfig.enabled) this.enableDisableConnection(newId, true)
+
+		return newId
+	}
+
 	getLabelForConnection(id: string): string | undefined {
 		return this.#configStore.getConfigOfTypeForId(id, ModuleInstanceType.Connection)?.label
 	}

--- a/companion/test/Instance/Connection/Duplicate.test.ts
+++ b/companion/test/Instance/Connection/Duplicate.test.ts
@@ -59,6 +59,10 @@ describe('InstanceController duplicateConnection', () => {
 			'disabled-source',
 			createConnection({ label: 'disabled', collectionId: undefined, enabled: false, sortOrder: 60 })
 		)
+		instances.set(
+			'legacy-enabled-source',
+			createConnection({ label: 'legacy-enabled', collectionId: undefined, enabled: undefined, sortOrder: 70 })
+		)
 
 		const appInfo = {
 			configDir: ':memory:',
@@ -159,6 +163,13 @@ describe('InstanceController duplicateConnection', () => {
 		expect(duplicate?.enabled).toBe(false)
 	})
 
+	it('keeps a legacy source without an enabled field enabled', () => {
+		const instances = db.getTableView<Record<string, InstanceConfig>>('instances')
+		const newId = controller.duplicateConnection('legacy-enabled-source')
+		const duplicate = instances.get(newId!)
+		expect(duplicate?.enabled).toBe(true)
+	})
+
 	it('duplicates an ungrouped connection immediately after its source', () => {
 		const newId = controller.duplicateConnection('ungrouped')
 		const instances = db.getTableView<Record<string, InstanceConfig>>('instances').all()
@@ -167,7 +178,7 @@ describe('InstanceController duplicateConnection', () => {
 			.sort(([, a], [, b]) => a.sortOrder - b.sortOrder)
 			.map(([id]) => id)
 
-		expect(ungroupedOrder).toEqual(['ungrouped', newId, 'disabled-source'])
+		expect(ungroupedOrder).toEqual(['ungrouped', newId, 'disabled-source', 'legacy-enabled-source'])
 	})
 
 	it('uses stable labels and ordering when the same connection is duplicated repeatedly', () => {

--- a/companion/test/Instance/Connection/Duplicate.test.ts
+++ b/companion/test/Instance/Connection/Duplicate.test.ts
@@ -1,0 +1,192 @@
+import express from 'express'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mockDeep } from 'vitest-mock-extended'
+import {
+	InstanceVersionUpdatePolicy,
+	ModuleInstanceType,
+	type InstanceConfig,
+} from '@companion-app/shared/Model/Instance.js'
+import type { IControlStore } from '../../../lib/Controls/IControlStore.js'
+import { DataCache } from '../../../lib/Data/Cache.js'
+import { DataDatabase } from '../../../lib/Data/Database.js'
+import type { MetricsRegistry } from '../../../lib/Data/Metrics.js'
+import { InstanceController } from '../../../lib/Instance/Controller.js'
+import type { AppInfo } from '../../../lib/Registry.js'
+import type { ServiceOscSender } from '../../../lib/Service/OscSender.js'
+import type { SurfaceController } from '../../../lib/Surface/Controller.js'
+import type { VariablesController } from '../../../lib/Variables/Controller.js'
+
+const SOURCE_ID = 'source-connection'
+const COLLECTION_ID = 'camera-collection'
+
+function createConnection(overrides: Partial<InstanceConfig> = {}): InstanceConfig {
+	return {
+		moduleInstanceType: ModuleInstanceType.Connection,
+		moduleId: 'test-camera',
+		moduleVersionId: '1.2.3',
+		label: 'camera',
+		config: { host: '192.0.2.10', nested: { port: 1234 } },
+		secrets: { password: 'secret' },
+		isFirstInit: false,
+		lastUpgradeIndex: 7,
+		enabled: true,
+		sortOrder: 20,
+		updatePolicy: InstanceVersionUpdatePolicy.Beta,
+		collectionId: COLLECTION_ID,
+		...overrides,
+	}
+}
+
+describe('InstanceController duplicateConnection', () => {
+	let db: DataDatabase
+	let cache: DataCache
+	let controlsStore: ReturnType<typeof mockDeep<IControlStore>>
+	let controller: InstanceController
+
+	beforeEach(() => {
+		vi.useFakeTimers()
+
+		db = new DataDatabase(':memory:')
+		cache = new DataCache(':memory:')
+		controlsStore = mockDeep<IControlStore>()
+
+		const instances = db.getTableView<Record<string, InstanceConfig>>('instances')
+		instances.set('before', createConnection({ label: 'before', sortOrder: 10 }))
+		instances.set(SOURCE_ID, createConnection())
+		instances.set('after', createConnection({ label: 'after', sortOrder: 40 }))
+		instances.set('ungrouped', createConnection({ label: 'ungrouped', collectionId: undefined, sortOrder: 50 }))
+		instances.set(
+			'disabled-source',
+			createConnection({ label: 'disabled', collectionId: undefined, enabled: false, sortOrder: 60 })
+		)
+
+		const appInfo = {
+			configDir: ':memory:',
+			logsDir: undefined,
+			modulesDirs: {
+				[ModuleInstanceType.Connection]: '',
+				[ModuleInstanceType.Surface]: '',
+			},
+			builtinModuleDirs: {
+				[ModuleInstanceType.Connection]: null,
+				[ModuleInstanceType.Surface]: null,
+			},
+			udevRulesDir: '',
+			machineId: 'test-machine',
+			appVersion: 'test',
+			appBuild: 'test',
+			pkgInfo: {},
+			options: {
+				notifications: false,
+				enableShellCommandSupport: false,
+				enableRestrictedModules: false,
+				trustedProxies: undefined,
+				installNameOverride: undefined,
+			},
+		} as AppInfo
+
+		controller = new InstanceController(
+			appInfo,
+			db,
+			cache,
+			express.Router(),
+			controlsStore,
+			mockDeep<VariablesController>(),
+			mockDeep<SurfaceController>(),
+			mockDeep<ServiceOscSender>(),
+			mockDeep<MetricsRegistry>()
+		)
+		vi.spyOn(controller.userModulesManager, 'ensureModuleIsInstalled').mockImplementation(() => undefined)
+		vi.clearAllMocks()
+	})
+
+	afterEach(() => {
+		vi.clearAllTimers()
+		vi.useRealTimers()
+		cache.close()
+		db.close()
+	})
+
+	it('copies the connection configuration and inserts it immediately after the source', () => {
+		const newId = controller.duplicateConnection(SOURCE_ID)
+		expect(newId).toBeTypeOf('string')
+		expect(newId).not.toBe(SOURCE_ID)
+		expect(controller.userModulesManager.ensureModuleIsInstalled).toHaveBeenCalledWith(
+			ModuleInstanceType.Connection,
+			'test-camera',
+			'1.2.3'
+		)
+
+		const instances = db.getTableView<Record<string, InstanceConfig>>('instances').all()
+		const source = instances[SOURCE_ID]
+		const duplicate = instances[newId!]
+
+		expect(duplicate).toMatchObject({
+			moduleInstanceType: ModuleInstanceType.Connection,
+			moduleId: source.moduleId,
+			moduleVersionId: source.moduleVersionId,
+			label: 'camera_2',
+			config: source.config,
+			secrets: source.secrets,
+			isFirstInit: false,
+			lastUpgradeIndex: source.lastUpgradeIndex,
+			enabled: source.enabled,
+			updatePolicy: source.updatePolicy,
+			collectionId: source.collectionId,
+		})
+
+		const collectionOrder = Object.entries(instances)
+			.filter(([, config]) => config.collectionId === COLLECTION_ID)
+			.sort(([, a], [, b]) => a.sortOrder - b.sortOrder)
+			.map(([id]) => id)
+		expect(collectionOrder).toEqual(['before', SOURCE_ID, newId, 'after'])
+		expect(instances.ungrouped.sortOrder).toBe(50)
+	})
+
+	it('does not copy or rewrite controls that reference the source connection', () => {
+		controller.duplicateConnection(SOURCE_ID)
+
+		expect(controlsStore.renameVariables).not.toHaveBeenCalled()
+		expect(controlsStore.forgetConnection).not.toHaveBeenCalled()
+		expect(controlsStore.clearConnectionState).not.toHaveBeenCalled()
+		expect(controlsStore.updateFeedbackValues).not.toHaveBeenCalled()
+	})
+
+	it('keeps a disabled source disabled', () => {
+		const instances = db.getTableView<Record<string, InstanceConfig>>('instances')
+		const newId = controller.duplicateConnection('disabled-source')
+		const duplicate = instances.get(newId!)
+		expect(duplicate?.enabled).toBe(false)
+	})
+
+	it('duplicates an ungrouped connection immediately after its source', () => {
+		const newId = controller.duplicateConnection('ungrouped')
+		const instances = db.getTableView<Record<string, InstanceConfig>>('instances').all()
+		const ungroupedOrder = Object.entries(instances)
+			.filter(([, config]) => !config.collectionId)
+			.sort(([, a], [, b]) => a.sortOrder - b.sortOrder)
+			.map(([id]) => id)
+
+		expect(ungroupedOrder).toEqual(['ungrouped', newId, 'disabled-source'])
+	})
+
+	it('uses stable labels and ordering when the same connection is duplicated repeatedly', () => {
+		const firstId = controller.duplicateConnection(SOURCE_ID)
+		const secondId = controller.duplicateConnection(SOURCE_ID)
+		const instances = db.getTableView<Record<string, InstanceConfig>>('instances').all()
+
+		expect(instances[firstId!].label).toBe('camera_2')
+		expect(instances[secondId!].label).toBe('camera_3')
+
+		const collectionOrder = Object.entries(instances)
+			.filter(([, config]) => config.collectionId === COLLECTION_ID)
+			.sort(([, a], [, b]) => a.sortOrder - b.sortOrder)
+			.map(([id]) => id)
+		expect(collectionOrder).toEqual(['before', SOURCE_ID, secondId, firstId, 'after'])
+	})
+
+	it('returns undefined when the source connection does not exist', () => {
+		expect(controller.duplicateConnection('missing')).toBeUndefined()
+		expect(controller.userModulesManager.ensureModuleIsInstalled).not.toHaveBeenCalled()
+	})
+})

--- a/webui/src/Connections/ConnectionList/ConnectionsTableRow.tsx
+++ b/webui/src/Connections/ConnectionList/ConnectionsTableRow.tsx
@@ -1,4 +1,4 @@
-import { faDollarSign } from '@fortawesome/free-solid-svg-icons'
+import { faClone, faDollarSign } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
 import { useCallback, useContext } from 'react'
@@ -23,7 +23,17 @@ export const ConnectionsTableRow = observer(function ConnectionsTableRow({
 	const id = connection.id
 
 	const deleteMutation = useMutationExt(trpc.instances.connections.delete.mutationOptions())
+	const duplicateMutation = useMutationExt(trpc.instances.connections.duplicate.mutationOptions())
 	const setEnabledMutation = useMutationExt(trpc.instances.connections.setEnabled.mutationOptions())
+
+	const doDuplicate = useCallback(() => {
+		duplicateMutation
+			.mutateAsync({ connectionId: id })
+			.then((connectionId) => configureConnection(connectionId))
+			.catch((e) => {
+				console.error('Duplicate failed', e)
+			})
+	}, [duplicateMutation, id, configureConnection])
 
 	const doDelete = useCallback(() => {
 		deleteModalRef.current?.show(
@@ -62,14 +72,20 @@ export const ConnectionsTableRow = observer(function ConnectionsTableRow({
 			instance={connection}
 			instanceStatus={connection.status}
 			extraMenuItems={
-				<Popover.Item
-					onClick={doShowVariables}
-					title="Variables"
-					disabled={!isEnabled || !(connectionVariables && connectionVariables.size > 0)}
-				>
-					<FontAwesomeIcon icon={faDollarSign} className="me-2" />
-					Variables
-				</Popover.Item>
+				<>
+					<Popover.Item onClick={doDuplicate} title="Duplicate">
+						<FontAwesomeIcon icon={faClone} className="me-2" />
+						Duplicate
+					</Popover.Item>
+					<Popover.Item
+						onClick={doShowVariables}
+						title="Variables"
+						disabled={!isEnabled || !(connectionVariables && connectionVariables.size > 0)}
+					>
+						<FontAwesomeIcon icon={faDollarSign} className="me-2" />
+						Variables
+					</Popover.Item>
+				</>
 			}
 			labelStr="connection"
 			doDelete={doDelete}

--- a/webui/src/Connections/ConnectionList/__tests__/ConnectionsTableRow.test.tsx
+++ b/webui/src/Connections/ConnectionList/__tests__/ConnectionsTableRow.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { InstanceVersionUpdatePolicy, ModuleInstanceType } from '@companion-app/shared/Model/Instance.js'
+import { RootAppStoreContext, type RootAppStore } from '~/Stores/RootAppStore.js'
+import type { ClientConnectionConfigWithId } from '../ConnectionList.js'
+import { ConnectionListContextProvider, type ConnectionListContextType } from '../ConnectionListContext.js'
+import { ConnectionsTableRow } from '../ConnectionsTableRow.js'
+
+const mutationMocks = vi.hoisted(() => ({
+	delete: vi.fn(),
+	duplicate: vi.fn(),
+	setEnabled: vi.fn(),
+}))
+
+vi.mock('~/Resources/TRPC.js', () => ({
+	trpc: {
+		instances: {
+			connections: {
+				delete: { mutationOptions: () => 'delete' },
+				duplicate: { mutationOptions: () => 'duplicate' },
+				setEnabled: { mutationOptions: () => 'setEnabled' },
+			},
+		},
+	},
+	useMutationExt: (mutation: keyof typeof mutationMocks) => ({ mutateAsync: mutationMocks[mutation] }),
+}))
+
+vi.mock('~/Components/Popover.js', () => ({
+	Popover: {
+		Item: ({ children, ...props }: { children: ReactNode; onClick: () => void; title: string; disabled?: boolean }) => (
+			<button {...props}>{children}</button>
+		),
+	},
+}))
+
+vi.mock('~/Instances/List/InstancesListTableRow.js', () => ({
+	InstancesListTableRow: ({ extraMenuItems }: { extraMenuItems: ReactNode }) => <div>{extraMenuItems}</div>,
+}))
+
+const connection: ClientConnectionConfigWithId = {
+	id: 'source-connection',
+	label: 'camera',
+	moduleType: ModuleInstanceType.Connection,
+	moduleId: 'test-camera',
+	moduleVersionId: '1.2.3',
+	updatePolicy: InstanceVersionUpdatePolicy.Stable,
+	enabled: true,
+	sortOrder: 0,
+	collectionId: null,
+	hasRecordActionsHandler: false,
+	status: undefined,
+}
+
+function renderRow(configureConnection: ConnectionListContextType['configureConnection']) {
+	const rootStore = {
+		connections: {},
+		variablesStore: { variables: new Map() },
+	} as unknown as RootAppStore
+
+	render(
+		<RootAppStoreContext.Provider value={rootStore}>
+			<ConnectionListContextProvider
+				visibleConnections={{} as ConnectionListContextType['visibleConnections']}
+				showVariables={vi.fn()}
+				deleteModalRef={{ current: null }}
+				configureConnection={configureConnection}
+			>
+				<ConnectionsTableRow connection={connection} isSelected={false} />
+			</ConnectionListContextProvider>
+		</RootAppStoreContext.Provider>
+	)
+}
+
+describe('ConnectionsTableRow duplicate', () => {
+	it('duplicates the connection and opens the new connection', async () => {
+		const user = userEvent.setup()
+		const configureConnection = vi.fn()
+		mutationMocks.duplicate.mockResolvedValueOnce('duplicated-connection')
+		renderRow(configureConnection)
+
+		await user.click(screen.getByRole('button', { name: 'Duplicate' }))
+
+		expect(mutationMocks.duplicate).toHaveBeenCalledWith({ connectionId: 'source-connection' })
+		await waitFor(() => expect(configureConnection).toHaveBeenCalledWith('duplicated-connection'))
+	})
+})


### PR DESCRIPTION
## Summary

- add a Duplicate command to each connection row
- copy the source module, version, config, secrets, update policy, enabled state, and upgrade index
- place the new connection immediately after the source in the same collection
- open the duplicated connection for editing without copying or rewriting actions and feedbacks

The duplication is owned by the backend because connection config and secrets are intentionally not exposed in the connection-list client model. It reuses the existing connection creation, configuration, and reorder paths. The duplicate is created disabled, fully configured and positioned, and only then enabled when the source was enabled, so it cannot start with the temporary default config.

For legacy connections whose module version is `null`, duplication follows the existing add-connection behavior and resolves the latest installed version.

## Validation

- Node 26.5.0 / Yarn 4.17.1
- `yarn install --immutable`
- `yarn build:ts`
- `yarn build:graphics-types`
- `yarn prettier --check .`
- `yarn lint` (no errors; six existing warnings)
- `yarn check-types`
- generated config-reference and satellite-schema checks
- `yarn workspace @companion-app/webui build`
- focused backend tests: 7 passed
- focused Web UI test: 1 passed
- browser layout check at 1440x900 and 390x844
- full test suite: 3994 passed, 1 unrelated existing sunset scheduling assertion failed

Closes #4034

AI assistance was used for repository research, implementation, and test preparation. The resulting changes and validation output were reviewed locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Duplicate** action for connections in the connection list.
  * Duplicated connections copy configuration and secrets, preserve enabled/disabled state, and receive a unique label.
  * New duplicates are inserted immediately after the original within their collection ordering.

* **Bug Fixes**
  * Displays/handles duplication failures when the source connection is unavailable.

* **Tests**
  * Added coverage for connection duplication behavior and the UI duplicate action flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
