### PR TITLE
feat: allow value feedbacks as layered-button style overrides

### DIFF
--- a/companion/lib/Controls/ControlTypes/Button/LayeredButtonDrawer.ts
+++ b/companion/lib/Controls/ControlTypes/Button/LayeredButtonDrawer.ts
@@ -1,8 +1,7 @@
 import debounceFn from 'debounce-fn'
-import type { JsonValue } from 'type-fest'
 import { formatLocation } from '@companion-app/shared/ControlId.js'
 import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
-import type { ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
+import type { ResolvedFeedbackStyleOverride } from '@companion-app/shared/Model/EntityModel.js'
 import type { SomeButtonGraphicsElement } from '@companion-app/shared/Model/StyleLayersModel.js'
 import {
 	ButtonGraphicsShowStatusIcons,
@@ -31,7 +30,7 @@ export interface DrawElementsVisitor {
  */
 export interface LayeredButtonDrawerEntitySource {
 	getLocalVariableEntities(): ControlEntityInstance[]
-	getFeedbackStyleOverrides(): ReadonlyMap<string, ReadonlyMap<string, ExpressionOrValue<JsonValue | undefined>>>
+	getFeedbackStyleOverrides(): ReadonlyMap<string, ReadonlyMap<string, ResolvedFeedbackStyleOverride>>
 }
 
 /**

--- a/companion/lib/Controls/Entities/EntityListPoolBase.ts
+++ b/companion/lib/Controls/Entities/EntityListPoolBase.ts
@@ -1,12 +1,11 @@
 import debounceFn from 'debounce-fn'
-import type { JsonValue } from 'type-fest'
 import {
 	EntityModelType,
 	type FeedbackEntityStyleOverride,
+	type ResolvedFeedbackStyleOverride,
 	type SomeReplaceableEntityModel,
 	type SomeSocketEntityLocation,
 } from '@companion-app/shared/Model/EntityModel.js'
-import type { ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
 import { stringifyVariableValue, type VariableValues } from '@companion-app/shared/Model/Variables.js'
 import type { InstanceProcessManager } from '../../Instance/ProcessManager.js'
 import type { InternalController } from '../../Internal/Controller.js'
@@ -223,12 +222,9 @@ export abstract class ControlEntityListPoolBase {
 
 	/**
 	 * Get all the style overrides for the layered drawing elements
-	 * @returns A map of elementId -> elementProperty -> override value
+	 * @returns A map of elementId -> elementProperty -> resolved override
 	 */
-	abstract getFeedbackStyleOverrides(): ReadonlyMap<
-		string,
-		ReadonlyMap<string, ExpressionOrValue<JsonValue | undefined>>
-	>
+	abstract getFeedbackStyleOverrides(): ReadonlyMap<string, ReadonlyMap<string, ResolvedFeedbackStyleOverride>>
 
 	getLocalVariableValues(): VariableValues {
 		const entities = this.getLocalVariableEntities()

--- a/companion/lib/Controls/Entities/EntityListPoolButton.ts
+++ b/companion/lib/Controls/Entities/EntityListPoolButton.ts
@@ -5,10 +5,10 @@ import type { ButtonModelBase, ButtonOptionsBase, NormalButtonSteps } from '@com
 import {
 	EntityModelType,
 	FeedbackEntitySubType,
+	type ResolvedFeedbackStyleOverride,
 	type SomeEntityModel,
 	type SomeSocketEntityLocation,
 } from '@companion-app/shared/Model/EntityModel.js'
-import type { ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
 import { stringifyVariableValue, type VariableValues } from '@companion-app/shared/Model/Variables.js'
 import { assertNever } from '@companion-app/shared/Util.js'
 import type { IPageStore } from '../../Page/Store.js'
@@ -202,29 +202,30 @@ export abstract class ButtonEntityListPoolBase extends ControlEntityListPoolBase
 		return entityLists
 	}
 
-	getFeedbackStyleOverrides(): ReadonlyMap<string, ReadonlyMap<string, ExpressionOrValue<JsonValue | undefined>>> {
-		const result = new Map<string, Map<string, ExpressionOrValue<JsonValue | undefined>>>()
+	getFeedbackStyleOverrides(): ReadonlyMap<string, ReadonlyMap<string, ResolvedFeedbackStyleOverride>> {
+		const result = new Map<string, Map<string, ResolvedFeedbackStyleOverride>>()
 
-		const pushOverride = (
-			elementId: string,
-			elementProperty: string,
-			override: ExpressionOrValue<JsonValue | undefined>
-		) => {
-			const targetMap = result.get(elementId) ?? new Map<string, ExpressionOrValue<JsonValue | undefined>>()
+		const pushOverride = (elementId: string, elementProperty: string, override: ResolvedFeedbackStyleOverride) => {
+			const targetMap = result.get(elementId) ?? new Map<string, ResolvedFeedbackStyleOverride>()
 
 			// Hack: merge imageBuffers so that they stack instead of replacing
-			if (elementProperty === 'base64Image') {
+			// Only applies to plain (boolean/advanced) overrides, not value-feedback transforms
+			if (elementProperty === 'base64Image' && override.thisContext === null) {
 				const existing = targetMap.get(elementProperty)
 				if (
 					existing &&
-					!existing.isExpression &&
-					!override.isExpression &&
-					Array.isArray(existing.value) &&
-					Array.isArray(override.value)
+					existing.thisContext === null &&
+					!existing.value.isExpression &&
+					!override.value.isExpression &&
+					Array.isArray(existing.value.value) &&
+					Array.isArray(override.value.value)
 				) {
 					override = {
-						isExpression: false,
-						value: [...existing.value, ...override.value],
+						thisContext: null,
+						value: {
+							isExpression: false,
+							value: [...existing.value.value, ...override.value.value],
+						},
 					}
 				}
 			}
@@ -264,7 +265,10 @@ export abstract class ButtonEntityListPoolBase extends ControlEntityListPoolBase
 					// And the override stores the value to be applied
 					if (feedback.getBooleanFeedbackValue(null)) {
 						for (const override of overrides) {
-							pushOverride(override.elementId, override.elementProperty, override.override)
+							pushOverride(override.elementId, override.elementProperty, {
+								value: override.override,
+								thisContext: null,
+							})
 						}
 					}
 					break
@@ -282,15 +286,25 @@ export abstract class ButtonEntityListPoolBase extends ControlEntityListPoolBase
 							override.elementProperty
 						)
 						if (newValue) {
-							pushOverride(override.elementId, override.elementProperty, newValue)
+							pushOverride(override.elementId, override.elementProperty, { value: newValue, thisContext: null })
 						}
 					}
 
 					break
 				}
-				case FeedbackEntitySubType.Value:
-					// Not compatible here
+				case FeedbackEntitySubType.Value: {
+					// For value feedbacks, the override is an expression transform of the feedback's value.
+					// The feedback value is bound to `$(this:value)` and the expression is evaluated at draw time
+					// (see ElementExpressionHelper), where an `undefined` result means "no override".
+					const thisContext = { value: feedback.feedbackValue as JsonValue | undefined }
+					for (const override of overrides) {
+						pushOverride(override.elementId, override.elementProperty, {
+							value: override.override,
+							thisContext,
+						})
+					}
 					break
+				}
 				case FeedbackEntitySubType.StyleOverride:
 				case null:
 					// Not a real feedback

--- a/companion/lib/Controls/Entities/EntityListPoolExpressionVariable.ts
+++ b/companion/lib/Controls/Entities/EntityListPoolExpressionVariable.ts
@@ -1,11 +1,10 @@
-import type { JsonValue } from 'type-fest'
 import {
 	EntityModelType,
 	FeedbackEntitySubType,
+	type ResolvedFeedbackStyleOverride,
 	type SomeSocketEntityLocation,
 } from '@companion-app/shared/Model/EntityModel.js'
 import type { ExpressionVariableModel } from '@companion-app/shared/Model/ExpressionVariableModel.js'
-import type { ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
 import type { VariableValues } from '@companion-app/shared/Model/Variables.js'
 import type {
 	ExpressionParserOptions,
@@ -99,10 +98,7 @@ export class EntityListPoolExpressionVariable extends WithEntityEditing(ControlE
 		this.tryTriggerLocalVariablesChanged(...changedVariableEntities)
 	}
 
-	public getFeedbackStyleOverrides(): ReadonlyMap<
-		string,
-		ReadonlyMap<string, ExpressionOrValue<JsonValue | undefined>>
-	> {
+	public getFeedbackStyleOverrides(): ReadonlyMap<string, ReadonlyMap<string, ResolvedFeedbackStyleOverride>> {
 		return new Map()
 	}
 

--- a/companion/lib/Controls/Entities/EntityListPoolPage.ts
+++ b/companion/lib/Controls/Entities/EntityListPoolPage.ts
@@ -1,11 +1,10 @@
-import type { JsonValue } from 'type-fest'
 import { ParseControlId } from '@companion-app/shared/ControlId.js'
 import {
 	EntityModelType,
 	FeedbackEntitySubType,
+	type ResolvedFeedbackStyleOverride,
 	type SomeSocketEntityLocation,
 } from '@companion-app/shared/Model/EntityModel.js'
-import type { ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
 import type { PageControlModel } from '@companion-app/shared/Model/PageControlModel.js'
 import type { VariableValues } from '@companion-app/shared/Model/Variables.js'
 import type { IPageStore } from '../../Page/Store.js'
@@ -101,10 +100,7 @@ export class EntityListPoolPage extends WithEntityEditing(ControlEntityListPoolB
 		this.tryTriggerLocalVariablesChanged(...changedVariableEntities)
 	}
 
-	public getFeedbackStyleOverrides(): ReadonlyMap<
-		string,
-		ReadonlyMap<string, ExpressionOrValue<JsonValue | undefined>>
-	> {
+	public getFeedbackStyleOverrides(): ReadonlyMap<string, ReadonlyMap<string, ResolvedFeedbackStyleOverride>> {
 		return new Map()
 	}
 

--- a/companion/lib/Controls/Entities/EntityListPoolTrigger.ts
+++ b/companion/lib/Controls/Entities/EntityListPoolTrigger.ts
@@ -1,10 +1,9 @@
-import type { JsonValue } from 'type-fest'
 import {
 	EntityModelType,
 	FeedbackEntitySubType,
+	type ResolvedFeedbackStyleOverride,
 	type SomeSocketEntityLocation,
 } from '@companion-app/shared/Model/EntityModel.js'
-import type { ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
 import type { TriggerModel } from '@companion-app/shared/Model/TriggerModel.js'
 import type { VariableValues } from '@companion-app/shared/Model/Variables.js'
 import type {
@@ -120,10 +119,7 @@ export class ControlEntityListPoolTrigger extends WithEntityEditing(ControlEntit
 		this.tryTriggerLocalVariablesChanged(...changedVariableEntities)
 	}
 
-	public getFeedbackStyleOverrides(): ReadonlyMap<
-		string,
-		ReadonlyMap<string, ExpressionOrValue<JsonValue | undefined>>
-	> {
+	public getFeedbackStyleOverrides(): ReadonlyMap<string, ReadonlyMap<string, ResolvedFeedbackStyleOverride>> {
 		return new Map()
 	}
 

--- a/companion/lib/Graphics/ConvertGraphicsElements.ts
+++ b/companion/lib/Graphics/ConvertGraphicsElements.ts
@@ -6,6 +6,7 @@ import {
 	getElementSchemaProperty,
 } from '@companion-app/shared/Graphics/ElementPropertiesSchemas.js'
 import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
+import type { ResolvedFeedbackStyleOverride } from '@companion-app/shared/Model/EntityModel.js'
 import type { ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
 import type {
 	ButtonGraphicsBorder,
@@ -96,7 +97,7 @@ export async function ConvertSomeButtonGraphicsElementForDrawing(
 	parser: VariablesAndExpressionParser,
 	drawPixelBuffers: DrawPixelBuffers,
 	elements: SomeButtonGraphicsElement[],
-	feedbackOverrides: ReadonlyMap<string, ReadonlyMap<string, ExpressionOrValue<JsonValue | undefined>>>,
+	feedbackOverrides: ReadonlyMap<string, ReadonlyMap<string, ResolvedFeedbackStyleOverride>>,
 	onlyEnabled: boolean,
 	cache: ElementConversionCache | null,
 	currentLocationStr: string | null = null,

--- a/companion/lib/Graphics/ConvertGraphicsElements/Helper.ts
+++ b/companion/lib/Graphics/ConvertGraphicsElements/Helper.ts
@@ -3,6 +3,7 @@ import type { JsonValue } from 'type-fest'
 import type { ExecuteExpressionResult } from '@companion-app/shared/ExpressionResult.js'
 import type { HorizontalAlignment, VerticalAlignment } from '@companion-app/shared/Graphics/Util.js'
 import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
+import type { ResolvedFeedbackStyleOverride } from '@companion-app/shared/Model/EntityModel.js'
 import { isExpressionOrValue, type ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
 import type { DrawImageBuffer } from '@companion-app/shared/Model/StyleModel.js'
 import {
@@ -53,6 +54,27 @@ export function mergeElementReferences(global: ExpressionReferences, element: El
 	if (element.clockSensitive) global.clockSensitive = true
 }
 
+/** Shared empty override map, so the common (no-override) path allocates nothing. */
+const NO_VARIABLE_OVERRIDES: VariableValues = Object.freeze({})
+const EMPTY_VARIABLE_IDS: ReadonlySet<string> = new Set()
+
+/**
+ * The raw (unparsed) value for an element property, plus the context needed to parse it. Callers parse
+ * `value` themselves - injecting `variableOverrides` (e.g. `$(this:value)` for value feedbacks) - so the
+ * expression is parsed in exactly one place, with the getter's own required type.
+ */
+interface ResolvedElementValue {
+	/** The value/expression to use: the feedback override if one is present, otherwise the element's own value. */
+	value: ExpressionOrValue<JsonValue | undefined>
+	/** Variables to inject while parsing `value` as an expression (e.g. `this:value`); empty for the common case. */
+	variableOverrides: VariableValues
+	/**
+	 * For value-feedback overrides only: the element's own value, applied when the override expression
+	 * resolves to `undefined` ("no override"). `null` for every other case.
+	 */
+	undefinedFallback: ExpressionOrValue<JsonValue | undefined> | null
+}
+
 export class ElementExpressionHelper<T> {
 	readonly #parser: VariablesAndExpressionParser
 
@@ -60,13 +82,13 @@ export class ElementExpressionHelper<T> {
 	readonly #references: ElementReferences
 
 	readonly #element: T
-	readonly #elementOverrides: ReadonlyMap<string, ExpressionOrValue<JsonValue | undefined>> | undefined
+	readonly #elementOverrides: ReadonlyMap<string, ResolvedFeedbackStyleOverride> | undefined
 
 	constructor(
 		parser: VariablesAndExpressionParser,
 		references: ElementReferences,
 		element: T,
-		elementOverrides: ReadonlyMap<string, ExpressionOrValue<JsonValue | undefined>> | undefined
+		elementOverrides: ReadonlyMap<string, ResolvedFeedbackStyleOverride> | undefined
 	) {
 		this.#parser = parser
 		this.#references = references
@@ -76,7 +98,16 @@ export class ElementExpressionHelper<T> {
 	}
 
 	executeExpressionAndTrackVariables(str: string, requiredType: string | undefined): ExecuteExpressionResult {
-		const result = this.#parser.executeExpression(str, requiredType)
+		return this.#trackExpression(this.#parser, str, requiredType)
+	}
+
+	/** Execute an expression with the given parser, recording its variable/clock dependencies. */
+	#trackExpression(
+		parser: VariablesAndExpressionParser,
+		str: string,
+		requiredType: string | undefined
+	): ExecuteExpressionResult {
+		const result = parser.executeExpression(str, requiredType)
 
 		// Track the variables used in the expression, even when it failed
 		for (const variable of result.variableIds) {
@@ -85,6 +116,32 @@ export class ElementExpressionHelper<T> {
 
 		// Track clock sensitivity, even when the expression failed
 		if (result.clockSensitive) this.#references.clockSensitive = true
+
+		return result
+	}
+
+	/**
+	 * Parse a property's override expression: evaluate `str` (with `variableOverrides` injected, e.g.
+	 * `$(this:value)`), and for value-feedback overrides fall back to the element's own value when the
+	 * expression fails or resolves to `undefined` ("no override"). This is the single place override
+	 * expressions are parsed - the getters route their expression branch through here.
+	 */
+	#resolveOverrideExpression(
+		str: string,
+		requiredType: string | undefined,
+		variableOverrides: VariableValues,
+		undefinedFallback: ExpressionOrValue<JsonValue | undefined> | null
+	): ExecuteExpressionResult {
+		const parser =
+			Object.keys(variableOverrides).length > 0 ? this.#parser.createChildParser(variableOverrides) : this.#parser
+		const result = this.#trackExpression(parser, str, requiredType)
+
+		if (undefinedFallback && (!result.ok || result.value === undefined)) {
+			if (!undefinedFallback.isExpression) {
+				return { ok: true, value: undefinedFallback.value, variableIds: EMPTY_VARIABLE_IDS, clockSensitive: false }
+			}
+			return this.#trackExpression(this.#parser, undefinedFallback.value, requiredType)
+		}
 
 		return result
 	}
@@ -105,17 +162,40 @@ export class ElementExpressionHelper<T> {
 		}
 	}
 
-	#getValue(propertyName: keyof T): ExpressionOrValue<JsonValue | undefined> {
+	/**
+	 * Resolve which raw value a property should use - the feedback override if present, otherwise the
+	 * element's own value - WITHOUT parsing any expression. The caller parses `value`, injecting the
+	 * returned `variableOverrides`, so nothing is evaluated for a property that is never read.
+	 */
+	#getValue(propertyName: keyof T): ResolvedElementValue {
+		const base = ((this.#element as any)[propertyName] as ExpressionOrValue<JsonValue | undefined>) ?? {
+			isExpression: false,
+			value: undefined,
+		}
+
 		const override = this.#elementOverrides?.get(String(propertyName))
-		return override ?? (this.#element as any)[propertyName] ?? { isExpression: false, value: undefined }
+		if (!override) return { value: base, variableOverrides: NO_VARIABLE_OVERRIDES, undefinedFallback: null }
+
+		// Boolean/advanced overrides apply directly, parsed like any element value
+		if (override.thisContext === null) {
+			return { value: override.value, variableOverrides: NO_VARIABLE_OVERRIDES, undefinedFallback: null }
+		}
+
+		// Value-feedback override: an expression transform of the feedback value. Expose the value as
+		// `$(this:value)` while parsing, and fall back to the element's own value if it resolves to undefined.
+		return {
+			value: override.value,
+			variableOverrides: { 'this:value': override.thisContext.value },
+			undefinedFallback: base,
+		}
 	}
 
 	getUnknown(propertyName: keyof T, defaultValue: VariableValue): VariableValue | undefined {
-		const value = this.#getValue(propertyName)
+		const { value, variableOverrides, undefinedFallback } = this.#getValue(propertyName)
 
 		if (!value.isExpression) return value.value
 
-		const result = this.executeExpressionAndTrackVariables(value.value, undefined)
+		const result = this.#resolveOverrideExpression(value.value, undefined, variableOverrides, undefinedFallback)
 		if (!result.ok) {
 			return defaultValue
 		}
@@ -124,7 +204,7 @@ export class ElementExpressionHelper<T> {
 	}
 
 	getParsedString(propertyName: keyof T, defaultValue: string): string {
-		const value = this.#getValue(propertyName)
+		const { value } = this.#getValue(propertyName)
 		if (value.isExpression) {
 			return stringifyVariableValue(this.getUnknown(propertyName, defaultValue)) ?? defaultValue
 		} else {
@@ -133,14 +213,14 @@ export class ElementExpressionHelper<T> {
 	}
 
 	getNumber(propertyName: keyof T, defaultValue: number, scale = 1): number {
-		const value = this.#getValue(propertyName)
+		const { value, variableOverrides, undefinedFallback } = this.#getValue(propertyName)
 
 		if (!value.isExpression) {
 			const num = Number(value.value)
 			return isNaN(num) ? defaultValue : num * scale
 		}
 
-		const result = this.executeExpressionAndTrackVariables(value.value, 'number')
+		const result = this.#resolveOverrideExpression(value.value, 'number', variableOverrides, undefinedFallback)
 		if (!result.ok) {
 			return defaultValue
 		}
@@ -160,14 +240,14 @@ export class ElementExpressionHelper<T> {
 	 * forced fully opaque.
 	 */
 	getColor(propertyName: keyof T, defaultValue: number | string, allowAlpha = true): number | string {
-		const value = this.#getValue(propertyName)
+		const { value, variableOverrides, undefinedFallback } = this.#getValue(propertyName)
 
 		let raw: unknown
 		if (!value.isExpression) {
 			raw = value.value
 		} else {
 			// Do not force a 'number' result type, otherwise a css color string would be rejected
-			const result = this.executeExpressionAndTrackVariables(value.value, undefined)
+			const result = this.#resolveOverrideExpression(value.value, undefined, variableOverrides, undefinedFallback)
 			raw = result.ok ? result.value : undefined
 		}
 
@@ -191,14 +271,14 @@ export class ElementExpressionHelper<T> {
 	}
 
 	getString<TVal extends string | null | undefined>(propertyName: keyof T, defaultValue: TVal): TVal {
-		const value = this.#getValue(propertyName)
+		const { value, variableOverrides, undefinedFallback } = this.#getValue(propertyName)
 
 		if (!value.isExpression) {
 			if (value.value === null || value.value === undefined) return value.value as TVal
 			return stringifyVariableValue(value.value) as TVal
 		}
 
-		const result = this.executeExpressionAndTrackVariables(value.value, undefined)
+		const result = this.#resolveOverrideExpression(value.value, undefined, variableOverrides, undefinedFallback)
 		if (!result.ok) {
 			return defaultValue
 		}
@@ -210,13 +290,15 @@ export class ElementExpressionHelper<T> {
 	}
 
 	getEnum<TVal extends string | number>(propertyName: keyof T, values: TVal[], defaultValue: TVal): TVal {
-		const value = this.#getValue(propertyName)
+		const { value, variableOverrides, undefinedFallback } = this.#getValue(propertyName)
 
 		let actualValue: TVal = value.value as TVal
 		if (value.isExpression) {
-			const result = this.executeExpressionAndTrackVariables(
+			const result = this.#resolveOverrideExpression(
 				value.value,
-				typeof defaultValue === 'number' ? 'number' : 'string'
+				typeof defaultValue === 'number' ? 'number' : 'string',
+				variableOverrides,
+				undefinedFallback
 			)
 			if (!result.ok) {
 				return defaultValue
@@ -236,11 +318,11 @@ export class ElementExpressionHelper<T> {
 	 * Resolves an expression if present, requires an array result, and filters to the allowed values.
 	 */
 	getEnumArray<TVal extends string>(propertyName: keyof T, values: readonly TVal[], defaultValue: TVal[]): TVal[] {
-		const value = this.#getValue(propertyName)
+		const { value, variableOverrides, undefinedFallback } = this.#getValue(propertyName)
 
 		let actualValue: unknown = value.value
 		if (value.isExpression) {
-			const result = this.executeExpressionAndTrackVariables(value.value, undefined)
+			const result = this.#resolveOverrideExpression(value.value, undefined, variableOverrides, undefinedFallback)
 			if (!result.ok) {
 				return defaultValue
 			}
@@ -268,7 +350,7 @@ export class ElementExpressionHelper<T> {
 	}
 
 	getBoolean(propertyName: keyof T, defaultValue: boolean): boolean {
-		const value = this.#getValue(propertyName)
+		const { value, variableOverrides, undefinedFallback } = this.#getValue(propertyName)
 
 		if (!value.isExpression) {
 			// A missing property (added to the schema after an element was saved) surfaces as
@@ -278,7 +360,7 @@ export class ElementExpressionHelper<T> {
 			return Boolean(value.value)
 		}
 
-		const result = this.executeExpressionAndTrackVariables(value.value, 'boolean')
+		const result = this.#resolveOverrideExpression(value.value, 'boolean', variableOverrides, undefinedFallback)
 		if (!result.ok) {
 			return defaultValue
 		}
@@ -287,13 +369,13 @@ export class ElementExpressionHelper<T> {
 	}
 
 	getHorizontalAlignment(propertyName: keyof T): HorizontalAlignment {
-		const value = this.#getValue(propertyName)
+		const { value, variableOverrides, undefinedFallback } = this.#getValue(propertyName)
 
 		if (!value.isExpression) {
 			return this.getEnum<HorizontalAlignment>(propertyName, ['left', 'center', 'right'], 'center')
 		}
 
-		const result = this.executeExpressionAndTrackVariables(value.value, 'string')
+		const result = this.#resolveOverrideExpression(value.value, 'string', variableOverrides, undefinedFallback)
 		if (!result.ok) return 'center'
 
 		const firstChar = (stringifyVariableValue(result.value) ?? '').trim().toLowerCase()[0]
@@ -326,13 +408,13 @@ export class ElementExpressionHelper<T> {
 	}
 
 	getVerticalAlignment(propertyName: keyof T): VerticalAlignment {
-		const value = this.#getValue(propertyName)
+		const { value, variableOverrides, undefinedFallback } = this.#getValue(propertyName)
 
 		if (!value.isExpression) {
 			return this.getEnum<VerticalAlignment>(propertyName, ['top', 'center', 'bottom'], 'center')
 		}
 
-		const result = this.executeExpressionAndTrackVariables(value.value, 'string')
+		const result = this.#resolveOverrideExpression(value.value, 'string', variableOverrides, undefinedFallback)
 		if (!result.ok) return 'center'
 
 		const firstChar = (stringifyVariableValue(result.value) ?? '').trim().toLowerCase()[0]
@@ -407,7 +489,7 @@ export function createParseElementsContext(
 	compositeElementStore: InstanceDefinitions,
 	parser: VariablesAndExpressionParser,
 	drawPixelBuffers: DrawPixelBuffers,
-	feedbackOverrides: ReadonlyMap<string, ReadonlyMap<string, ExpressionOrValue<JsonValue | undefined>>>,
+	feedbackOverrides: ReadonlyMap<string, ReadonlyMap<string, ResolvedFeedbackStyleOverride>>,
 	onlyEnabled: boolean,
 	cache: ElementConversionCache | null,
 	globalReferences: ExpressionReferences,

--- a/companion/lib/Graphics/ConvertGraphicsElements/Helper.ts
+++ b/companion/lib/Graphics/ConvertGraphicsElements/Helper.ts
@@ -204,12 +204,31 @@ export class ElementExpressionHelper<T> {
 	}
 
 	getParsedString(propertyName: keyof T, defaultValue: string): string {
-		const { value } = this.#getValue(propertyName)
-		if (value.isExpression) {
-			return stringifyVariableValue(this.getUnknown(propertyName, defaultValue)) ?? defaultValue
-		} else {
+		const { value, variableOverrides, undefinedFallback } = this.#getValue(propertyName)
+
+		// A plain string (the element's own value, or a boolean/advanced override) is a template: interpolate
+		// its variables.
+		if (!value.isExpression) {
 			return this.parseVariablesInString(stringifyVariableValue(value.value) ?? '', defaultValue)
 		}
+
+		// An expression (an expression element value, or a value-feedback transform). Evaluate it - but pass
+		// `null` for the fallback: a value-feedback override that resolves to `undefined` means "no override",
+		// and the element's own value is a template that must be variable-interpolated, not stringified raw.
+		const result = this.#resolveOverrideExpression(value.value, undefined, variableOverrides, null)
+		if (result.ok && result.value !== undefined) {
+			return stringifyVariableValue(result.value) ?? defaultValue
+		}
+
+		if (undefinedFallback) {
+			if (!undefinedFallback.isExpression) {
+				return this.parseVariablesInString(stringifyVariableValue(undefinedFallback.value) ?? '', defaultValue)
+			}
+			const fallback = this.executeExpressionAndTrackVariables(undefinedFallback.value, undefined)
+			return fallback.ok ? (stringifyVariableValue(fallback.value) ?? defaultValue) : defaultValue
+		}
+
+		return defaultValue
 	}
 
 	getNumber(propertyName: keyof T, defaultValue: number, scale = 1): number {

--- a/companion/lib/Instance/Connection/ChildHandlerLegacy.ts
+++ b/companion/lib/Instance/Connection/ChildHandlerLegacy.ts
@@ -801,6 +801,7 @@ export class ConnectionChildHandlerLegacy implements ChildProcessHandlerBase, Co
 				feedbackStyle: undefined,
 				feedbackAffectedProperties: undefined,
 				feedbackDisableStyleOverrides: false,
+				feedbackStyleOverridesUnsupported: false,
 				optionsSupportExpressions: false, // Expressions not supported from 1.x modules
 			} satisfies Complete<ClientEntityDefinition>
 		}
@@ -842,6 +843,7 @@ export class ConnectionChildHandlerLegacy implements ChildProcessHandlerBase, Co
 
 				feedbackAffectedProperties: undefined,
 				feedbackDisableStyleOverrides: false,
+				feedbackStyleOverridesUnsupported: false,
 				showButtonPreview: false,
 				supportsChildGroups: [],
 				optionsSupportExpressions: false, // Expressions not supported from 1.x modules

--- a/companion/lib/Instance/Connection/Thread/HostContext.ts
+++ b/companion/lib/Instance/Connection/Thread/HostContext.ts
@@ -85,6 +85,7 @@ export class HostContext<TConfig, TSecrets> implements ModuleHostContext<TConfig
 				feedbackStyle: undefined,
 				feedbackAffectedProperties: undefined,
 				feedbackDisableStyleOverrides: false,
+				feedbackStyleOverridesUnsupported: false,
 
 				optionsSupportExpressions: true,
 			} satisfies Complete<ClientEntityDefinition>
@@ -110,6 +111,7 @@ export class HostContext<TConfig, TSecrets> implements ModuleHostContext<TConfig
 				feedbackStyle: rawFeedback.defaultStyle,
 				feedbackAffectedProperties: rawFeedback.affectedProperties,
 				feedbackDisableStyleOverrides: false,
+				feedbackStyleOverridesUnsupported: false,
 				hasLifecycleFunctions: true, // Feedbacks always have lifecycle functions
 				hasLearn: !!rawFeedback.hasLearn,
 				learnTimeout: rawFeedback.learnTimeout,

--- a/companion/lib/Internal/Controller.ts
+++ b/companion/lib/Internal/Controller.ts
@@ -701,6 +701,7 @@ export class InternalController {
 						feedbackStyle: undefined,
 						feedbackAffectedProperties: undefined,
 						feedbackDisableStyleOverrides: false,
+						feedbackStyleOverridesUnsupported: false,
 
 						optionsSupportExpressions: action.optionsSupportExpressions ?? false,
 
@@ -735,6 +736,7 @@ export class InternalController {
 						supportsChildGroups: feedback.supportsChildGroups ?? [],
 						feedbackAffectedProperties: feedback.feedbackAffectedProperties ?? undefined,
 						feedbackDisableStyleOverrides: feedback.feedbackDisableStyleOverrides ?? false,
+						feedbackStyleOverridesUnsupported: feedback.feedbackStyleOverridesUnsupported ?? false,
 
 						optionsSupportExpressions: feedback.optionsSupportExpressions ?? false,
 

--- a/companion/lib/Internal/Variables.ts
+++ b/companion/lib/Internal/Variables.ts
@@ -189,6 +189,8 @@ export class InternalVariables extends EventEmitter<InternalModuleFragmentEvents
 				description: 'A value that can be used in other fields',
 				feedbackStyle: undefined,
 				showInvert: false,
+				// A user value is only meaningful as a local variable, not as a style override
+				feedbackStyleOverridesUnsupported: true,
 				options: [
 					{
 						type: 'checkbox',

--- a/companion/lib/Resources/Util.ts
+++ b/companion/lib/Resources/Util.ts
@@ -68,6 +68,7 @@ export const rgb = (r: number | string, g: number | string, b: number | string, 
 
 /**
  * Parse a css color string to a number
+ * Note: alpha is not preserved, and will be ignored
  */
 export const parseColorToNumber = (color: string | number | Uint8Array): number | false => {
 	if (typeof color === 'string') {

--- a/companion/test/Controls/Entities/EntityListPool.test.ts
+++ b/companion/test/Controls/Entities/EntityListPool.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import type { ButtonModelBase } from '@companion-app/shared/Model/ButtonModel.js'
+import { EntityModelType, FeedbackEntitySubType } from '@companion-app/shared/Model/EntityModel.js'
 import type { ControlEntityListChangeProps } from '../../../lib/Controls/Entities/EntityListPoolBase.js'
 import {
 	ControlEntityListPoolButton,
@@ -357,7 +358,11 @@ describe('EntityListPool - getFeedbackStyleOverrides (layered button)', () => {
 
 		const overrides = pool.getFeedbackStyleOverrides()
 
-		expect(overrides.get('el1')?.get('color')).toEqual({ isExpression: false, value: 0xff0000 })
+		// Boolean/advanced overrides carry no `this:value` binding
+		expect(overrides.get('el1')?.get('color')).toEqual({
+			value: { isExpression: false, value: 0xff0000 },
+			thisContext: null,
+		})
 	})
 
 	test('a boolean feedback that is false contributes no overrides', () => {
@@ -367,6 +372,27 @@ describe('EntityListPool - getFeedbackStyleOverrides (layered button)', () => {
 		pool.updateFeedbackValues('conn01', feedbackValues({ [feedback.id]: false }))
 
 		expect(pool.getFeedbackStyleOverrides().size).toBe(0)
+	})
+
+	test('a value feedback binds its value to thisContext for the override expression', () => {
+		const valueFeedbackDefinition = (entityType: EntityModelType) =>
+			entityType === EntityModelType.Feedback
+				? ({ entityType, feedbackType: FeedbackEntitySubType.Value } as any)
+				: ({ entityType } as any)
+
+		const { pool } = createPool({ isLayered: true, getEntityDefinition: valueFeedbackDefinition })
+		const feedback = feedbackModel({
+			styleOverrides: [styleOverride({ override: { isExpression: true, value: '$(this:value) + 1' } })],
+		})
+		pool.entityAdd('feedbacks', null, feedback)
+		pool.updateFeedbackValues('conn01', feedbackValues({ [feedback.id]: 41 }))
+
+		// The pool does not evaluate the expression here - it carries the raw expression plus the feedback
+		// value as `thisContext` for the drawer to evaluate.
+		expect(pool.getFeedbackStyleOverrides().get('el1')?.get('color')).toEqual({
+			value: { isExpression: true, value: '$(this:value) + 1' },
+			thisContext: { value: 41 },
+		})
 	})
 })
 

--- a/companion/test/Graphics/ConvertGraphicsElements.test.ts
+++ b/companion/test/Graphics/ConvertGraphicsElements.test.ts
@@ -1,6 +1,6 @@
-import type { JsonValue } from 'type-fest'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import type { HorizontalAlignment, VerticalAlignment } from '@companion-app/shared/Graphics/Util.js'
+import type { ResolvedFeedbackStyleOverride } from '@companion-app/shared/Model/EntityModel.js'
 import { CompanionFieldVariablesSupport, type ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
 import type {
 	ButtonGraphicsBoxDrawElement,
@@ -1346,9 +1346,11 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 		test('applies feedback overrides to element', async () => {
 			const elements: SomeButtonGraphicsElement[] = [makeTextEl({ text: val('Original') })]
 
-			// feedbackOverrides is Map<elementId, Map<propertyName, ExpressionOrValue>>
-			const text1Overrides = new Map<string, ExpressionOrValue<JsonValue | undefined>>([['text', val('Overridden')]])
-			const globalReferences = new Map<string, ReadonlyMap<string, ExpressionOrValue<JsonValue | undefined>>>([
+			// feedbackOverrides is Map<elementId, Map<propertyName, ResolvedFeedbackStyleOverride>>
+			const text1Overrides = new Map<string, ResolvedFeedbackStyleOverride>([
+				['text', { value: val('Overridden'), thisContext: null }],
+			])
+			const globalReferences = new Map<string, ReadonlyMap<string, ResolvedFeedbackStyleOverride>>([
 				['text1', text1Overrides],
 			])
 
@@ -1365,6 +1367,32 @@ describe('ConvertSomeButtonGraphicsElementForDrawing', () => {
 			)
 
 			expect((result.elements[0] as { text: string }).text).toBe('Overridden')
+		})
+
+		test('applies a value-feedback override as an expression transform of $(this:value)', async () => {
+			const elements: SomeButtonGraphicsElement[] = [makeTextEl({ text: val('Original') })]
+
+			// A value feedback binds its value to $(this:value); the override is an expression transform of it
+			const text1Overrides = new Map<string, ResolvedFeedbackStyleOverride>([
+				['text', { value: { isExpression: true, value: '$(this:value) * 2' }, thisContext: { value: 21 } }],
+			])
+			const globalReferences = new Map<string, ReadonlyMap<string, ResolvedFeedbackStyleOverride>>([
+				['text1', text1Overrides],
+			])
+
+			const result = await ConvertSomeButtonGraphicsElementForDrawing(
+				createMockInstanceDefinitions(),
+				createMockParser(),
+				mockDrawPixelBuffers,
+				elements,
+				globalReferences,
+				true,
+				null,
+				null,
+				null
+			)
+
+			expect((result.elements[0] as { text: string }).text).toBe('42')
 		})
 	})
 

--- a/companion/test/Graphics/ConvertGraphicsElements/Helper.test.ts
+++ b/companion/test/Graphics/ConvertGraphicsElements/Helper.test.ts
@@ -284,6 +284,24 @@ describe('ElementExpressionHelper', () => {
 			expect(helper.getParsedString('strProp', '')).toBe('World')
 		})
 
+		test('value-feedback override transforms $(this:value) for a string property', () => {
+			const overrides = new Map<string, ResolvedFeedbackStyleOverride>([
+				['strProp', valueOverride('$(this:value)', 'Hello')],
+			])
+			const { helper } = makeHelper(makeEl({ strProp: val('base') }), {}, overrides)
+			expect(helper.getParsedString('strProp', 'default')).toBe('Hello')
+		})
+
+		test('value-feedback override resolving to undefined uses the element value, still interpolating variables', () => {
+			// `$(ns:missing)` is unknown -> the override resolves to undefined ("no override"), so the element's
+			// own template `$(ns:name)` must be rendered AND variable-interpolated.
+			const overrides = new Map<string, ResolvedFeedbackStyleOverride>([
+				['strProp', valueOverride('$(ns:missing)', 'ignored')],
+			])
+			const { helper } = makeHelper(makeEl({ strProp: val('$(ns:name)') }), { ns: { name: 'World' } }, overrides)
+			expect(helper.getParsedString('strProp', 'default')).toBe('World')
+		})
+
 		test('evaluates expression and stringifies result', () => {
 			const { helper } = makeHelper(makeEl({ strProp: expr('$(ns:count) + 1') }), { ns: { count: 5 } })
 			expect(helper.getParsedString('strProp', '')).toBe('6')

--- a/companion/test/Graphics/ConvertGraphicsElements/Helper.test.ts
+++ b/companion/test/Graphics/ConvertGraphicsElements/Helper.test.ts
@@ -1,5 +1,6 @@
 import type { JsonValue } from 'type-fest'
 import { describe, expect, test, vi } from 'vitest'
+import type { ResolvedFeedbackStyleOverride } from '@companion-app/shared/Model/EntityModel.js'
 import type { ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
 import type { VariableValues } from '@companion-app/shared/Model/Variables.js'
 import { VARIABLE_UNKNOWN_VALUE } from '@companion-app/shared/Variables.js'
@@ -25,6 +26,16 @@ function val<T>(value: T): ExpressionOrValue<T> {
 
 function expr<T>(value: string): ExpressionOrValue<T> {
 	return { isExpression: true, value }
+}
+
+/** A boolean/advanced style override (applied as-is, no `this:value` binding). */
+function staticOverride(value: ExpressionOrValue<JsonValue | undefined>): ResolvedFeedbackStyleOverride {
+	return { value, thisContext: null }
+}
+
+/** A value-feedback style override: an expression transform of `$(this:value)`. */
+function valueOverride(expression: string, thisValue: JsonValue | undefined): ResolvedFeedbackStyleOverride {
+	return { value: { isExpression: true, value: expression }, thisContext: { value: thisValue } }
 }
 
 function createMockParser(
@@ -93,7 +104,7 @@ function makeEl(overrides: Partial<TestEl> = {}): TestEl {
 function makeHelper(
 	element: TestEl,
 	variableValues: Record<string, Record<string, string | number | boolean>> = {},
-	overrides?: ReadonlyMap<string, ExpressionOrValue<JsonValue | undefined>>
+	overrides?: ReadonlyMap<string, ResolvedFeedbackStyleOverride>
 ): { helper: ElementExpressionHelper<TestEl>; usedVariables: Set<string> } {
 	const references = createElementReferences()
 	const parser = createMockParser(variableValues)
@@ -127,7 +138,7 @@ function makeCtx(
 	options: {
 		compositeElements?: Record<string, Record<string, CompositeElementDefinition>>
 		variableValues?: Record<string, Record<string, string | number | boolean>>
-		feedbackOverrides?: ReadonlyMap<string, ReadonlyMap<string, ExpressionOrValue<JsonValue | undefined>>>
+		feedbackOverrides?: ReadonlyMap<string, ReadonlyMap<string, ResolvedFeedbackStyleOverride>>
 	} = {}
 ) {
 	return createParseElementsContext(
@@ -951,22 +962,22 @@ describe('ElementExpressionHelper', () => {
 	describe('elementOverrides', () => {
 		test('override takes precedence over element property value', () => {
 			const element = makeEl({ strProp: val('original') })
-			const overrides = new Map<string, ExpressionOrValue<JsonValue | undefined>>([['strProp', val('overridden')]])
+			const overrides = new Map<string, ResolvedFeedbackStyleOverride>([['strProp', staticOverride(val('overridden'))]])
 			const { helper } = makeHelper(element, {}, overrides)
 			expect(helper.getString('strProp', '')).toBe('overridden')
 		})
 
 		test('non-overridden properties use the element value', () => {
 			const element = makeEl({ strProp: val('original'), numProp: val(42) })
-			const overrides = new Map<string, ExpressionOrValue<JsonValue | undefined>>([['strProp', val('overridden')]])
+			const overrides = new Map<string, ResolvedFeedbackStyleOverride>([['strProp', staticOverride(val('overridden'))]])
 			const { helper } = makeHelper(element, {}, overrides)
 			expect(helper.getNumber('numProp', 0)).toBe(42)
 		})
 
 		test('override can itself be an expression', () => {
 			const element = makeEl({ strProp: val('original') })
-			const overrides = new Map<string, ExpressionOrValue<JsonValue | undefined>>([
-				['strProp', expr<JsonValue>('"computed"')],
+			const overrides = new Map<string, ResolvedFeedbackStyleOverride>([
+				['strProp', staticOverride(expr<JsonValue>('"computed"'))],
 			])
 			const { helper } = makeHelper(element, {}, overrides)
 			expect(helper.getString('strProp', '')).toBe('computed')
@@ -974,8 +985,8 @@ describe('ElementExpressionHelper', () => {
 
 		test('override expression tracks its variable IDs', () => {
 			const element = makeEl({ strProp: val('original') })
-			const overrides = new Map<string, ExpressionOrValue<JsonValue | undefined>>([
-				['strProp', expr<JsonValue>('$(ns:x)')],
+			const overrides = new Map<string, ResolvedFeedbackStyleOverride>([
+				['strProp', staticOverride(expr<JsonValue>('$(ns:x)'))],
 			])
 			const { helper, usedVariables } = makeHelper(element, { ns: { x: 'value' } }, overrides)
 			helper.getString('strProp', '')
@@ -995,8 +1006,8 @@ describe('createParseElementsContext', () => {
 		})
 
 		test('applies feedback overrides to the matching element ID only', () => {
-			const feedbackOverrides = new Map<string, ReadonlyMap<string, ExpressionOrValue<JsonValue | undefined>>>([
-				['el1', new Map([['strProp', val('overridden')]])],
+			const feedbackOverrides = new Map<string, ReadonlyMap<string, ResolvedFeedbackStyleOverride>>([
+				['el1', new Map([['strProp', staticOverride(val('overridden'))]])],
 			])
 			const ctx = makeCtx({ feedbackOverrides })
 
@@ -1008,12 +1019,57 @@ describe('createParseElementsContext', () => {
 		})
 
 		test('element without matching feedback override uses its own property', () => {
-			const feedbackOverrides = new Map<string, ReadonlyMap<string, ExpressionOrValue<JsonValue | undefined>>>([
-				['other-id', new Map([['strProp', val('overridden')]])],
+			const feedbackOverrides = new Map<string, ReadonlyMap<string, ResolvedFeedbackStyleOverride>>([
+				['other-id', new Map([['strProp', staticOverride(val('overridden'))]])],
 			])
 			const ctx = makeCtx({ feedbackOverrides })
 			const { helper } = ctx.createHelper({ id: 'el1', strProp: val('original') })
 			expect(helper.getString('strProp', '')).toBe('original')
+		})
+
+		test('value-feedback override transforms $(this:value) into the property', () => {
+			const feedbackOverrides = new Map<string, ReadonlyMap<string, ResolvedFeedbackStyleOverride>>([
+				['el1', new Map([['numProp', valueOverride('$(this:value) * 2', 21)]])],
+			])
+			const ctx = makeCtx({ feedbackOverrides })
+			const { helper } = ctx.createHelper({ id: 'el1', numProp: val(0) })
+			expect(helper.getNumber('numProp', -1)).toBe(42)
+		})
+
+		test('value-feedback override returning undefined falls back to the base value', () => {
+			const feedbackOverrides = new Map<string, ReadonlyMap<string, ResolvedFeedbackStyleOverride>>([
+				// `$(ns:missing)` is unknown, so the expression resolves to undefined -> no override
+				['el1', new Map([['strProp', valueOverride('$(ns:missing)', 'ignored')]])],
+			])
+			const ctx = makeCtx({ feedbackOverrides })
+			const { helper } = ctx.createHelper({ id: 'el1', strProp: val('base') })
+			expect(helper.getString('strProp', '')).toBe('base')
+		})
+
+		test('value-feedback override tracks variables referenced alongside $(this:value)', () => {
+			const feedbackOverrides = new Map<string, ReadonlyMap<string, ResolvedFeedbackStyleOverride>>([
+				['el1', new Map([['numProp', valueOverride('$(this:value) + $(ns:x)', 10)]])],
+			])
+			const ctx = makeCtx({ feedbackOverrides, variableValues: { ns: { x: 5 } } })
+			const { helper, references } = ctx.createHelper({ id: 'el1', numProp: val(0) })
+			expect(helper.getNumber('numProp', -1)).toBe(15)
+			expect(references.usedVariables.has('ns:x')).toBe(true)
+		})
+
+		test('a value-feedback override is not evaluated or tracked until its property is read', () => {
+			const feedbackOverrides = new Map<string, ReadonlyMap<string, ResolvedFeedbackStyleOverride>>([
+				['el1', new Map([['strProp', valueOverride('$(ns:x)', 1)]])],
+			])
+			const ctx = makeCtx({ feedbackOverrides, variableValues: { ns: { x: 5 } } })
+			const { helper, references } = ctx.createHelper({ id: 'el1', strProp: val('base'), numProp: val(0) })
+
+			// Reading a different property must not evaluate the strProp override or register its variables
+			helper.getNumber('numProp', -1)
+			expect(references.usedVariables.has('ns:x')).toBe(false)
+
+			// Reading the overridden property now evaluates it and registers the dependency
+			helper.getString('strProp', '')
+			expect(references.usedVariables.has('ns:x')).toBe(true)
 		})
 	})
 

--- a/shared-lib/lib/Entity.ts
+++ b/shared-lib/lib/Entity.ts
@@ -19,9 +19,12 @@ export function canAddEntityToFeedbackList(
 			)
 		case FeedbackEntitySubType.Advanced:
 		case FeedbackEntitySubType.StyleOverride:
+			// A feedback can opt out of being used as a style override entirely, regardless of its type
+			if (definition.feedbackStyleOverridesUnsupported) return false
 			return (
 				definition.feedbackType === FeedbackEntitySubType.Advanced ||
-				definition.feedbackType === FeedbackEntitySubType.Boolean
+				definition.feedbackType === FeedbackEntitySubType.Boolean ||
+				definition.feedbackType === FeedbackEntitySubType.Value
 			)
 		default:
 			assertNever(feedbackListType)

--- a/shared-lib/lib/Model/EntityDefinitionModel.ts
+++ b/shared-lib/lib/Model/EntityDefinitionModel.ts
@@ -20,6 +20,8 @@ export interface ClientEntityDefinition {
 	 * Special case for 'conditionalise existing feedbacks' to avoid the root getting style overrides, as we defer that to the children feedbacks
 	 */
 	feedbackDisableStyleOverrides?: boolean
+	/** When true, this feedback cannot be used as a style override: it is hidden from the add menu and rejected by validation. */
+	feedbackStyleOverridesUnsupported?: boolean
 	hasLifecycleFunctions: boolean
 	hasLearn: boolean
 	learnTimeout: number | undefined

--- a/shared-lib/lib/Model/EntityModel.ts
+++ b/shared-lib/lib/Model/EntityModel.ts
@@ -123,6 +123,25 @@ export const schemaFeedbackEntityStyleOverride: z.ZodType<FeedbackEntityStyleOve
 	override: ExpressionOrJsonValueSchema,
 })
 
+/**
+ * A style override resolved from a feedback, ready to be applied to a button element property.
+ * This is a computed (non-persisted) shape produced when merging a control's feedbacks into the
+ * per-element overrides used at draw time.
+ */
+export interface ResolvedFeedbackStyleOverride {
+	/** The value/expression to apply for this override. */
+	value: ExpressionOrValue<JsonValue | undefined>
+	/**
+	 * When non-null, this override is a value-feedback transform: `value` is evaluated as an expression
+	 * with `$(this:value)` bound to `thisContext.value`, and an `undefined` result means "no override"
+	 * (the element's base value is used instead).
+	 *
+	 * A nested object (rather than a bare `JsonValue | undefined`) so that a value-feedback whose value
+	 * is `undefined` stays distinguishable from a boolean/advanced override, which uses `thisContext: null`.
+	 */
+	thisContext: { value: JsonValue | undefined } | null
+}
+
 export interface EntityModelBase {
 	readonly type: EntityModelType
 

--- a/shared-lib/lib/__tests__/Entity.test.ts
+++ b/shared-lib/lib/__tests__/Entity.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'vitest'
+import { canAddEntityToFeedbackList } from '../Entity.js'
+import type { ClientEntityDefinition } from '../Model/EntityDefinitionModel.js'
+import { FeedbackEntitySubType } from '../Model/EntityModel.js'
+
+function feedbackDefinition(
+	feedbackType: FeedbackEntitySubType | null,
+	extra: Partial<ClientEntityDefinition> = {}
+): ClientEntityDefinition {
+	return { feedbackType, ...extra } as ClientEntityDefinition
+}
+
+describe('canAddEntityToFeedbackList', () => {
+	describe('StyleOverride list (layered button feedbacks)', () => {
+		test.each([FeedbackEntitySubType.Boolean, FeedbackEntitySubType.Advanced, FeedbackEntitySubType.Value])(
+			'allows %s feedbacks',
+			(feedbackType) => {
+				expect(canAddEntityToFeedbackList(FeedbackEntitySubType.StyleOverride, feedbackDefinition(feedbackType))).toBe(
+					true
+				)
+			}
+		)
+
+		test('rejects feedbacks with no feedbackType', () => {
+			expect(canAddEntityToFeedbackList(FeedbackEntitySubType.StyleOverride, feedbackDefinition(null))).toBe(false)
+		})
+
+		test.each([FeedbackEntitySubType.Boolean, FeedbackEntitySubType.Advanced, FeedbackEntitySubType.Value])(
+			'rejects %s feedbacks that opt out via feedbackStyleOverridesUnsupported',
+			(feedbackType) => {
+				expect(
+					canAddEntityToFeedbackList(
+						FeedbackEntitySubType.StyleOverride,
+						feedbackDefinition(feedbackType, { feedbackStyleOverridesUnsupported: true })
+					)
+				).toBe(false)
+			}
+		)
+	})
+
+	describe('Value list (local variable feedbacks)', () => {
+		test('allows Value and Boolean feedbacks', () => {
+			expect(
+				canAddEntityToFeedbackList(FeedbackEntitySubType.Value, feedbackDefinition(FeedbackEntitySubType.Value))
+			).toBe(true)
+			expect(
+				canAddEntityToFeedbackList(FeedbackEntitySubType.Value, feedbackDefinition(FeedbackEntitySubType.Boolean))
+			).toBe(true)
+		})
+
+		test('still allows a Value feedback that opts out of style overrides (flag only affects the style list)', () => {
+			// e.g. internal 'user_value' - blocked from style overrides but still valid as a local variable
+			expect(
+				canAddEntityToFeedbackList(
+					FeedbackEntitySubType.Value,
+					feedbackDefinition(FeedbackEntitySubType.Value, { feedbackStyleOverridesUnsupported: true })
+				)
+			).toBe(true)
+		})
+
+		test('rejects Advanced feedbacks', () => {
+			expect(
+				canAddEntityToFeedbackList(FeedbackEntitySubType.Value, feedbackDefinition(FeedbackEntitySubType.Advanced))
+			).toBe(false)
+		})
+	})
+
+	describe('Boolean list', () => {
+		test('allows only Boolean feedbacks', () => {
+			expect(
+				canAddEntityToFeedbackList(FeedbackEntitySubType.Boolean, feedbackDefinition(FeedbackEntitySubType.Boolean))
+			).toBe(true)
+			expect(
+				canAddEntityToFeedbackList(FeedbackEntitySubType.Boolean, feedbackDefinition(FeedbackEntitySubType.Value))
+			).toBe(false)
+		})
+	})
+
+	describe('null list', () => {
+		test('allows everything except Value feedbacks', () => {
+			expect(canAddEntityToFeedbackList(null, feedbackDefinition(FeedbackEntitySubType.Boolean))).toBe(true)
+			expect(canAddEntityToFeedbackList(null, feedbackDefinition(FeedbackEntitySubType.Advanced))).toBe(true)
+			expect(canAddEntityToFeedbackList(null, feedbackDefinition(FeedbackEntitySubType.Value))).toBe(false)
+		})
+	})
+})

--- a/webui/src/Controls/Components/EntityCommonCells.tsx
+++ b/webui/src/Controls/Components/EntityCommonCells.tsx
@@ -194,7 +194,8 @@ export const EntityCommonCells = observer(function EntityCommonCells({
 					{!!entity &&
 						entity.type === EntityModelType.Feedback &&
 						feedbackListType === FeedbackEntitySubType.StyleOverride &&
-						!entityDefinition?.feedbackDisableStyleOverrides && (
+						!entityDefinition?.feedbackDisableStyleOverrides &&
+						!entityDefinition?.feedbackStyleOverridesUnsupported && (
 							<LayeredStylesOverrides
 								feedback={entity}
 								feedbackType={entityDefinition?.feedbackType}

--- a/webui/src/Controls/Components/LayeredStylesOverrides.tsx
+++ b/webui/src/Controls/Components/LayeredStylesOverrides.tsx
@@ -26,7 +26,11 @@ import { InlineHelpCustom } from '~/Components/InlineHelp.js'
 import { Table } from '~/Components/Table.js'
 import { useComputed } from '~/Resources/util.js'
 import type { IEntityEditorActionService } from '~/Services/Controls/ControlEntitiesService'
-import { FeedbackValueContextVariables, type LocalVariablesStore } from '../LocalVariablesStore.js'
+import {
+	EntityListActionContext,
+	FeedbackValueContextVariables,
+	type LocalVariablesStore,
+} from '../LocalVariablesStore.js'
 import { OptionsInputControl } from '../OptionsInputControl.js'
 import { AddElementPickerModal } from './AddElementPickerModal.js'
 import { ElementPickerModal } from './ElementPickerModal.js'
@@ -424,7 +428,7 @@ const ValueFeedbackOverrideInput = observer(function ValueFeedbackOverrideInput(
 				entityType: EntityModelType.Feedback,
 				internalParser: true,
 				isLocatedInGrid: true,
-				insideActionsList: false,
+				actionContext: EntityListActionContext.NotActions,
 			}) ?? []),
 			...FeedbackValueContextVariables,
 		],

--- a/webui/src/Controls/Components/LayeredStylesOverrides.tsx
+++ b/webui/src/Controls/Components/LayeredStylesOverrides.tsx
@@ -1,4 +1,5 @@
-import { faPencil, faTrash } from '@fortawesome/free-solid-svg-icons'
+import type { IconDefinition } from '@fortawesome/fontawesome-svg-core'
+import { faPalette, faPencil, faSquareRootVariable, faToggleOn, faTrash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
 import { nanoid } from 'nanoid'
@@ -14,15 +15,18 @@ import {
 } from '@companion-app/shared/Model/EntityModel.js'
 import type { ExpressionOrValue } from '@companion-app/shared/Model/Options.js'
 import type { SomeButtonGraphicsElement } from '@companion-app/shared/Model/StyleLayersModel.js'
+import { stringifyVariableValue } from '@companion-app/shared/Model/Variables.js'
 import { ButtonStylePropertiesWithBuffer } from '@companion-app/shared/Style.js'
 import { assertNever } from '@companion-app/shared/Util.js'
 import { Button } from '~/Components/Button.js'
 import { DropdownInputField } from '~/Components/DropdownInputField.js'
+import { ExpressionInputField } from '~/Components/ExpressionInputField.js'
 import { FieldOrExpression } from '~/Components/FieldOrExpression.js'
+import { InlineHelpCustom } from '~/Components/InlineHelp.js'
 import { Table } from '~/Components/Table.js'
 import { useComputed } from '~/Resources/util.js'
 import type { IEntityEditorActionService } from '~/Services/Controls/ControlEntitiesService'
-import type { LocalVariablesStore } from '../LocalVariablesStore.js'
+import { FeedbackValueContextVariables, type LocalVariablesStore } from '../LocalVariablesStore.js'
 import { OptionsInputControl } from '../OptionsInputControl.js'
 import { AddElementPickerModal } from './AddElementPickerModal.js'
 import { ElementPickerModal } from './ElementPickerModal.js'
@@ -34,6 +38,78 @@ interface LayeredStylesOverridesProps {
 	service: IEntityEditorActionService
 	localVariablesStore: LocalVariablesStore | null
 }
+
+/**
+ * The value a freshly-added style override starts from. Value feedbacks override via an expression
+ * transform of `$(this:value)` (the feedback's current value), so their overrides are seeded as that
+ * expression. Other feedback types start from an empty plain value.
+ */
+export function defaultStyleOverrideValue(
+	feedbackType: FeedbackEntitySubType | null | undefined
+): ExpressionOrValue<JsonValue | undefined> {
+	return feedbackType === FeedbackEntitySubType.Value
+		? { isExpression: true, value: '$(this:value)' }
+		: { isExpression: false, value: '' }
+}
+
+/**
+ * Describe how a feedback of the given type interacts with the style overrides below it, shown as the
+ * hover text on the style-overrides indicator icon. Returns null for types with no style-override editor.
+ *
+ * Note: the module-api name for the legacy style feedback is "advanced", but that is not surfaced to
+ * users - it is the oldest/most basic feedback type, and calling it "advanced" is misleading.
+ */
+export function feedbackTypeInteractionHelp(
+	feedbackType: FeedbackEntitySubType | null | undefined
+): { icon: IconDefinition; title: string; description: string } | null {
+	switch (feedbackType) {
+		case FeedbackEntitySubType.Value:
+			return {
+				icon: faSquareRootVariable,
+				title: 'Value feedback',
+				description:
+					'Each override is an expression that can transform the feedback value with $(this:value). The property is overridden unless the expression returns undefined.',
+			}
+		case FeedbackEntitySubType.Boolean:
+			return {
+				icon: faToggleOn,
+				title: 'Boolean feedback',
+				description: 'The overrides below are applied whenever the feedback is active.',
+			}
+		case FeedbackEntitySubType.Advanced:
+			return {
+				icon: faPalette,
+				title: 'Legacy style feedback',
+				description:
+					'An older style-based feedback. Each override copies one of the style properties it produces onto an element property.',
+			}
+		default:
+			return null
+	}
+}
+
+const FeedbackTypeIndicator = observer(function FeedbackTypeIndicator({
+	feedbackType,
+}: {
+	feedbackType: FeedbackEntitySubType | null | undefined
+}) {
+	const info = feedbackTypeInteractionHelp(feedbackType)
+	if (!info) return null
+
+	return (
+		<InlineHelpCustom
+			help={
+				<>
+					<strong>{info.title}</strong>
+					<br />
+					{info.description}
+				</>
+			}
+		>
+			<FontAwesomeIcon icon={info.icon} className="text-info" />
+		</InlineHelpCustom>
+	)
+})
 
 export const LayeredStylesOverrides = observer(function LayeredStylesOverrides({
 	feedback,
@@ -97,18 +173,20 @@ export const LayeredStylesOverrides = observer(function LayeredStylesOverrides({
 		(elementId: string, properties: string[]) => {
 			console.log('AddElementPickerModal save:', { elementId, properties })
 
+			const defaultOverride = defaultStyleOverrideValue(feedbackType)
+
 			// Create multiple overrides, one for each selected property
 			properties.forEach((propertyId) => {
 				const newOverride: FeedbackEntityStyleOverride = {
 					overrideId: nanoid(),
 					elementId,
 					elementProperty: propertyId,
-					override: { isExpression: false, value: '' },
+					override: defaultOverride,
 				}
 				service.replaceStyleOverride(newOverride)
 			})
 		},
-		[service]
+		[service, feedbackType]
 	)
 
 	return (
@@ -116,7 +194,10 @@ export const LayeredStylesOverrides = observer(function LayeredStylesOverrides({
 			<hr />
 
 			<div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
-				<strong>Style Overrides</strong>
+				<span className="d-flex align-items-center gap-2">
+					<strong>Style Overrides</strong>
+					<FeedbackTypeIndicator feedbackType={feedbackType} />
+				</span>
 				<div></div>
 			</div>
 
@@ -304,8 +385,18 @@ const PropertyValueInput = observer(function PropertyValueInput({
 					/>
 				</FieldOrExpression>
 			)
-		case FeedbackEntitySubType.StyleOverride:
 		case FeedbackEntitySubType.Value:
+			// Value feedbacks always override via an expression, transforming `$(this:value)` (the feedback's
+			// current value). An expression returning `undefined` means "no override".
+			return (
+				<ValueFeedbackOverrideInput
+					inputId={inputId}
+					value={row.override.isExpression ? (stringifyVariableValue(row.override.value) ?? '') : ''}
+					setValue={(value) => setOverride({ isExpression: true, value })}
+					localVariablesStore={localVariablesStore}
+				/>
+			)
+		case FeedbackEntitySubType.StyleOverride:
 		case undefined:
 		case null:
 			return <p>Unsupported feedback type</p>
@@ -313,4 +404,34 @@ const PropertyValueInput = observer(function PropertyValueInput({
 			assertNever(feedbackType)
 			return <p>Unsupported feedback type</p>
 	}
+})
+
+const ValueFeedbackOverrideInput = observer(function ValueFeedbackOverrideInput({
+	inputId,
+	value,
+	setValue,
+	localVariablesStore,
+}: {
+	inputId: string | undefined
+	value: string
+	setValue: (value: string) => void
+	localVariablesStore: LocalVariablesStore | null
+}) {
+	// Offer the control's local variables plus the `$(this:value)` context variable in the picker
+	const expressionLocalVariables = useComputed(
+		() => [
+			...(localVariablesStore?.getOptions({
+				entityType: EntityModelType.Feedback,
+				internalParser: true,
+				isLocatedInGrid: true,
+				insideActionsList: false,
+			}) ?? []),
+			...FeedbackValueContextVariables,
+		],
+		[localVariablesStore]
+	)
+
+	return (
+		<ExpressionInputField id={inputId} value={value} setValue={setValue} localVariables={expressionLocalVariables} />
+	)
 })

--- a/webui/src/Controls/Components/__tests__/LayeredStylesOverrides.test.ts
+++ b/webui/src/Controls/Components/__tests__/LayeredStylesOverrides.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'vitest'
+import { FeedbackEntitySubType } from '@companion-app/shared/Model/EntityModel.js'
+import { defaultStyleOverrideValue, feedbackTypeInteractionHelp } from '../LayeredStylesOverrides.js'
+
+describe('defaultStyleOverrideValue', () => {
+	test('value feedbacks are seeded with a $(this:value) expression', () => {
+		expect(defaultStyleOverrideValue(FeedbackEntitySubType.Value)).toEqual({
+			isExpression: true,
+			value: '$(this:value)',
+		})
+	})
+
+	test('boolean feedbacks start from an empty plain value', () => {
+		expect(defaultStyleOverrideValue(FeedbackEntitySubType.Boolean)).toEqual({ isExpression: false, value: '' })
+	})
+
+	test('advanced feedbacks start from an empty plain value', () => {
+		expect(defaultStyleOverrideValue(FeedbackEntitySubType.Advanced)).toEqual({ isExpression: false, value: '' })
+	})
+
+	test('undefined feedback type starts from an empty plain value', () => {
+		expect(defaultStyleOverrideValue(undefined)).toEqual({ isExpression: false, value: '' })
+	})
+})
+
+describe('feedbackTypeInteractionHelp', () => {
+	test.each([FeedbackEntitySubType.Value, FeedbackEntitySubType.Boolean, FeedbackEntitySubType.Advanced])(
+		'returns an icon, title and description for %s feedbacks',
+		(feedbackType) => {
+			const info = feedbackTypeInteractionHelp(feedbackType)
+			expect(info).not.toBeNull()
+			expect(info?.icon).toBeTruthy()
+			expect(info?.title.length).toBeGreaterThan(0)
+			expect(info?.description.length).toBeGreaterThan(0)
+		}
+	)
+
+	test('value feedback description mentions $(this:value) and the undefined behaviour', () => {
+		const info = feedbackTypeInteractionHelp(FeedbackEntitySubType.Value)
+		expect(info?.description).toContain('$(this:value)')
+		expect(info?.description).toContain('undefined')
+	})
+
+	test('the legacy style feedback is not surfaced to users as "advanced"', () => {
+		const info = feedbackTypeInteractionHelp(FeedbackEntitySubType.Advanced)
+		expect(info?.title.toLowerCase()).not.toContain('advanced')
+		expect(info?.description.toLowerCase()).not.toContain('advanced')
+		expect(info?.title.toLowerCase()).toContain('legacy')
+	})
+
+	test('returns null for unknown / non-override feedback types', () => {
+		expect(feedbackTypeInteractionHelp(FeedbackEntitySubType.StyleOverride)).toBeNull()
+		expect(feedbackTypeInteractionHelp(null)).toBeNull()
+		expect(feedbackTypeInteractionHelp(undefined)).toBeNull()
+	})
+})

--- a/webui/src/Controls/LocalVariablesStore.tsx
+++ b/webui/src/Controls/LocalVariablesStore.tsx
@@ -225,3 +225,8 @@ type _VerifyPageVariablesDropdownIsComplete = Expect<
 export const DeferredParsingContextVariables: DropdownChoiceInt[] = [
 	{ value: 'this:current', label: 'Current value of this variable' },
 ]
+
+/** Variable picker entry injected when editing a value-feedback's style override expression. */
+export const FeedbackValueContextVariables: DropdownChoiceInt[] = [
+	{ value: 'this:value', label: 'Current value of this feedback' },
+]

--- a/webui/src/scss/_button-edit.scss
+++ b/webui/src/scss/_button-edit.scss
@@ -553,6 +553,24 @@
 	}
 }
 
-.layered-overrides-table > tbody > tr {
-	border-color: #ccc;
+.layered-overrides-table {
+	// Fixed layout so the value control (esp. the expression editor for value feedbacks) can't gobble
+	// the row width and squash the element/property column - all feedback types then line up the same.
+	table-layout: fixed;
+
+	> thead > tr > th,
+	> tbody > tr > td {
+		// Element & Property column
+		&:first-child {
+			width: 40%;
+		}
+		// Trailing add/delete action column
+		&:last-child {
+			width: 3rem;
+		}
+	}
+
+	> tbody > tr {
+		border-color: #ccc;
+	}
 }


### PR DESCRIPTION
An absurd example:

<img width="1270" height="643" alt="image" src="https://github.com/user-attachments/assets/839e6b0c-966c-4f36-8349-879171b905d0" />

Which results in the feedback applying every other second, setting the button text to the `abc 05:22:20` when it is active

Also adds some tooltips, which I am not 100% happy with placement/style of, but I think necessary to have somewhere:

<img width="495" height="401" alt="image" src="https://github.com/user-attachments/assets/fd7ed221-ee43-489c-a955-aa276da45e2c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for value-based feedback style overrides using feedback values in expressions.
  * Added context-aware expression editing, guidance, and feedback-specific defaults.
  * Added validation to hide and reject unsupported feedback types.
  * Improved fallback handling when overrides are unavailable or invalid.

* **Style**
  * Improved the layered style override table layout and presentation.
  * Added clearer guidance and interaction details for feedback style overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->