### PR TITLE
Add new aspect ratio option for Stream Deck Neo

### DIFF
--- a/webui/src/Buttons/EditButton/LayeredButtonEditor/Preview/LayeredButtonPreviewRenderer.tsx
+++ b/webui/src/Buttons/EditButton/LayeredButtonEditor/Preview/LayeredButtonPreviewRenderer.tsx
@@ -111,6 +111,7 @@ const ASPECT_RATIO_OPTIONS: DropdownChoice[] = [
 	{ id: '1:1', label: '1:1 (Square)' },
 	{ id: '9:7', label: '9:7 (Stream Deck Studio)' },
 	{ id: '2:1', label: '2:1 (Stream Deck Plus & Plus XL)' },
+	{ id: '124:29', label: '124:29 (Stream Deck Neo)' },
 ]
 
 interface LayeredButtonCanvasProps {


### PR DESCRIPTION
Currently entirely untested, but pretty trivial...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a 124:29 aspect-ratio option for Stream Deck Neo previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->