### PR TITLE
feat: Show local variable value when collapsed

### DIFF
--- a/webui/src/Controls/Components/EntityCellControls.tsx
+++ b/webui/src/Controls/Components/EntityCellControls.tsx
@@ -2,11 +2,14 @@ import { faClone, faCompressArrowsAlt, faExpandArrowsAlt, faPencil, faTrash } fr
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { observer } from 'mobx-react-lite'
 import { useCallback } from 'react'
-import { EntityModelType, type EntityOwner, type SomeEntityModel } from '@companion-app/shared/Model/EntityModel.js'
+import type { EntityOwner, SomeEntityModel } from '@companion-app/shared/Model/EntityModel.js'
 import { Button, ButtonGroup } from '~/Components/Button.js'
 import { SwitchInputField } from '~/Components/SwitchInputField'
 import { TextInputFieldSimple } from '~/Components/TextInputField.js'
+import { VariableValueDisplayPopover } from '~/Components/VariableValueDisplay.js'
 import type { IEntityEditorActionService } from '~/Services/Controls/ControlEntitiesService.js'
+import type { LocalVariablesStore } from '../LocalVariablesStore.js'
+import { getEntityRowHeaderDisplay } from './EntityRowHeaderDisplay.js'
 
 interface EntityCellControlProps {
 	service: IEntityEditorActionService
@@ -20,6 +23,7 @@ interface EntityCellControlProps {
 	headlineExpanded: boolean
 	setHeadlineExpanded: () => void
 	readonly: boolean
+	localVariablesStore: LocalVariablesStore | null
 	localVariablePrefix: string | null
 }
 
@@ -35,25 +39,36 @@ export const EntityRowHeader = observer(function EntityRowHeader({
 	headlineExpanded,
 	setHeadlineExpanded,
 	readonly,
+	localVariablesStore,
 	localVariablePrefix,
 }: EntityCellControlProps) {
 	const doCollapse = useCallback(() => setPanelCollapsed(true), [setPanelCollapsed])
 	const doExpand = useCallback(() => setPanelCollapsed(false), [setPanelCollapsed])
 
-	let headline = entity.headline || definitionName
-	if (isPanelCollapsed && localVariablePrefix && entity.type === EntityModelType.Feedback && !ownerId) {
-		if (entity.variableName) {
-			headline = `$(${localVariablePrefix}:${entity.variableName}) ${entity.headline || ''}`
-		} else {
-			headline = `Unnamed: ${entity.headline || ''}`
-		}
-	}
+	// When a local variable is collapsed, show its name and current value instead of the definition name
+	const { headline, localVariableValueName } = getEntityRowHeaderDisplay(
+		entity,
+		ownerId,
+		definitionName,
+		isPanelCollapsed,
+		localVariablePrefix
+	)
 
 	return (
 		<div className="editor-grid-header">
 			<div className="cell-name">
 				{!service.setHeadline || !headlineExpanded || isPanelCollapsed ? (
-					headline
+					localVariableValueName !== null && localVariablesStore ? (
+						<div className="cell-name-local-variable">
+							<span className="cell-name-local-variable-label">{headline}</span>
+							<VariableValueDisplayPopover
+								value={localVariablesStore.getValue(localVariableValueName)}
+								showCopy={false}
+							/>
+						</div>
+					) : (
+						headline
+					)
 				) : (
 					<TextInputFieldSimple
 						id={undefined}

--- a/webui/src/Controls/Components/EntityCellControls.tsx
+++ b/webui/src/Controls/Components/EntityCellControls.tsx
@@ -60,11 +60,15 @@ export const EntityRowHeader = observer(function EntityRowHeader({
 				{!service.setHeadline || !headlineExpanded || isPanelCollapsed ? (
 					localVariableValueName !== null && localVariablesStore ? (
 						<div className="cell-name-local-variable">
-							<span className="cell-name-local-variable-label">{headline}</span>
-							<VariableValueDisplayPopover
-								value={localVariablesStore.getValue(localVariableValueName)}
-								showCopy={false}
-							/>
+							<span className="cell-name-local-variable-label" title={headline}>
+								{headline}
+							</span>
+							<div className="cell-name-local-variable-value">
+								<VariableValueDisplayPopover
+									value={localVariablesStore.getValue(localVariableValueName)}
+									showCopy={false}
+								/>
+							</div>
 						</div>
 					) : (
 						headline

--- a/webui/src/Controls/Components/EntityEditorRow.tsx
+++ b/webui/src/Controls/Components/EntityEditorRow.tsx
@@ -169,7 +169,7 @@ export const EntityEditorRowContent = observer(function EntityEditorRowContent({
 	feedbackListType,
 	disableLazyMount,
 }: EntityEditorRowContentProps) {
-	const { serviceFactory, readonly, localVariablePrefix } = useEntityEditorContext()
+	const { serviceFactory, readonly, localVariablesStore, localVariablePrefix } = useEntityEditorContext()
 	const entityService = useControlEntityService(serviceFactory, entity, entityTypeLabel)
 
 	const { connections, entityDefinitions } = useContext(RootAppStoreContext)
@@ -206,6 +206,7 @@ export const EntityEditorRowContent = observer(function EntityEditorRowContent({
 				headlineExpanded={headlineExpanded}
 				setHeadlineExpanded={doEditHeadline}
 				readonly={readonly}
+				localVariablesStore={localVariablesStore}
 				localVariablePrefix={localVariablePrefix}
 			/>
 

--- a/webui/src/Controls/Components/EntityRowHeaderDisplay.ts
+++ b/webui/src/Controls/Components/EntityRowHeaderDisplay.ts
@@ -1,0 +1,37 @@
+import { EntityModelType, type EntityOwner, type SomeEntityModel } from '@companion-app/shared/Model/EntityModel.js'
+
+export interface EntityRowHeaderDisplay {
+	/** The text to show as the row's name */
+	headline: string
+	/** The name of the local variable whose current value should be previewed, or null to show no value */
+	localVariableValueName: string | null
+}
+
+/**
+ * Work out what a collapsed entity row's header should display. For a named local variable (a
+ * top-level value-feedback in a local-variables list) this returns the `$(prefix:name)` label and
+ * the variable name to preview its current value; otherwise it falls back to the definition name.
+ */
+export function getEntityRowHeaderDisplay(
+	entity: SomeEntityModel,
+	ownerId: EntityOwner | null,
+	definitionName: string,
+	isPanelCollapsed: boolean,
+	localVariablePrefix: string | null
+): EntityRowHeaderDisplay {
+	const isCollapsedLocalVariable =
+		isPanelCollapsed && !!localVariablePrefix && entity.type === EntityModelType.Feedback && !ownerId
+
+	if (!isCollapsedLocalVariable) {
+		return { headline: entity.headline || definitionName, localVariableValueName: null }
+	}
+
+	if (entity.variableName) {
+		return {
+			headline: `$(${localVariablePrefix}:${entity.variableName}) ${entity.headline || ''}`,
+			localVariableValueName: entity.variableName,
+		}
+	}
+
+	return { headline: `Unnamed: ${entity.headline || ''}`, localVariableValueName: null }
+}

--- a/webui/src/Controls/Components/__tests__/EntityRowHeaderDisplay.test.ts
+++ b/webui/src/Controls/Components/__tests__/EntityRowHeaderDisplay.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from 'vitest'
+import {
+	EntityModelType,
+	type ActionEntityModel,
+	type EntityOwner,
+	type FeedbackEntityModel,
+	type SomeEntityModel,
+} from '@companion-app/shared/Model/EntityModel.js'
+import { getEntityRowHeaderDisplay } from '../EntityRowHeaderDisplay.js'
+
+function feedback(props: Partial<FeedbackEntityModel>): SomeEntityModel {
+	return {
+		type: EntityModelType.Feedback,
+		id: 'test',
+		definitionId: 'def',
+		connectionId: 'conn',
+		options: {},
+		upgradeIndex: undefined,
+		...props,
+	}
+}
+
+function action(props: Partial<ActionEntityModel>): SomeEntityModel {
+	return {
+		type: EntityModelType.Action,
+		id: 'test',
+		definitionId: 'def',
+		connectionId: 'conn',
+		options: {},
+		upgradeIndex: undefined,
+		...props,
+	}
+}
+
+describe('getEntityRowHeaderDisplay', () => {
+	test('collapsed named local variable shows the variable name and previews its value', () => {
+		const result = getEntityRowHeaderDisplay(feedback({ variableName: 'foo' }), null, 'conn: Def', true, 'local')
+
+		expect(result).toEqual({ headline: '$(local:foo) ', localVariableValueName: 'foo' })
+	})
+
+	test('collapsed named local variable includes the headline text after the name', () => {
+		const result = getEntityRowHeaderDisplay(
+			feedback({ variableName: 'foo', headline: 'My note' }),
+			null,
+			'conn: Def',
+			true,
+			'local'
+		)
+
+		expect(result).toEqual({ headline: '$(local:foo) My note', localVariableValueName: 'foo' })
+	})
+
+	test('respects a non-default local variable prefix', () => {
+		const result = getEntityRowHeaderDisplay(feedback({ variableName: 'foo' }), null, 'conn: Def', true, 'page')
+
+		expect(result).toEqual({ headline: '$(page:foo) ', localVariableValueName: 'foo' })
+	})
+
+	test('collapsed local variable without a name is labelled Unnamed and has no value to preview', () => {
+		const result = getEntityRowHeaderDisplay(feedback({ headline: 'My note' }), null, 'conn: Def', true, 'local')
+
+		expect(result).toEqual({ headline: 'Unnamed: My note', localVariableValueName: null })
+	})
+
+	test('expanded local variable falls back to the definition name and previews nothing', () => {
+		const result = getEntityRowHeaderDisplay(feedback({ variableName: 'foo' }), null, 'conn: Def', false, 'local')
+
+		expect(result).toEqual({ headline: 'conn: Def', localVariableValueName: null })
+	})
+
+	test('nested (owned) local variable is not treated as a top-level local variable', () => {
+		const ownerId: EntityOwner = { parentId: 'parent', childGroup: 'group' }
+		const result = getEntityRowHeaderDisplay(feedback({ variableName: 'foo' }), ownerId, 'conn: Def', true, 'local')
+
+		expect(result).toEqual({ headline: 'conn: Def', localVariableValueName: null })
+	})
+
+	test('regular feedback (no local variable prefix) shows headline or definition name and no value', () => {
+		expect(getEntityRowHeaderDisplay(feedback({ variableName: 'foo' }), null, 'conn: Def', true, null)).toEqual({
+			headline: 'conn: Def',
+			localVariableValueName: null,
+		})
+
+		expect(getEntityRowHeaderDisplay(feedback({ headline: 'My feedback' }), null, 'conn: Def', true, null)).toEqual({
+			headline: 'My feedback',
+			localVariableValueName: null,
+		})
+	})
+
+	test('actions never show a local variable value preview', () => {
+		const result = getEntityRowHeaderDisplay(action({ headline: 'Do thing' }), null, 'conn: Def', true, 'local')
+
+		expect(result).toEqual({ headline: 'Do thing', localVariableValueName: null })
+	})
+})

--- a/webui/src/scss/_button-edit.scss
+++ b/webui/src/scss/_button-edit.scss
@@ -176,6 +176,7 @@
 
 		.cell-name {
 			flex-grow: 1;
+			min-width: 0;
 
 			font-weight: bold;
 			align-self: center;
@@ -183,6 +184,20 @@
 			input {
 				font-weight: bold;
 				margin-bottom: 5px;
+			}
+
+			// A collapsed local variable shows its name alongside a compact preview of its current value
+			.cell-name-local-variable {
+				display: flex;
+				flex-direction: row;
+				align-items: center;
+				gap: 0.5rem;
+				min-width: 0;
+
+				.cell-name-local-variable-label {
+					flex-shrink: 0;
+					white-space: nowrap;
+				}
 			}
 		}
 		.cell-controls {

--- a/webui/src/scss/_button-edit.scss
+++ b/webui/src/scss/_button-edit.scss
@@ -173,6 +173,7 @@
 		display: flex;
 		flex-direction: row;
 		margin-right: -0.75rem;
+		min-width: 0;
 
 		.cell-name {
 			flex-grow: 1;
@@ -181,8 +182,10 @@
 			font-weight: bold;
 			align-self: center;
 
-			// Long headlines/names (including unbreakable strings) wrap instead of overflowing the row
+			// Long headlines/names (including unbreakable strings) wrap instead of overflowing the row,
+			// and anything that still can't fit is clipped here rather than spilling under the controls
 			overflow-wrap: anywhere;
+			overflow: hidden;
 
 			input {
 				font-weight: bold;
@@ -201,21 +204,27 @@
 					// Fixed-basis column so the value previews line up across rows. A name longer than the
 					// column is truncated with an ellipsis (full text on hover) rather than overflowing, and
 					// the column shrinks gracefully when the panel is too narrow to fit it.
-					flex: 0 1 16rem;
+					flex: 0 1 14rem;
+					min-width: 0;
 					overflow: hidden;
 					text-overflow: ellipsis;
 					white-space: nowrap;
 				}
 
 				.cell-name-local-variable-value {
+					// Takes the remaining space; clips its own overflow so a long value can't slide under
+					// the controls on a narrow panel
 					flex: 1 1 auto;
 					min-width: 0;
+					overflow: hidden;
 				}
 			}
 		}
 		.cell-controls {
 			text-align: right;
 			align-self: center;
+			// Never shrink the buttons - otherwise they get squeezed and overlap the name/value
+			flex-shrink: 0;
 		}
 	}
 	.editor-grid {

--- a/webui/src/scss/_button-edit.scss
+++ b/webui/src/scss/_button-edit.scss
@@ -195,8 +195,11 @@
 				min-width: 0;
 
 				.cell-name-local-variable-label {
-					flex-shrink: 0;
+					flex: 0 0 auto;
 					white-space: nowrap;
+					// Give the name a shared minimum width so the value previews line up into a column across
+					// rows (for typical names); longer names simply push their own value past the column.
+					min-width: 12rem;
 				}
 			}
 		}

--- a/webui/src/scss/_button-edit.scss
+++ b/webui/src/scss/_button-edit.scss
@@ -181,6 +181,9 @@
 			font-weight: bold;
 			align-self: center;
 
+			// Long headlines/names (including unbreakable strings) wrap instead of overflowing the row
+			overflow-wrap: anywhere;
+
 			input {
 				font-weight: bold;
 				margin-bottom: 5px;
@@ -195,11 +198,18 @@
 				min-width: 0;
 
 				.cell-name-local-variable-label {
-					flex: 0 0 auto;
+					// Fixed-basis column so the value previews line up across rows. A name longer than the
+					// column is truncated with an ellipsis (full text on hover) rather than overflowing, and
+					// the column shrinks gracefully when the panel is too narrow to fit it.
+					flex: 0 1 16rem;
+					overflow: hidden;
+					text-overflow: ellipsis;
 					white-space: nowrap;
-					// Give the name a shared minimum width so the value previews line up into a column across
-					// rows (for typical names); longer names simply push their own value past the column.
-					min-width: 12rem;
+				}
+
+				.cell-name-local-variable-value {
+					flex: 1 1 auto;
+					min-width: 0;
 				}
 			}
 		}


### PR DESCRIPTION

Closes #4385

<img width="773" height="347" alt="image" src="https://github.com/user-attachments/assets/7a4520ba-1764-450e-a329-52a34c189a16" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved collapsed entity-row headers to show local-variable references and previews, including clear handling for unnamed variables.
  * Added fallback display for entity headlines and definition names.

* **Bug Fixes**
  * Prevented long cell names from expanding the editor grid.
  * Improved text truncation and prevented header controls from overlapping.

* **Tests**
  * Added coverage for local variables, nested and expanded entities, custom prefixes, and fallback labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->