### PR TITLE
fix(variables): synchronize blinker ticks with epoch phase to prevent clock drift

### DIFF
--- a/companion/lib/Variables/VariablesBlinker.ts
+++ b/companion/lib/Variables/VariablesBlinker.ts
@@ -55,11 +55,15 @@ export class VariablesBlinker {
 
 		this.#logger.debug(`Starting new blinker interval: ${onPeriod}ms/${offPeriod}ms`)
 
+		const now = Date.now()
+		const phase = now % interval
+		const isCurrentlyOn = onPeriod > 0 && phase < onPeriod
+
 		const newEntry: BlinkingInterval = {
 			interval: interval,
 			onPeriod: onPeriod,
 			offPeriod: offPeriod,
-			lastProbed: Date.now(),
+			lastProbed: now,
 			name: {
 				variableId: `internal:__interval_${onPeriod}_${offPeriod}`,
 				label: 'internal',
@@ -67,56 +71,69 @@ export class VariablesBlinker {
 			},
 			aborted: false,
 			handle: null,
-			value: false,
+			value: isCurrentlyOn,
 		}
 		this.#intervals.set(intervalId, newEntry)
 
-		// Calculate the time until the next aligned tick. Do this relative to unix epoch to keep all intervals aligned amongst each other and across restarts
-		const timeToNextTick = interval - (Date.now() % interval)
+		// Calculate time until next phase transition
+		const timeToNextTick =
+			onPeriod === 0 || offPeriod === 0
+				? interval - phase
+				: isCurrentlyOn
+					? onPeriod - phase
+					: interval - phase
 
-		// Start the interval after the calculated delay
-		setTimeout(() => {
+		// Schedule ticks
+		const scheduleNextTick = () => {
 			if (newEntry.aborted) return
 
-			// First tick (respect 0/1 duty)
-			newEntry.value = newEntry.onPeriod > 0
-			this.#emitChange([
-				{
-					id: newEntry.name.name,
-					value: newEntry.value,
-				},
-			])
+			// Perform bounded notification loop to catch up with current epoch phase
+			let iterations = 0
+			while (iterations < 3) {
+				iterations++
+				const currentNow = Date.now()
+				const currentPhase = currentNow % newEntry.interval
+				const targetValue = newEntry.onPeriod > 0 && currentPhase < newEntry.onPeriod
+
+				if (newEntry.value === targetValue) break
+
+				newEntry.value = targetValue
+				this.#emitChange([
+					{
+						id: newEntry.name.name,
+						value: newEntry.value,
+					},
+				])
+
+				if (newEntry.aborted) return
+			}
 
 			// If dutyCycle is 0 or 1, keep a constant state (no toggling)
 			if (newEntry.onPeriod === 0 || newEntry.offPeriod === 0) return
 
-			// Subsequent ticks
-			const scheduleNextTick = () => {
-				if (newEntry.aborted) return
+			const finalNow = Date.now()
+			const finalPhase = finalNow % newEntry.interval
+			const finalIsOn = newEntry.onPeriod > 0 && finalPhase < newEntry.onPeriod
 
-				// If currently true, wait onPeriod before turning off
-				// If currently false, wait offPeriod before turning on
-				const delay = newEntry.value ? newEntry.onPeriod : newEntry.offPeriod
-
-				newEntry.handle = setTimeout(() => {
-					if (newEntry.aborted) return
-
-					newEntry.value = !newEntry.value
-
-					// TODO - could/should these be batched? to make it cheaper when timers align
-					this.#emitChange([
-						{
-							id: newEntry.name.name,
-							value: newEntry.value,
-						},
-					])
-
-					scheduleNextTick()
-				}, delay)
+			// If still out of phase after exhausting iterations, yield event loop with a positive deferred tick
+			// so subscribers are reliably notified of the phase change without blocking the process
+			if (newEntry.value !== finalIsOn) {
+				newEntry.handle = setTimeout(scheduleNextTick, 1)
+				return
 			}
 
-			scheduleNextTick()
-		}, timeToNextTick)
+			// Otherwise, schedule for the next future phase boundary
+			const delay = finalIsOn
+				? newEntry.onPeriod - finalPhase
+				: newEntry.interval - finalPhase
+
+			newEntry.handle = setTimeout(
+				scheduleNextTick,
+				delay > 0 ? delay : newEntry.interval
+			)
+		}
+
+		newEntry.handle = setTimeout(scheduleNextTick, timeToNextTick)
 
 		return newEntry.name
 	}

--- a/companion/test/Variables/VariablesBlinker.test.ts
+++ b/companion/test/Variables/VariablesBlinker.test.ts
@@ -164,17 +164,149 @@ describe('VariablesBlinker', () => {
 			vi.setSystemTime(new Date(0))
 			blinker.trackDependencyOnInterval(1000, 0.2) // 200ms on, 800ms off
 
-			// Advance to first tick
-			vi.advanceTimersByTime(1000)
-			expect(emitChange).toHaveBeenLastCalledWith([{ id: '__interval_200_800', value: true }])
-
-			// After onPeriod (200ms), should turn off
+			// Advance to first transition (200ms)
 			vi.advanceTimersByTime(200)
 			expect(emitChange).toHaveBeenLastCalledWith([{ id: '__interval_200_800', value: false }])
 
-			// After offPeriod (800ms), should turn on
+			// After offPeriod (800ms), should turn on at epoch boundary 1000ms
 			vi.advanceTimersByTime(800)
 			expect(emitChange).toHaveBeenLastCalledWith([{ id: '__interval_200_800', value: true }])
+		})
+
+		test('synchronizes initial value when created during off-phase', () => {
+			const emitChange = vi.fn()
+			const blinker = new VariablesBlinker(emitChange)
+
+			// Start during off phase (600ms into 1000ms interval with 500ms onPeriod)
+			vi.setSystemTime(new Date(600))
+			blinker.trackDependencyOnInterval(1000, 0.5)
+
+			// Advance 400ms to reach the epoch boundary (1000ms)
+			vi.advanceTimersByTime(400)
+			expect(emitChange).toHaveBeenLastCalledWith([{ id: '__interval_500_500', value: true }])
+
+			// After another 500ms, turns off
+			vi.advanceTimersByTime(500)
+			expect(emitChange).toHaveBeenLastCalledWith([{ id: '__interval_500_500', value: false }])
+		})
+
+		test('synchronizes initial value when created during on-phase', () => {
+			const emitChange = vi.fn()
+			const blinker = new VariablesBlinker(emitChange)
+
+			// Start during on phase (200ms into 1000ms interval with 500ms onPeriod)
+			vi.setSystemTime(new Date(200))
+			blinker.trackDependencyOnInterval(1000, 0.5)
+
+			// Advance 300ms to reach the on-to-off transition (500ms)
+			vi.advanceTimersByTime(300)
+			expect(emitChange).toHaveBeenLastCalledWith([{ id: '__interval_500_500', value: false }])
+		})
+
+		test('recovers synchronization when emitChange callback spans across a phase boundary', () => {
+			let isSlow = true
+			const emitChange = vi.fn().mockImplementation(() => {
+				// First callback runs slow, advancing time by 600ms
+				if (isSlow) {
+					isSlow = false
+					vi.setSystemTime(new Date(Date.now() + 600))
+				}
+			})
+			const blinker = new VariablesBlinker(emitChange)
+
+			// Start at epoch 0 (1000ms interval, 500ms onPeriod)
+			vi.setSystemTime(new Date(0))
+			blinker.trackDependencyOnInterval(1000, 0.5)
+
+			// At 500ms: off-transition fires, callback advances time to 1100ms.
+			// Post-callback reconciliation emits corrective true for the 1100ms on-phase,
+			// and schedules the next off-transition at 1500ms (delay = 400ms)
+			vi.advanceTimersByTime(500)
+			expect(emitChange).toHaveBeenNthCalledWith(1, [{ id: '__interval_500_500', value: false }])
+			expect(emitChange).toHaveBeenNthCalledWith(2, [{ id: '__interval_500_500', value: true }])
+			expect(emitChange).toHaveBeenCalledTimes(2)
+
+			// At 1500ms (advancing 400ms): off-transition fires cleanly at epoch phase 500ms
+			vi.advanceTimersByTime(400)
+			expect(emitChange).toHaveBeenNthCalledWith(3, [{ id: '__interval_500_500', value: false }])
+			expect(emitChange).toHaveBeenCalledTimes(3)
+
+			// At 2000ms (advancing 500ms): on-transition fires at epoch boundary
+			vi.advanceTimersByTime(500)
+			expect(emitChange).toHaveBeenNthCalledWith(4, [{ id: '__interval_500_500', value: true }])
+			expect(emitChange).toHaveBeenCalledTimes(4)
+		})
+
+		test('recovers synchronization when multiple consecutive callbacks span across phase boundaries', () => {
+			let slowCount = 2
+			const emitChange = vi.fn().mockImplementation(() => {
+				// Two consecutive callbacks run slow, advancing time by 600ms each
+				if (slowCount > 0) {
+					slowCount--
+					vi.setSystemTime(new Date(Date.now() + 600))
+				}
+			})
+			const blinker = new VariablesBlinker(emitChange)
+
+			// Start at epoch 0 (1000ms interval, 500ms onPeriod)
+			vi.setSystemTime(new Date(0))
+			blinker.trackDependencyOnInterval(1000, 0.5)
+
+			// At 500ms:
+			// 1. Off-transition fires at 500ms -> emits false, callback advances time to 1100ms.
+			// 2. Loop catches up to on-phase at 1100ms -> emits true, callback advances time to 1700ms.
+			// 3. Loop catches up to off-phase at 1700ms -> emits false.
+			// 4. Fully reconciled to false; schedules next on-transition at 2000ms (delay = 300ms).
+			vi.advanceTimersByTime(500)
+			expect(emitChange).toHaveBeenNthCalledWith(1, [{ id: '__interval_500_500', value: false }])
+			expect(emitChange).toHaveBeenNthCalledWith(2, [{ id: '__interval_500_500', value: true }])
+			expect(emitChange).toHaveBeenNthCalledWith(3, [{ id: '__interval_500_500', value: false }])
+			expect(emitChange).toHaveBeenCalledTimes(3)
+
+			// At 2000ms (advancing 300ms): on-transition fires cleanly
+			vi.advanceTimersByTime(300)
+			expect(emitChange).toHaveBeenNthCalledWith(4, [{ id: '__interval_500_500', value: true }])
+			expect(emitChange).toHaveBeenCalledTimes(4)
+		})
+
+		test('bounds emissions and schedules positive future delay under sustained phase overruns', () => {
+			let slowCount = 3
+			const emitChange = vi.fn().mockImplementation(() => {
+				// First 3 callbacks run slow (500ms each), then callbacks run normally
+				if (slowCount > 0) {
+					slowCount--
+					vi.setSystemTime(new Date(Date.now() + 500))
+				}
+			})
+			const blinker = new VariablesBlinker(emitChange)
+
+			// Start at epoch 0 (1000ms interval, 500ms onPeriod)
+			vi.setSystemTime(new Date(0))
+			blinker.trackDependencyOnInterval(1000, 0.5)
+
+			// Advance to first transition at 500ms
+			// Bounded loop executes 3 synchronous emissions (at t=500 -> false, t=1000 -> true, t=1500 -> false)
+			// At t=2000, current phase is true. Since limit was reached, a 1ms deferred tick is scheduled.
+			vi.advanceTimersByTime(500)
+			expect(emitChange).toHaveBeenCalledTimes(3)
+			expect(emitChange).toHaveBeenNthCalledWith(1, [{ id: '__interval_500_500', value: false }])
+			expect(emitChange).toHaveBeenNthCalledWith(2, [{ id: '__interval_500_500', value: true }])
+			expect(emitChange).toHaveBeenNthCalledWith(3, [{ id: '__interval_500_500', value: false }])
+
+			// Advance 1ms to execute the deferred catch-up tick (at t=2001ms, callback emits true)
+			vi.advanceTimersByTime(1)
+			expect(emitChange).toHaveBeenCalledTimes(4)
+			expect(emitChange).toHaveBeenNthCalledWith(4, [{ id: '__interval_500_500', value: true }])
+
+			// At t=2001ms, phase is 1ms into on-period. Next transition is off at t=2500ms (delay = 499ms).
+			// Assert no premature emissions before the boundary:
+			vi.advanceTimersByTime(498)
+			expect(emitChange).toHaveBeenCalledTimes(4)
+
+			// Advance the remaining 1ms to reach t=2500ms: off-transition fires cleanly
+			vi.advanceTimersByTime(1)
+			expect(emitChange).toHaveBeenCalledTimes(5)
+			expect(emitChange).toHaveBeenNthCalledWith(5, [{ id: '__interval_500_500', value: false }])
 		})
 	})
 


### PR DESCRIPTION
## Summary
`VariablesBlinker` previously scheduled ticks using relative delays (`onPeriod` / `offPeriod`), which caused timer drift to accumulate over time. This caused multiple blink buttons with the same or harmonically related intervals to desynchronize over long runtimes, and caused newly registered intervals to start unaligned with existing intervals.

This PR:
1. Derives initial blinker state and first transition timing directly from `Date.now() % interval` relative to Unix epoch.
2. Recalculates each subsequent tick delay against the absolute epoch phase to eliminate drift accumulation.
3. Implements bounded synchronization recovery under slow listener callbacks without event-loop starvation.
4. Adds unit test coverage verifying phase alignment, asymmetric duty cycles, and slow callback recovery.

Fixes #4292


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blinker timing by aligning transitions with the current cycle phase and state.
  * Preserved correct behavior for continuously on or off configurations.
  * Improved recovery when slow callbacks cause timing delays.
  * Prevented unnecessary emissions and maintained accurate transition timing after catch-up.

* **Tests**
  * Added coverage for phase alignment, delayed callbacks, recovery behavior, and bounded catch-up processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->