### PR TITLE
feat: better custom preview aspect ratios

### DIFF
--- a/companion/lib/Surface/Config.ts
+++ b/companion/lib/Surface/Config.ts
@@ -79,6 +79,7 @@ export function createOrSanitizeSurfaceHandlerConfig(
 		type: panel.info.description || 'Unknown',
 		integrationType,
 		gridSize: panel.gridSize,
+		layout: panel.surfaceLayout,
 	}
 
 	// Forget old values

--- a/companion/lib/Surface/Controller.ts
+++ b/companion/lib/Surface/Controller.ts
@@ -13,6 +13,7 @@
 import { createHash } from 'node:crypto'
 import { EventEmitter } from 'node:events'
 import debounceFn from 'debounce-fn'
+import isEqual from 'fast-deep-equal'
 import jsonPatch from 'fast-json-patch'
 import HID from 'node-hid'
 import pDebounce from 'p-debounce'
@@ -24,7 +25,9 @@ import type { EmulatorListItem, EmulatorPageConfig } from '@companion-app/shared
 import { JsonValueSchema } from '@companion-app/shared/Model/Options.js'
 import type {
 	ClientDevicesListItem,
+	ClientSurfaceButtonSizesItem,
 	ClientSurfaceItem,
+	ClientSurfaceLayoutItem,
 	OutboundSurfaceInfo,
 	SurfaceConfig,
 	SurfaceGroupConfig,
@@ -49,13 +52,15 @@ import LogController from '../Log/Controller.js'
 import { publicProcedure, router, toIterable } from '../UI/TRPC.js'
 import { createOrSanitizeSurfaceHandlerConfig, PanelDefaults } from './Config.js'
 import { SurfaceGroup, validateGroupConfigValue } from './Group.js'
-import { getSurfaceName, SurfaceHandler } from './Handler.js'
+import { SurfaceHandler } from './Handler.js'
 import { EmulatorRoom, SurfaceIPElgatoEmulator } from './IP/ElgatoEmulator.js'
 import { SurfaceIPSatellite, type SatelliteDeviceInfo } from './IP/Satellite.js'
+import { surfaceButtonSizesFromLayouts, surfaceLayoutsFromConfigs, type SurfaceLayoutSource } from './LayoutSummary.js'
 import { SurfaceOutboundController } from './Outbound.js'
 import type { SurfacePluginPanel } from './PluginPanel.js'
 import { stripReferenceSurfaceId } from './ReferenceSurfaceId.js'
 import type { SurfaceHandlerDependencies, SurfacePanel, UpdateEvents } from './Types.js'
+import { getSurfaceName } from './Util.js'
 
 /**
  * Interface for a handler that can process HID device scans.
@@ -103,6 +108,9 @@ export class SurfaceController extends EventEmitter<SurfaceControllerEvents> {
 	 * The last sent json object
 	 */
 	#lastSentJson: Record<string, ClientDevicesListItem> = {}
+	/** Only maintained while something is subscribed to the matching update event */
+	#lastSentLayoutsJson: Record<string, ClientSurfaceLayoutItem> | null = null
+	#lastSentButtonSizesJson: Record<string, ClientSurfaceButtonSizesItem> | null = null
 
 	/**
 	 * All the opened and active surfaces
@@ -428,6 +436,32 @@ export class SurfaceController extends EventEmitter<SurfaceControllerEvents> {
 
 				for await (const [info] of changes) {
 					yield info
+				}
+			}),
+
+			watchSurfaceLayouts: publicProcedure.subscription(async function* ({ signal }) {
+				const changes = toIterable(self.#updateEvents, 'surfaceLayouts', signal)
+
+				// Seed the cache, so that the first change is compared against what was sent here
+				const initial = self.getSurfaceLayouts()
+				self.#lastSentLayoutsJson = initial
+				yield initial
+
+				for await (const [layouts] of changes) {
+					yield layouts
+				}
+			}),
+
+			watchSurfaceButtonSizes: publicProcedure.subscription(async function* ({ signal }) {
+				const changes = toIterable(self.#updateEvents, 'surfaceButtonSizes', signal)
+
+				// Seed the cache, so that the first change is compared against what was sent here
+				const initial = self.getSurfaceButtonSizes()
+				self.#lastSentButtonSizesJson = initial
+				yield initial
+
+				for await (const [sizes] of changes) {
+					yield sizes
 				}
 			}),
 
@@ -1132,6 +1166,44 @@ export class SurfaceController extends EventEmitter<SurfaceControllerEvents> {
 		return result
 	}
 
+	/**
+	 * Gather every surface which has a known layout, connected or not. Connected surfaces use the config held
+	 * by their handler, the rest fall back to what was persisted the last time they were connected.
+	 */
+	#collectLayoutSources(): SurfaceLayoutSource[] {
+		const sources: SurfaceLayoutSource[] = []
+		const connectedIds = new Set<string>()
+
+		for (const [surfaceId, handler] of this.#surfaceHandlers) {
+			if (!handler) continue
+
+			connectedIds.add(surfaceId)
+			sources.push({ surfaceId, config: handler.getFullConfig(), isConnected: true })
+		}
+
+		for (const [surfaceId, config] of Object.entries(this.#dbTableSurfaces.all())) {
+			if (connectedIds.has(surfaceId)) continue
+
+			sources.push({ surfaceId, config, isConnected: false })
+		}
+
+		return sources
+	}
+
+	/**
+	 * The full layout manifest of every surface with a known layout
+	 */
+	getSurfaceLayouts(): Record<string, ClientSurfaceLayoutItem> {
+		return surfaceLayoutsFromConfigs(this.#collectLayoutSources())
+	}
+
+	/**
+	 * The distinct button sizes of every surface with a known layout
+	 */
+	getSurfaceButtonSizes(): Record<string, ClientSurfaceButtonSizesItem> {
+		return surfaceButtonSizesFromLayouts(this.getSurfaceLayouts())
+	}
+
 	async reset(): Promise<void> {
 		// Each active handler will re-add itself when doing the save as part of its own reset
 		this.#dbTableGroups.clear()
@@ -1158,6 +1230,8 @@ export class SurfaceController extends EventEmitter<SurfaceControllerEvents> {
 		if (this.#updateEvents.listenerCount('emulatorList') > 0) {
 			this.#updateEvents.emit('emulatorList', this.#compileEmulatorList())
 		}
+
+		this.#updateSurfaceLayouts()
 
 		const hasSubscribers = this.#updateEvents.listenerCount('surfaces') > 0
 
@@ -1209,6 +1283,40 @@ export class SurfaceController extends EventEmitter<SurfaceControllerEvents> {
 			}
 		}
 		this.#lastSentJson = newJson
+	}
+
+	/**
+	 * Push out the surface layouts and the button sizes derived from them, if anything is listening.
+	 * These are only rebuilt when subscribed to, as they are much larger than they are volatile.
+	 */
+	#updateSurfaceLayouts(): void {
+		const hasLayoutSubscribers = this.#updateEvents.listenerCount('surfaceLayouts') > 0
+		const hasButtonSizeSubscribers = this.#updateEvents.listenerCount('surfaceButtonSizes') > 0
+		if (!hasLayoutSubscribers && !hasButtonSizeSubscribers) {
+			// Drop the caches, so that the next subscriber gets a fresh comparison
+			this.#lastSentLayoutsJson = null
+			this.#lastSentButtonSizesJson = null
+			return
+		}
+
+		const newLayouts = this.getSurfaceLayouts()
+
+		if (hasLayoutSubscribers) {
+			if (!this.#lastSentLayoutsJson || !isEqual(this.#lastSentLayoutsJson, newLayouts)) {
+				this.#updateEvents.emit('surfaceLayouts', newLayouts)
+			}
+		}
+		this.#lastSentLayoutsJson = newLayouts
+
+		if (hasButtonSizeSubscribers) {
+			const newButtonSizes = surfaceButtonSizesFromLayouts(newLayouts)
+			if (!this.#lastSentButtonSizesJson || !isEqual(this.#lastSentButtonSizesJson, newButtonSizes)) {
+				this.#updateEvents.emit('surfaceButtonSizes', newButtonSizes)
+			}
+			this.#lastSentButtonSizesJson = newButtonSizes
+		} else {
+			this.#lastSentButtonSizesJson = null
+		}
 	}
 
 	/**
@@ -1653,6 +1761,7 @@ export class SurfaceController extends EventEmitter<SurfaceControllerEvents> {
 			type: description || 'Unknown',
 			integrationType: undefined,
 			gridSize: undefined,
+			layout: undefined,
 		}
 
 		this.setDeviceConfig(surfaceId, minimalConfig)

--- a/companion/lib/Surface/Handler.ts
+++ b/companion/lib/Surface/Handler.ts
@@ -31,14 +31,7 @@ import { createDefaultSurfacePanelConfig } from './Config.js'
 import type { SurfaceController } from './Controller.js'
 import { SurfaceGroup } from './Group.js'
 import type { DrawButtonItem, SurfaceHandlerDependencies, SurfacePanel, UpdateEvents } from './Types.js'
-import { rotateXYForPanel, unrotateXYForPanel } from './Util.js'
-
-/**
- * Get the display name of a surface
- */
-export function getSurfaceName(config: Record<string, any>, surfaceId: string): string {
-	return `${config?.name || config?.type || 'Unknown'} (${surfaceId})`
-}
+import { getSurfaceName, rotateXYForPanel, unrotateXYForPanel } from './Util.js'
 
 interface SurfaceHandlerEvents {
 	interaction: []
@@ -411,7 +404,11 @@ export class SurfaceHandler extends EventEmitter<SurfaceHandlerEvents> {
 		if (!this.panel) return
 
 		this.#surfaceConfig.gridSize = this.panel.gridSize
+		this.#surfaceConfig.layout = this.panel.surfaceLayout
 		this.#saveConfig()
+
+		// Saving the config doesn't push the new size/layout to the ui, so do that here
+		this.#surfaces.triggerUpdateDevicesList()
 
 		this.#drawPage()
 	}

--- a/companion/lib/Surface/IP/ElgatoEmulator.ts
+++ b/companion/lib/Surface/IP/ElgatoEmulator.ts
@@ -17,7 +17,7 @@ import type { EmulatorConfig, EmulatorImage, EmulatorLockedState } from '@compan
 import type {
 	CompanionSurfaceConfigField,
 	GridSize,
-	SurfaceLayoutDefinition,
+	SurfaceSchemaLayoutDefinition,
 } from '@companion-app/shared/Model/Surfaces.js'
 import { PREVIEW_RENDER_SIZE, type ImageResult } from '../../Graphics/ImageResult.js'
 import LogController from '../../Log/Controller.js'
@@ -162,7 +162,7 @@ export class SurfaceIPElgatoEmulator extends EventEmitter<SurfacePanelEvents> im
 		}
 	}
 
-	get surfaceLayout(): SurfaceLayoutDefinition {
+	get surfaceLayout(): SurfaceSchemaLayoutDefinition {
 		// The emulator draws every button itself, at the same size the button preview images are rendered at
 		return buildGridSurfaceLayout(this.gridSize, { w: PREVIEW_RENDER_SIZE, h: PREVIEW_RENDER_SIZE })
 	}

--- a/companion/lib/Surface/IP/ElgatoEmulator.ts
+++ b/companion/lib/Surface/IP/ElgatoEmulator.ts
@@ -14,11 +14,16 @@ import { EventEmitter } from 'node:events'
 import debounceFn from 'debounce-fn'
 import isEqual from 'fast-deep-equal'
 import type { EmulatorConfig, EmulatorImage, EmulatorLockedState } from '@companion-app/shared/Model/Common.js'
-import type { CompanionSurfaceConfigField, GridSize } from '@companion-app/shared/Model/Surfaces.js'
+import type {
+	CompanionSurfaceConfigField,
+	GridSize,
+	SurfaceLayoutDefinition,
+} from '@companion-app/shared/Model/Surfaces.js'
 import { PREVIEW_RENDER_SIZE, type ImageResult } from '../../Graphics/ImageResult.js'
 import LogController from '../../Log/Controller.js'
 import { ImageWriteQueue } from '../../Resources/ImageWriteQueue.js'
 import { OffsetConfigFields, RotationConfigField } from '../CommonConfigFields.js'
+import { buildGridSurfaceLayout } from '../LayoutSummary.js'
 import type { DrawButtonItem, SurfacePanel, SurfacePanelEvents, SurfacePanelInfo } from '../Types.js'
 
 export function EmulatorRoom(id: string): string {
@@ -155,6 +160,11 @@ export class SurfaceIPElgatoEmulator extends EventEmitter<SurfacePanelEvents> im
 			columns: this.#lastSentConfigJson?.emulator_columns || 8,
 			rows: this.#lastSentConfigJson?.emulator_rows || 4,
 		}
+	}
+
+	get surfaceLayout(): SurfaceLayoutDefinition {
+		// The emulator draws every button itself, at the same size the button preview images are rendered at
+		return buildGridSurfaceLayout(this.gridSize, { w: PREVIEW_RENDER_SIZE, h: PREVIEW_RENDER_SIZE })
 	}
 
 	latestConfig(): EmulatorConfig {

--- a/companion/lib/Surface/IP/Satellite.ts
+++ b/companion/lib/Surface/IP/Satellite.ts
@@ -15,7 +15,7 @@ import { BANNED_PROPS } from '@companion-app/shared/Expressions.js'
 import type {
 	CompanionSurfaceConfigField,
 	GridSize,
-	SurfaceLayoutDefinition,
+	SurfaceSchemaLayoutDefinition,
 } from '@companion-app/shared/Model/Surfaces.js'
 import { stringifyVariableValue, type VariableValue } from '@companion-app/shared/Model/Variables.js'
 import { stringifyError } from '@companion-app/shared/Stringify.js'
@@ -205,7 +205,7 @@ export class SurfaceIPSatellite extends EventEmitter<SurfacePanelEvents> impleme
 
 	readonly info: SurfacePanelInfo
 	readonly gridSize: GridSize
-	readonly surfaceLayout: SurfaceLayoutDefinition
+	readonly surfaceLayout: SurfaceSchemaLayoutDefinition
 	readonly deviceId: string
 	readonly socket: SatelliteSocketWrapper
 

--- a/companion/lib/Surface/IP/Satellite.ts
+++ b/companion/lib/Surface/IP/Satellite.ts
@@ -12,7 +12,11 @@ import { EventEmitter } from 'node:events'
 import debounceFn from 'debounce-fn'
 import type { JsonValue, ReadonlyDeep } from 'type-fest'
 import { BANNED_PROPS } from '@companion-app/shared/Expressions.js'
-import type { CompanionSurfaceConfigField, GridSize } from '@companion-app/shared/Model/Surfaces.js'
+import type {
+	CompanionSurfaceConfigField,
+	GridSize,
+	SurfaceLayoutDefinition,
+} from '@companion-app/shared/Model/Surfaces.js'
 import { stringifyVariableValue, type VariableValue } from '@companion-app/shared/Model/Variables.js'
 import { stringifyError } from '@companion-app/shared/Stringify.js'
 import { VARIABLE_UNKNOWN_VALUE } from '@companion-app/shared/Variables.js'
@@ -201,6 +205,7 @@ export class SurfaceIPSatellite extends EventEmitter<SurfacePanelEvents> impleme
 
 	readonly info: SurfacePanelInfo
 	readonly gridSize: GridSize
+	readonly surfaceLayout: SurfaceLayoutDefinition
 	readonly deviceId: string
 	readonly socket: SatelliteSocketWrapper
 
@@ -219,6 +224,7 @@ export class SurfaceIPSatellite extends EventEmitter<SurfacePanelEvents> impleme
 		this.socket = deviceInfo.socket
 
 		this.surfaceManifestFromClient = deviceInfo.surfaceManifestFromClient
+		this.surfaceLayout = deviceInfo.surfaceManifest
 		this.#surfaceManifest = deviceInfo.surfaceManifest
 		this.#controlDefinitions = resolveControlDefinitions(deviceInfo.surfaceManifest)
 		this.#supportsLockedState = deviceInfo.supportsLockedState

--- a/companion/lib/Surface/LayoutSummary.ts
+++ b/companion/lib/Surface/LayoutSummary.ts
@@ -4,9 +4,9 @@ import type {
 	GridSize,
 	SurfaceConfig,
 	SurfaceLayoutBitmapSize,
-	SurfaceLayoutControl,
-	SurfaceLayoutDefinition,
-	SurfaceLayoutStylePreset,
+	SurfaceSchemaControlDefinition,
+	SurfaceSchemaControlStylePreset,
+	SurfaceSchemaLayoutDefinition,
 } from '@companion-app/shared/Model/Surfaces.js'
 import { getSurfaceName } from './Util.js'
 
@@ -21,9 +21,9 @@ export interface SurfaceLayoutSource {
  * An unknown preset name falls back to the default, matching how the panels resolve their own controls.
  */
 export function resolveControlStylePreset(
-	layout: SurfaceLayoutDefinition,
-	control: SurfaceLayoutControl
-): SurfaceLayoutStylePreset {
+	layout: SurfaceSchemaLayoutDefinition,
+	control: SurfaceSchemaControlDefinition
+): SurfaceSchemaControlStylePreset {
 	if (control.stylePreset) {
 		const preset = layout.stylePresets[control.stylePreset]
 		if (preset) return preset
@@ -95,8 +95,11 @@ export function surfaceButtonSizesFromLayouts(
 /**
  * A layout for a surface which is a plain grid of identical controls, such as the emulator.
  */
-export function buildGridSurfaceLayout(gridSize: GridSize, bitmap: SurfaceLayoutBitmapSize): SurfaceLayoutDefinition {
-	const controls: Record<string, SurfaceLayoutControl> = {}
+export function buildGridSurfaceLayout(
+	gridSize: GridSize,
+	bitmap: SurfaceLayoutBitmapSize
+): SurfaceSchemaLayoutDefinition {
+	const controls: Record<string, SurfaceSchemaControlDefinition> = {}
 
 	for (let row = 0; row < gridSize.rows; row++) {
 		for (let column = 0; column < gridSize.columns; column++) {

--- a/companion/lib/Surface/LayoutSummary.ts
+++ b/companion/lib/Surface/LayoutSummary.ts
@@ -1,0 +1,113 @@
+import type {
+	ClientSurfaceButtonSizesItem,
+	ClientSurfaceLayoutItem,
+	GridSize,
+	SurfaceConfig,
+	SurfaceLayoutBitmapSize,
+	SurfaceLayoutControl,
+	SurfaceLayoutDefinition,
+	SurfaceLayoutStylePreset,
+} from '@companion-app/shared/Model/Surfaces.js'
+import { getSurfaceName } from './Util.js'
+
+export interface SurfaceLayoutSource {
+	surfaceId: string
+	config: SurfaceConfig
+	isConnected: boolean
+}
+
+/**
+ * The style a control is drawn with: its named preset if it has one, otherwise the required default preset.
+ * An unknown preset name falls back to the default, matching how the panels resolve their own controls.
+ */
+export function resolveControlStylePreset(
+	layout: SurfaceLayoutDefinition,
+	control: SurfaceLayoutControl
+): SurfaceLayoutStylePreset {
+	if (control.stylePreset) {
+		const preset = layout.stylePresets[control.stylePreset]
+		if (preset) return preset
+	}
+
+	return layout.stylePresets.default
+}
+
+/**
+ * Collect the stored layout of each surface, connected or not. Surfaces which have never reported a layout
+ * (older configs, or entries created for a surface which has not been opened yet) are omitted.
+ */
+export function surfaceLayoutsFromConfigs(
+	sources: Iterable<SurfaceLayoutSource>
+): Record<string, ClientSurfaceLayoutItem> {
+	const result: Record<string, ClientSurfaceLayoutItem> = {}
+
+	for (const { surfaceId, config, isConnected } of sources) {
+		if (!config.layout) continue
+
+		result[surfaceId] = {
+			id: surfaceId,
+			type: config.type || 'Unknown',
+			displayName: getSurfaceName(config, surfaceId),
+			isConnected,
+			layout: config.layout,
+		}
+	}
+
+	return result
+}
+
+/**
+ * The distinct sizes the controls of each surface are drawn at. Controls whose style has no bitmap (text or
+ * led only controls) contribute nothing, so a surface can end up with no sizes at all.
+ */
+export function surfaceButtonSizesFromLayouts(
+	layouts: Record<string, ClientSurfaceLayoutItem>
+): Record<string, ClientSurfaceButtonSizesItem> {
+	const result: Record<string, ClientSurfaceButtonSizesItem> = {}
+
+	for (const [surfaceId, item] of Object.entries(layouts)) {
+		const bitmapSizes: SurfaceLayoutBitmapSize[] = []
+		const seenSizes = new Set<string>()
+
+		for (const control of Object.values(item.layout.controls)) {
+			const bitmap = resolveControlStylePreset(item.layout, control).bitmap
+			if (!bitmap) continue
+
+			const key = `${bitmap.w}x${bitmap.h}`
+			if (seenSizes.has(key)) continue
+			seenSizes.add(key)
+
+			bitmapSizes.push({ w: bitmap.w, h: bitmap.h })
+		}
+
+		result[surfaceId] = {
+			id: item.id,
+			type: item.type,
+			displayName: item.displayName,
+			isConnected: item.isConnected,
+			bitmapSizes,
+		}
+	}
+
+	return result
+}
+
+/**
+ * A layout for a surface which is a plain grid of identical controls, such as the emulator.
+ */
+export function buildGridSurfaceLayout(gridSize: GridSize, bitmap: SurfaceLayoutBitmapSize): SurfaceLayoutDefinition {
+	const controls: Record<string, SurfaceLayoutControl> = {}
+
+	for (let row = 0; row < gridSize.rows; row++) {
+		for (let column = 0; column < gridSize.columns; column++) {
+			controls[`${row}/${column}`] = { row, column }
+		}
+	}
+
+	return {
+		stylePresets: {
+			default: { bitmap: { ...bitmap } },
+		},
+		controls,
+	}
+}

--- a/companion/lib/Surface/PluginPanel.ts
+++ b/companion/lib/Surface/PluginPanel.ts
@@ -3,11 +3,7 @@ import debounceFn from 'debounce-fn'
 import type { JsonValue, ReadonlyDeep } from 'type-fest'
 import { sampleLedsToBuffer } from '@companion-app/shared/Graphics/GaugeLeds.js'
 import { parseColor } from '@companion-app/shared/Graphics/Util.js'
-import type {
-	CompanionSurfaceConfigField,
-	GridSize,
-	SurfaceLayoutDefinition,
-} from '@companion-app/shared/Model/Surfaces.js'
+import type { CompanionSurfaceConfigField, GridSize } from '@companion-app/shared/Model/Surfaces.js'
 import type { VariableValue } from '@companion-app/shared/Model/Variables.js'
 import { stringifyError } from '@companion-app/shared/Stringify.js'
 import { VARIABLE_UNKNOWN_VALUE } from '@companion-app/shared/Variables.js'
@@ -172,7 +168,7 @@ export class SurfacePluginPanel extends EventEmitter<SurfacePanelEvents> impleme
 
 	readonly info: SurfacePanelInfo
 	readonly gridSize: GridSize
-	readonly surfaceLayout: SurfaceLayoutDefinition
+	readonly surfaceLayout: SurfaceSchemaLayoutDefinition
 
 	#config: Record<string, any>
 

--- a/companion/lib/Surface/PluginPanel.ts
+++ b/companion/lib/Surface/PluginPanel.ts
@@ -3,7 +3,11 @@ import debounceFn from 'debounce-fn'
 import type { JsonValue, ReadonlyDeep } from 'type-fest'
 import { sampleLedsToBuffer } from '@companion-app/shared/Graphics/GaugeLeds.js'
 import { parseColor } from '@companion-app/shared/Graphics/Util.js'
-import type { CompanionSurfaceConfigField, GridSize } from '@companion-app/shared/Model/Surfaces.js'
+import type {
+	CompanionSurfaceConfigField,
+	GridSize,
+	SurfaceLayoutDefinition,
+} from '@companion-app/shared/Model/Surfaces.js'
 import type { VariableValue } from '@companion-app/shared/Model/Variables.js'
 import { stringifyError } from '@companion-app/shared/Stringify.js'
 import { VARIABLE_UNKNOWN_VALUE } from '@companion-app/shared/Variables.js'
@@ -168,6 +172,7 @@ export class SurfacePluginPanel extends EventEmitter<SurfacePanelEvents> impleme
 
 	readonly info: SurfacePanelInfo
 	readonly gridSize: GridSize
+	readonly surfaceLayout: SurfaceLayoutDefinition
 
 	#config: Record<string, any>
 
@@ -262,6 +267,8 @@ export class SurfacePluginPanel extends EventEmitter<SurfacePanelEvents> impleme
 				return
 			}
 		})
+
+		this.surfaceLayout = surfaceInfo.surfaceLayout
 
 		// Find the max bounds of this surface
 		this.gridSize = Object.values(surfaceInfo.surfaceLayout.controls).reduce(

--- a/companion/lib/Surface/Types.ts
+++ b/companion/lib/Surface/Types.ts
@@ -3,10 +3,13 @@ import type { ExecuteExpressionResult } from '@companion-app/shared/ExpressionRe
 import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
 import type { EmulatorListItem, EmulatorPageConfig } from '@companion-app/shared/Model/Emulator.js'
 import type {
+	ClientSurfaceButtonSizesItem,
+	ClientSurfaceLayoutItem,
 	CompanionSurfaceConfigField,
 	GridSize,
 	SurfaceFirmwareUpdateInfo,
 	SurfaceGroupConfig,
+	SurfaceLayoutDefinition,
 	SurfacesUpdate,
 } from '@companion-app/shared/Model/Surfaces.js'
 import type { VariableValue } from '@companion-app/shared/Model/Variables.js'
@@ -35,6 +38,8 @@ export interface SurfacePanel extends EventEmitter<SurfacePanelEvents> {
 
 	readonly info: SurfacePanelInfo
 	readonly gridSize: GridSize
+	/** The layout manifest describing the controls this panel has, and how they are drawn */
+	readonly surfaceLayout: SurfaceLayoutDefinition
 	clearDeck(): void
 	draw(item: DrawButtonItem): void
 	setConfig(config: any, force?: boolean): void
@@ -102,6 +107,8 @@ export type UpdateEvents = EmulatorUpdateEvents & {
 	emulatorList: [list: EmulatorListItem[]]
 
 	surfaces: [changes: SurfacesUpdate[]]
+	surfaceLayouts: [layouts: Record<string, ClientSurfaceLayoutItem>]
+	surfaceButtonSizes: [sizes: Record<string, ClientSurfaceButtonSizesItem>]
 
 	[id: `groupConfig:${string}`]: [config: SurfaceGroupConfig | null]
 }

--- a/companion/lib/Surface/Types.ts
+++ b/companion/lib/Surface/Types.ts
@@ -9,7 +9,7 @@ import type {
 	GridSize,
 	SurfaceFirmwareUpdateInfo,
 	SurfaceGroupConfig,
-	SurfaceLayoutDefinition,
+	SurfaceSchemaLayoutDefinition,
 	SurfacesUpdate,
 } from '@companion-app/shared/Model/Surfaces.js'
 import type { VariableValue } from '@companion-app/shared/Model/Variables.js'
@@ -39,7 +39,7 @@ export interface SurfacePanel extends EventEmitter<SurfacePanelEvents> {
 	readonly info: SurfacePanelInfo
 	readonly gridSize: GridSize
 	/** The layout manifest describing the controls this panel has, and how they are drawn */
-	readonly surfaceLayout: SurfaceLayoutDefinition
+	readonly surfaceLayout: SurfaceSchemaLayoutDefinition
 	clearDeck(): void
 	draw(item: DrawButtonItem): void
 	setConfig(config: any, force?: boolean): void

--- a/companion/lib/Surface/Util.ts
+++ b/companion/lib/Surface/Util.ts
@@ -1,6 +1,13 @@
 import type { GridSize, SurfaceRotation } from '@companion-app/shared/Model/Surfaces.js'
 
 /**
+ * Get the display name of a surface
+ */
+export function getSurfaceName(config: Record<string, any>, surfaceId: string): string {
+	return `${config?.name || config?.type || 'Unknown'} (${surfaceId})`
+}
+
+/**
  * Convert a coordinate to surface index
  */
 export function convertXYToIndexForPanel(x: number, y: number, gridSize: GridSize): number | null {

--- a/companion/test/Surface/Config.test.ts
+++ b/companion/test/Surface/Config.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from 'vitest'
-import type { SurfaceConfig, SurfaceLayoutDefinition } from '@companion-app/shared/Model/Surfaces.js'
+import type { SurfaceConfig, SurfaceSchemaLayoutDefinition } from '@companion-app/shared/Model/Surfaces.js'
 import type { UserConfigGridSize } from '@companion-app/shared/Model/UserConfigModel.js'
 import { createDefaultSurfacePanelConfig, createOrSanitizeSurfaceHandlerConfig } from '../../lib/Surface/Config.js'
 import type { SurfacePanel } from '../../lib/Surface/Types.js'
 
-const layout: SurfaceLayoutDefinition = {
+const layout: SurfaceSchemaLayoutDefinition = {
 	stylePresets: { default: { bitmap: { w: 96, h: 96 } } },
 	controls: { '0/0': { row: 0, column: 0 } },
 }
@@ -83,7 +83,7 @@ describe('createOrSanitizeSurfaceHandlerConfig', () => {
 	})
 
 	test('replaces a stale stored layout with the one the panel now reports', () => {
-		const newLayout: SurfaceLayoutDefinition = {
+		const newLayout: SurfaceSchemaLayoutDefinition = {
 			stylePresets: { default: { bitmap: { w: 120, h: 120 } } },
 			controls: { '0/0': { row: 0, column: 0 }, '0/1': { row: 0, column: 1 } },
 		}

--- a/companion/test/Surface/Config.test.ts
+++ b/companion/test/Surface/Config.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, test } from 'vitest'
+import type { SurfaceConfig, SurfaceLayoutDefinition } from '@companion-app/shared/Model/Surfaces.js'
+import type { UserConfigGridSize } from '@companion-app/shared/Model/UserConfigModel.js'
+import { createDefaultSurfacePanelConfig, createOrSanitizeSurfaceHandlerConfig } from '../../lib/Surface/Config.js'
+import type { SurfacePanel } from '../../lib/Surface/Types.js'
+
+const layout: SurfaceLayoutDefinition = {
+	stylePresets: { default: { bitmap: { w: 96, h: 96 } } },
+	controls: { '0/0': { row: 0, column: 0 } },
+}
+
+const defaultGridSize: UserConfigGridSize = { minColumn: 0, maxColumn: 7, minRow: 0, maxRow: 3 }
+
+function makePanel(overrides: Partial<SurfacePanel> = {}): SurfacePanel {
+	return {
+		info: {
+			surfaceId: 'surface0',
+			description: 'Test Deck',
+			configFields: [],
+			location: null,
+			isRemote: false,
+		},
+		gridSize: { columns: 1, rows: 1 },
+		surfaceLayout: layout,
+		...overrides,
+	} as unknown as SurfacePanel
+}
+
+describe('createDefaultSurfacePanelConfig', () => {
+	test('is the shared defaults for a panel with no config fields', () => {
+		expect(createDefaultSurfacePanelConfig(makePanel())).toEqual({
+			brightness: 100,
+			rotation: 0,
+			xOffset: 0,
+			yOffset: 0,
+			groupId: null,
+		})
+	})
+
+	test('adds the defaults of the fields the panel defines', () => {
+		const panel = makePanel({
+			info: {
+				surfaceId: 'surface0',
+				description: 'Test Deck',
+				configFields: [
+					{ id: 'someToggle', type: 'checkbox', label: 'Toggle', default: true },
+					{ id: 'someText', type: 'textinput', label: 'Text', default: 'hello' },
+				],
+				location: null,
+				isRemote: false,
+			},
+		})
+
+		const config = createDefaultSurfacePanelConfig(panel)
+
+		expect(config.someToggle).toBe(true)
+		expect(config.someText).toBe('hello')
+	})
+
+	test('does not share state between calls', () => {
+		const first = createDefaultSurfacePanelConfig(makePanel())
+		first.brightness = 20
+
+		expect(createDefaultSurfacePanelConfig(makePanel()).brightness).toBe(100)
+	})
+})
+
+describe('createOrSanitizeSurfaceHandlerConfig', () => {
+	test('creates a config from scratch', () => {
+		const config = createOrSanitizeSurfaceHandlerConfig('test', makePanel(), undefined, defaultGridSize)
+
+		expect(config.type).toBe('Test Deck')
+		expect(config.integrationType).toBe('test')
+		expect(config.gridSize).toEqual({ columns: 1, rows: 1 })
+		expect(config.enabled).toBe(true)
+		expect(config.config.brightness).toBe(100)
+	})
+
+	test('stores the layout reported by the panel', () => {
+		const config = createOrSanitizeSurfaceHandlerConfig('test', makePanel(), undefined, defaultGridSize)
+
+		expect(config.layout).toEqual(layout)
+	})
+
+	test('replaces a stale stored layout with the one the panel now reports', () => {
+		const newLayout: SurfaceLayoutDefinition = {
+			stylePresets: { default: { bitmap: { w: 120, h: 120 } } },
+			controls: { '0/0': { row: 0, column: 0 }, '0/1': { row: 0, column: 1 } },
+		}
+		const existing = createOrSanitizeSurfaceHandlerConfig('test', makePanel(), undefined, defaultGridSize)
+
+		const updated = createOrSanitizeSurfaceHandlerConfig(
+			'test',
+			makePanel({ surfaceLayout: newLayout }),
+			existing,
+			defaultGridSize
+		)
+
+		expect(updated.layout).toEqual(newLayout)
+	})
+
+	test('fills in the layout of a config saved before layouts were stored', () => {
+		const existing = {
+			config: { brightness: 50, rotation: 0, xOffset: 2, yOffset: 1, groupId: null },
+			groupConfig: {
+				name: '',
+				last_page_id: '1',
+				startup_page_id: '1',
+				use_last_page: true,
+				never_lock: false,
+			},
+			groupId: null,
+			type: 'Test Deck',
+			integrationType: 'test',
+			gridSize: { columns: 1, rows: 1 },
+		} as unknown as SurfaceConfig
+
+		const config = createOrSanitizeSurfaceHandlerConfig('test', makePanel(), existing, defaultGridSize)
+
+		expect(config.layout).toEqual(layout)
+	})
+
+	test('keeps the existing panel config rather than resetting it', () => {
+		const existing = createOrSanitizeSurfaceHandlerConfig('test', makePanel(), undefined, defaultGridSize)
+		existing.config.brightness = 42
+		existing.name = 'Desk'
+
+		const updated = createOrSanitizeSurfaceHandlerConfig('test', makePanel(), existing, defaultGridSize)
+
+		expect(updated.config.brightness).toBe(42)
+		expect(updated.name).toBe('Desk')
+	})
+
+	test('adds newly defined config fields to an existing config', () => {
+		const existing = createOrSanitizeSurfaceHandlerConfig('test', makePanel(), undefined, defaultGridSize)
+
+		const panelWithField = makePanel({
+			info: {
+				surfaceId: 'surface0',
+				description: 'Test Deck',
+				configFields: [{ id: 'someToggle', type: 'checkbox', label: 'Toggle', default: true }],
+				location: null,
+				isRemote: false,
+			},
+		})
+
+		const updated = createOrSanitizeSurfaceHandlerConfig('test', panelWithField, existing, defaultGridSize)
+
+		expect(updated.config.someToggle).toBe(true)
+	})
+
+	test('a new config starts at the top left of the grid bounds', () => {
+		const config = createOrSanitizeSurfaceHandlerConfig('test', makePanel(), undefined, {
+			minColumn: -2,
+			maxColumn: 7,
+			minRow: 3,
+			maxRow: 6,
+		})
+
+		// A negative bound means the grid extends left of the origin, and the surface still starts at the origin
+		expect(config.config.xOffset).toBe(0)
+		expect(config.config.yOffset).toBe(3)
+	})
+
+	// Documents existing behaviour, which does not look intentional: the "check for new properties" loop above
+	// copies xOffset/yOffset in from PanelDefaults (both 0), so the `=== undefined` branch which would place the
+	// surface at the top left of the grid bounds can never be reached for an existing config.
+	test('offsets missing from an existing config are filled from the panel defaults, not the grid bounds', () => {
+		const existing = createOrSanitizeSurfaceHandlerConfig('test', makePanel(), undefined, defaultGridSize)
+		delete (existing.config as Record<string, unknown>).xOffset
+		delete (existing.config as Record<string, unknown>).yOffset
+
+		const updated = createOrSanitizeSurfaceHandlerConfig('test', makePanel(), existing, {
+			minColumn: 1,
+			maxColumn: 7,
+			minRow: 2,
+			maxRow: 3,
+		})
+
+		expect(updated.config.xOffset).toBe(0)
+		expect(updated.config.yOffset).toBe(0)
+	})
+
+	test('migrates the deprecated page fields into the group config', () => {
+		const existing = {
+			config: { brightness: 100, rotation: 0, xOffset: 0, yOffset: 0, groupId: null, page: 4 },
+			groupId: null,
+		} as unknown as SurfaceConfig
+
+		const config = createOrSanitizeSurfaceHandlerConfig('test', makePanel(), existing, defaultGridSize)
+
+		expect(config.groupConfig.startup_page).toBe(4)
+		// A page had been chosen, so the surface should not resume on the last page it was on
+		expect(config.groupConfig.use_last_page).toBe(false)
+		expect(config.config.page).toBeUndefined()
+	})
+
+	test('a config with no chosen page resumes on the last page', () => {
+		const existing = {
+			config: { brightness: 100, rotation: 0, xOffset: 0, yOffset: 0, groupId: null },
+			groupId: null,
+		} as unknown as SurfaceConfig
+
+		const config = createOrSanitizeSurfaceHandlerConfig('test', makePanel(), existing, defaultGridSize)
+
+		expect(config.groupConfig.use_last_page).toBe(true)
+		expect(config.groupConfig.startup_page).toBe(1)
+	})
+
+	test('keeps a surface which had been disabled disabled', () => {
+		const existing = createOrSanitizeSurfaceHandlerConfig('test', makePanel(), undefined, defaultGridSize)
+		existing.enabled = false
+
+		expect(createOrSanitizeSurfaceHandlerConfig('test', makePanel(), existing, defaultGridSize).enabled).toBe(false)
+	})
+})

--- a/companion/test/Surface/ControllerLayouts.test.ts
+++ b/companion/test/Surface/ControllerLayouts.test.ts
@@ -1,0 +1,288 @@
+import { initTRPC } from '@trpc/server'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { mockDeep } from 'vitest-mock-extended'
+import type {
+	ClientSurfaceButtonSizesItem,
+	ClientSurfaceLayoutItem,
+	SurfaceConfig,
+	SurfaceLayoutDefinition,
+} from '@companion-app/shared/Model/Surfaces.js'
+import { createTables } from '../../lib/Data/Schema/v1.js'
+import { DataStoreBase } from '../../lib/Data/StoreBase.js'
+import { SurfaceController } from '../../lib/Surface/Controller.js'
+import type { SatelliteDeviceInfo } from '../../lib/Surface/IP/Satellite.js'
+import type { SurfaceHandlerDependencies } from '../../lib/Surface/Types.js'
+import type { TrpcContext } from '../../lib/UI/TRPC.js'
+import { createMockTrpcContext } from '../Util.js'
+import { SubscriptionTester } from '../utils/SubscriptionTester.js'
+
+const t = initTRPC.context<TrpcContext>().create()
+const testCtx: TrpcContext = createMockTrpcContext()
+
+class TestDatabase extends DataStoreBase<any> {
+	constructor() {
+		super(':memory:', '', 'main', 'Data/Database', () => {})
+		this.startSQLite()
+	}
+	protected create(): void {
+		createTables(this.store, this.defaultTable, this.logger)
+	}
+	protected loadDefaults(): void {}
+	protected migrateFileToSqlite(): void {}
+}
+
+const neoLayout: SurfaceLayoutDefinition = {
+	stylePresets: {
+		default: { bitmap: { w: 96, h: 96 } },
+		infoBar: { bitmap: { w: 248, h: 58 } },
+	},
+	controls: {
+		'0/0': { row: 0, column: 0 },
+		'1/0': { row: 1, column: 0, stylePreset: 'infoBar' },
+	},
+}
+
+function makeStoredConfig(partial: Partial<SurfaceConfig>): SurfaceConfig {
+	return {
+		config: { brightness: 100, rotation: 0, xOffset: 0, yOffset: 0, groupId: null },
+		groupConfig: {
+			name: '',
+			last_page_id: '1',
+			startup_page_id: '1',
+			use_last_page: true,
+			never_lock: false,
+		},
+		groupId: null,
+		type: 'Stream Deck Neo',
+		integrationType: 'satellite',
+		gridSize: { columns: 1, rows: 2 },
+		layout: undefined,
+		...partial,
+	}
+}
+
+function createController() {
+	const db = new TestDatabase()
+	const deps = mockDeep<SurfaceHandlerDependencies>({
+		fallbackMockImplementation: () => undefined,
+	})
+	// The controller reads these while opening a surface
+	deps.userconfig.getKey.mockImplementation((key: string) => {
+		if (key === 'gridSize') return { minColumn: 0, maxColumn: 7, minRow: 0, maxRow: 3 }
+		return undefined
+	})
+	deps.pageStore.getFirstPageId.mockReturnValue('page1')
+
+	const controller = new SurfaceController(db as any, deps)
+
+	return { controller, db }
+}
+
+function satelliteDeviceInfo(overrides: Partial<SatelliteDeviceInfo> = {}): SatelliteDeviceInfo {
+	return {
+		connectionId: 'conn1',
+		deviceId: 'dev1',
+		serial: 'dev1',
+		serialIsUnique: true,
+		productName: 'Stream Deck Neo',
+		socket: { remoteAddress: '1.2.3.4', write: vi.fn(), sendMessage: vi.fn() } as any,
+		gridSize: { columns: 1, rows: 2 },
+		supportsBrightness: true,
+		transferVariables: [],
+		supportsLockedState: false,
+		surfaceManifestFromClient: true,
+		surfaceManifest: neoLayout,
+		configFields: undefined,
+		canChangePage: undefined,
+		bitmapFormat: 'rgb',
+		...overrides,
+	}
+}
+
+describe('SurfaceController layouts', () => {
+	let controller: SurfaceController
+	let db: TestDatabase
+
+	beforeEach(() => {
+		;({ controller, db } = createController())
+	})
+
+	test('has nothing to report with no surfaces', () => {
+		expect(controller.getSurfaceLayouts()).toEqual({})
+		expect(controller.getSurfaceButtonSizes()).toEqual({})
+	})
+
+	test('reports the stored layout of an offline surface', () => {
+		db.getTableView('surfaces').set('offline1', makeStoredConfig({ layout: neoLayout }))
+
+		const layouts = controller.getSurfaceLayouts()
+
+		expect(layouts.offline1).toEqual({
+			id: 'offline1',
+			type: 'Stream Deck Neo',
+			displayName: 'Stream Deck Neo (offline1)',
+			isConnected: false,
+			layout: neoLayout,
+		})
+	})
+
+	test('omits a stored surface which has never reported a layout', () => {
+		db.getTableView('surfaces').set('old1', makeStoredConfig({ layout: undefined }))
+
+		expect(controller.getSurfaceLayouts()).toEqual({})
+	})
+
+	test('derives the button sizes of an offline surface from its stored layout', () => {
+		db.getTableView('surfaces').set('offline1', makeStoredConfig({ layout: neoLayout }))
+
+		expect(controller.getSurfaceButtonSizes().offline1.bitmapSizes).toEqual([
+			{ w: 96, h: 96 },
+			{ w: 248, h: 58 },
+		])
+	})
+
+	test('reports a connected surface as connected, with the layout it reported', () => {
+		controller.addSatelliteDevice(satelliteDeviceInfo())
+
+		const layouts = controller.getSurfaceLayouts()
+		const ids = Object.keys(layouts)
+
+		expect(ids).toHaveLength(1)
+		expect(layouts[ids[0]].isConnected).toBe(true)
+		expect(layouts[ids[0]].type).toBe('Stream Deck Neo')
+		expect(layouts[ids[0]].layout).toEqual(neoLayout)
+	})
+
+	test('reports a connected surface once, not also as a stored one', () => {
+		const device = controller.addSatelliteDevice(satelliteDeviceInfo())
+		const surfaceId = device.info.surfaceId
+
+		// The surface has been persisted by being opened, so it is in both places it is gathered from
+		expect(db.getTableView('surfaces').get(surfaceId)).toBeTruthy()
+		expect(Object.keys(controller.getSurfaceLayouts())).toEqual([surfaceId])
+	})
+
+	test('keeps reporting a surface once it disconnects, now as offline', () => {
+		const device = controller.addSatelliteDevice(satelliteDeviceInfo())
+		const surfaceId = device.info.surfaceId
+
+		controller.removeDevice(surfaceId)
+
+		const layouts = controller.getSurfaceLayouts()
+		expect(layouts[surfaceId].isConnected).toBe(false)
+		expect(layouts[surfaceId].layout).toEqual(neoLayout)
+	})
+
+	test('stops reporting a surface which is forgotten', () => {
+		const device = controller.addSatelliteDevice(satelliteDeviceInfo())
+		const surfaceId = device.info.surfaceId
+
+		controller.removeDevice(surfaceId)
+		// What the surfaceForget mutation does once the surface is no longer active
+		controller.setDeviceConfig(surfaceId, undefined)
+
+		expect(controller.getSurfaceLayouts()).toEqual({})
+	})
+})
+
+describe('SurfaceController layout subscriptions', () => {
+	let controller: SurfaceController
+	let db: TestDatabase
+
+	beforeEach(() => {
+		;({ controller, db } = createController())
+	})
+
+	async function watchButtonSizes() {
+		const caller = t.createCallerFactory(controller.createTrpcRouter())(testCtx)
+		return caller.watchSurfaceButtonSizes() as Promise<AsyncIterable<Record<string, ClientSurfaceButtonSizesItem>>>
+	}
+
+	test('sends the current button sizes when the subscription starts', async () => {
+		controller.addSatelliteDevice(satelliteDeviceInfo())
+
+		const sub = new SubscriptionTester(await watchButtonSizes(), { timeoutMs: 2000 })
+
+		const initial = await sub.next()
+		expect(Object.values(initial).map((s) => s.bitmapSizes)).toEqual([
+			[
+				{ w: 96, h: 96 },
+				{ w: 248, h: 58 },
+			],
+		])
+
+		await sub.cleanup()
+	})
+
+	test('pushes an update when a surface is added', async () => {
+		const sub = new SubscriptionTester(await watchButtonSizes(), { timeoutMs: 2000 })
+
+		expect(await sub.next()).toEqual({})
+
+		controller.addSatelliteDevice(satelliteDeviceInfo())
+
+		const update = await sub.next()
+		expect(Object.values(update).map((s) => s.type)).toEqual(['Stream Deck Neo'])
+
+		await sub.cleanup()
+	})
+
+	test('pushes an update when a surface is forgotten', async () => {
+		const device = controller.addSatelliteDevice(satelliteDeviceInfo())
+		const surfaceId = device.info.surfaceId
+
+		const sub = new SubscriptionTester(await watchButtonSizes(), { timeoutMs: 2000 })
+		expect(Object.keys(await sub.next())).toEqual([surfaceId])
+
+		controller.removeDevice(surfaceId)
+		controller.setDeviceConfig(surfaceId, undefined)
+		controller.triggerUpdateDevicesList()
+
+		expect(await sub.next()).toEqual({})
+
+		await sub.cleanup()
+	})
+
+	test('the layouts subscription carries the full manifest, the button sizes one does not', async () => {
+		db.getTableView('surfaces').set('offline1', makeStoredConfig({ layout: neoLayout }))
+
+		const caller = t.createCallerFactory(controller.createTrpcRouter())(testCtx)
+		const layoutSub = new SubscriptionTester(
+			(await caller.watchSurfaceLayouts()) as AsyncIterable<Record<string, ClientSurfaceLayoutItem>>,
+			{ timeoutMs: 2000 }
+		)
+		const sizesSub = new SubscriptionTester(await watchButtonSizes(), { timeoutMs: 2000 })
+
+		expect((await layoutSub.next()).offline1.layout).toEqual(neoLayout)
+
+		const sizes = (await sizesSub.next()).offline1 as unknown as Record<string, unknown>
+		expect(sizes.bitmapSizes).toBeTruthy()
+		expect(sizes.layout).toBeUndefined()
+		expect(sizes.controls).toBeUndefined()
+		expect(sizes.stylePresets).toBeUndefined()
+
+		await layoutSub.cleanup()
+		await sizesSub.cleanup()
+	})
+
+	test('does not push anything when nothing about the surfaces changed', async () => {
+		// Stored surfaces rather than connected ones, so nothing can change underneath the assertions
+		db.getTableView('surfaces').set('offline1', makeStoredConfig({ layout: neoLayout }))
+
+		const sub = new SubscriptionTester(await watchButtonSizes(), { timeoutMs: 2000 })
+		expect(Object.keys(await sub.next())).toEqual(['offline1'])
+
+		// A surfaces list update which leaves the layouts alone, such as a brightness change elsewhere
+		controller.triggerUpdateDevicesList()
+		// Long enough that this update cannot be coalesced into the next one by the debounce
+		await new Promise((resolve) => setTimeout(resolve, 300))
+
+		db.getTableView('surfaces').set('offline2', makeStoredConfig({ layout: neoLayout }))
+		controller.triggerUpdateDevicesList()
+
+		// The very next push is the real change: the no-op update above sent nothing
+		expect(Object.keys(await sub.next())).toEqual(['offline1', 'offline2'])
+
+		await sub.cleanup()
+	})
+})

--- a/companion/test/Surface/ControllerLayouts.test.ts
+++ b/companion/test/Surface/ControllerLayouts.test.ts
@@ -5,7 +5,7 @@ import type {
 	ClientSurfaceButtonSizesItem,
 	ClientSurfaceLayoutItem,
 	SurfaceConfig,
-	SurfaceLayoutDefinition,
+	SurfaceSchemaLayoutDefinition,
 } from '@companion-app/shared/Model/Surfaces.js'
 import { createTables } from '../../lib/Data/Schema/v1.js'
 import { DataStoreBase } from '../../lib/Data/StoreBase.js'
@@ -31,7 +31,7 @@ class TestDatabase extends DataStoreBase<any> {
 	protected migrateFileToSqlite(): void {}
 }
 
-const neoLayout: SurfaceLayoutDefinition = {
+const neoLayout: SurfaceSchemaLayoutDefinition = {
 	stylePresets: {
 		default: { bitmap: { w: 96, h: 96 } },
 		infoBar: { bitmap: { w: 248, h: 58 } },

--- a/companion/test/Surface/LayoutSummary.test.ts
+++ b/companion/test/Surface/LayoutSummary.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import type { SurfaceConfig, SurfaceLayoutDefinition } from '@companion-app/shared/Model/Surfaces.js'
+import type { SurfaceConfig, SurfaceSchemaLayoutDefinition } from '@companion-app/shared/Model/Surfaces.js'
 import {
 	buildGridSurfaceLayout,
 	resolveControlStylePreset,
@@ -28,7 +28,7 @@ function makeConfig(partial: Partial<SurfaceConfig>): SurfaceConfig {
 }
 
 /** A surface shaped like a Stream Deck Neo: square keys plus a wide info bar */
-const neoLayout: SurfaceLayoutDefinition = {
+const neoLayout: SurfaceSchemaLayoutDefinition = {
 	stylePresets: {
 		default: { bitmap: { w: 96, h: 96 } },
 		infoBar: { bitmap: { w: 248, h: 58 } },
@@ -40,7 +40,7 @@ const neoLayout: SurfaceLayoutDefinition = {
 	},
 }
 
-const squareLayout: SurfaceLayoutDefinition = {
+const squareLayout: SurfaceSchemaLayoutDefinition = {
 	stylePresets: { default: { bitmap: { w: 72, h: 72 } } },
 	controls: { '0/0': { row: 0, column: 0 } },
 }
@@ -124,7 +124,7 @@ describe('surfaceLayoutsFromConfigs', () => {
 })
 
 describe('surfaceButtonSizesFromLayouts', () => {
-	function sizesFor(layout: SurfaceLayoutDefinition) {
+	function sizesFor(layout: SurfaceSchemaLayoutDefinition) {
 		const layouts = surfaceLayoutsFromConfigs([{ surfaceId: 'abc', config: makeConfig({ layout }), isConnected: true }])
 		return surfaceButtonSizesFromLayouts(layouts).abc.bitmapSizes
 	}

--- a/companion/test/Surface/LayoutSummary.test.ts
+++ b/companion/test/Surface/LayoutSummary.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, test } from 'vitest'
+import type { SurfaceConfig, SurfaceLayoutDefinition } from '@companion-app/shared/Model/Surfaces.js'
+import {
+	buildGridSurfaceLayout,
+	resolveControlStylePreset,
+	surfaceButtonSizesFromLayouts,
+	surfaceLayoutsFromConfigs,
+	type SurfaceLayoutSource,
+} from '../../lib/Surface/LayoutSummary.js'
+
+function makeConfig(partial: Partial<SurfaceConfig>): SurfaceConfig {
+	return {
+		config: { brightness: 100, rotation: 0, xOffset: 0, yOffset: 0, groupId: null },
+		groupConfig: {
+			name: '',
+			last_page_id: '1',
+			startup_page_id: '1',
+			use_last_page: true,
+			never_lock: false,
+		},
+		groupId: null,
+		type: 'Test Surface',
+		integrationType: 'test',
+		gridSize: { columns: 2, rows: 1 },
+		layout: undefined,
+		...partial,
+	}
+}
+
+/** A surface shaped like a Stream Deck Neo: square keys plus a wide info bar */
+const neoLayout: SurfaceLayoutDefinition = {
+	stylePresets: {
+		default: { bitmap: { w: 96, h: 96 } },
+		infoBar: { bitmap: { w: 248, h: 58 } },
+	},
+	controls: {
+		'0/0': { row: 0, column: 0 },
+		'0/1': { row: 0, column: 1 },
+		'1/0': { row: 1, column: 0, stylePreset: 'infoBar' },
+	},
+}
+
+const squareLayout: SurfaceLayoutDefinition = {
+	stylePresets: { default: { bitmap: { w: 72, h: 72 } } },
+	controls: { '0/0': { row: 0, column: 0 } },
+}
+
+describe('resolveControlStylePreset', () => {
+	test('uses the default preset when the control names none', () => {
+		expect(resolveControlStylePreset(neoLayout, { row: 0, column: 0 })).toEqual({ bitmap: { w: 96, h: 96 } })
+	})
+
+	test('uses the named preset when the control names one', () => {
+		expect(resolveControlStylePreset(neoLayout, { row: 1, column: 0, stylePreset: 'infoBar' })).toEqual({
+			bitmap: { w: 248, h: 58 },
+		})
+	})
+
+	test('falls back to the default preset when the named one is unknown', () => {
+		expect(resolveControlStylePreset(neoLayout, { row: 1, column: 0, stylePreset: 'nope' })).toEqual({
+			bitmap: { w: 96, h: 96 },
+		})
+	})
+})
+
+describe('surfaceLayoutsFromConfigs', () => {
+	test('includes connected and offline surfaces alike', () => {
+		const sources: SurfaceLayoutSource[] = [
+			{ surfaceId: 'online', config: makeConfig({ layout: squareLayout }), isConnected: true },
+			{ surfaceId: 'offline', config: makeConfig({ layout: neoLayout }), isConnected: false },
+		]
+
+		const result = surfaceLayoutsFromConfigs(sources)
+
+		expect(Object.keys(result)).toEqual(['online', 'offline'])
+		expect(result.online.isConnected).toBe(true)
+		expect(result.online.layout).toEqual(squareLayout)
+		expect(result.offline.isConnected).toBe(false)
+		expect(result.offline.layout).toEqual(neoLayout)
+	})
+
+	test('omits surfaces which have no stored layout', () => {
+		const result = surfaceLayoutsFromConfigs([
+			{ surfaceId: 'noLayout', config: makeConfig({ layout: undefined }), isConnected: true },
+			{ surfaceId: 'hasLayout', config: makeConfig({ layout: squareLayout }), isConnected: true },
+		])
+
+		expect(Object.keys(result)).toEqual(['hasLayout'])
+	})
+
+	test('reports the model name and the display name of the surface', () => {
+		const result = surfaceLayoutsFromConfigs([
+			{ surfaceId: 'abc', config: makeConfig({ layout: squareLayout, type: 'Stream Deck Neo' }), isConnected: true },
+		])
+
+		expect(result.abc.type).toBe('Stream Deck Neo')
+		expect(result.abc.displayName).toBe('Stream Deck Neo (abc)')
+	})
+
+	test('prefers the user given name for the display name', () => {
+		const result = surfaceLayoutsFromConfigs([
+			{
+				surfaceId: 'abc',
+				config: makeConfig({ layout: squareLayout, type: 'Stream Deck Neo', name: 'Desk' }),
+				isConnected: true,
+			},
+		])
+
+		expect(result.abc.type).toBe('Stream Deck Neo')
+		expect(result.abc.displayName).toBe('Desk (abc)')
+	})
+
+	test('falls back to Unknown for a config with no type', () => {
+		const result = surfaceLayoutsFromConfigs([
+			{ surfaceId: 'abc', config: makeConfig({ layout: squareLayout, type: undefined }), isConnected: true },
+		])
+
+		expect(result.abc.type).toBe('Unknown')
+	})
+
+	test('produces nothing for no sources', () => {
+		expect(surfaceLayoutsFromConfigs([])).toEqual({})
+	})
+})
+
+describe('surfaceButtonSizesFromLayouts', () => {
+	function sizesFor(layout: SurfaceLayoutDefinition) {
+		const layouts = surfaceLayoutsFromConfigs([{ surfaceId: 'abc', config: makeConfig({ layout }), isConnected: true }])
+		return surfaceButtonSizesFromLayouts(layouts).abc.bitmapSizes
+	}
+
+	test('dedupes the sizes shared by several controls', () => {
+		expect(sizesFor(neoLayout)).toEqual([
+			{ w: 96, h: 96 },
+			{ w: 248, h: 58 },
+		])
+	})
+
+	test('a control with no bitmap contributes nothing', () => {
+		expect(
+			sizesFor({
+				stylePresets: { default: { bitmap: { w: 72, h: 72 } }, textOnly: { text: true } },
+				controls: {
+					'0/0': { row: 0, column: 0 },
+					'0/1': { row: 0, column: 1, stylePreset: 'textOnly' },
+				},
+			})
+		).toEqual([{ w: 72, h: 72 }])
+	})
+
+	test('a surface with no drawn controls has no sizes', () => {
+		expect(
+			sizesFor({
+				stylePresets: { default: { text: true } },
+				controls: { '0/0': { row: 0, column: 0 } },
+			})
+		).toEqual([])
+	})
+
+	test('a surface with no controls at all has no sizes', () => {
+		expect(sizesFor({ stylePresets: { default: { bitmap: { w: 72, h: 72 } } }, controls: {} })).toEqual([])
+	})
+
+	test('carries through the identifying fields of each surface', () => {
+		const layouts = surfaceLayoutsFromConfigs([
+			{ surfaceId: 'abc', config: makeConfig({ layout: squareLayout, type: 'Emulator' }), isConnected: false },
+		])
+
+		expect(surfaceButtonSizesFromLayouts(layouts)).toEqual({
+			abc: {
+				id: 'abc',
+				type: 'Emulator',
+				displayName: 'Emulator (abc)',
+				isConnected: false,
+				bitmapSizes: [{ w: 72, h: 72 }],
+			},
+		})
+	})
+})
+
+describe('buildGridSurfaceLayout', () => {
+	test('has a control per grid cell, keyed by row and column', () => {
+		const layout = buildGridSurfaceLayout({ columns: 3, rows: 2 }, { w: 288, h: 288 })
+
+		expect(Object.keys(layout.controls)).toEqual(['0/0', '0/1', '0/2', '1/0', '1/1', '1/2'])
+		expect(layout.controls['1/2']).toEqual({ row: 1, column: 2 })
+		expect(layout.stylePresets.default).toEqual({ bitmap: { w: 288, h: 288 } })
+	})
+
+	test('an empty grid has no controls', () => {
+		expect(buildGridSurfaceLayout({ columns: 0, rows: 0 }, { w: 288, h: 288 }).controls).toEqual({})
+	})
+
+	test('reports a single size for the whole grid', () => {
+		const layouts = surfaceLayoutsFromConfigs([
+			{
+				surfaceId: 'emulator:1',
+				config: makeConfig({ layout: buildGridSurfaceLayout({ columns: 8, rows: 4 }, { w: 288, h: 288 }) }),
+				isConnected: true,
+			},
+		])
+
+		expect(surfaceButtonSizesFromLayouts(layouts)['emulator:1'].bitmapSizes).toEqual([{ w: 288, h: 288 }])
+	})
+})

--- a/companion/test/Surface/PanelLayouts.test.ts
+++ b/companion/test/Surface/PanelLayouts.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'node:events'
 import { describe, expect, test, vi } from 'vitest'
-import type { SurfaceLayoutDefinition } from '@companion-app/shared/Model/Surfaces.js'
+import type { SurfaceSchemaLayoutDefinition } from '@companion-app/shared/Model/Surfaces.js'
 import { PREVIEW_RENDER_SIZE } from '../../lib/Graphics/ImageResult.js'
 import type { SatelliteSurfaceLayout } from '../../lib/Service/Satellite/SatelliteSurfaceManifestSchema.js'
 import { SurfaceIPElgatoEmulator } from '../../lib/Surface/IP/ElgatoEmulator.js'
@@ -62,7 +62,7 @@ describe('SurfaceIPElgatoEmulator', () => {
 	}
 
 	test('reports a grid of square controls matching the default size', () => {
-		const layout: SurfaceLayoutDefinition = makeEmulator().surfaceLayout
+		const layout: SurfaceSchemaLayoutDefinition = makeEmulator().surfaceLayout
 
 		expect(layout.stylePresets).toEqual({
 			default: { bitmap: { w: PREVIEW_RENDER_SIZE, h: PREVIEW_RENDER_SIZE } },
@@ -83,7 +83,7 @@ describe('SurfaceIPElgatoEmulator', () => {
 
 describe('SurfacePluginPanel', () => {
 	test('exposes the layout reported by the surface module', () => {
-		const surfaceLayout: SurfaceLayoutDefinition = {
+		const surfaceLayout: SurfaceSchemaLayoutDefinition = {
 			stylePresets: {
 				default: { bitmap: { w: 120, h: 120 } },
 				encoder: { bitmap: { w: 200, h: 100 }, leds: { segments: 16, mode: 'full-ring' } },

--- a/companion/test/Surface/PanelLayouts.test.ts
+++ b/companion/test/Surface/PanelLayouts.test.ts
@@ -1,0 +1,115 @@
+import { EventEmitter } from 'node:events'
+import { describe, expect, test, vi } from 'vitest'
+import type { SurfaceLayoutDefinition } from '@companion-app/shared/Model/Surfaces.js'
+import { PREVIEW_RENDER_SIZE } from '../../lib/Graphics/ImageResult.js'
+import type { SatelliteSurfaceLayout } from '../../lib/Service/Satellite/SatelliteSurfaceManifestSchema.js'
+import { SurfaceIPElgatoEmulator } from '../../lib/Surface/IP/ElgatoEmulator.js'
+import { SurfaceIPSatellite, type SatelliteDeviceInfo } from '../../lib/Surface/IP/Satellite.js'
+import { SurfacePluginPanel } from '../../lib/Surface/PluginPanel.js'
+
+describe('SurfaceIPSatellite', () => {
+	function makeSatellite(surfaceManifest: SatelliteSurfaceLayout) {
+		const deviceInfo: SatelliteDeviceInfo = {
+			connectionId: 'conn1',
+			deviceId: 'dev1',
+			serial: 'serial1',
+			serialIsUnique: true,
+			productName: 'Test Deck',
+			socket: { remoteAddress: '1.2.3.4', write: vi.fn() } as any,
+			gridSize: { columns: 2, rows: 2 },
+			supportsBrightness: true,
+			transferVariables: [],
+			supportsLockedState: false,
+			surfaceManifestFromClient: true,
+			surfaceManifest,
+			configFields: undefined,
+			canChangePage: undefined,
+			bitmapFormat: 'rgb',
+		}
+
+		return new SurfaceIPSatellite(deviceInfo, 'satellite:dev1', vi.fn())
+	}
+
+	test('exposes the manifest reported by the client', () => {
+		const manifest: SatelliteSurfaceLayout = {
+			stylePresets: {
+				default: { bitmap: { w: 96, h: 96 } },
+				infoBar: { bitmap: { w: 248, h: 58 } },
+			},
+			controls: {
+				'0/0': { row: 0, column: 0 },
+				'1/0': { row: 1, column: 0, stylePreset: 'infoBar' },
+			},
+		}
+
+		expect(makeSatellite(manifest).surfaceLayout).toEqual(manifest)
+	})
+
+	test('exposes a manifest which requests no bitmaps unchanged', () => {
+		const manifest: SatelliteSurfaceLayout = {
+			stylePresets: { default: { text: true } },
+			controls: { '0/0': { row: 0, column: 0 } },
+		}
+
+		expect(makeSatellite(manifest).surfaceLayout).toEqual(manifest)
+	})
+})
+
+describe('SurfaceIPElgatoEmulator', () => {
+	function makeEmulator() {
+		const events = new EventEmitter() as any
+		return new SurfaceIPElgatoEmulator(events, 'emu1')
+	}
+
+	test('reports a grid of square controls matching the default size', () => {
+		const layout: SurfaceLayoutDefinition = makeEmulator().surfaceLayout
+
+		expect(layout.stylePresets).toEqual({
+			default: { bitmap: { w: PREVIEW_RENDER_SIZE, h: PREVIEW_RENDER_SIZE } },
+		})
+		expect(Object.keys(layout.controls)).toHaveLength(8 * 4)
+		expect(layout.controls['3/7']).toEqual({ row: 3, column: 7 })
+	})
+
+	test('follows the emulator being resized', () => {
+		const emulator = makeEmulator()
+
+		emulator.setConfig({ emulator_columns: 3, emulator_rows: 2 } as any, true)
+
+		expect(emulator.gridSize).toEqual({ columns: 3, rows: 2 })
+		expect(Object.keys(emulator.surfaceLayout.controls)).toEqual(['0/0', '0/1', '0/2', '1/0', '1/1', '1/2'])
+	})
+})
+
+describe('SurfacePluginPanel', () => {
+	test('exposes the layout reported by the surface module', () => {
+		const surfaceLayout: SurfaceLayoutDefinition = {
+			stylePresets: {
+				default: { bitmap: { w: 120, h: 120 } },
+				encoder: { bitmap: { w: 200, h: 100 }, leds: { segments: 16, mode: 'full-ring' } },
+			},
+			controls: {
+				'0/0': { row: 0, column: 0 },
+				'1/0': { row: 1, column: 0, stylePreset: 'encoder' },
+			},
+		}
+
+		const panel = new SurfacePluginPanel(
+			{ sendWithCb: vi.fn() } as any,
+			'instance1',
+			{
+				surfaceId: 'plugin:dev1',
+				description: 'Test Deck',
+				surfaceLayout,
+				supportsBrightness: true,
+				isRemote: false,
+				transferVariables: [],
+			} as any,
+			vi.fn()
+		)
+
+		expect(panel.surfaceLayout).toEqual(surfaceLayout)
+		// The grid is derived from the same controls, so the two stay consistent
+		expect(panel.gridSize).toEqual({ columns: 1, rows: 2 })
+	})
+})

--- a/shared-lib/lib/Model/Surfaces.ts
+++ b/shared-lib/lib/Model/Surfaces.ts
@@ -23,6 +23,72 @@ export interface SurfaceFirmwareUpdateInfo {
 	updaterDownloadUrl: string
 }
 
+/**
+ * Pixel dimensions of the bitmap a surface control expects to be drawn at.
+ */
+export interface SurfaceLayoutBitmapSize {
+	w: number
+	h: number
+}
+
+export interface SurfaceLayoutLedsConfig {
+	segments: number
+	mode: 'full-ring' | 'simple'
+}
+
+/**
+ * The styling a surface requests for a control. Mirrors the style presets in the surface layout schemas used
+ * by the plugin (`@companion-surface/host`) and satellite APIs, so that a layout from either can be described
+ * with these types without depending on those packages.
+ */
+export interface SurfaceLayoutStylePreset {
+	bitmap?: SurfaceLayoutBitmapSize
+	text?: boolean
+	textStyle?: boolean
+	colors?: 'hex' | 'rgb'
+	leds?: SurfaceLayoutLedsConfig
+}
+
+export interface SurfaceLayoutControl {
+	row: number
+	column: number
+	stylePreset?: string
+}
+
+/**
+ * The layout manifest a surface reports when it connects: the styles it can draw, and the controls it has.
+ */
+export interface SurfaceLayoutDefinition {
+	stylePresets: Record<string, SurfaceLayoutStylePreset> & { default: SurfaceLayoutStylePreset }
+	controls: Record<string, SurfaceLayoutControl>
+}
+
+/**
+ * The full layout manifest of a surface, as pushed to the client.
+ */
+export interface ClientSurfaceLayoutItem {
+	id: string
+	/** The model name of the surface, matching `ClientSurfaceItem.type` */
+	type: string
+	displayName: string
+	isConnected: boolean
+	layout: SurfaceLayoutDefinition
+}
+
+/**
+ * The button sizes of a surface, as pushed to the client. A summary of `ClientSurfaceLayoutItem` for consumers
+ * which only care about how large the buttons are, and shouldn't have to receive every control to find out.
+ */
+export interface ClientSurfaceButtonSizesItem {
+	id: string
+	/** The model name of the surface, matching `ClientSurfaceItem.type` */
+	type: string
+	displayName: string
+	isConnected: boolean
+	/** The distinct sizes this surface's controls are drawn at */
+	bitmapSizes: SurfaceLayoutBitmapSize[]
+}
+
 export interface ClientSurfaceItem {
 	id: string
 	type: string
@@ -81,6 +147,7 @@ export interface SurfaceConfig {
 	type: string | undefined
 	integrationType: string | undefined
 	gridSize: GridSize | undefined
+	layout: SurfaceLayoutDefinition | undefined
 }
 
 export interface SurfaceGroupConfig {

--- a/shared-lib/lib/Model/Surfaces.ts
+++ b/shared-lib/lib/Model/Surfaces.ts
@@ -1,4 +1,10 @@
 import type { Operation as JsonPatchOperation } from 'fast-json-patch'
+import type {
+	SurfaceSchemaBitmapConfig,
+	SurfaceSchemaControlDefinition,
+	SurfaceSchemaControlStylePreset,
+	SurfaceSchemaLayoutDefinition,
+} from '@companion-surface/base'
 import type { CollectionBase } from './Collections.js'
 import type { DropdownChoice } from './Common.js'
 import type {
@@ -10,6 +16,18 @@ import type {
 	CompanionInputFieldStaticTextExtended,
 	CompanionInputFieldTextInputExtended,
 } from './Options.js'
+
+/**
+ * The surface layout schema is owned by the surface api package, which both the plugin and satellite surfaces
+ * describe their layouts with. Re-exported here so that consumers of the models below get the same types from
+ * the same place, rather than a second description of the same thing.
+ */
+export type {
+	SurfaceSchemaBitmapConfig,
+	SurfaceSchemaControlDefinition,
+	SurfaceSchemaControlStylePreset,
+	SurfaceSchemaLayoutDefinition,
+}
 
 export type GridSize = { columns: number; rows: number }
 export type SurfaceRotation = 'surface90' | 'surface-90' | 'surface180' | 'surface0' | 0 | -90 | 90 | 180
@@ -24,44 +42,10 @@ export interface SurfaceFirmwareUpdateInfo {
 }
 
 /**
- * Pixel dimensions of the bitmap a surface control expects to be drawn at.
+ * Pixel dimensions of the bitmap a surface control is drawn at, without the pixel format which is only of
+ * interest to whatever is doing the drawing.
  */
-export interface SurfaceLayoutBitmapSize {
-	w: number
-	h: number
-}
-
-export interface SurfaceLayoutLedsConfig {
-	segments: number
-	mode: 'full-ring' | 'simple'
-}
-
-/**
- * The styling a surface requests for a control. Mirrors the style presets in the surface layout schemas used
- * by the plugin (`@companion-surface/host`) and satellite APIs, so that a layout from either can be described
- * with these types without depending on those packages.
- */
-export interface SurfaceLayoutStylePreset {
-	bitmap?: SurfaceLayoutBitmapSize
-	text?: boolean
-	textStyle?: boolean
-	colors?: 'hex' | 'rgb'
-	leds?: SurfaceLayoutLedsConfig
-}
-
-export interface SurfaceLayoutControl {
-	row: number
-	column: number
-	stylePreset?: string
-}
-
-/**
- * The layout manifest a surface reports when it connects: the styles it can draw, and the controls it has.
- */
-export interface SurfaceLayoutDefinition {
-	stylePresets: Record<string, SurfaceLayoutStylePreset> & { default: SurfaceLayoutStylePreset }
-	controls: Record<string, SurfaceLayoutControl>
-}
+export type SurfaceLayoutBitmapSize = Pick<SurfaceSchemaBitmapConfig, 'w' | 'h'>
 
 /**
  * The full layout manifest of a surface, as pushed to the client.
@@ -72,7 +56,7 @@ export interface ClientSurfaceLayoutItem {
 	type: string
 	displayName: string
 	isConnected: boolean
-	layout: SurfaceLayoutDefinition
+	layout: SurfaceSchemaLayoutDefinition
 }
 
 /**
@@ -147,7 +131,7 @@ export interface SurfaceConfig {
 	type: string | undefined
 	integrationType: string | undefined
 	gridSize: GridSize | undefined
-	layout: SurfaceLayoutDefinition | undefined
+	layout: SurfaceSchemaLayoutDefinition | undefined
 }
 
 export interface SurfaceGroupConfig {

--- a/shared-lib/package.json
+++ b/shared-lib/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@companion-app/expressions": "^1.0.1",
+    "@companion-surface/base": "1.4.0",
     "colord": "^2.10.0",
     "quick-lru": "^7.3.0",
     "semver": "^7.8.5",

--- a/webui/src/Buttons/EditButton/EditButton.css
+++ b/webui/src/Buttons/EditButton/EditButton.css
@@ -402,13 +402,17 @@
 
 /* Portaled to the body, so it can't live inside the .button-layer-preview block */
 .button-layer-aspect-custom {
-	/* Sized for the two-digit values these ratios realistically use */
-	width: 135px;
+	/* Sized so a surface entry - a ratio plus the model name - fits on one line */
+	width: 230px;
 	min-width: 0;
 	padding: 6px;
 	display: flex;
 	flex-direction: column;
 	gap: 4px;
+}
+
+.button-layer-aspect-surfaces {
+	min-width: 0;
 }
 
 .add-layered-element-popover {

--- a/webui/src/Buttons/EditButton/EditButton.css
+++ b/webui/src/Buttons/EditButton/EditButton.css
@@ -272,13 +272,6 @@
 				font-size: inherit;
 				min-width: 0;
 			}
-
-			/* Outlined rectangle drawn to the option's ratio; currentColor flips to white when active */
-			.button-layer-aspect-glyph {
-				display: block;
-				border: 1.5px solid currentColor;
-				border-radius: 1px;
-			}
 		}
 
 		/* Must shrink-wrap the canvas exactly: the selection overlay positions its handles and snap guides as
@@ -411,8 +404,47 @@
 	gap: 4px;
 }
 
-.button-layer-aspect-surfaces {
-	min-width: 0;
+/* Separates the surface shapes below from the W/H fields above */
+.button-layer-aspect-surfaces-label {
+	margin-top: 2px;
+	padding-top: 6px;
+	border-top: 1px solid var(--color-border);
+	font-size: 0.7rem;
+	text-transform: uppercase;
+	letter-spacing: 0.03em;
+	opacity: 0.6;
+}
+
+/* A popover item, but sized to the compact popup rather than the default menu metrics */
+.button-layer-aspect-surface.popover2-item {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 3px 4px;
+	border-radius: 3px;
+	font-size: 0.8rem;
+
+	/* A long model name ellipsizes rather than wrapping the row onto a second line */
+	.button-layer-aspect-surface-label {
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	&.active {
+		background: var(--color-toolbar-accent);
+		color: var(--color-on-dark);
+	}
+}
+
+/* Outlined rectangle drawn to an option's ratio; currentColor flips to white when active. Used both by the
+   footer buttons and by the surface rows in the popover, so it is not scoped to either. */
+.button-layer-aspect-glyph {
+	display: block;
+	flex: 0 0 auto;
+	border: 1.5px solid currentColor;
+	border-radius: 1px;
 }
 
 .add-layered-element-popover {

--- a/webui/src/Buttons/EditButton/EditButton.css
+++ b/webui/src/Buttons/EditButton/EditButton.css
@@ -212,68 +212,6 @@
 			overflow: hidden;
 		}
 
-		/* A compact control strip at the bottom of the canvas box */
-		.button-layer-canvas-footer {
-			flex: 0 0 auto;
-			display: flex;
-			align-items: center;
-			gap: 0.5rem;
-			padding: 2px 6px;
-			border-top: 1px solid var(--color-border);
-			background-color: var(--color-toolbar-bg);
-
-			/* Truncates rather than pushing the buttons out of the strip when the panel is narrow */
-			.button-layer-footer-label {
-				white-space: nowrap;
-				font-size: 0.85em;
-				color: var(--color-toolbar-fg);
-				min-width: 0;
-				overflow: hidden;
-				text-overflow: ellipsis;
-			}
-
-			.button-layer-aspect-options {
-				display: flex;
-				gap: 2px;
-				margin-left: auto;
-				flex: 0 0 auto;
-			}
-
-			.button-layer-aspect-option {
-				display: flex;
-				align-items: center;
-				justify-content: center;
-				flex: 0 0 auto;
-				width: 24px;
-				height: 24px;
-				padding: 0;
-				border: 1px solid transparent;
-				border-radius: 3px;
-				background: transparent;
-				color: var(--color-toolbar-fg);
-				cursor: pointer;
-
-				&:hover:not(.active) {
-					background: var(--color-surface-hover);
-					border-color: var(--color-border);
-				}
-
-				&.active {
-					background: var(--color-toolbar-accent);
-					border-color: var(--color-toolbar-accent);
-					color: var(--color-on-dark);
-				}
-			}
-
-			/* The custom option is a popover trigger, which always carries the `btn` class - undo its metrics
-			   so it keeps the same 24x24 box as the preset buttons */
-			.button-layer-aspect-option.btn {
-				line-height: 1;
-				font-size: inherit;
-				min-width: 0;
-			}
-		}
-
 		/* Must shrink-wrap the canvas exactly: the selection overlay positions its handles and snap guides as
 		   percentages of this box, so any difference between it and the canvas's displayed box offsets them. */
 		.button-layer-canvas-wrapper {
@@ -391,67 +329,6 @@
 
 		padding: 0.5rem;
 	}
-}
-
-/* Portaled to the body, so it can't live inside the .button-layer-preview block */
-.button-layer-aspect-custom {
-	/* Sized so a surface entry - a ratio plus the model name - fits on one line */
-	width: 230px;
-	min-width: 0;
-	padding: 6px;
-	display: flex;
-	flex-direction: column;
-	gap: 4px;
-
-	/* These size to their text by default, which leaves the single letter W and H prefixes different widths
-	   and the two fields misaligned. Wide enough for either, with the letter centred in it. */
-	.input-group2-text {
-		min-width: 2.75rem;
-		justify-content: center;
-	}
-}
-
-/* Separates the surface shapes below from the W/H fields above */
-.button-layer-aspect-surfaces-label {
-	margin-top: 2px;
-	padding-top: 6px;
-	border-top: 1px solid var(--color-border);
-	font-size: 0.7rem;
-	text-transform: uppercase;
-	letter-spacing: 0.03em;
-	opacity: 0.6;
-}
-
-/* A popover item, but sized to the compact popup rather than the default menu metrics */
-.button-layer-aspect-surface.popover2-item {
-	display: flex;
-	align-items: center;
-	gap: 6px;
-	padding: 3px 4px;
-	border-radius: 3px;
-	font-size: 0.8rem;
-
-	/* A long model name ellipsizes rather than wrapping the row onto a second line */
-	.button-layer-aspect-surface-label {
-		min-width: 0;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-	}
-
-	&.active {
-		background: var(--color-toolbar-accent);
-		color: var(--color-on-dark);
-	}
-}
-
-/* Outlined rectangle drawn to an option's ratio; currentColor flips to white when active. Used both by the
-   footer buttons and by the surface rows in the popover, so it is not scoped to either. */
-.button-layer-aspect-glyph {
-	display: block;
-	flex: 0 0 auto;
-	border: 1.5px solid currentColor;
-	border-radius: 1px;
 }
 
 .add-layered-element-popover {

--- a/webui/src/Buttons/EditButton/EditButton.css
+++ b/webui/src/Buttons/EditButton/EditButton.css
@@ -402,6 +402,13 @@
 	display: flex;
 	flex-direction: column;
 	gap: 4px;
+
+	/* These size to their text by default, which leaves the single letter W and H prefixes different widths
+	   and the two fields misaligned. Wide enough for either, with the letter centred in it. */
+	.input-group2-text {
+		min-width: 2.75rem;
+		justify-content: center;
+	}
 }
 
 /* Separates the surface shapes below from the W/H fields above */

--- a/webui/src/Buttons/EditButton/LayeredButtonEditor/Preview/AspectRatioPicker.css
+++ b/webui/src/Buttons/EditButton/LayeredButtonEditor/Preview/AspectRatioPicker.css
@@ -1,0 +1,124 @@
+/* Styles for AspectRatioPicker.tsx: the control strip under the preview canvas, and the popover it opens.
+   The popover is portaled to the body, so none of this can be nested under the preview panel. */
+
+/* A compact control strip at the bottom of the canvas box */
+.button-layer-canvas-footer {
+	flex: 0 0 auto;
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 2px 6px;
+	border-top: 1px solid var(--color-border);
+	background-color: var(--color-toolbar-bg);
+
+	/* Truncates rather than pushing the buttons out of the strip when the panel is narrow */
+	.button-layer-footer-label {
+		white-space: nowrap;
+		font-size: 0.85em;
+		color: var(--color-toolbar-fg);
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.button-layer-aspect-options {
+		display: flex;
+		gap: 2px;
+		margin-left: auto;
+		flex: 0 0 auto;
+	}
+
+	.button-layer-aspect-option {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		flex: 0 0 auto;
+		width: 24px;
+		height: 24px;
+		padding: 0;
+		border: 1px solid transparent;
+		border-radius: 3px;
+		background: transparent;
+		color: var(--color-toolbar-fg);
+		cursor: pointer;
+
+		&:hover:not(.active) {
+			background: var(--color-surface-hover);
+			border-color: var(--color-border);
+		}
+
+		&.active {
+			background: var(--color-toolbar-accent);
+			border-color: var(--color-toolbar-accent);
+			color: var(--color-on-dark);
+		}
+	}
+
+	/* The custom option is a popover trigger, which always carries the `btn` class - undo its metrics
+	   so it keeps the same 24x24 box as the preset buttons */
+	.button-layer-aspect-option.btn {
+		line-height: 1;
+		font-size: inherit;
+		min-width: 0;
+	}
+}
+
+.button-layer-aspect-custom {
+	/* Sized so a surface entry - a ratio plus the model name - fits on one line */
+	width: 230px;
+	min-width: 0;
+	padding: 6px;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+
+	/* These size to their text by default, which leaves the single letter W and H prefixes different widths
+	   and the two fields misaligned. Wide enough for either, with the letter centred in it. */
+	.input-group2-text {
+		min-width: 2.75rem;
+		justify-content: center;
+	}
+}
+
+/* Separates the surface shapes below from the W/H fields above */
+.button-layer-aspect-surfaces-label {
+	margin-top: 2px;
+	padding-top: 6px;
+	border-top: 1px solid var(--color-border);
+	font-size: 0.7rem;
+	text-transform: uppercase;
+	letter-spacing: 0.03em;
+	opacity: 0.6;
+}
+
+/* A popover item, but sized to the compact popup rather than the default menu metrics */
+.button-layer-aspect-surface.popover2-item {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 3px 4px;
+	border-radius: 3px;
+	font-size: 0.8rem;
+
+	/* A long model name ellipsizes rather than wrapping the row onto a second line */
+	.button-layer-aspect-surface-label {
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	&.active {
+		background: var(--color-toolbar-accent);
+		color: var(--color-on-dark);
+	}
+}
+
+/* Outlined rectangle drawn to an option's ratio; currentColor flips to white when active. Used both by the
+   footer buttons and by the surface rows in the popover, so it is not scoped to either. */
+.button-layer-aspect-glyph {
+	display: block;
+	flex: 0 0 auto;
+	border: 1.5px solid currentColor;
+	border-radius: 1px;
+}

--- a/webui/src/Buttons/EditButton/LayeredButtonEditor/Preview/AspectRatioPicker.stories.tsx
+++ b/webui/src/Buttons/EditButton/LayeredButtonEditor/Preview/AspectRatioPicker.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { useArgs } from 'storybook/preview-api'
+import { Popover } from '~/Components/Popover.js'
+import { CustomAspectRatioBody } from './AspectRatioPicker'
+// These styles live in the feature stylesheet rather than being imported by the component, so the story has
+// to pull them in itself
+import '../../EditButton.css'
+
+const meta = {
+	component: CustomAspectRatioBody,
+	args: {
+		value: '9:7',
+		// Replaced by the render below, which feeds changes back into the story args
+		setValue: () => {},
+		surfaceChoices: [],
+	},
+	render: function Render(args) {
+		const [, setArgs] = useArgs<{ value: string }>()
+		return (
+			<Popover.Root open>
+				<Popover.Trigger className="button-layer-aspect-option">edit</Popover.Trigger>
+				<Popover.Popup className="button-layer-aspect-custom" align="end">
+					<CustomAspectRatioBody {...args} setValue={(value) => setArgs({ value })} />
+				</Popover.Popup>
+			</Popover.Root>
+		)
+	},
+} satisfies Meta<typeof CustomAspectRatioBody>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** No surface has a shape the preset buttons don't already cover, so only the fields show */
+export const NoSurfaceShapes: Story = {}
+
+/** A Stream Deck Neo is connected, so its info bar shape is offered */
+export const OneSurfaceShape: Story = {
+	args: {
+		surfaceChoices: [{ id: '124:29', label: '124:29 (Stream Deck Neo)' }],
+	},
+}
+
+/** Several surfaces with unusual shapes, one of them currently applied */
+export const ManySurfaceShapes: Story = {
+	args: {
+		value: '124:29',
+		surfaceChoices: [
+			{ id: '124:29', label: '124:29 (Stream Deck Neo)' },
+			{ id: '3:2', label: '3:2 (Loupedeck Live)' },
+			{ id: '5:3', label: '5:3 (Some Very Long Surface Name)' },
+		],
+	},
+}

--- a/webui/src/Buttons/EditButton/LayeredButtonEditor/Preview/AspectRatioPicker.stories.tsx
+++ b/webui/src/Buttons/EditButton/LayeredButtonEditor/Preview/AspectRatioPicker.stories.tsx
@@ -2,9 +2,6 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { useArgs } from 'storybook/preview-api'
 import { Popover } from '~/Components/Popover.js'
 import { CustomAspectRatioBody } from './AspectRatioPicker'
-// These styles live in the feature stylesheet rather than being imported by the component, so the story has
-// to pull them in itself
-import '../../EditButton.css'
 
 const meta = {
 	component: CustomAspectRatioBody,

--- a/webui/src/Buttons/EditButton/LayeredButtonEditor/Preview/AspectRatioPicker.tsx
+++ b/webui/src/Buttons/EditButton/LayeredButtonEditor/Preview/AspectRatioPicker.tsx
@@ -1,0 +1,189 @@
+import { useSubscription } from '@trpc/tanstack-react-query'
+import { PencilIcon } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import type { ClientSurfaceButtonSizesItem } from '@companion-app/shared/Model/Surfaces.js'
+import type { DropdownChoice } from '@companion-module/base'
+import { InputGroup, InputGroupText } from '~/Components/Form.js'
+import { NumberInputField } from '~/Components/NumberInputField.js'
+import { Popover } from '~/Components/Popover.js'
+import { trpc } from '~/Resources/TRPC.js'
+import { parseAspectRatio } from './canvasSize.js'
+import { collectSurfaceAspectRatios, type SurfaceAspectRatioChoice } from './surfaceAspectRatios.js'
+
+const ASPECT_RATIO_OPTIONS: DropdownChoice[] = [
+	{ id: '1:1', label: '1:1 (Square)' },
+	{ id: '9:7', label: '9:7 (Stream Deck Studio)' },
+	{ id: '2:1', label: '2:1 (Stream Deck Plus & Plus XL)' },
+]
+
+/** The ratios the preset buttons already cover, which the surface list therefore leaves out */
+const PRESET_ASPECT_RATIO_IDS: readonly string[] = ASPECT_RATIO_OPTIONS.map((option) => String(option.id))
+
+const CUSTOM_RATIO_MIN = 1
+// Large enough for the ratios real surfaces produce, such as the 124:29 of a Stream Deck Neo's info bar
+const CUSTOM_RATIO_MAX = 999
+
+/**
+ * The control strip under the preview canvas: a button per common ratio, plus a popover for anything else.
+ */
+export function AspectRatioPicker({
+	value,
+	setValue,
+}: {
+	value: string
+	setValue: (value: string) => void
+}): React.JSX.Element {
+	return (
+		<div className="button-layer-canvas-footer">
+			<span className="button-layer-footer-label">Aspect Ratio</span>
+			<div className="button-layer-aspect-options">
+				{ASPECT_RATIO_OPTIONS.map((option) => {
+					const id = String(option.id)
+					return (
+						<button
+							key={id}
+							type="button"
+							title={option.label}
+							className={`button-layer-aspect-option${value === id ? ' active' : ''}`}
+							onClick={() => setValue(id)}
+						>
+							<AspectRatioGlyph ratio={parseAspectRatio(id)} />
+						</button>
+					)
+				})}
+				<CustomAspectRatioButton value={value} setValue={setValue} active={!PRESET_ASPECT_RATIO_IDS.includes(value)} />
+			</div>
+		</div>
+	)
+}
+
+/**
+ * Lets a ratio be entered by hand, or picked from the surfaces Companion knows about, for surfaces that don't
+ * have a preset button. The value is the same "w:h" string the presets use, so it needs no special handling
+ * anywhere else.
+ */
+function CustomAspectRatioButton({
+	value,
+	setValue,
+	active,
+}: {
+	value: string
+	setValue: (value: string) => void
+	active: boolean
+}) {
+	return (
+		<Popover.Root>
+			<Popover.Trigger
+				color={null}
+				className={`button-layer-aspect-option${active ? ' active' : ''}`}
+				title="Custom aspect ratio"
+			>
+				<PencilIcon size={14} />
+			</Popover.Trigger>
+			<Popover.Popup className="button-layer-aspect-custom" align="end">
+				<CustomAspectRatioPopoverContent value={value} setValue={setValue} />
+			</Popover.Popup>
+		</Popover.Root>
+	)
+}
+
+/**
+ * Only mounted while the popover is open, so nothing subscribes until the picker is actually opened.
+ */
+function CustomAspectRatioPopoverContent({ value, setValue }: { value: string; setValue: (value: string) => void }) {
+	const [surfaces, setSurfaces] = useState<ClientSurfaceButtonSizesItem[]>([])
+
+	useSubscription(
+		trpc.surfaces.watchSurfaceButtonSizes.subscriptionOptions(undefined, {
+			onData: (data) => setSurfaces(Object.values(data)),
+			onError: (error) => {
+				console.error('Failed to subscribe to surface button sizes:', error)
+				setSurfaces([])
+			},
+		})
+	)
+
+	const surfaceChoices = useMemo(() => collectSurfaceAspectRatios(surfaces, PRESET_ASPECT_RATIO_IDS), [surfaces])
+
+	return <CustomAspectRatioBody value={value} setValue={setValue} surfaceChoices={surfaceChoices} />
+}
+
+/**
+ * The body of the custom ratio popover, split out from the subscription above so it can be rendered in
+ * isolation.
+ */
+export function CustomAspectRatioBody({
+	value,
+	setValue,
+	surfaceChoices,
+}: {
+	value: string
+	setValue: (value: string) => void
+	surfaceChoices: SurfaceAspectRatioChoice[]
+}): React.JSX.Element {
+	// Seeded from whatever is currently applied, preset or not, so opening this is a starting point rather
+	// than a jump to some unrelated ratio
+	const [w, h] = value.split(':').map(Number)
+	const width = isFinite(w) && w > 0 ? w : 4
+	const height = isFinite(h) && h > 0 ? h : 3
+
+	const clamp = (val: number) => Math.min(CUSTOM_RATIO_MAX, Math.max(CUSTOM_RATIO_MIN, Math.round(val)))
+
+	return (
+		<>
+			<InputGroup>
+				<InputGroupText>W</InputGroupText>
+				<NumberInputField
+					id={undefined}
+					value={width}
+					setValue={(val) => setValue(`${clamp(val)}:${height}`)}
+					min={CUSTOM_RATIO_MIN}
+					max={CUSTOM_RATIO_MAX}
+				/>
+			</InputGroup>
+			<InputGroup>
+				<InputGroupText>H</InputGroupText>
+				<NumberInputField
+					id={undefined}
+					value={height}
+					setValue={(val) => setValue(`${width}:${clamp(val)}`)}
+					min={CUSTOM_RATIO_MIN}
+					max={CUSTOM_RATIO_MAX}
+				/>
+			</InputGroup>
+
+			{/*
+			 * One row per button shape the user's surfaces have, so that connecting a surface is enough for its
+			 * shape to be offered here - rather than every surface model having to be listed in the ui. The ratios
+			 * already on the preset bar are left out, so this only ever offers something new.
+			 *
+			 * These are actions rather than a bound selection: what is currently applied is shown by the preset bar
+			 * and the fields above, and there is simply nothing to show when no surface has an unusual shape.
+			 */}
+			{surfaceChoices.length > 0 && (
+				<>
+					<div className="button-layer-aspect-surfaces-label">From your surfaces</div>
+					{surfaceChoices.map((choice) => (
+						<Popover.Item
+							key={choice.id}
+							className={`button-layer-aspect-surface${value === choice.id ? ' active' : ''}`}
+							title={choice.label}
+							onClick={() => setValue(choice.id)}
+						>
+							<AspectRatioGlyph ratio={parseAspectRatio(choice.id)} />
+							<span className="button-layer-aspect-surface-label">{choice.label}</span>
+						</Popover.Item>
+					))}
+				</>
+			)}
+		</>
+	)
+}
+
+// A little outlined rectangle drawn to the ratio, so the option reads at a glance
+function AspectRatioGlyph({ ratio }: { ratio: number }) {
+	const max = 15
+	const glyphWidth = ratio >= 1 ? max : max * ratio
+	const glyphHeight = ratio >= 1 ? max / ratio : max
+	return <span className="button-layer-aspect-glyph" style={{ width: glyphWidth, height: glyphHeight }} />
+}

--- a/webui/src/Buttons/EditButton/LayeredButtonEditor/Preview/AspectRatioPicker.tsx
+++ b/webui/src/Buttons/EditButton/LayeredButtonEditor/Preview/AspectRatioPicker.tsx
@@ -1,4 +1,5 @@
 import { useSubscription } from '@trpc/tanstack-react-query'
+import './AspectRatioPicker.css'
 import { PencilIcon } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import type { ClientSurfaceButtonSizesItem } from '@companion-app/shared/Model/Surfaces.js'

--- a/webui/src/Buttons/EditButton/LayeredButtonEditor/Preview/LayeredButtonPreviewRenderer.tsx
+++ b/webui/src/Buttons/EditButton/LayeredButtonEditor/Preview/LayeredButtonPreviewRenderer.tsx
@@ -1,8 +1,8 @@
+import { useSubscription } from '@trpc/tanstack-react-query'
 import { PencilIcon } from 'lucide-react'
 import { observer } from 'mobx-react-lite'
 import QuickLRU from 'quick-lru'
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
-import { useLocalStorage } from 'usehooks-ts'
 import type { ElementGeometry } from '@companion-app/shared/Graphics/Geometry.js'
 import type { TextLayoutCache } from '@companion-app/shared/Graphics/ImageBase.js'
 import { GraphicsLayeredButtonRenderer } from '@companion-app/shared/Graphics/LayeredRenderer.js'
@@ -10,11 +10,14 @@ import { DrawBounds, type ResolveButtonStylePropertiesConfig } from '@companion-
 import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
 import type { RendererButtonStyle } from '@companion-app/shared/Model/Render.js'
 import { ButtonGraphicsDecorationType } from '@companion-app/shared/Model/StyleModel.js'
+import type { ClientSurfaceButtonSizesItem } from '@companion-app/shared/Model/Surfaces.js'
 import { PromiseDebounce } from '@companion-app/shared/PromiseDebounce.js'
 import type { DropdownChoice } from '@companion-module/base'
+import { SimpleDropdownInputField } from '~/Components/DropdownInputFieldSimple.js'
 import { InputGroup, InputGroupText } from '~/Components/Form.js'
 import { NumberInputField } from '~/Components/NumberInputField.js'
 import { Popover } from '~/Components/Popover.js'
+import { useLocalStorage } from '~/Hooks/useLocalStorage.js'
 import { useResizeObserver } from '~/Hooks/useResizeObserver.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC.js'
 import { useComputed } from '~/Resources/util.js'
@@ -35,6 +38,7 @@ import { GraphicsImage } from './Image.js'
 import { LineSelectionOverlay } from './LineSelectionOverlay.js'
 import { QuickActionsToolbar } from './QuickActionsToolbar.js'
 import { SelectionOverlay } from './SelectionOverlay.js'
+import { collectSurfaceAspectRatios } from './surfaceAspectRatios.js'
 
 interface LayeredButtonPreviewRendererProps {
 	controlId: string
@@ -254,11 +258,13 @@ const ASPECT_RATIO_OPTIONS: DropdownChoice[] = [
 ]
 
 const CUSTOM_RATIO_MIN = 1
-const CUSTOM_RATIO_MAX = 100
+// Large enough for the ratios real surfaces produce, such as the 124:29 of a Stream Deck Neo's info bar
+const CUSTOM_RATIO_MAX = 999
 
 /**
- * Lets a ratio be entered by hand, for surfaces that don't have a preset button. The value is the same
- * "w:h" string the presets use, so it needs no special handling anywhere else.
+ * Lets a ratio be entered by hand, or picked from the surfaces Companion knows about, for surfaces that don't
+ * have a preset button. The value is the same "w:h" string the presets use, so it needs no special handling
+ * anywhere else.
  */
 function CustomAspectRatioButton({
 	value,
@@ -287,6 +293,7 @@ function CustomAspectRatioButton({
 				<PencilIcon size={14} />
 			</Popover.Trigger>
 			<Popover.Popup className="button-layer-aspect-custom" align="end">
+				<SurfaceAspectRatioDropdown value={value} setValue={setValue} />
 				<InputGroup>
 					<InputGroupText>W</InputGroupText>
 					<NumberInputField
@@ -309,6 +316,42 @@ function CustomAspectRatioButton({
 				</InputGroup>
 			</Popover.Popup>
 		</Popover.Root>
+	)
+}
+
+/**
+ * The ratios of the buttons on the surfaces Companion knows about, so that connecting a surface is enough for
+ * its shape to be offered here - rather than every surface model having to be listed in the ui.
+ *
+ * This only mounts while the popover is open, so nothing subscribes until the picker is actually opened.
+ */
+function SurfaceAspectRatioDropdown({ value, setValue }: { value: string; setValue: (value: string) => void }) {
+	const [surfaces, setSurfaces] = useState<ClientSurfaceButtonSizesItem[]>([])
+
+	useSubscription(
+		trpc.surfaces.watchSurfaceButtonSizes.subscriptionOptions(undefined, {
+			onData: (data) => setSurfaces(Object.values(data)),
+			onError: (error) => {
+				console.error('Failed to subscribe to surface button sizes:', error)
+				setSurfaces([])
+			},
+		})
+	)
+
+	const choices = useMemo(() => collectSurfaceAspectRatios(surfaces), [surfaces])
+
+	return (
+		<SimpleDropdownInputField
+			id={undefined}
+			className="button-layer-aspect-surfaces"
+			choices={choices}
+			value={value}
+			setValue={(val) => setValue(String(val))}
+			tooltip="Match a surface you have"
+			disabled={choices.length === 0}
+			noOptionsMessage="No surfaces with buttons"
+			badOptionPrefix="Custom"
+		/>
 	)
 }
 

--- a/webui/src/Buttons/EditButton/LayeredButtonEditor/Preview/LayeredButtonPreviewRenderer.tsx
+++ b/webui/src/Buttons/EditButton/LayeredButtonEditor/Preview/LayeredButtonPreviewRenderer.tsx
@@ -1,5 +1,3 @@
-import { useSubscription } from '@trpc/tanstack-react-query'
-import { PencilIcon } from 'lucide-react'
 import { observer } from 'mobx-react-lite'
 import QuickLRU from 'quick-lru'
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
@@ -10,19 +8,14 @@ import { DrawBounds, type ResolveButtonStylePropertiesConfig } from '@companion-
 import type { ControlLocation } from '@companion-app/shared/Model/Common.js'
 import type { RendererButtonStyle } from '@companion-app/shared/Model/Render.js'
 import { ButtonGraphicsDecorationType } from '@companion-app/shared/Model/StyleModel.js'
-import type { ClientSurfaceButtonSizesItem } from '@companion-app/shared/Model/Surfaces.js'
 import { PromiseDebounce } from '@companion-app/shared/PromiseDebounce.js'
-import type { DropdownChoice } from '@companion-module/base'
-import { SimpleDropdownInputField } from '~/Components/DropdownInputFieldSimple.js'
-import { InputGroup, InputGroupText } from '~/Components/Form.js'
-import { NumberInputField } from '~/Components/NumberInputField.js'
-import { Popover } from '~/Components/Popover.js'
 import { useLocalStorage } from '~/Hooks/useLocalStorage.js'
 import { useResizeObserver } from '~/Hooks/useResizeObserver.js'
 import { trpc, useMutationExt } from '~/Resources/TRPC.js'
 import { useComputed } from '~/Resources/util.js'
 import { RootAppStoreContext } from '~/Stores/RootAppStore.js'
 import type { LayeredStyleStore } from '../StyleStore.js'
+import { AspectRatioPicker } from './AspectRatioPicker.js'
 import {
 	buildOptionValues,
 	getDraggableBoundsFields,
@@ -30,7 +23,7 @@ import {
 	type BoundsFractions,
 	type BoundsKey,
 } from './boundsFields.js'
-import { fitCanvasSize, PAD_X, PAD_Y, parseAspectRatio } from './canvasSize.js'
+import { fitCanvasSize, PAD_X, PAD_Y } from './canvasSize.js'
 import { useLayeredButtonDrawStyleParser } from './DrawStyleParser.js'
 import { filterElementRects, findElementRect, hitTestElements } from './elementHitTest.js'
 import FontLoader from './FontLoader.js'
@@ -38,7 +31,6 @@ import { GraphicsImage } from './Image.js'
 import { LineSelectionOverlay } from './LineSelectionOverlay.js'
 import { QuickActionsToolbar } from './QuickActionsToolbar.js'
 import { SelectionOverlay } from './SelectionOverlay.js'
-import { collectSurfaceAspectRatios } from './surfaceAspectRatios.js'
 
 interface LayeredButtonPreviewRendererProps {
 	controlId: string
@@ -118,30 +110,7 @@ export const LayeredButtonPreviewRenderer = observer(function LayeredButtonPrevi
 						snapEnabledRef={snapEnabledRef}
 					/>
 				</div>
-				<div className="button-layer-canvas-footer">
-					<span className="button-layer-footer-label">Aspect Ratio</span>
-					<div className="button-layer-aspect-options">
-						{ASPECT_RATIO_OPTIONS.map((option) => {
-							const id = String(option.id)
-							return (
-								<button
-									key={id}
-									type="button"
-									title={option.label}
-									className={`button-layer-aspect-option${aspectRatio === id ? ' active' : ''}`}
-									onClick={() => setAspectRatio(id)}
-								>
-									<AspectRatioGlyph ratio={parseAspectRatio(id)} />
-								</button>
-							)
-						})}
-						<CustomAspectRatioButton
-							value={aspectRatio}
-							setValue={setAspectRatio}
-							active={!ASPECT_RATIO_OPTIONS.some((option) => String(option.id) === aspectRatio)}
-						/>
-					</div>
-				</div>
+				<AspectRatioPicker value={aspectRatio} setValue={setAspectRatio} />
 			</div>
 		</div>
 	)
@@ -250,118 +219,6 @@ const ElementQuickActions = observer(function ElementQuickActions({
 		/>
 	)
 })
-
-const ASPECT_RATIO_OPTIONS: DropdownChoice[] = [
-	{ id: '1:1', label: '1:1 (Square)' },
-	{ id: '9:7', label: '9:7 (Stream Deck Studio)' },
-	{ id: '2:1', label: '2:1 (Stream Deck Plus & Plus XL)' },
-]
-
-const CUSTOM_RATIO_MIN = 1
-// Large enough for the ratios real surfaces produce, such as the 124:29 of a Stream Deck Neo's info bar
-const CUSTOM_RATIO_MAX = 999
-
-/**
- * Lets a ratio be entered by hand, or picked from the surfaces Companion knows about, for surfaces that don't
- * have a preset button. The value is the same "w:h" string the presets use, so it needs no special handling
- * anywhere else.
- */
-function CustomAspectRatioButton({
-	value,
-	setValue,
-	active,
-}: {
-	value: string
-	setValue: (value: string) => void
-	active: boolean
-}) {
-	// Seeded from whatever is currently applied, preset or not, so opening this is a starting point rather
-	// than a jump to some unrelated ratio
-	const [w, h] = value.split(':').map(Number)
-	const width = isFinite(w) && w > 0 ? w : 4
-	const height = isFinite(h) && h > 0 ? h : 3
-
-	const clamp = (val: number) => Math.min(CUSTOM_RATIO_MAX, Math.max(CUSTOM_RATIO_MIN, Math.round(val)))
-
-	return (
-		<Popover.Root>
-			<Popover.Trigger
-				color={null}
-				className={`button-layer-aspect-option${active ? ' active' : ''}`}
-				title="Custom aspect ratio"
-			>
-				<PencilIcon size={14} />
-			</Popover.Trigger>
-			<Popover.Popup className="button-layer-aspect-custom" align="end">
-				<SurfaceAspectRatioDropdown value={value} setValue={setValue} />
-				<InputGroup>
-					<InputGroupText>W</InputGroupText>
-					<NumberInputField
-						id={undefined}
-						value={width}
-						setValue={(val) => setValue(`${clamp(val)}:${height}`)}
-						min={CUSTOM_RATIO_MIN}
-						max={CUSTOM_RATIO_MAX}
-					/>
-				</InputGroup>
-				<InputGroup>
-					<InputGroupText>H</InputGroupText>
-					<NumberInputField
-						id={undefined}
-						value={height}
-						setValue={(val) => setValue(`${width}:${clamp(val)}`)}
-						min={CUSTOM_RATIO_MIN}
-						max={CUSTOM_RATIO_MAX}
-					/>
-				</InputGroup>
-			</Popover.Popup>
-		</Popover.Root>
-	)
-}
-
-/**
- * The ratios of the buttons on the surfaces Companion knows about, so that connecting a surface is enough for
- * its shape to be offered here - rather than every surface model having to be listed in the ui.
- *
- * This only mounts while the popover is open, so nothing subscribes until the picker is actually opened.
- */
-function SurfaceAspectRatioDropdown({ value, setValue }: { value: string; setValue: (value: string) => void }) {
-	const [surfaces, setSurfaces] = useState<ClientSurfaceButtonSizesItem[]>([])
-
-	useSubscription(
-		trpc.surfaces.watchSurfaceButtonSizes.subscriptionOptions(undefined, {
-			onData: (data) => setSurfaces(Object.values(data)),
-			onError: (error) => {
-				console.error('Failed to subscribe to surface button sizes:', error)
-				setSurfaces([])
-			},
-		})
-	)
-
-	const choices = useMemo(() => collectSurfaceAspectRatios(surfaces), [surfaces])
-
-	return (
-		<SimpleDropdownInputField
-			id={undefined}
-			className="button-layer-aspect-surfaces"
-			choices={choices}
-			value={value}
-			setValue={(val) => setValue(String(val))}
-			tooltip="Match a surface you have"
-			disabled={choices.length === 0}
-			noOptionsMessage="No surfaces with buttons"
-			badOptionPrefix="Custom"
-		/>
-	)
-}
-
-// A little outlined rectangle drawn to the ratio, so the option reads at a glance
-function AspectRatioGlyph({ ratio }: { ratio: number }) {
-	const max = 15
-	const glyphWidth = ratio >= 1 ? max : max * ratio
-	const glyphHeight = ratio >= 1 ? max / ratio : max
-	return <span className="button-layer-aspect-glyph" style={{ width: glyphWidth, height: glyphHeight }} />
-}
 
 interface LayeredButtonCanvasProps {
 	width: number

--- a/webui/src/Buttons/EditButton/LayeredButtonEditor/Preview/__tests__/surfaceAspectRatios.test.ts
+++ b/webui/src/Buttons/EditButton/LayeredButtonEditor/Preview/__tests__/surfaceAspectRatios.test.ts
@@ -45,23 +45,26 @@ describe('reduceToAspectRatio', () => {
 
 describe('collectSurfaceAspectRatios', () => {
 	test('has nothing to offer for no surfaces', () => {
-		expect(collectSurfaceAspectRatios([])).toEqual([])
+		expect(collectSurfaceAspectRatios([], [])).toEqual([])
 	})
 
 	test('names the model a ratio comes from', () => {
-		expect(collectSurfaceAspectRatios([makeSurface('Stream Deck Neo', [[248, 58]])])).toEqual([
+		expect(collectSurfaceAspectRatios([makeSurface('Stream Deck Neo', [[248, 58]])], [])).toEqual([
 			{ id: '124:29', label: '124:29 (Stream Deck Neo)' },
 		])
 	})
 
 	test('a surface with several button sizes offers each of them', () => {
 		expect(
-			collectSurfaceAspectRatios([
-				makeSurface('Stream Deck Neo', [
-					[96, 96],
-					[248, 58],
-				]),
-			])
+			collectSurfaceAspectRatios(
+				[
+					makeSurface('Stream Deck Neo', [
+						[96, 96],
+						[248, 58],
+					]),
+				],
+				[]
+			)
 		).toEqual([
 			{ id: '1:1', label: '1:1 (Stream Deck Neo)' },
 			{ id: '124:29', label: '124:29 (Stream Deck Neo)' },
@@ -70,13 +73,16 @@ describe('collectSurfaceAspectRatios', () => {
 
 	test('merges the models which share a ratio into one entry', () => {
 		expect(
-			collectSurfaceAspectRatios([
-				makeSurface('Stream Deck XL', [[96, 96]]),
-				makeSurface('Stream Deck Neo', [
-					[96, 96],
-					[248, 58],
-				]),
-			])
+			collectSurfaceAspectRatios(
+				[
+					makeSurface('Stream Deck XL', [[96, 96]]),
+					makeSurface('Stream Deck Neo', [
+						[96, 96],
+						[248, 58],
+					]),
+				],
+				[]
+			)
 		).toEqual([
 			{ id: '1:1', label: '1:1 (Stream Deck Neo, Stream Deck XL)' },
 			{ id: '124:29', label: '124:29 (Stream Deck Neo)' },
@@ -85,22 +91,75 @@ describe('collectSurfaceAspectRatios', () => {
 
 	test('lists a model once for a ratio, however many of them are connected', () => {
 		expect(
-			collectSurfaceAspectRatios([makeSurface('Stream Deck XL', [[72, 72]]), makeSurface('Stream Deck XL', [[96, 96]])])
+			collectSurfaceAspectRatios(
+				[makeSurface('Stream Deck XL', [[72, 72]]), makeSurface('Stream Deck XL', [[96, 96]])],
+				[]
+			)
 		).toEqual([{ id: '1:1', label: '1:1 (Stream Deck XL)' }])
 	})
 
 	test('a surface with no drawn buttons offers nothing', () => {
-		expect(collectSurfaceAspectRatios([makeSurface('Contour Shuttle', [])])).toEqual([])
+		expect(collectSurfaceAspectRatios([makeSurface('Contour Shuttle', [])], [])).toEqual([])
 	})
 
 	test('skips sizes which describe no shape', () => {
 		expect(
-			collectSurfaceAspectRatios([
-				makeSurface('Broken', [
-					[0, 0],
-					[72, 72],
-				]),
-			])
+			collectSurfaceAspectRatios(
+				[
+					makeSurface('Broken', [
+						[0, 0],
+						[72, 72],
+					]),
+				],
+				[]
+			)
 		).toEqual([{ id: '1:1', label: '1:1 (Broken)' }])
+	})
+})
+
+describe('collectSurfaceAspectRatios exclusions', () => {
+	const presets = ['1:1', '9:7', '2:1']
+
+	test('leaves out the ratios already offered by the preset buttons', () => {
+		expect(
+			collectSurfaceAspectRatios(
+				[
+					makeSurface('Stream Deck Neo', [
+						[96, 96],
+						[248, 58],
+					]),
+				],
+				presets
+			)
+		).toEqual([{ id: '124:29', label: '124:29 (Stream Deck Neo)' }])
+	})
+
+	test('offers nothing when every surface is a shape the presets cover', () => {
+		expect(
+			collectSurfaceAspectRatios(
+				[makeSurface('Stream Deck XL', [[96, 96]]), makeSurface('Stream Deck Plus', [[200, 100]])],
+				presets
+			)
+		).toEqual([])
+	})
+
+	test('excludes by the reduced ratio, not the pixel size', () => {
+		// 120x60 reduces to 2:1, which is a preset, so it should not be offered
+		expect(collectSurfaceAspectRatios([makeSurface('Stream Deck Plus', [[120, 60]])], presets)).toEqual([])
+	})
+
+	test('a model is dropped from a label only for the excluded ratio', () => {
+		expect(
+			collectSurfaceAspectRatios(
+				[
+					makeSurface('Stream Deck Neo', [
+						[96, 96],
+						[248, 58],
+					]),
+					makeSurface('Stream Deck XL', [[96, 96]]),
+				],
+				presets
+			)
+		).toEqual([{ id: '124:29', label: '124:29 (Stream Deck Neo)' }])
 	})
 })

--- a/webui/src/Buttons/EditButton/LayeredButtonEditor/Preview/__tests__/surfaceAspectRatios.test.ts
+++ b/webui/src/Buttons/EditButton/LayeredButtonEditor/Preview/__tests__/surfaceAspectRatios.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from 'vitest'
+import type { ClientSurfaceButtonSizesItem } from '@companion-app/shared/Model/Surfaces.js'
+import { collectSurfaceAspectRatios, reduceToAspectRatio } from '../surfaceAspectRatios.js'
+
+function makeSurface(type: string, sizes: Array<[number, number]>): ClientSurfaceButtonSizesItem {
+	return {
+		id: type.toLowerCase().replace(/\s/g, '-'),
+		type,
+		displayName: `${type} (surface0)`,
+		isConnected: true,
+		bitmapSizes: sizes.map(([w, h]) => ({ w, h })),
+	}
+}
+
+describe('reduceToAspectRatio', () => {
+	test('reduces to the smallest whole number ratio', () => {
+		expect(reduceToAspectRatio(248, 58)).toBe('124:29')
+		expect(reduceToAspectRatio(120, 60)).toBe('2:1')
+		expect(reduceToAspectRatio(200, 100)).toBe('2:1')
+		expect(reduceToAspectRatio(90, 60)).toBe('3:2')
+	})
+
+	test('a square of any size is 1:1', () => {
+		expect(reduceToAspectRatio(72, 72)).toBe('1:1')
+		expect(reduceToAspectRatio(96, 96)).toBe('1:1')
+		expect(reduceToAspectRatio(1000, 1000)).toBe('1:1')
+	})
+
+	test('an already reduced ratio is left alone', () => {
+		expect(reduceToAspectRatio(9, 7)).toBe('9:7')
+	})
+
+	test('rounds non-integer sizes', () => {
+		expect(reduceToAspectRatio(100.4, 50.2)).toBe('2:1')
+	})
+
+	test('rejects sizes which describe no shape', () => {
+		expect(reduceToAspectRatio(0, 72)).toBeNull()
+		expect(reduceToAspectRatio(72, 0)).toBeNull()
+		expect(reduceToAspectRatio(-72, 72)).toBeNull()
+		expect(reduceToAspectRatio(NaN, 72)).toBeNull()
+		expect(reduceToAspectRatio(Infinity, 72)).toBeNull()
+	})
+})
+
+describe('collectSurfaceAspectRatios', () => {
+	test('has nothing to offer for no surfaces', () => {
+		expect(collectSurfaceAspectRatios([])).toEqual([])
+	})
+
+	test('names the model a ratio comes from', () => {
+		expect(collectSurfaceAspectRatios([makeSurface('Stream Deck Neo', [[248, 58]])])).toEqual([
+			{ id: '124:29', label: '124:29 (Stream Deck Neo)' },
+		])
+	})
+
+	test('a surface with several button sizes offers each of them', () => {
+		expect(
+			collectSurfaceAspectRatios([
+				makeSurface('Stream Deck Neo', [
+					[96, 96],
+					[248, 58],
+				]),
+			])
+		).toEqual([
+			{ id: '1:1', label: '1:1 (Stream Deck Neo)' },
+			{ id: '124:29', label: '124:29 (Stream Deck Neo)' },
+		])
+	})
+
+	test('merges the models which share a ratio into one entry', () => {
+		expect(
+			collectSurfaceAspectRatios([
+				makeSurface('Stream Deck XL', [[96, 96]]),
+				makeSurface('Stream Deck Neo', [
+					[96, 96],
+					[248, 58],
+				]),
+			])
+		).toEqual([
+			{ id: '1:1', label: '1:1 (Stream Deck Neo, Stream Deck XL)' },
+			{ id: '124:29', label: '124:29 (Stream Deck Neo)' },
+		])
+	})
+
+	test('lists a model once for a ratio, however many of them are connected', () => {
+		expect(
+			collectSurfaceAspectRatios([makeSurface('Stream Deck XL', [[72, 72]]), makeSurface('Stream Deck XL', [[96, 96]])])
+		).toEqual([{ id: '1:1', label: '1:1 (Stream Deck XL)' }])
+	})
+
+	test('a surface with no drawn buttons offers nothing', () => {
+		expect(collectSurfaceAspectRatios([makeSurface('Contour Shuttle', [])])).toEqual([])
+	})
+
+	test('skips sizes which describe no shape', () => {
+		expect(
+			collectSurfaceAspectRatios([
+				makeSurface('Broken', [
+					[0, 0],
+					[72, 72],
+				]),
+			])
+		).toEqual([{ id: '1:1', label: '1:1 (Broken)' }])
+	})
+})

--- a/webui/src/Buttons/EditButton/LayeredButtonEditor/Preview/surfaceAspectRatios.ts
+++ b/webui/src/Buttons/EditButton/LayeredButtonEditor/Preview/surfaceAspectRatios.ts
@@ -1,0 +1,56 @@
+import type { ClientSurfaceButtonSizesItem } from '@companion-app/shared/Model/Surfaces.js'
+
+export interface SurfaceAspectRatioChoice {
+	/** The ratio, in the same "w:h" form the presets use */
+	id: string
+	label: string
+}
+
+function greatestCommonDivisor(a: number, b: number): number {
+	while (b) {
+		;[a, b] = [b, a % b]
+	}
+	return a
+}
+
+/**
+ * Reduce a pixel size to the smallest whole number ratio which describes it, so that a 248x58 info bar reads as
+ * "124:29" rather than repeating the pixel dimensions back at the user.
+ */
+export function reduceToAspectRatio(w: number, h: number): string | null {
+	if (!isFinite(w) || !isFinite(h) || w <= 0 || h <= 0) return null
+
+	const divisor = greatestCommonDivisor(Math.round(w), Math.round(h))
+	if (!divisor) return null
+
+	return `${Math.round(w) / divisor}:${Math.round(h) / divisor}`
+}
+
+/**
+ * The distinct aspect ratios of the buttons across all of the known surfaces, labelled with the models which
+ * have buttons of that shape. A surface with more than one button size contributes to more than one ratio.
+ */
+export function collectSurfaceAspectRatios(surfaces: ClientSurfaceButtonSizesItem[]): SurfaceAspectRatioChoice[] {
+	const namesByRatio = new Map<string, Set<string>>()
+
+	for (const surface of surfaces) {
+		for (const size of surface.bitmapSizes) {
+			const ratio = reduceToAspectRatio(size.w, size.h)
+			if (!ratio) continue
+
+			let names = namesByRatio.get(ratio)
+			if (!names) {
+				names = new Set()
+				namesByRatio.set(ratio, names)
+			}
+			names.add(surface.type)
+		}
+	}
+
+	return Array.from(namesByRatio.entries())
+		.map(([id, names]) => ({
+			id,
+			label: `${id} (${Array.from(names).sort().join(', ')})`,
+		}))
+		.sort((a, b) => a.id.localeCompare(b.id))
+}

--- a/webui/src/Buttons/EditButton/LayeredButtonEditor/Preview/surfaceAspectRatios.ts
+++ b/webui/src/Buttons/EditButton/LayeredButtonEditor/Preview/surfaceAspectRatios.ts
@@ -29,14 +29,21 @@ export function reduceToAspectRatio(w: number, h: number): string | null {
 /**
  * The distinct aspect ratios of the buttons across all of the known surfaces, labelled with the models which
  * have buttons of that shape. A surface with more than one button size contributes to more than one ratio.
+ *
+ * `excludeRatios` drops the ratios which are already offered elsewhere - the preset buttons in the footer -
+ * so that this only ever adds shapes the user could not otherwise reach.
  */
-export function collectSurfaceAspectRatios(surfaces: ClientSurfaceButtonSizesItem[]): SurfaceAspectRatioChoice[] {
+export function collectSurfaceAspectRatios(
+	surfaces: ClientSurfaceButtonSizesItem[],
+	excludeRatios: readonly string[]
+): SurfaceAspectRatioChoice[] {
+	const excluded = new Set(excludeRatios)
 	const namesByRatio = new Map<string, Set<string>>()
 
 	for (const surface of surfaces) {
 		for (const size of surface.bitmapSizes) {
 			const ratio = reduceToAspectRatio(size.w, size.h)
-			if (!ratio) continue
+			if (!ratio || excluded.has(ratio)) continue
 
 			let names = namesByRatio.get(ratio)
 			if (!names) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1773,6 +1773,7 @@ __metadata:
   resolution: "@companion-app/shared@workspace:shared-lib"
   dependencies:
     "@companion-app/expressions": "npm:^1.0.1"
+    "@companion-surface/base": "npm:1.4.0"
     "@types/semver": "npm:^7.8.0"
     colord: "npm:^2.10.0"
     quick-lru: "npm:^7.3.0"
@@ -1965,7 +1966,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@companion-surface/base@npm:~1.4.0":
+"@companion-surface/base@npm:1.4.0, @companion-surface/base@npm:~1.4.0":
   version: 1.4.0
   resolution: "@companion-surface/base@npm:1.4.0"
   dependencies:


### PR DESCRIPTION
Replaces #4381

Shortcuts for more aspect ratios for different surfaces in the style editor.

There isn't enough space on the bar to show everything the user could end up with, and if that list becomes dynamic they will need some better way to identify them.

So instead, we add some options to the bottom of the popover:

<img width="598" height="686" alt="image" src="https://github.com/user-attachments/assets/5f45ce9c-a95d-4a8a-8f7f-ccdb185ca69f" />

This uses data sourced from the 'known' surfaces (the ones both connected and disconnected in the surfaces table).
To do this we are now storing the full surface layout definition they provide, which we can use for more in the future. So this will start working after Companion next sees those surfaces.  

So this will work for any connected surfaces that use different aspect ratios, not just official ones. Anything connected over satellite will appear here too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added surface layout and button-size information for connected and offline surfaces.
  - Added live updates for surface layouts and available button dimensions.
  - Added an aspect-ratio picker with presets, custom width/height values, and ratios derived from connected surfaces.
  - Surface layouts now persist with surface configuration.

- **Improvements**
  - Aspect-ratio controls are organized into a dedicated, more compact picker beneath the layered button preview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->